### PR TITLE
fix(ci): give pr-assistant the workspace path and clean failure comments

### DIFF
--- a/.github/jazz/workflows/pr-assistant/WORKFLOW.md
+++ b/.github/jazz/workflows/pr-assistant/WORKFLOW.md
@@ -21,13 +21,14 @@ The requester said:
 ## Context
 
 - Repository: `__REPO__`
+- Repository checkout path: `__WORKSPACE__` (the absolute path to the working tree on this runner — every git/file tool call MUST pass this as the `path` argument)
 - Base SHA: `__PR_BASE_SHA__`
 - Head SHA: `__PR_HEAD_SHA__`
 
 ## Instructions
 
-1. Inspect the pull request diff with `git_diff` using `__PR_BASE_SHA__...__PR_HEAD_SHA__`.
-2. Read surrounding code and tests for any touched areas.
+1. Inspect the pull request diff. Call `git_diff` with `path: "__WORKSPACE__"` and `commit: "__PR_BASE_SHA__...__PR_HEAD_SHA__"`. Do NOT call `git_diff` without `path` — the runner's default cwd is not the repository.
+2. Read surrounding code and tests for any touched areas. When using `read_file`, `ls`, `find`, or `grep`, pass paths under `__WORKSPACE__/...`.
 3. Answer the request above. If the request is vague, infer the most helpful PR-focused action and say what you assumed.
 4. If the request looks like a review request, prioritize correctness, security, and maintainability.
 5. If the request is asking for code changes, explain the exact files or functions that need to change and what to do.

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -411,6 +411,7 @@ jobs:
           PR_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           REQUEST: ${{ needs.resolve.outputs.request }}
           REPO: ${{ github.repository }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.jazz/agents" workflows/pr-assistant
@@ -424,6 +425,7 @@ jobs:
             '__PR_HEAD_SHA__': process.env.PR_HEAD_SHA,
             '__REQUEST__': process.env.REQUEST,
             '__REPO__': process.env.REPO,
+            '__WORKSPACE__': process.env.WORKSPACE,
           };
           let output = template;
           for (const [needle, value] of Object.entries(replacements)) {
@@ -449,21 +451,46 @@ jobs:
         if: always()
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const output = fs.readFileSync('/tmp/jazz-pr-assistant.txt', 'utf8');
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const runUrl = process.env.RUN_URL;
 
+            // Prefer the markdown block the agent is supposed to emit as its
+            // final answer (FOUR-backtick form, falling back to triple).
             let mdBlocks = [...output.matchAll(/````markdown\s*\n([\s\S]*?)````/g)];
             if (mdBlocks.length === 0) {
               mdBlocks = [...output.matchAll(/```markdown\s*\n([\s\S]*?)```/g)];
             }
 
-            const commentBody = mdBlocks.length > 0
-              ? mdBlocks[mdBlocks.length - 1][1].trim()
-              : (output.trim() || '_No output from Jazz assistant._');
+            let commentBody;
+            if (mdBlocks.length > 0) {
+              commentBody = mdBlocks[mdBlocks.length - 1][1].trim();
+            } else {
+              // No markdown block — the agent didn't follow the output contract,
+              // usually because it errored mid-run. Post a clean failure summary
+              // with a link to the workflow logs instead of dumping raw shell
+              // output (tool error transcripts, git usage text, etc.).
+              const lower = output.toLowerCase();
+              const looksLikeFailure =
+                lower.includes('llmrequesterror') ||
+                lower.includes('failed after') ||
+                lower.includes('git diff failed') ||
+                lower.includes('not a git repository') ||
+                lower.includes('error:');
+
+              if (looksLikeFailure) {
+                commentBody =
+                  `_The Jazz assistant didn't produce a usable answer. ` +
+                  `See the [workflow run](${runUrl}) for details._`;
+              } else {
+                commentBody = output.trim() || '_No output from Jazz assistant._';
+              }
+            }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## What and why

When someone leaves a `/jazz <something>` comment on a PR, the assistant agent runs in CI and tries to inspect the diff — but it doesn't know where the repo lives on the runner, so `git_diff` (and friends) fall through to `/home/runner` and fail with `not a git repository`. The agent then flails through `find` / `ls` looking for the repo, never produces a real answer, and the failure transcript — git's full usage table — gets posted as the PR comment. This PR fixes both halves: the agent is now told the workspace path, and a failed run posts a clean error link instead of a wall of shell text.

## Before this PR

- The pr-assistant `WORKFLOW.md` template told the agent to call `git_diff` with `commit: "<base>...<head>"` but no `path`. The git_diff tool falls back to `process.cwd()`, which on a GHA `issue_comment` step resolves to `/home/runner`, not the checked-out repo at `${{ github.workspace }}` (`/home/runner/work/jazz/jazz`).
- Every `/jazz` invocation produced output like:
  ```
  ✗ git diff failed in directory '/home/runner' with exit code 129:
    warning: Not a git repository …
    usage: git diff --no-index […]
  ```
  followed by the agent doing `find name: jazz`, `ls dir: …`, retrying `git_diff` from one level up, failing again.
- When the run finished, the "Post PR comment" step had no ```markdown final block to extract, so it posted the raw shell transcript verbatim — multi-screen of git's usage page — as the PR comment.

## After this PR

- The workflow template now substitutes `__WORKSPACE__` with `${{ github.workspace }}`, and the `WORKFLOW.md` instructions tell the agent to pass that path on every git/file tool call (`git_diff path: "<workspace>" commit: …`, `read_file path: "<workspace>/…"`, etc.).
- The post-comment step detects known failure shapes in the output (`LLMRequestError`, `Failed after`, `git diff failed`, `not a git repository`, plain `error:`) and posts a single-line message linking to the workflow run, instead of dumping the raw transcript.
- A successful `/jazz review this` actually reviews the PR. A failed one leaves a clean trace.

## Changes made

- `.github/jazz/workflows/pr-assistant/WORKFLOW.md` — adds `Repository checkout path: __WORKSPACE__` to the Context block and rewrites instruction #1 to require `path` on `git_diff` and on subsequent `read_file` / `ls` / `find` / `grep` calls. Explicitly forbids calling `git_diff` without `path` because the runner's default cwd isn't the repo.
- `.github/workflows/jazz.yml` — assistant job:
  - Adds `WORKSPACE: ${{ github.workspace }}` to the env of the "Setup Jazz agent and workflow" step and threads it through the Node substitution as `__WORKSPACE__`.
  - Rewrites the "Post PR comment" script: keeps the existing markdown-block extraction, but when no block is found, runs a lower-cased substring check for failure markers; on a hit, posts `_The Jazz assistant didn't produce a usable answer. See the [workflow run](…) for details._` instead of the raw output. Adds `RUN_URL` to the step env so the comment can link to the run.

## Impact

- **PR authors / reviewers using `/jazz`**: the assistant produces real reviews and answers instead of dumping git's man page. When something does go wrong, the failure comment is one sentence with a link, not a screenful.
- **Code-review job**: untouched. This PR only modifies the `assistant` job's setup step and post-comment step, plus the `pr-assistant` workflow template. The `code-review` workflow's WORKFLOW.md and YAML steps were left alone (it currently works because of how its own substitution is wired; touching it is out of scope here, though the same `__WORKSPACE__` pattern would harden it).
- **No code changes**: this is config-only. CLI users running `jazz workflow run` locally are unaffected because their cwd already is the repo.
- **Out of scope**: a deeper fix in Jazz itself would be to call `initializeSession` (which `setCwd`s the agent to `process.cwd()`) for `workflow run` invocations, the way the interactive chat command does. That would let the agent's tools default to the runner's working directory without prompt-level hand-holding. Worth a follow-up issue.

## How to test

1. **Happy path** — leave a comment `/jazz review this` on any PR targeting this branch (or merge first and try on a fresh PR). Expected: the assistant calls `git_diff path: "<workspace>" commit: "<base>...<head>"` once, succeeds, reads relevant files, and posts a focused review comment. No `Not a git repository` lines in the workflow log.
2. **Confirm the substitution** — in the workflow run log, the "Setup Jazz agent and workflow" step prints the substituted WORKFLOW.md. Verify it contains `Repository checkout path: /home/runner/work/jazz/jazz` (or whatever the runner's workspace is) and the `path: "/home/runner/work/jazz/jazz"` instruction.
3. **Edge: agent failure** — temporarily break the agent (e.g. point it at a non-existent OpenRouter model id) and rerun the workflow. Expected: the PR comment is `_The Jazz assistant didn't produce a usable answer. See the [workflow run](…) for details._`, not the failure transcript. Revert after.
4. **Edge: agent succeeds with a non-markdown final** — if the model emits prose without the required ```markdown final block, the comment should be the prose verbatim (the existing fallback for the "no markdown block but no error markers" path), not a failure stub. Hand-craft a `/tmp/jazz-pr-assistant.txt` to verify if needed.

## Notes for reviewers

- The failure-detection heuristic is intentionally substring-based and case-insensitive — it's catching shell/agent failure shapes, not parsing structured error output. If a future error mode lands, just add another marker to the `lower.includes(…)` chain.
- The same `__WORKSPACE__` mechanism could be applied to the `code-review` workflow template too. It currently works because its WORKFLOW.md doesn't tell the agent to chase the diff path the same way, but if it ever drifts the same fix applies. Out of scope here.
- Closes the loop on the user-reported failure mode where `/jazz review this` produced a comment that was just git's `git diff --help` output.
