### PR TITLE
feat(ci,cli): /jazz PR trigger; redact API keys in terminal history

### DIFF
--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -1,7 +1,7 @@
 {
   "id": "pr-assistant",
   "name": "pr-assistant",
-  "description": "Pull request assistant agent for @jazz mentions",
+  "description": "Pull request assistant agent for /jazz PR comments",
   "model": "openai/gpt-5.4-mini",
   "config": {
     "persona": "coder",

--- a/.github/jazz/workflows/pr-assistant/WORKFLOW.md
+++ b/.github/jazz/workflows/pr-assistant/WORKFLOW.md
@@ -1,6 +1,6 @@
 ---
 name: pr-assistant
-description: Respond to @jazz PR comments with PR-aware assistance
+description: Respond to /jazz PR comments with PR-aware assistance
 autoApprove: true
 agent: pr-assistant
 maxIterations: 100
@@ -10,7 +10,7 @@ skills:
 
 # Pull Request Assistant
 
-A reviewer mentioned `@jazz` on pull request **#__PR_NUMBER__**.
+A reviewer invoked `/jazz` on pull request **#__PR_NUMBER__**.
 
 ## Request
 

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -48,7 +48,9 @@ jobs:
           script: |
             function extractRequest(body) {
               if (!body) return '';
-              const match = body.match(/@jazz(?:\s*[:,-])?\s*([\s\S]*)/i);
+              const trimmed = body.trim();
+              // Slash command avoids GitHub @-mention UX; exclude /jazz-review so review-only comments do not capture "-review…" as the request.
+              const match = trimmed.match(/^\/jazz(?!-review)(?:\s*[:,-])?\s*([\s\S]*)/i);
               return match?.[1]?.trim() ?? '';
             }
 
@@ -104,7 +106,8 @@ jobs:
         if: |
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
-          contains(github.event.comment.body, '@jazz') && (
+          contains(github.event.comment.body, '/jazz') &&
+          !contains(github.event.comment.body, '/jazz-review') && (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
             github.event.comment.author_association == 'COLLABORATOR'
@@ -373,13 +376,14 @@ jobs:
               });
             }
 
-  # On-demand PR assistant — triggered by @jazz mentions or manual workflow dispatch.
+  # On-demand PR assistant — triggered by a /jazz comment or manual workflow dispatch.
   assistant:
     needs: resolve
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'assistant' && needs.resolve.outputs.pr_head_repo_full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@jazz') && (
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/jazz') &&
+        !contains(github.event.comment.body, '/jazz-review') && (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -117,7 +117,11 @@ export function setConfigCommand(
 
         yield* terminal.info(`Configuring ${provider}...`);
 
-        const apiKey = yield* terminal.ask("Enter API Key:");
+        const apiKey = yield* terminal.ask("Enter API Key:", {
+          simple: true,
+          secret: true,
+          placeholder: "Paste your API key...",
+        });
         yield* configService.set(`llm.${provider}.api_key`, apiKey);
 
         yield* terminal.success(`Configuration for ${provider} updated.`);

--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -6,6 +6,7 @@ import { handleWebSearchConfiguration } from "@/cli/helpers/web-search";
 import { THEME } from "@/cli/ui/theme";
 import { registerMCPServerTools } from "@/core/agent/tools/mcp-tools";
 import {
+  BUILTIN_TOOL_CATEGORIES,
   createCategoryMappings,
   FILE_MANAGEMENT_CATEGORY,
   getMCPServerCategories,
@@ -13,7 +14,6 @@ import {
   HTTP_CATEGORY,
   SHELL_COMMANDS_CATEGORY,
   WEB_SEARCH_CATEGORY,
-  BUILTIN_TOOL_CATEGORIES,
 } from "@/core/agent/tools/register-tools";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
@@ -428,6 +428,9 @@ async function promptForAgentInfo(
           const isOptional = result === "ollama";
           const apiKey = await Effect.runPromise(
             terminal.ask(`${providerDisplayName} API Key${isOptional ? " (optional)" : ""}:`, {
+              simple: true,
+              secret: true,
+              placeholder: "Paste your API key...",
               validate: (inputValue: string): boolean | string => {
                 if (isOptional) return true;
                 if (!inputValue || inputValue.trim().length === 0) {

--- a/src/cli/commands/edit-agent.ts
+++ b/src/cli/commands/edit-agent.ts
@@ -616,6 +616,9 @@ async function promptForAgentUpdates(
 
       const apiKey = await Effect.runPromise(
         terminal.ask(`${providerDisplayName} API Key:`, {
+          simple: true,
+          secret: true,
+          placeholder: "Paste your API key...",
           validate: (inputValue: string): boolean | string => {
             if (!inputValue || inputValue.trim().length === 0) {
               return "API key cannot be empty";

--- a/src/cli/helpers/web-search.ts
+++ b/src/cli/helpers/web-search.ts
@@ -77,6 +77,9 @@ export function handleWebSearchConfiguration(
     if (!hasApiKey) {
       // Prompt for API key
       const apiKey = yield* terminal.ask(`Enter API Key for ${provider}:`, {
+        simple: true,
+        secret: true,
+        placeholder: "Paste your API key...",
         validate: (input) => (input.trim().length > 0 ? true : "API Key cannot be empty"),
       });
 

--- a/src/cli/ui/OutputEntryView.tsx
+++ b/src/cli/ui/OutputEntryView.tsx
@@ -98,7 +98,7 @@ export const OutputEntryView = React.memo(function OutputEntryView({
     return (
       <Box
         marginTop={addSpacing ? 1 : 0}
-        marginBottom={isDebug ? 0 : 1}
+        marginBottom={1}
         paddingLeft={isDebug ? PADDING.content : 0}
       >
         {icon}

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -9,7 +9,7 @@ import { ScrollableMultiSelect } from "./components/ScrollableMultiSelect";
 import { ScrollableSelect } from "./components/ScrollableSelect";
 import { SearchSelect } from "./components/SearchSelect";
 import { TextInput } from "./components/TextInput";
-import { useInputHandler, InputResults, useTextInput } from "./hooks/use-input-service";
+import { InputResults, useInputHandler, useTextInput } from "./hooks/use-input-service";
 import { PADDING, THEME } from "./theme";
 import type { PromptState } from "./types";
 
@@ -97,7 +97,7 @@ function PromptComponent({
     currentPrompt.resolve(val);
   }, []);
 
-  const textInputActive = prompt.type === "chat" || prompt.type === "password";
+  const textInputActive = prompt.type === "chat";
   const { value, cursor, setValue } = useTextInput({
     id: "text-input",
     isActive: textInputActive,
@@ -265,6 +265,7 @@ function PromptComponent({
           <TextInput
             inputId={`password-${prompt.message}`}
             mask="*"
+            maskRevealTail={5}
             onSubmit={(value: string) => prompt.resolve(value)}
             onCancel={() => prompt.reject?.()}
           />

--- a/src/cli/ui/components/TextInput.tsx
+++ b/src/cli/ui/components/TextInput.tsx
@@ -3,6 +3,24 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTextInput } from "../hooks/use-input-service";
 import { THEME } from "../theme";
 
+/** Build display string for masked input; length always matches `value` for cursor alignment. */
+function formatMaskedDisplayValue(
+  value: string,
+  maskChar: string,
+  revealTailCount?: number,
+): string {
+  const n = value.length;
+  if (n === 0) {
+    return "";
+  }
+  if (revealTailCount === undefined || revealTailCount <= 0) {
+    return maskChar.repeat(n);
+  }
+  const tailLen = Math.min(revealTailCount, n);
+  const hiddenLen = n - tailLen;
+  return maskChar.repeat(hiddenLen) + value.slice(-tailLen);
+}
+
 export interface TextInputProps {
   /** Unique identifier for this input (used to prevent state sharing) */
   inputId: string;
@@ -10,6 +28,8 @@ export interface TextInputProps {
   placeholder?: string;
   /** Mask character for password input (e.g., "*") */
   mask?: string;
+  /** When set with `mask`, show this many characters from the end in plaintext (rest stay masked). */
+  maskRevealTail?: number;
   validate?: (input: string) => boolean | string;
   onSubmit: (value: string) => void;
   onCancel?: () => void;
@@ -27,6 +47,7 @@ export const TextInput = React.memo(function TextInput({
   defaultValue = "",
   placeholder = "",
   mask,
+  maskRevealTail,
   validate,
   onSubmit,
   onCancel,
@@ -101,7 +122,7 @@ export const TextInput = React.memo(function TextInput({
       );
     }
 
-    const displayValue = mask ? mask.repeat(value.length) : value;
+    const displayValue = mask ? formatMaskedDisplayValue(value, mask, maskRevealTail) : value;
 
     const beforeCursor = displayValue.slice(0, cursor);
     const cursorChar = cursor < displayValue.length ? displayValue[cursor] : " ";

--- a/src/core/interfaces/terminal.ts
+++ b/src/core/interfaces/terminal.ts
@@ -96,6 +96,8 @@ export interface TerminalService {
       hidden?: boolean;
       /** Optional placeholder text to show when input is empty. */
       placeholder?: string;
+      /** When true, mask the echoed value in the terminal history (e.g. for API keys). */
+      secret?: boolean;
     },
   ) => Effect.Effect<string | undefined, never>;
 

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -167,6 +167,7 @@ export class InkTerminalService implements TerminalService {
       simple?: boolean;
       hidden?: boolean;
       placeholder?: string;
+      secret?: boolean;
     },
   ): Effect.Effect<string | undefined, never> {
     return Effect.async<string, Error>((resume) => {
@@ -174,6 +175,7 @@ export class InkTerminalService implements TerminalService {
       const isCancellable = options?.cancellable === true;
       const isSimple = options?.simple === true;
       const isHidden = options?.hidden === true;
+      const isSecret = options?.secret === true;
       const placeholder = options?.placeholder;
 
       const promptType = isHidden ? "hidden" : isSimple ? "text" : "chat";
@@ -211,7 +213,8 @@ export class InkTerminalService implements TerminalService {
           // Pre-wrap user message to fit terminal width, consistent with how
           // agent responses are pre-wrapped. The offset accounts for App paddingX=3
           // (6 chars) + the "›" icon + space (2 chars) = 8 chars total.
-          const rawMessage = `${message} ${chalk.green(inputValue)}`;
+          const displayValue = isSecret ? "•".repeat(Math.min(inputValue.length, 8)) : inputValue;
+          const rawMessage = `${message} ${chalk.green(displayValue)}`;
           const available = getTerminalWidth() - 8;
           store.printOutput({
             type: "user",


### PR DESCRIPTION
## Summary

This PR bundles workflow and CLI changes that were sitting in the working tree.

### CI / PR assistant
- Trigger the on-demand PR assistant with a `/jazz` comment on a PR instead of `@jazz`, avoiding GitHub @-mention behavior.
- Ignore `/jazz-review` so review-only comments do not match or capture the wrong request body.
- Align pr-assistant agent description and workflow copy with the slash command.

### CLI
- Add `secret` option to `terminal.ask` so submitted API keys are not echoed in plain text in the transcript (replaced with a short bullet mask).
- Use `simple`, `secret`, and `placeholder` for API key prompts in config, create-agent, edit-agent, and web-search helper.
- Password-style `TextInput` can show the last few characters (`maskRevealTail`) while masking the rest.
- Stop routing the shared chat `useTextInput` hook for password prompts so masked inputs do not fight for focus.

## Testing
- [ ] Manual: comment `/jazz …` on a PR and confirm assistant runs; `/jazz-review` does not trigger it.
- [ ] Manual: run a flow that asks for an API key and confirm transcript redaction and input behavior.

Made with [Cursor](https://cursor.com)