### PR TITLE
fix(ci): use full namespaced model id for openrouter agents

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -6,7 +6,7 @@
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "free",
+    "llmModel": "openrouter/free",
     "reasoningEffort": "medium",
     "tools": [
       "find",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -6,7 +6,7 @@
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "free",
+    "llmModel": "openrouter/free",
     "reasoningEffort": "medium",
     "tools": [
       "find",

--- a/.github/jazz/agents/release-notes.json
+++ b/.github/jazz/agents/release-notes.json
@@ -6,7 +6,7 @@
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "free",
+    "llmModel": "openrouter/free",
     "reasoningEffort": "medium",
     "tools": [
       "find",


### PR DESCRIPTION
## What and why

Every code-review, pr-assistant, and release-notes CI run since #198 has been failing immediately with `LLMRequestError: Failed after 3 attempts. Last error: Invalid URL:` — an opaque error that wasted hours of debugging. Root cause is a config-shape mismatch: the three OpenRouter-backed agent JSONs ship with `llmModel: "free"` but OpenRouter's model registry expects the namespaced form `openrouter/free`. With the bare suffix, OpenRouter routes the request to a misconfigured upstream provider that 502s with the empty `Invalid URL:` body.

## Before this PR

- `.github/jazz/agents/ci-reviewer.json`, `pr-assistant.json`, and `release-notes.json` all use `"llmModel": "free"`.
- Every CI workflow that invokes one of these agents fails after 3 retries with `Last error: Invalid URL:`.
- Diagnosing the root cause required intercepting OpenRouter's actual response body, which surfaces:
  ```json
  {"error":{"message":"Invalid URL: ","code":502,"metadata":{"provider_name":"Stealth"}}}
  ```
- The error appeared after #198 because that PR switched these three agents from `openai` to `openrouter` — OpenAI accepts bare suffixes (`gpt-5.4-mini`), so the bug was masked until OpenRouter started seeing the same shape.

## After this PR

- All three agent JSONs use `"llmModel": "openrouter/free"`, matching OpenRouter's expected namespaced model id.
- CI runs hit the right model. The Stealth-provider 502 disappears.
- No code changes — purely the agent JSON config fix.

## Changes made

- `.github/jazz/agents/ci-reviewer.json` — `llmModel: "free"` → `"openrouter/free"`.
- `.github/jazz/agents/pr-assistant.json` — same.
- `.github/jazz/agents/release-notes.json` — same.

## Impact

- **CI**: code-review, pr-assistant, and release-notes workflows actually run instead of failing instantly. Re-running any blocked PR's workflow should now produce a real review/comment/release-notes draft.
- **Cost**: trivially negative — failed runs were burning ~30 seconds of OpenRouter retries per CI invocation for no work product. Successful runs do the work they're supposed to.
- **No code paths touched**: this is config-only. No risk of behavioral regression in the CLI or runtime.

## How to test

1. **Local repro of the original bug** — run the minimal `streamText` call against OpenRouter with the bare `"free"` model id; confirm it fails with `Last error: Invalid URL:` and the response body contains `provider_name: "Stealth"`. This was reproduced during investigation; the script is intentionally not committed.
2. **Local fix verification** — same `streamText` call with `"openrouter/free"` — expect a normal text stream (`"Hi there!"`-style response). This was confirmed.
3. **CI happy path** — merge or rebase a PR onto this branch and trigger the `code-review` workflow on it. Expected: ci-reviewer enters the thinking phase, calls `git_diff` and other tools, and posts review comments without `Invalid URL:` in the log.
4. **Edge case: `pr-assistant`** — leave a `@jazz` comment on a PR that's based on this branch. Expected: the assistant agent responds normally instead of erroring.
5. **Edge case: release-notes** — when this branch (or anything containing it) gets cut for release, the `release.yml` workflow's release-notes step should produce a draft instead of the same `Invalid URL:` failure.

## Notes for reviewers

- Fixes #201.
- The OpenRouter SDK has no client-side validation that the model id is namespaced — you only see the failure as a 502 from the upstream provider. Worth a separate quality-of-life follow-up: when `llmProvider === "openrouter"` and `llmModel` lacks a `/`, either auto-prefix it or raise a friendlier error before the call. Out of scope here.
- The agent's top-level `model` field already used the full `openrouter/free` form, so the displayed model in PR comments is unchanged.
- Independent of either open PR (#199 llama.cpp, #200 reasoning-surfacing). Should land first so those PRs' CI checks can actually exercise the reviewer.
