### PR TITLE
fix(ci): handle pr-assistant empty-response in post-comment

### DIFF
--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -476,6 +476,9 @@ jobs:
               // with a link to the workflow logs instead of dumping raw shell
               // output (tool error transcripts, git usage text, etc.).
               const lower = output.toLowerCase();
+              const emptyResponse =
+                lower.includes('returned an empty response') ||
+                lower.includes('model returned no');
               const looksLikeFailure =
                 lower.includes('llmrequesterror') ||
                 lower.includes('failed after') ||
@@ -483,7 +486,16 @@ jobs:
                 lower.includes('not a git repository') ||
                 lower.includes('error:');
 
-              if (looksLikeFailure) {
+              if (emptyResponse) {
+                // The model produced no text content (often because the chosen
+                // OpenRouter model emits reasoning_content that the published
+                // jazz-ai version doesn't surface yet). Don't paste the
+                // workflow header/footer onto the PR — explain the situation.
+                commentBody =
+                  `_The model returned an empty response. This usually means the ` +
+                  `selected model emitted reasoning rather than a final answer. ` +
+                  `See the [workflow run](${runUrl}) for the full transcript._`;
+              } else if (looksLikeFailure) {
                 commentBody =
                   `_The Jazz assistant didn't produce a usable answer. ` +
                   `See the [workflow run](${runUrl}) for details._`;


### PR DESCRIPTION
## What and why

PR #205 caught most pr-assistant failure modes (`Invalid URL`, `git diff failed`, `Not a git repository`, generic `LLMRequestError`) and posted a clean error link instead of the raw shell transcript. One mode slipped through: when the model emits **no text content at all**, Jazz prints `⚠️ pr-assistant: model returned an empty response` and exits `0`. There's no markdown block to extract and none of the existing failure markers fire, so the post-comment fallback dumps the workflow's banner + the warning line onto the PR. This PR adds that case to the detection list.

## Before this PR

- Latest run [25079335204](https://github.com/lvndry/jazz/actions/runs/25079335204/job/73480323470) on PR #199:
  ```
  🚀 Running workflow: pr-assistant
  ℹ Using agent: pr-assistant
  ℹ Auto-approve policy: true
  ◉  pr-assistant is thinking...✔  pr-assistant completed successfully⚠️  pr-assistant: model returned an empty response
  ✓ Workflow completed: pr-assistant
  ```
- The post-comment script saw no ` ```markdown ` block and no error markers, so it pasted those five lines verbatim as the PR comment — useless to the reviewer who ran `/jazz`.

## After this PR

- The detection list grows two markers: `returned an empty response` and `model returned no`.
- When matched, the comment becomes:
  > *The model returned an empty response. This usually means the selected model emitted reasoning rather than a final answer. See the [workflow run](…) for the full transcript.*
- This sits in front of the existing generic-failure branch so the message is specific to the cause when we recognize it.

## Changes made

- `.github/workflows/jazz.yml` (assistant job → `Post PR comment`):
  - Add `emptyResponse` substring check (`returned an empty response`, `model returned no`).
  - Add a dedicated branch that posts the empty-response message with a link to the workflow run.
  - Existing markdown-block extraction and generic-failure fallback are unchanged.

## Impact

- **PR authors using `/jazz`**: failure comments are useful at a glance instead of pasting the runtime banner. Same shape as existing failure handling — one line + run link.
- **No code changes**: config-only, runs against published `jazz-ai`.
- **Deeper fix is upstream**: surfacing `reasoning_content` as the response when content is empty needs to land in published `jazz-ai` (this was PR #200's intent; that branch is closed but the diff lives on `feat/llamacpp-provider`'s history via #204). Until that ships and the version bumps in CI, this PR is the cosmetic guardrail.

## How to test

1. **Synthetic empty response** — temporarily change the assistant invocation to `printf '... model returned an empty response\n' > /tmp/jazz-pr-assistant.txt` (skip the actual jazz call). Re-run the assistant workflow. Expected comment: the empty-response stub with the run link.
2. **Real empty response** — leave a one-word `/jazz hi` on a small PR. The free-tier model will likely emit reasoning-only output. Expected: same stub, no banner dump.
3. **Edge: real markdown answer still works** — leave `/jazz review this` on a substantive PR. Expected: a real review (markdown block extracted), unchanged from PR #205's behavior.
4. **Edge: other failures still work** — kill the OpenRouter API key in secrets temporarily and rerun. Expected: the existing generic "didn't produce a usable answer" stub fires (matches `llmrequesterror` / `failed after`), not the empty-response one.

## Notes for reviewers

- The order matters: `emptyResponse` is checked before `looksLikeFailure` so the more specific message wins. If both somehow match, the user sees the specific one.
- Stacks naturally on top of #205 — no conflicts, single-file change.
- Worth tracking: the underlying reasoning-only-response handling needs to ship in `jazz-ai` proper. PR #200 did the work; it was closed in favor of the `feat/llamacpp-provider`-merged version. A follow-up PR to surface that into a published release will eliminate the need for this comment-side guardrail.