### PR TITLE
feat: surface reasoning-only responses instead of warning empty

### DIFF
--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -528,6 +528,84 @@ describe("activity-reducer", () => {
       expect(result.activity).toEqual({ phase: "complete" });
       expect(result.outputs).toHaveLength(0);
     });
+
+    test("flushes completedReasoning to outputs when no text was streamed", () => {
+      // Reasoning-only response (e.g. llama.cpp --jinja routing the entire
+      // response into reasoning_content). The reducer should emit the
+      // reasoning text as a Static output entry so the user sees it instead
+      // of an empty live area being cleared.
+      const ink = createCapturingInk();
+      const a = acc({
+        completedReasoning: "let me think carefully about this answer",
+        liveText: "",
+      });
+
+      const result = reduceEvent(
+        a,
+        {
+          type: "complete",
+          response: { content: "", role: "assistant", usage: undefined, toolCalls: [] },
+          totalDurationMs: 100,
+        },
+        identity,
+        ink.render,
+      );
+
+      expect(result.activity).toEqual({ phase: "complete" });
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs[0]!.type).toBe("log");
+      expect(extractText(ink.nodes[0])).toContain("let me think carefully about this answer");
+    });
+
+    test("does not flush reasoning when text content was already streamed", () => {
+      const ink = createCapturingInk();
+      const a = acc({
+        completedReasoning: "thinking",
+        liveText: "actual answer",
+      });
+
+      const result = reduceEvent(
+        a,
+        {
+          type: "complete",
+          response: {
+            content: "actual answer",
+            role: "assistant",
+            usage: undefined,
+            toolCalls: [],
+          },
+          totalDurationMs: 100,
+        },
+        identity,
+        ink.render,
+      );
+
+      expect(result.outputs).toHaveLength(0);
+      expect(ink.nodes).toHaveLength(0);
+    });
+
+    test("flushes a still-buffered reasoning chunk if reasoning-end did not fire", () => {
+      const ink = createCapturingInk();
+      const a = acc({
+        completedReasoning: "",
+        reasoningBuffer: "incomplete thought",
+        liveText: "",
+      });
+
+      const result = reduceEvent(
+        a,
+        {
+          type: "complete",
+          response: { content: "", role: "assistant", usage: undefined, toolCalls: [] },
+          totalDurationMs: 100,
+        },
+        identity,
+        ink.render,
+      );
+
+      expect(result.outputs).toHaveLength(1);
+      expect(extractText(ink.nodes[0])).toContain("incomplete thought");
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -487,7 +487,34 @@ export function reduceEvent(
     // ---- Complete -------------------------------------------------------
 
     case "complete": {
-      return { activity: { phase: "complete" }, outputs: [] };
+      // If the model produced reasoning but no text content (common with
+      // OpenAI-compatible local servers like llama-server --jinja, where
+      // jinja templates route the entire response into reasoning_content),
+      // surface the reasoning as the visible response so the user sees it
+      // instead of nothing.
+      const pendingReasoning = acc.reasoningBuffer.trim();
+      const finalReasoning =
+        pendingReasoning.length > 0
+          ? acc.completedReasoning.trim().length > 0
+            ? `${acc.completedReasoning}\n\n---\n\n${pendingReasoning}`
+            : pendingReasoning
+          : acc.completedReasoning;
+
+      if (finalReasoning.trim().length > 0 && acc.liveText.length === 0) {
+        outputs.push({
+          type: "log",
+          message: inkRender(
+            React.createElement(
+              Box,
+              { flexDirection: "column", paddingLeft: PADDING.content },
+              React.createElement(Text, { color: THEME.reasoning, italic: true }, finalReasoning),
+            ),
+          ),
+          timestamp: new Date(),
+        });
+      }
+
+      return { activity: { phase: "complete" }, outputs };
     }
   }
 }

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -374,6 +374,58 @@ describe("executeAgentLoop", () => {
     expect(warningCalls.some((msg) => msg.includes("empty response"))).toBe(true);
   });
 
+  it("does not warn empty when the model produced reasoning but no content", async () => {
+    const warningCalls: string[] = [];
+    const trackingPresentationService = {
+      ...mockPresentationService,
+      presentWarning: (_name: string, msg: string) => {
+        warningCalls.push(msg);
+        return Effect.void;
+      },
+    };
+
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: {
+            id: "c1",
+            model: "llamacpp/qwen",
+            content: "",
+            reasoning: "the answer is 42",
+          },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, trackingPresentationService as any),
+      Layer.succeed(LLMServiceTag, mockLLMService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry),
+      Layer.succeed(MCPServerManagerTag, {} as any),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(FileSystem.FileSystem, {} as any),
+      Layer.succeed(TerminalServiceTag, {} as any),
+      Layer.succeed(FileSystemContextServiceTag, {} as any),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+    );
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
+        Effect.provide(testLayer),
+      ),
+    );
+
+    expect(warningCalls.some((msg) => msg.includes("empty response"))).toBe(false);
+    // Reasoning text becomes the visible content for downstream consumers.
+    expect(result.content).toBe("the answer is 42");
+    expect(result.reasoning).toBe("the answer is 42");
+  });
+
   it("should record token usage from completions", async () => {
     const strategy: CompletionStrategy = {
       shouldShowThinking: false,

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -418,7 +418,19 @@ export function executeAgentLoop(
               totalToolsUsed: runMetrics.toolCalls,
             });
 
-            response = { ...response, content: completion.content };
+            // If the model produced reasoning but no text content (e.g. llama.cpp
+            // with --jinja routing the entire response into reasoning_content),
+            // surface the reasoning as the visible content so downstream
+            // consumers — conversation history, summarization, batch rendering —
+            // see what the model actually said.
+            const visibleContent = completion.content?.trim().length
+              ? completion.content
+              : (completion.reasoning ?? completion.content);
+            response = {
+              ...response,
+              content: visibleContent,
+              ...(completion.reasoning ? { reasoning: completion.reasoning } : {}),
+            };
 
             // Let strategy present the response (batch renders markdown, streaming is already rendered)
             yield* strategy.presentResponse(agent.name, completion.content, completion);
@@ -440,7 +452,12 @@ export function executeAgentLoop(
             agent.name,
             `iteration limit reached (${maxIterations}) - type 'continue' to resume`,
           );
-        } else if (!response.content?.trim() && !response.toolCalls && !interrupted) {
+        } else if (
+          !response.content?.trim() &&
+          !response.reasoning?.trim() &&
+          !response.toolCalls &&
+          !interrupted
+        ) {
           yield* presentationService.presentWarning(agent.name, "model returned an empty response");
         }
 

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -112,6 +112,13 @@ export interface AgentResponse {
    */
   readonly content: string;
   /**
+   * Reasoning / chain-of-thought text emitted by the model, when the provider
+   * exposes it as a separate channel. Populated when the response carried
+   * `reasoning_content` (e.g. llama.cpp with `--jinja`). Useful for callers
+   * that want to distinguish "the model thought" from "the model answered".
+   */
+  readonly reasoning?: string;
+  /**
    * The conversation identifier for this run.
    * This will be the same as the `conversationId` provided in options, or a newly generated
    * ID if one wasn't provided. Use this to track and correlate related conversation turns.

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -5,6 +5,13 @@ export interface ChatCompletionResponse {
   id: string;
   model: string;
   content: string;
+  /**
+   * Reasoning / chain-of-thought text emitted by the model, when the provider
+   * exposes it as a separate channel (e.g. OpenAI-compatible servers returning
+   * `reasoning_content`). Surfaced so callers can detect reasoning-only
+   * responses where `content` would otherwise look empty.
+   */
+  reasoning?: string;
   toolCalls?: ToolCall[];
   usage?: {
     promptTokens: number;

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -72,4 +72,77 @@ describe("StreamProcessor", () => {
     );
     expect(events.some((e) => e.type === "thinking_complete")).toBe(true);
   });
+
+  it("surfaces reasoning even when reasoning was not user-enabled", async () => {
+    // Local OpenAI-compatible servers (e.g. llama.cpp with --jinja) may emit
+    // reasoning_content for any chat completion regardless of whether the
+    // caller asked for reasoning. The processor should still capture and
+    // expose that text rather than silently drop it.
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+
+    const processor = new StreamProcessor(
+      {
+        providerName: "llamacpp",
+        modelName: "qwen",
+        hasReasoningEnabled: false,
+        startTime: Date.now(),
+      },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "reasoning-start" };
+        yield { type: "reasoning-delta", text: "let me think... " };
+        yield { type: "reasoning-delta", text: "the answer is 42." };
+        yield { type: "reasoning-end" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({}),
+    } as any;
+
+    const finalResponse = await processor.process(mockResult);
+
+    expect(finalResponse.content).toBe("");
+    expect(finalResponse.reasoning).toBe("let me think... the answer is 42.");
+    expect(events.some((e) => e.type === "thinking_start")).toBe(true);
+    expect(
+      events.some((e) => e.type === "thinking_chunk" && e.content === "let me think... "),
+    ).toBe(true);
+  });
+
+  it("populates response.reasoning alongside content when both are present", async () => {
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+
+    const processor = new StreamProcessor(
+      { providerName: "p1", modelName: "m1", hasReasoningEnabled: true, startTime: Date.now() },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "reasoning-start" };
+        yield { type: "reasoning-delta", text: "deliberation" };
+        yield { type: "reasoning-end" };
+        yield { type: "text-delta", text: "answer" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({}),
+    } as any;
+
+    const finalResponse = await processor.process(mockResult);
+
+    expect(finalResponse.content).toBe("answer");
+    expect(finalResponse.reasoning).toBe("deliberation");
+  });
 });

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -56,6 +56,14 @@ interface StreamProcessorState {
   reasoningSequence: number;
   reasoningTokens: number | undefined;
   reasoningStreamCompleted: boolean;
+  /**
+   * Reasoning text accumulated across reasoning-delta events. Always captured
+   * (regardless of whether the user enabled reasoning) so a response that
+   * emits only reasoning — e.g. llama.cpp models with `--jinja` routing
+   * everything into `reasoning_content` — can still be surfaced to the user
+   * instead of looking empty.
+   */
+  accumulatedReasoning: string;
 
   // Tool calls
   collectedToolCalls: ToolCall[];
@@ -86,6 +94,7 @@ function createInitialState(): StreamProcessorState {
     reasoningSequence: 0,
     reasoningTokens: undefined,
     reasoningStreamCompleted: false,
+    accumulatedReasoning: "",
     collectedToolCalls: [],
     pendingNativeToolCalls: new Map(),
     firstTokenTime: null,
@@ -237,12 +246,11 @@ export class StreamProcessor {
           }
 
           case "reasoning-start": {
-            // Handle reasoning start event (emitted before reasoning-delta chunks)
-            if (!this.config.hasReasoningEnabled) {
-              break;
-            }
-
-            // Emit thinking start on reasoning-start event
+            // Emit thinking start on reasoning-start event. Reasoning is always
+            // surfaced when the provider sends it: providers that respect
+            // disabled reasoning won't emit these parts, and providers that
+            // emit reasoning anyway (e.g. llama-server with --jinja) should
+            // remain visible to the user rather than be silently dropped.
             if (this.state.reasoningSequence === 0) {
               const firstReasoningLatency = Date.now() - this.config.startTime;
               void this.logger.debug(
@@ -255,13 +263,11 @@ export class StreamProcessor {
           }
 
           case "reasoning-delta": {
-            if (!this.config.hasReasoningEnabled) {
-              break;
-            }
-
             const textDelta = part.text;
 
             if (textDelta && textDelta.length > 0) {
+              this.state.accumulatedReasoning += textDelta;
+
               // Emit thinking start if we haven't received reasoning-start event
               if (this.state.reasoningSequence === 0) {
                 const firstReasoningLatency = Date.now() - this.config.startTime;
@@ -487,10 +493,13 @@ export class StreamProcessor {
       // Ignore usage errors
     }
 
+    const reasoningText = this.state.accumulatedReasoning;
+
     return {
       id: "",
       model: this.config.modelName,
       content: finalText,
+      ...(reasoningText.length > 0 && { reasoning: reasoningText }),
       ...(toolCalls && { toolCalls }),
       ...(usage && { usage }),
       ...(this.config.toolsDisabled ? { toolsDisabled: true } : {}),


### PR DESCRIPTION
## What and why

When a model emits its entire response as reasoning/chain-of-thought (no `content`), Jazz currently drops the reasoning text and warns "model returned an empty response" — even though the model did say something. This is the dominant failure mode for local llama.cpp servers running with `--jinja`, where many chat templates (Gemma 4, DeepSeek R1, Hermes, etc.) route the answer through the `reasoning_content` channel by default. This PR makes Jazz capture and surface that reasoning so the user sees what the model produced.

## Before this PR

- Jazz threw away reasoning text entirely when `reasoning_effort` wasn't explicitly enabled (the `hasReasoningEnabled` gate in `StreamProcessor` discarded `reasoning-start` / `reasoning-delta` / `reasoning-end` events).
- `ChatCompletionResponse` had no `reasoning` field, so callers couldn't distinguish "the model thought" from "the model didn't answer."
- `agent-loop`'s empty-response warning only checked `response.content`, so a reasoning-only turn always tripped it.
- The activity reducer's `complete` handler emitted no outputs, meaning a reasoning-only turn left the chat with no visible response — the live "is thinking" area cleared and nothing replaced it.

## After this PR

- The `StreamProcessor` always accumulates reasoning text (regardless of whether the caller enabled reasoning), and exposes it through a new optional `ChatCompletionResponse.reasoning` field.
- `AgentResponse` gains a matching optional `reasoning` field.
- When a turn ends with empty content but non-empty reasoning, `agent-loop` fills `response.content` from the reasoning text. Conversation history, summarization, and batch rendering now see what the model actually said.
- The empty-response warning fires only when both `content` AND `reasoning` are empty.
- The activity reducer flushes the completed (or still-buffered) reasoning to the terminal as Static output on stream complete when no text was streamed, so the user sees the response.

## Changes made

- `src/core/types/chat.ts` — added `ChatCompletionResponse.reasoning?: string` for callers that want to distinguish reasoning from final content.
- `src/core/agent/types.ts` — mirrored the field on `AgentResponse.reasoning?` so it propagates into the public agent-run result.
- `src/services/llm/stream-processor.ts` — added `accumulatedReasoning` to processor state, removed the `hasReasoningEnabled` gate on `reasoning-*` parts, and populated the new `reasoning` field on the final response.
- `src/services/llm/stream-processor.test.ts` — added cases for reasoning surfacing when not user-enabled and for content + reasoning coexisting.
- `src/core/agent/execution/agent-loop.ts` — empty-response warning considers reasoning, and the final-response branch falls back to reasoning text when content is empty so downstream consumers get the visible answer.
- `src/core/agent/execution/agent-loop.test.ts` — added a test asserting no warning + reasoning-as-content fallback when only reasoning is produced.
- `src/cli/presentation/activity-reducer.ts` — `case "complete"` now flushes the completed reasoning (joining any still-buffered chunk) to Static outputs when no text was streamed, rendered in the dimmed/italic reasoning style.
- `src/cli/presentation/activity-reducer.test.ts` — added three tests: flush-on-text-less-complete, no-flush-when-text-streamed, flush-buffered-when-reasoning-end-missing.

## Impact

- **Local model users** (llama.cpp / vLLM / TGI / Ollama with reasoning-capable templates): chats no longer go silent when the model puts everything in `reasoning_content`. The reasoning shows up in the terminal and in the agent's response object.
- **Cloud reasoning users** (Claude, OpenAI o-series, Gemini thinking): unchanged — those providers emit content alongside reasoning, so existing rendering paths stay the same. The only behavioral change is that `reasoning` is now exposed on `AgentResponse`, which is purely additive.
- **Cloud non-reasoning users**: unchanged — these providers don't emit reasoning parts at all.
- The reasoning-events gate removal does mean any provider that emits reasoning will now surface it during streaming, which is the desired transparency: a model emitting reasoning while the caller didn't request it is itself useful information.
- Conversation history may now contain longer assistant turns when fallback fires (reasoning text becomes the message). Summarization downstream handles the size; no truncation logic was added.

## How to test

1. **Unit tests** — `bun test src/services/llm/stream-processor.test.ts src/core/agent/execution/agent-loop.test.ts src/cli/presentation/activity-reducer.test.ts`. All pass; the new cases are clearly labeled in each file.

2. **Reasoning-only happy path** — run `llama-server -m <some-reasoning-gguf>.gguf --jinja --port 8080`. In Jazz, point a llama.cpp agent at `http://localhost:8080/v1` and send a short prompt. Expected: the model's reasoning appears as the visible response in the chat (italic / dimmed style during streaming, persisted as a log entry on completion). No "empty response" warning.

3. **Edge: content + reasoning coexist** — switch to `llama-server` with `--reasoning-format none --reasoning-budget 0` so the same model emits a normal `content` answer (with `<think>` tags inline). Expected: response renders as text content as before; `response.reasoning` may be undefined or short; no warning.

4. **Edge: genuinely empty response** — point the agent at any model and force `max_tokens: 0` (or use a degenerate prompt that produces no output). Expected: "model returned an empty response" warning still fires because both content and reasoning are empty.

5. **Regression on cloud providers** — run a normal Anthropic / OpenAI chat with `reasoning_effort` unset. Expected: no UI change; reasoning never appears because the provider doesn't emit it; `response.reasoning` is undefined.

## Notes for reviewers

- This PR is **stacked on `feat/llamacpp-provider`** (the llama.cpp provider PR), since the user-facing problem only shows up against an OpenAI-compatible local server. The base branch on this PR should be `feat/llamacpp-provider`; once that merges, GitHub will retarget this onto `main` automatically.
- Removing the `hasReasoningEnabled` gate on event emission is the most opinionated change. The motivation: when a provider emits reasoning that the caller didn't request, hiding it makes Jazz silently lose information. Showing it makes the provider's behavior visible and lets the user decide. If a future caller really wants to suppress reasoning UI, that's better expressed as a render-time setting on the activity reducer than a stream-processor gate.
- The fallback in `agent-loop` (treat reasoning as content when content is empty) only fires in the "no tool calls, final response" branch — the tool-call paths still keep `content: ""` since OpenAI-compat tool messages expect empty assistant content.
- I did not add a real-server integration test against `llama-server`. The unit tests cover the wiring; the live behavior is validated against the user's running setup.
