### PR TITLE
feat(llm): client-side reasoning-tag parsing for local models

### DIFF
--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -31,7 +31,7 @@ jobs:
   resolve:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
       issues: write
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
@@ -127,12 +127,19 @@ jobs:
                 content: 'eyes',
               });
             } catch (e) {
-              // Duplicate reaction (e.g. workflow re-run) returns 422
+              // The reaction is cosmetic — never fail the workflow because of it.
+              // 422 = duplicate reaction (workflow re-run). 403 = token missing
+              // issues/pull-requests write (e.g. repo Actions setting restricting
+              // GITHUB_TOKEN). Anything else: warn and continue.
               if (e.status === 422) {
-                core.info('Reaction already present or not applicable; continuing');
+                core.info('Reaction already present; continuing');
                 return;
               }
-              throw e;
+              if (e.status === 403) {
+                core.warning(`Could not react with eyes (403): ${e.message}`);
+                return;
+              }
+              core.warning(`Could not react with eyes: ${e.message}`);
             }
 
   # Automated code review — runs on PR open or when a trusted author comments /jazz-review.

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -3,6 +3,12 @@ name: Jazz
 on:
   pull_request:
     types: [opened, ready_for_review]
+  # Re-run all jazz jobs when the workflow file itself changes, so a fix or
+  # tweak to jazz.yml gets exercised end-to-end against any open PR for the
+  # pushed branch (or just validated for direct pushes to default).
+  push:
+    paths:
+      - ".github/workflows/jazz.yml"
   workflow_dispatch:
     inputs:
       pull_request_number:
@@ -73,6 +79,44 @@ jobs:
               headSha = pr.head.sha;
               prHeadRepoFullName = pr.head.repo.full_name;
               request = String(context.payload.inputs.request ?? '').trim();
+            } else if (context.eventName === 'push') {
+              // push event: only fires when the workflow file itself changed
+              // (paths filter on the trigger). Look up the open PR for the
+              // pushed branch and use its context. If there is no open PR
+              // (e.g. direct push to the default branch), skip downstream
+              // jobs by leaving pr_number empty.
+              const ref = context.payload.ref ?? '';
+              const branch = ref.replace(/^refs\/heads\//, '');
+              const defaultBranch = context.payload.repository?.default_branch;
+              if (!branch || branch === defaultBranch) {
+                core.notice(`Push to ${branch || '(no branch)'}; no PR context, skipping jazz jobs.`);
+                core.setOutput('pr_number', '');
+                core.setOutput('base_sha', '');
+                core.setOutput('head_sha', context.payload.after ?? '');
+                core.setOutput('pr_head_repo_full_name', '');
+                core.setOutput('request', '');
+                return;
+              }
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open',
+              });
+              const pr = prs[0];
+              if (!pr) {
+                core.notice(`No open PR for branch ${branch}; skipping jazz jobs.`);
+                core.setOutput('pr_number', '');
+                core.setOutput('base_sha', '');
+                core.setOutput('head_sha', context.payload.after ?? '');
+                core.setOutput('pr_head_repo_full_name', '');
+                core.setOutput('request', '');
+                return;
+              }
+              prNumber = pr.number;
+              baseSha = pr.base.sha;
+              headSha = context.payload.after ?? pr.head.sha;
+              prHeadRepoFullName = pr.head.repo.full_name;
             } else {
               // issue_comment
               const issueNumber = context.payload.issue?.number;
@@ -156,7 +200,8 @@ jobs:
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'
-      ) && needs.resolve.outputs.pr_head_repo_full_name == github.repository)
+      ) && needs.resolve.outputs.pr_head_repo_full_name == github.repository) ||
+      (github.event_name == 'push' && needs.resolve.outputs.pr_number != '' && needs.resolve.outputs.pr_head_repo_full_name == github.repository)
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -437,7 +482,8 @@ jobs:
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'
-      ) && needs.resolve.outputs.pr_head_repo_full_name == github.repository)
+      ) && needs.resolve.outputs.pr_head_repo_full_name == github.repository) ||
+      (github.event_name == 'push' && needs.resolve.outputs.pr_number != '' && needs.resolve.outputs.pr_head_repo_full_name == github.repository)
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -439,7 +439,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v8.1.0
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import React from "react";
-import { createAccumulator, reduceEvent } from "./activity-reducer";
+import { AWAITING_LABELS, createAccumulator, reduceEvent } from "./activity-reducer";
 import type { ReducerAccumulator } from "./activity-reducer";
 
 /** Identity formatter — returns text unchanged so assertions are straightforward. */
@@ -81,6 +81,7 @@ describe("activity-reducer", () => {
         expect(result.activity.agentName).toBe("TestAgent");
         expect(result.activity.provider).toBe("openai");
         expect(result.activity.model).toBe("gpt-4");
+        expect(AWAITING_LABELS).toContain(result.activity.label);
       }
       expect(result.outputs).toHaveLength(1);
       expect(result.outputs[0]!.type).toBe("info");

--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -66,7 +66,7 @@ describe("activity-reducer", () => {
   // -------------------------------------------------------------------------
 
   describe("stream_start", () => {
-    test("emits info log, stores provider/model, returns no activity", () => {
+    test("emits info log, stores provider/model, transitions to awaiting phase", () => {
       const a = acc();
       const result = reduceEvent(
         a,
@@ -75,7 +75,13 @@ describe("activity-reducer", () => {
         stubInk,
       );
 
-      expect(result.activity).toBeNull();
+      expect(result.activity).not.toBeNull();
+      expect(result.activity!.phase).toBe("awaiting");
+      if (result.activity!.phase === "awaiting") {
+        expect(result.activity.agentName).toBe("TestAgent");
+        expect(result.activity.provider).toBe("openai");
+        expect(result.activity.model).toBe("gpt-4");
+      }
       expect(result.outputs).toHaveLength(1);
       expect(result.outputs[0]!.type).toBe("info");
       expect(result.outputs[0]!.message).toContain("TestAgent");
@@ -638,14 +644,14 @@ describe("activity-reducer", () => {
     test("thinking → text produces correct phase transitions", () => {
       const a = acc();
 
-      // stream_start
+      // stream_start → awaiting phase (visible while we wait for first event)
       const r1 = reduceEvent(
         a,
         { type: "stream_start", provider: "p", model: "m", timestamp: 0 },
         identity,
         stubInk,
       );
-      expect(r1.activity).toBeNull();
+      expect(r1.activity!.phase).toBe("awaiting");
 
       // thinking_start → thinking phase
       const r2 = reduceEvent(a, { type: "thinking_start", provider: "p" }, identity, stubInk);

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -232,7 +232,20 @@ export function reduceEvent(
         timestamp: new Date(),
       });
 
-      return { activity: null, outputs };
+      // Show an awaiting indicator until the first real event arrives.
+      // For local models with long prompt eval (llama.cpp, ollama with
+      // big contexts) this gap is otherwise visually silent, which looks
+      // like a hang. The next thinking_start/text_start/tool_call replaces
+      // this state automatically.
+      return {
+        activity: {
+          phase: "awaiting",
+          agentName: acc.agentName,
+          provider: event.provider,
+          model: event.model,
+        },
+        outputs,
+      };
     }
 
     // ---- Thinking / Reasoning -------------------------------------------

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -28,6 +28,40 @@ interface TodoSnapshotItem {
   status: "pending" | "in_progress" | "completed" | "cancelled";
 }
 
+/**
+ * Playful gerund-form labels shown while waiting for the model's first stream
+ * event. Picked at random on each stream_start so the UX during prompt eval
+ * reads as deliberate-and-interesting rather than blank-and-broken.
+ *
+ * Each label is the full predicate so it composes as
+ * "{agentName} {label}…" in ActivityView, e.g. "Cassandra is cooking…".
+ */
+export const AWAITING_LABELS: readonly string[] = [
+  "is cooking",
+  "is brewing",
+  "is pondering",
+  "is noodling",
+  "is mulling",
+  "is ruminating",
+  "is concocting",
+  "is percolating",
+  "is conjuring",
+  "is simmering",
+  "is plotting",
+  "is hatching",
+  "is warming up",
+  "is gathering its wits",
+  "is consulting the oracle",
+  "is doing math",
+  "is reading tea leaves",
+  "is cracking knuckles",
+];
+
+function pickAwaitingLabel(): string {
+  const i = Math.floor(Math.random() * AWAITING_LABELS.length);
+  return AWAITING_LABELS[i] ?? "is cooking";
+}
+
 function renderToolBadge(label: string): React.ReactElement {
   return React.createElement(
     Box,
@@ -236,13 +270,15 @@ export function reduceEvent(
       // For local models with long prompt eval (llama.cpp, ollama with
       // big contexts) this gap is otherwise visually silent, which looks
       // like a hang. The next thinking_start/text_start/tool_call replaces
-      // this state automatically.
+      // this state automatically. The label is picked at random per turn
+      // so long waits feel less like a hang and more like a personality.
       return {
         activity: {
           phase: "awaiting",
           agentName: acc.agentName,
           provider: event.provider,
           model: event.model,
+          label: pickAwaitingLabel(),
         },
         outputs,
       };

--- a/src/cli/ui/ActivityView.tsx
+++ b/src/cli/ui/ActivityView.tsx
@@ -121,6 +121,35 @@ export const ActivityView = React.memo(function ActivityView({
     case "complete":
       return null;
 
+    case "awaiting":
+      return (
+        <Box
+          flexDirection="column"
+          marginTop={1}
+          paddingX={PADDING.content}
+        >
+          <Box>
+            <Text color={THEME.agent}>{G.bullet}</Text>
+            <Text> </Text>
+            <Text
+              bold
+              color={THEME.agent}
+            >
+              {activity.agentName}
+            </Text>
+            <Text dimColor> is preparing</Text>
+            <AnimatedEllipsis
+              label=""
+              color={THEME.agent}
+            />
+            <Text dimColor>
+              {" "}
+              ({activity.provider}/{activity.model})
+            </Text>
+          </Box>
+        </Box>
+      );
+
     case "thinking":
       return (
         <Box

--- a/src/cli/ui/ActivityView.tsx
+++ b/src/cli/ui/ActivityView.tsx
@@ -137,7 +137,7 @@ export const ActivityView = React.memo(function ActivityView({
             >
               {activity.agentName}
             </Text>
-            <Text dimColor> is preparing</Text>
+            <Text dimColor> {activity.label}</Text>
             <AnimatedEllipsis
               label=""
               color={THEME.agent}

--- a/src/cli/ui/activity-state.test.ts
+++ b/src/cli/ui/activity-state.test.ts
@@ -38,6 +38,28 @@ describe("isActivityEqual", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // awaiting
+  // ---------------------------------------------------------------------------
+
+  test("awaiting states with same agent/provider/model are equal", () => {
+    expect(
+      isActivityEqual(
+        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
+        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
+      ),
+    ).toBe(true);
+  });
+
+  test("awaiting states differ by model", () => {
+    expect(
+      isActivityEqual(
+        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
+        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "deepseek" },
+      ),
+    ).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
   // thinking
   // ---------------------------------------------------------------------------
 

--- a/src/cli/ui/activity-state.test.ts
+++ b/src/cli/ui/activity-state.test.ts
@@ -41,11 +41,23 @@ describe("isActivityEqual", () => {
   // awaiting
   // ---------------------------------------------------------------------------
 
-  test("awaiting states with same agent/provider/model are equal", () => {
+  test("awaiting states with same agent/provider/model/label are equal", () => {
     expect(
       isActivityEqual(
-        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
-        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "qwen3",
+          label: "is cooking",
+        },
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "qwen3",
+          label: "is cooking",
+        },
       ),
     ).toBe(true);
   });
@@ -53,8 +65,41 @@ describe("isActivityEqual", () => {
   test("awaiting states differ by model", () => {
     expect(
       isActivityEqual(
-        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "qwen3" },
-        { phase: "awaiting", agentName: "A", provider: "llamacpp", model: "deepseek" },
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "qwen3",
+          label: "is cooking",
+        },
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "deepseek",
+          label: "is cooking",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("awaiting states differ by label", () => {
+    expect(
+      isActivityEqual(
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "qwen3",
+          label: "is cooking",
+        },
+        {
+          phase: "awaiting",
+          agentName: "A",
+          provider: "llamacpp",
+          model: "qwen3",
+          label: "is brewing",
+        },
       ),
     ).toBe(false);
   });

--- a/src/cli/ui/activity-state.ts
+++ b/src/cli/ui/activity-state.ts
@@ -39,6 +39,8 @@ export type ActivityState =
       agentName: string;
       provider: string;
       model: string;
+      /** Playful gerund-form predicate shown after the agent name (e.g. "is cooking"). */
+      label: string;
     }
   | {
       phase: "thinking";
@@ -79,7 +81,8 @@ export function isActivityEqual(a: ActivityState, b: ActivityState): boolean {
       return (
         a.agentName === (b as typeof a).agentName &&
         a.provider === (b as typeof a).provider &&
-        a.model === (b as typeof a).model
+        a.model === (b as typeof a).model &&
+        a.label === (b as typeof a).label
       );
 
     case "thinking":

--- a/src/cli/ui/activity-state.ts
+++ b/src/cli/ui/activity-state.ts
@@ -19,6 +19,7 @@ export interface TodoSnapshotItem {
 
 export type ActivityPhase =
   | "idle"
+  | "awaiting"
   | "thinking"
   | "streaming"
   | "tool-execution"
@@ -27,6 +28,18 @@ export type ActivityPhase =
 
 export type ActivityState =
   | { phase: "idle" }
+  | {
+      /**
+       * Request has been sent to the LLM but the first stream event (reasoning,
+       * text, or tool) hasn't arrived yet. Visible during prompt eval and any
+       * network/queue latency, especially for slow local models. Replaced as
+       * soon as a real activity event arrives.
+       */
+      phase: "awaiting";
+      agentName: string;
+      provider: string;
+      model: string;
+    }
   | {
       phase: "thinking";
       agentName: string;
@@ -61,6 +74,13 @@ export function isActivityEqual(a: ActivityState, b: ActivityState): boolean {
     case "idle":
     case "complete":
       return true;
+
+    case "awaiting":
+      return (
+        a.agentName === (b as typeof a).agentName &&
+        a.provider === (b as typeof a).provider &&
+        a.model === (b as typeof a).model
+      );
 
     case "thinking":
       return a.agentName === (b as typeof a).agentName && a.reasoning === (b as typeof a).reasoning;

--- a/src/core/types/llm.ts
+++ b/src/core/types/llm.ts
@@ -28,6 +28,10 @@ export interface ModelInfo {
   readonly supportsPdf?: boolean;
   /** Context window size in tokens. If not specified, defaults to 128000. */
   readonly contextWindow?: number;
+  /** Raw chat template string (Jinja for llama.cpp, Go-template for ollama). Used for reasoning-parser selection. */
+  readonly chatTemplate?: string;
+  /** Provider-reported capability tags (e.g. ["completion", "tools", "thinking"] from ollama). */
+  readonly capabilities?: readonly string[];
 }
 
 /**

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -67,6 +67,7 @@ import { createModelFetcher, type ModelFetcherService } from "./model-fetcher";
 import { PROVIDER_MODELS, resolveLocalProviderBaseUrl } from "./models";
 import { getMetadataFromMap, getModelsDevMap } from "@/core/utils/models-dev-client";
 import { StreamProcessor } from "./stream-processor";
+import { selectParser } from "./reasoning";
 import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 
 interface AISDKConfig {
@@ -1237,6 +1238,12 @@ class AISDKService implements LLMService {
                 );
 
                 const modelInfo = await this.resolveModelInfo(providerName, options.model);
+                const reasoningParser = selectParser({
+                  provider: providerName,
+                  modelId: options.model,
+                  ...(modelInfo?.chatTemplate ? { chatTemplate: modelInfo.chatTemplate } : {}),
+                  ...(modelInfo?.capabilities ? { capabilities: modelInfo.capabilities } : {}),
+                });
                 // OpenRouter gateway models (e.g., openrouter/free) are meta-models that route to various
                 // underlying models, so we assume tool support and pass tools through.
                 const isGatewayModel = OPENROUTER_GATEWAY_MODELS.has(options.model);
@@ -1285,6 +1292,7 @@ class AISDKService implements LLMService {
                     startTime: Date.now(),
                     toolsDisabled,
                     ...(providerNativeToolNames && { providerNativeToolNames }),
+                    ...(reasoningParser ? { reasoningParser } : {}),
                     ...(prepared
                       ? {
                           toolDefinitionChars: prepared.toolDefinitionChars,

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -160,4 +160,27 @@ describe("ModelFetcher", () => {
       expect(msg).toMatch(/no models loaded|llama-server/i);
     }
   });
+
+  it("captures chat_template from llama.cpp /props onto every ModelInfo", async () => {
+    const mockModelsResponse = { data: [{ id: "qwen3-4b" }] };
+    const mockPropsResponse = {
+      default_generation_settings: { n_ctx: 8192 },
+      chat_template_caps: { supports_tools: true, supports_tool_calls: true },
+      chat_template: "{% if reasoning %}<think>{% endif %}",
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/v1/models"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockModelsResponse) });
+      if (url.endsWith("/props"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockPropsResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("llamacpp", "http://localhost:8080/v1", "/models");
+    const result = await Effect.runPromise(program);
+
+    expect(result.length).toBe(1);
+    expect(result[0]!.chatTemplate).toBe("{% if reasoning %}<think>{% endif %}");
+  });
 });

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -161,6 +161,32 @@ describe("ModelFetcher", () => {
     }
   });
 
+  it("captures template and capabilities from ollama /api/show onto every ModelInfo", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "qwen3:8b", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "qwen3.context_length": 32768 },
+      template: "{{ if .Thinking }}<think>{{ end }}",
+      capabilities: ["completion", "tools", "thinking"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result.length).toBe(1);
+    expect(result[0]!.chatTemplate).toBe("{{ if .Thinking }}<think>{{ end }}");
+    expect(result[0]!.capabilities).toEqual(["completion", "tools", "thinking"]);
+  });
+
   it("captures chat_template from llama.cpp /props onto every ModelInfo", async () => {
     const mockModelsResponse = { data: [{ id: "qwen3-4b" }] };
     const mockPropsResponse = {

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -185,6 +185,31 @@ describe("ModelFetcher", () => {
     expect(result.length).toBe(1);
     expect(result[0]!.chatTemplate).toBe("{{ if .Thinking }}<think>{{ end }}");
     expect(result[0]!.capabilities).toEqual(["completion", "tools", "thinking"]);
+    expect(result[0]!.isReasoningModel).toBe(true);
+  });
+
+  it("sets isReasoningModel=false for ollama models without thinking capability or tag template", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "llama3.1:8b", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "llama.context_length": 131072 },
+      template: "{{ .System }}{{ .Prompt }}",
+      capabilities: ["completion", "tools"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.isReasoningModel).toBe(false);
   });
 
   it("captures chat_template from llama.cpp /props onto every ModelInfo", async () => {
@@ -208,5 +233,28 @@ describe("ModelFetcher", () => {
 
     expect(result.length).toBe(1);
     expect(result[0]!.chatTemplate).toBe("{% if reasoning %}<think>{% endif %}");
+    expect(result[0]!.isReasoningModel).toBe(true);
+  });
+
+  it("sets isReasoningModel=false for llama.cpp models without reasoning markers in chat_template", async () => {
+    const mockModelsResponse = { data: [{ id: "llama-3.1-8b" }] };
+    const mockPropsResponse = {
+      default_generation_settings: { n_ctx: 8192 },
+      chat_template_caps: { supports_tools: true, supports_tool_calls: true },
+      chat_template: "{% for m in messages %}{{ m.content }}{% endfor %}",
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/v1/models"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockModelsResponse) });
+      if (url.endsWith("/props"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockPropsResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("llamacpp", "http://localhost:8080/v1", "/models");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.isReasoningModel).toBe(false);
   });
 });

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -86,9 +86,15 @@ type OllamaModel = {
  */
 type OllamaShowResponse = {
   model_info?: Record<string, unknown>;
-  details?: {
-    family?: string;
-  };
+  details?: { family?: string };
+  template?: string;
+  capabilities?: string[];
+};
+
+type OllamaShowExtras = {
+  contextWindow?: number;
+  template?: string;
+  capabilities?: readonly string[];
 };
 
 type LlamaCppModelEntry = { id: string };
@@ -141,27 +147,28 @@ function extractOllamaContextLength(
 
 /**
  * Fetch detailed model info from Ollama /api/show endpoint
- * Returns the context window size, or undefined if not available
+ * Returns context window, template, and capabilities when available
  */
 async function fetchOllamaModelDetails(
   baseUrl: string,
   modelName: string,
-): Promise<number | undefined> {
+): Promise<OllamaShowExtras> {
   try {
     const response = await fetch(`${baseUrl}/api/show`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ model: modelName }),
     });
-
-    if (!response.ok) {
-      return undefined;
-    }
-
+    if (!response.ok) return {};
     const data = (await response.json()) as OllamaShowResponse;
-    return extractOllamaContextLength(data.model_info);
+    const extras: OllamaShowExtras = {};
+    const ctx = extractOllamaContextLength(data.model_info);
+    if (ctx !== undefined) extras.contextWindow = ctx;
+    if (typeof data.template === "string") extras.template = data.template;
+    if (Array.isArray(data.capabilities)) extras.capabilities = data.capabilities;
+    return extras;
   } catch {
-    return undefined;
+    return {};
   }
 }
 
@@ -300,21 +307,25 @@ async function transformOllamaModels(
     const batch = models.slice(i, i + CONCURRENCY_LIMIT);
     const batchResults = await Promise.all(
       batch.map(async (model): Promise<ModelInfo> => {
-        const entry: RawModelEntry = {
-          id: model.name,
-          displayName: model.name,
-        };
+        const extras = await fetchOllamaModelDetails(baseUrl, model.name);
+        const entry: RawModelEntry = { id: model.name, displayName: model.name };
         const dev = getMetadataFromMap(modelsDevMap, model.name);
+        let base: ModelInfo;
         if (dev) {
-          return resolveToModelInfo(entry, modelsDevMap);
+          base = resolveToModelInfo(entry, modelsDevMap);
+        } else {
+          entry.fallback = {
+            contextWindow: extras.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+            supportsTools: ollamaToolSupportFromMetadata(model),
+            isReasoningModel: false, // Only models.dev knows reasoning; no Ollama manifest field for this
+          };
+          base = resolveToModelInfo(entry, null);
         }
-        const contextWindow = await fetchOllamaModelDetails(baseUrl, model.name);
-        entry.fallback = {
-          contextWindow: contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-          supportsTools: ollamaToolSupportFromMetadata(model),
-          isReasoningModel: false, // Only models.dev knows reasoning; no Ollama manifest field for this
+        return {
+          ...base,
+          ...(extras.template ? { chatTemplate: extras.template } : {}),
+          ...(extras.capabilities ? { capabilities: extras.capabilities } : {}),
         };
-        return resolveToModelInfo(entry, null);
       }),
     );
     results.push(...batchResults);

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -96,6 +96,7 @@ type LlamaCppModelsResponse = { data?: LlamaCppModelEntry[] };
 type LlamaCppPropsResponse = {
   default_generation_settings?: { n_ctx?: number };
   chat_template_caps?: Record<string, boolean>;
+  chat_template?: string;
 };
 
 /**
@@ -343,17 +344,20 @@ async function transformLlamaCppModels(
   const ctx = props?.default_generation_settings?.n_ctx;
   const caps = props?.chat_template_caps ?? {};
   const supportsTools = caps["supports_tools"] === true && caps["supports_tool_calls"] === true;
+  const chatTemplate = props?.chat_template;
 
   return models.map((model) => {
     const entry: RawModelEntry = { id: model.id, displayName: model.id };
     const dev = getMetadataFromMap(modelsDevMap, model.id);
-    if (dev) return resolveToModelInfo(entry, modelsDevMap);
-    entry.fallback = {
-      contextWindow: ctx ?? DEFAULT_CONTEXT_WINDOW,
-      supportsTools,
-      isReasoningModel: false,
-    };
-    return resolveToModelInfo(entry, null);
+    if (!dev) {
+      entry.fallback = {
+        contextWindow: ctx ?? DEFAULT_CONTEXT_WINDOW,
+        supportsTools,
+        isReasoningModel: false,
+      };
+    }
+    const base = resolveToModelInfo(entry, dev ? modelsDevMap : null);
+    return chatTemplate ? { ...base, chatTemplate } : base;
   });
 }
 

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -8,6 +8,7 @@ import {
   getModelsDevMap,
   type ModelsDevMetadata,
 } from "@/core/utils/models-dev-client";
+import { hasReasoningParser } from "./reasoning";
 
 /**
  * Model fetcher: models.dev as single source of metadata
@@ -317,7 +318,12 @@ async function transformOllamaModels(
           entry.fallback = {
             contextWindow: extras.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
             supportsTools: ollamaToolSupportFromMetadata(model),
-            isReasoningModel: false, // Only models.dev knows reasoning; no Ollama manifest field for this
+            isReasoningModel: hasReasoningParser({
+              provider: "ollama",
+              modelId: model.name,
+              ...(extras.template ? { chatTemplate: extras.template } : {}),
+              ...(extras.capabilities ? { capabilities: extras.capabilities } : {}),
+            }),
           };
           base = resolveToModelInfo(entry, null);
         }
@@ -357,6 +363,12 @@ async function transformLlamaCppModels(
   const supportsTools = caps["supports_tools"] === true && caps["supports_tool_calls"] === true;
   const chatTemplate = props?.chat_template;
 
+  const isReasoning = hasReasoningParser({
+    provider: "llamacpp",
+    modelId: "",
+    ...(chatTemplate ? { chatTemplate } : {}),
+  });
+
   return models.map((model) => {
     const entry: RawModelEntry = { id: model.id, displayName: model.id };
     const dev = getMetadataFromMap(modelsDevMap, model.id);
@@ -364,7 +376,7 @@ async function transformLlamaCppModels(
       entry.fallback = {
         contextWindow: ctx ?? DEFAULT_CONTEXT_WINDOW,
         supportsTools,
-        isReasoningModel: false,
+        isReasoningModel: isReasoning,
       };
     }
     const base = resolveToModelInfo(entry, dev ? modelsDevMap : null);

--- a/src/services/llm/reasoning/index.ts
+++ b/src/services/llm/reasoning/index.ts
@@ -1,4 +1,4 @@
-export { selectParser } from "./registry";
+export { hasReasoningParser, selectParser } from "./registry";
 export { TagPairParser, TagPairParserFactory } from "./tag-pair-parser";
 export type {
   ParseChunk,

--- a/src/services/llm/reasoning/index.ts
+++ b/src/services/llm/reasoning/index.ts
@@ -1,0 +1,8 @@
+export { selectParser } from "./registry";
+export { TagPairParser, TagPairParserFactory } from "./tag-pair-parser";
+export type {
+  ParseChunk,
+  ParserSelectionContext,
+  ReasoningParser,
+  ReasoningParserFactory,
+} from "./types";

--- a/src/services/llm/reasoning/registry.test.ts
+++ b/src/services/llm/reasoning/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { selectParser } from "./registry";
+import { hasReasoningParser, selectParser } from "./registry";
 
 describe("selectParser", () => {
   it("returns the tag-pair parser when chatTemplate has <think>", () => {
@@ -38,5 +38,42 @@ describe("selectParser", () => {
     const a = selectParser({ provider: "llamacpp", modelId: "x", chatTemplate: "<think>" });
     const b = selectParser({ provider: "llamacpp", modelId: "x", chatTemplate: "<think>" });
     expect(a).not.toBe(b);
+  });
+});
+
+describe("hasReasoningParser", () => {
+  it("returns true for a chatTemplate with <think>", () => {
+    expect(
+      hasReasoningParser({ provider: "llamacpp", modelId: "x", chatTemplate: "<think>" }),
+    ).toBe(true);
+  });
+
+  it("returns true when ollama capabilities include 'thinking'", () => {
+    expect(
+      hasReasoningParser({ provider: "ollama", modelId: "qwen3:8b", capabilities: ["thinking"] }),
+    ).toBe(true);
+  });
+
+  it("returns false for a model with no template and no thinking capability", () => {
+    expect(
+      hasReasoningParser({ provider: "ollama", modelId: "llama3.1:8b", capabilities: ["tools"] }),
+    ).toBe(false);
+  });
+
+  it("returns false for an unrelated chatTemplate", () => {
+    expect(
+      hasReasoningParser({
+        provider: "llamacpp",
+        modelId: "x",
+        chatTemplate: "no markers here",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not allocate parser instances", () => {
+    // Pure boolean — calling many times in a hot path should be fine.
+    for (let i = 0; i < 1000; i++) {
+      hasReasoningParser({ provider: "ollama", modelId: "x", capabilities: ["thinking"] });
+    }
   });
 });

--- a/src/services/llm/reasoning/registry.test.ts
+++ b/src/services/llm/reasoning/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { selectParser } from "./registry";
+
+describe("selectParser", () => {
+  it("returns the tag-pair parser when chatTemplate has <think>", () => {
+    const parser = selectParser({
+      provider: "llamacpp",
+      modelId: "qwen3-4b",
+      chatTemplate: "<think>",
+    });
+    expect(parser).not.toBeNull();
+  });
+
+  it("returns the tag-pair parser when ollama capabilities include 'thinking'", () => {
+    const parser = selectParser({
+      provider: "ollama",
+      modelId: "qwen3:8b",
+      capabilities: ["thinking"],
+    });
+    expect(parser).not.toBeNull();
+  });
+
+  it("returns null for a cloud provider with no metadata", () => {
+    const parser = selectParser({ provider: "anthropic", modelId: "claude-sonnet-4-6" });
+    expect(parser).toBeNull();
+  });
+
+  it("returns null when no factory matches", () => {
+    const parser = selectParser({
+      provider: "llamacpp",
+      modelId: "no-reasoning",
+      chatTemplate: "no markers here",
+    });
+    expect(parser).toBeNull();
+  });
+
+  it("creates a fresh parser instance each call", () => {
+    const a = selectParser({ provider: "llamacpp", modelId: "x", chatTemplate: "<think>" });
+    const b = selectParser({ provider: "llamacpp", modelId: "x", chatTemplate: "<think>" });
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/services/llm/reasoning/registry.ts
+++ b/src/services/llm/reasoning/registry.ts
@@ -18,3 +18,13 @@ export function selectParser(ctx: ParserSelectionContext): ReasoningParser | nul
   }
   return null;
 }
+
+/**
+ * True when any registered parser would claim this model — i.e. the model
+ * emits in-band reasoning tags. Used by the model fetcher to derive
+ * `isReasoningModel` for local providers whose models aren't in models.dev.
+ * Auto-extends as new parser factories are added to PARSER_FACTORIES.
+ */
+export function hasReasoningParser(ctx: ParserSelectionContext): boolean {
+  return PARSER_FACTORIES.some((factory) => factory.canHandle(ctx));
+}

--- a/src/services/llm/reasoning/registry.ts
+++ b/src/services/llm/reasoning/registry.ts
@@ -1,0 +1,20 @@
+import { TagPairParserFactory } from "./tag-pair-parser";
+import type { ParserSelectionContext, ReasoningParser, ReasoningParserFactory } from "./types";
+
+/**
+ * Parser factories ordered from most-specific to least-specific. The first
+ * factory whose canHandle() returns true wins. Add new parsers (Harmony,
+ * Hermes, etc.) above TagPairParserFactory.
+ */
+const PARSER_FACTORIES: readonly ReasoningParserFactory[] = [
+  // HarmonyParserFactory,   // future: Group 2
+  // HermesParserFactory,    // future: Group 3
+  TagPairParserFactory,
+];
+
+export function selectParser(ctx: ParserSelectionContext): ReasoningParser | null {
+  for (const factory of PARSER_FACTORIES) {
+    if (factory.canHandle(ctx)) return factory.create();
+  }
+  return null;
+}

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -10,4 +10,13 @@ describe("TagPairParser", () => {
     expect(out.thinkingStarted).toBeUndefined();
     expect(out.thinkingEnded).toBeUndefined();
   });
+
+  it("splits a single complete <think>...</think> block in one feed", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("before<think>secret</think>after");
+    expect(out.visibleText).toBe("beforeafter");
+    expect(out.thinkingText).toBe("secret");
+    expect(out.thinkingStarted).toBe(true);
+    expect(out.thinkingEnded).toBe(true);
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { TagPairParser } from "./tag-pair-parser";
+import { TagPairParser, TagPairParserFactory } from "./tag-pair-parser";
 
 describe("TagPairParser", () => {
   it("passes plain text through as visibleText", () => {
@@ -141,5 +141,63 @@ describe("TagPairParser", () => {
     expect(out.thinkingText).toBe("onetwo");
     expect(out.thinkingStarted).toBe(true);
     expect(out.thinkingEnded).toBe(true);
+  });
+});
+
+describe("TagPairParserFactory.canHandle", () => {
+  it("returns true when chatTemplate contains <think>", () => {
+    expect(
+      TagPairParserFactory.canHandle({
+        provider: "llamacpp",
+        modelId: "qwen3-4b",
+        chatTemplate: "...{% if reasoning %}<think>{% endif %}...",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when chatTemplate contains <thinking>", () => {
+    expect(
+      TagPairParserFactory.canHandle({
+        provider: "llamacpp",
+        modelId: "custom",
+        chatTemplate: "<thinking>...</thinking>",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a Harmony-style chat template even if <think> appears elsewhere", () => {
+    expect(
+      TagPairParserFactory.canHandle({
+        provider: "llamacpp",
+        modelId: "gpt-oss-20b",
+        chatTemplate: "<|channel|>analysis<|message|>...<think>",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when ollama capabilities include 'thinking'", () => {
+    expect(
+      TagPairParserFactory.canHandle({
+        provider: "ollama",
+        modelId: "qwen3:8b",
+        capabilities: ["completion", "tools", "thinking"],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a model with no template and no thinking capability", () => {
+    expect(
+      TagPairParserFactory.canHandle({
+        provider: "ollama",
+        modelId: "llama3.1:8b",
+        capabilities: ["completion", "tools"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for a cloud provider with no metadata", () => {
+    expect(
+      TagPairParserFactory.canHandle({ provider: "anthropic", modelId: "claude-sonnet-4-6" }),
+    ).toBe(false);
   });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -124,4 +124,22 @@ describe("TagPairParser", () => {
     expect(out.thinkingStarted).toBeUndefined();
     expect(out.thinkingEnded).toBeUndefined();
   });
+
+  it("recognises <THINK>, <Thinking>, and mixed-case close tags", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<THINK>x</Think>b<Thinking>y</THINKING>c");
+    expect(out.visibleText).toBe("abc");
+    expect(out.thinkingText).toBe("xy");
+    expect(out.thinkingStarted).toBe(true);
+    expect(out.thinkingEnded).toBe(true);
+  });
+
+  it("handles two thinking blocks in one feed", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<think>one</think>b<think>two</think>c");
+    expect(out.visibleText).toBe("abc");
+    expect(out.thinkingText).toBe("onetwo");
+    expect(out.thinkingStarted).toBe(true);
+    expect(out.thinkingEnded).toBe(true);
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -45,4 +45,18 @@ describe("TagPairParser", () => {
     expect(c.thinkingEnded).toBe(true);
     expect(c.visibleText).toBe("after");
   });
+
+  it("treats <table> and other non-reasoning tags as visible text", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<table>row</table>b");
+    expect(out.visibleText).toBe("a<table>row</table>b");
+    expect(out.thinkingText).toBe("");
+    expect(out.thinkingStarted).toBeUndefined();
+  });
+
+  it("emits an unmatched lone < as visible text", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("2 < 3 is true");
+    expect(out.visibleText).toBe("2 < 3 is true");
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { TagPairParser } from "./tag-pair-parser";
+
+describe("TagPairParser", () => {
+  it("passes plain text through as visibleText", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("hello world");
+    expect(out.visibleText).toBe("hello world");
+    expect(out.thinkingText).toBe("");
+    expect(out.thinkingStarted).toBeUndefined();
+    expect(out.thinkingEnded).toBeUndefined();
+  });
+});

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -86,4 +86,42 @@ describe("TagPairParser", () => {
     expect(out.thinkingStarted).toBe(true);
     expect(out.thinkingEnded).toBe(true);
   });
+
+  it("flushes a partial open-tag buffer as visible text", () => {
+    const parser = new TagPairParser();
+    const a = parser.feed("a<thi");
+    const b = parser.flush();
+    expect(a.visibleText).toBe("a");
+    expect(b.visibleText).toBe("<thi");
+    expect(b.thinkingText).toBe("");
+  });
+
+  it("flushes mid-thinking content with thinkingEnded set", () => {
+    const parser = new TagPairParser();
+    const a = parser.feed("a<think>partial");
+    const b = parser.flush();
+    expect(a.thinkingStarted).toBe(true);
+    expect(a.thinkingText).toBe("partial");
+    expect(b.thinkingEnded).toBe(true);
+  });
+
+  it("flushes mid-MAYBE_CLOSE buffer back into thinking text", () => {
+    const parser = new TagPairParser();
+    const a = parser.feed("a<think>secret</thi");
+    const b = parser.flush();
+    expect(a.thinkingStarted).toBe(true);
+    expect(a.thinkingText).toBe("secret");
+    expect(b.thinkingText).toBe("</thi");
+    expect(b.thinkingEnded).toBe(true);
+  });
+
+  it("returns empty chunks on flush after a clean stream", () => {
+    const parser = new TagPairParser();
+    parser.feed("a<think>x</think>b");
+    const out = parser.flush();
+    expect(out.visibleText).toBe("");
+    expect(out.thinkingText).toBe("");
+    expect(out.thinkingStarted).toBeUndefined();
+    expect(out.thinkingEnded).toBeUndefined();
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -19,4 +19,30 @@ describe("TagPairParser", () => {
     expect(out.thinkingStarted).toBe(true);
     expect(out.thinkingEnded).toBe(true);
   });
+
+  it("stitches an open tag split across two feeds", () => {
+    const parser = new TagPairParser();
+    const a = parser.feed("a<thi");
+    const b = parser.feed("nk>secret</think>after");
+    expect(a.visibleText).toBe("a");
+    expect(a.thinkingText).toBe("");
+    expect(a.thinkingStarted).toBeUndefined();
+
+    expect(b.visibleText).toBe("after");
+    expect(b.thinkingText).toBe("secret");
+    expect(b.thinkingStarted).toBe(true);
+    expect(b.thinkingEnded).toBe(true);
+  });
+
+  it("stitches a close tag split across two feeds", () => {
+    const parser = new TagPairParser();
+    const a = parser.feed("a<think>secr");
+    const b = parser.feed("et</thi");
+    const c = parser.feed("nk>after");
+    expect(a.thinkingStarted).toBe(true);
+    expect(a.thinkingText).toBe("secr");
+    expect(b.thinkingText).toBe("et");
+    expect(c.thinkingEnded).toBe(true);
+    expect(c.visibleText).toBe("after");
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.test.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.test.ts
@@ -59,4 +59,31 @@ describe("TagPairParser", () => {
     const out = parser.feed("2 < 3 is true");
     expect(out.visibleText).toBe("2 < 3 is true");
   });
+
+  it("suppresses thinking events for an empty <think></think> block", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<think></think>b");
+    expect(out.visibleText).toBe("ab");
+    expect(out.thinkingText).toBe("");
+    expect(out.thinkingStarted).toBeUndefined();
+    expect(out.thinkingEnded).toBeUndefined();
+  });
+
+  it("suppresses thinking events for whitespace-only <think>\\n\\n</think>", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<think>\n\n</think>b");
+    expect(out.visibleText).toBe("ab");
+    expect(out.thinkingText).toBe("");
+    expect(out.thinkingStarted).toBeUndefined();
+    expect(out.thinkingEnded).toBeUndefined();
+  });
+
+  it("emits thinking events when first non-whitespace appears after leading whitespace", () => {
+    const parser = new TagPairParser();
+    const out = parser.feed("a<think>\n  reasoning</think>b");
+    expect(out.visibleText).toBe("ab");
+    expect(out.thinkingText).toBe("\n  reasoning");
+    expect(out.thinkingStarted).toBe(true);
+    expect(out.thinkingEnded).toBe(true);
+  });
 });

--- a/src/services/llm/reasoning/tag-pair-parser.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.ts
@@ -1,0 +1,11 @@
+import type { ParseChunk, ReasoningParser } from "./types";
+
+export class TagPairParser implements ReasoningParser {
+  feed(input: string): ParseChunk {
+    return { visibleText: input, thinkingText: "" };
+  }
+
+  flush(): ParseChunk {
+    return { visibleText: "", thinkingText: "" };
+  }
+}

--- a/src/services/llm/reasoning/tag-pair-parser.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.ts
@@ -1,4 +1,9 @@
-import type { ParseChunk, ReasoningParser, ReasoningParserFactory, ParserSelectionContext } from "./types";
+import type {
+  ParseChunk,
+  ReasoningParser,
+  ReasoningParserFactory,
+  ParserSelectionContext,
+} from "./types";
 
 type State = "OUTSIDE" | "MAYBE_OPEN" | "INSIDE" | "MAYBE_CLOSE";
 
@@ -166,7 +171,12 @@ export class TagPairParser implements ReasoningParser {
     thinkingStarted: boolean,
     thinkingEnded: boolean,
   ): ParseChunk {
-    const chunk: { visibleText: string; thinkingText: string; thinkingStarted?: boolean; thinkingEnded?: boolean } = {
+    const chunk: {
+      visibleText: string;
+      thinkingText: string;
+      thinkingStarted?: boolean;
+      thinkingEnded?: boolean;
+    } = {
       visibleText,
       thinkingText,
     };

--- a/src/services/llm/reasoning/tag-pair-parser.ts
+++ b/src/services/llm/reasoning/tag-pair-parser.ts
@@ -1,11 +1,192 @@
-import type { ParseChunk, ReasoningParser } from "./types";
+import type { ParseChunk, ReasoningParser, ReasoningParserFactory, ParserSelectionContext } from "./types";
+
+type State = "OUTSIDE" | "MAYBE_OPEN" | "INSIDE" | "MAYBE_CLOSE";
+
+const OPEN_TAGS = ["<think>", "<thinking>"];
+const CLOSE_TAGS = ["</think>", "</thinking>"];
+const MAX_OPEN_LEN = Math.max(...OPEN_TAGS.map((t) => t.length));
+const MAX_CLOSE_LEN = Math.max(...CLOSE_TAGS.map((t) => t.length));
+
+type MatchResult = "match" | "partial" | "fail";
+
+function matchAny(buf: string, candidates: readonly string[]): MatchResult {
+  const lower = buf.toLowerCase();
+  let anyPrefix = false;
+  for (const tag of candidates) {
+    if (lower === tag) return "match";
+    if (tag.startsWith(lower)) anyPrefix = true;
+  }
+  return anyPrefix ? "partial" : "fail";
+}
 
 export class TagPairParser implements ReasoningParser {
+  private state: State = "OUTSIDE";
+  private buffer = "";
+  private sawThinkingContent = false;
+  private pendingThinking = "";
+
   feed(input: string): ParseChunk {
-    return { visibleText: input, thinkingText: "" };
+    let visibleText = "";
+    let thinkingText = "";
+    let thinkingStarted = false;
+    let thinkingEnded = false;
+
+    for (const ch of input) {
+      const result = this.consume(ch);
+      visibleText += result.visibleText;
+      thinkingText += result.thinkingText;
+      if (result.thinkingStarted) thinkingStarted = true;
+      if (result.thinkingEnded) thinkingEnded = true;
+    }
+
+    return this.makeChunk(visibleText, thinkingText, thinkingStarted, thinkingEnded);
   }
 
   flush(): ParseChunk {
-    return { visibleText: "", thinkingText: "" };
+    let visibleText = "";
+    let thinkingText = "";
+    let thinkingStarted = false;
+    let thinkingEnded = false;
+
+    if (this.state === "MAYBE_OPEN") {
+      visibleText += this.buffer;
+      this.buffer = "";
+      this.state = "OUTSIDE";
+    } else if (this.state === "MAYBE_CLOSE") {
+      const text = this.pendingThinking + this.buffer;
+      if (this.sawThinkingContent) {
+        thinkingText += text;
+      } else if (/\S/.test(text)) {
+        thinkingStarted = true;
+        thinkingText += text;
+        this.sawThinkingContent = true;
+      }
+      this.buffer = "";
+      this.pendingThinking = "";
+      this.state = "INSIDE";
+    }
+
+    if (this.state === "INSIDE" && this.sawThinkingContent) {
+      thinkingEnded = true;
+    }
+
+    return this.makeChunk(visibleText, thinkingText, thinkingStarted, thinkingEnded);
+  }
+
+  private consume(ch: string): {
+    visibleText: string;
+    thinkingText: string;
+    thinkingStarted: boolean;
+    thinkingEnded: boolean;
+  } {
+    let visibleText = "";
+    let thinkingText = "";
+    let thinkingStarted = false;
+    let thinkingEnded = false;
+
+    switch (this.state) {
+      case "OUTSIDE": {
+        if (ch === "<") {
+          this.buffer = "<";
+          this.state = "MAYBE_OPEN";
+        } else {
+          visibleText += ch;
+        }
+        break;
+      }
+      case "MAYBE_OPEN": {
+        this.buffer += ch;
+        const m = matchAny(this.buffer, OPEN_TAGS);
+        if (m === "match") {
+          this.state = "INSIDE";
+          this.sawThinkingContent = false;
+          this.pendingThinking = "";
+          this.buffer = "";
+        } else if (m === "fail" || this.buffer.length > MAX_OPEN_LEN) {
+          visibleText += this.buffer;
+          this.buffer = "";
+          this.state = "OUTSIDE";
+        }
+        break;
+      }
+      case "INSIDE": {
+        if (ch === "<") {
+          this.buffer = "<";
+          this.state = "MAYBE_CLOSE";
+        } else if (this.sawThinkingContent) {
+          thinkingText += ch;
+        } else if (/\s/.test(ch)) {
+          this.pendingThinking += ch;
+        } else {
+          this.sawThinkingContent = true;
+          thinkingStarted = true;
+          thinkingText += this.pendingThinking + ch;
+          this.pendingThinking = "";
+        }
+        break;
+      }
+      case "MAYBE_CLOSE": {
+        this.buffer += ch;
+        const m = matchAny(this.buffer, CLOSE_TAGS);
+        if (m === "match") {
+          if (this.sawThinkingContent) {
+            thinkingEnded = true;
+          }
+          this.buffer = "";
+          this.pendingThinking = "";
+          this.sawThinkingContent = false;
+          this.state = "OUTSIDE";
+        } else if (m === "fail" || this.buffer.length > MAX_CLOSE_LEN) {
+          if (this.sawThinkingContent) {
+            thinkingText += this.buffer;
+          } else {
+            const idx = this.buffer.search(/\S/);
+            if (idx !== -1) {
+              this.sawThinkingContent = true;
+              thinkingStarted = true;
+              thinkingText += this.pendingThinking + this.buffer;
+              this.pendingThinking = "";
+            } else {
+              this.pendingThinking += this.buffer;
+            }
+          }
+          this.buffer = "";
+          this.state = "INSIDE";
+        }
+        break;
+      }
+    }
+
+    return { visibleText, thinkingText, thinkingStarted, thinkingEnded };
+  }
+
+  private makeChunk(
+    visibleText: string,
+    thinkingText: string,
+    thinkingStarted: boolean,
+    thinkingEnded: boolean,
+  ): ParseChunk {
+    const chunk: { visibleText: string; thinkingText: string; thinkingStarted?: boolean; thinkingEnded?: boolean } = {
+      visibleText,
+      thinkingText,
+    };
+    if (thinkingStarted) chunk.thinkingStarted = true;
+    if (thinkingEnded) chunk.thinkingEnded = true;
+    return chunk;
   }
 }
+
+export const TagPairParserFactory: ReasoningParserFactory = {
+  id: "tag-pair",
+  canHandle(ctx: ParserSelectionContext): boolean {
+    if (ctx.chatTemplate) {
+      if (/<\|channel\|>analysis/.test(ctx.chatTemplate)) return false;
+      if (/<think(ing)?>/i.test(ctx.chatTemplate)) return true;
+    }
+    if (ctx.capabilities?.includes("thinking")) return true;
+    return false;
+  },
+  create() {
+    return new TagPairParser();
+  },
+};

--- a/src/services/llm/reasoning/types.ts
+++ b/src/services/llm/reasoning/types.ts
@@ -1,0 +1,46 @@
+import type { ProviderName } from "@/core/constants/models";
+
+/**
+ * Output of a single parser feed/flush call.
+ *
+ * The parser splits a streaming text delta into visible text and thinking text.
+ * Either field may be empty. `thinkingStarted` and `thinkingEnded` flag the
+ * boundaries of a thinking region so the stream processor can emit the
+ * corresponding `thinking_start` / `thinking_complete` events.
+ */
+export interface ParseChunk {
+  readonly visibleText: string;
+  readonly thinkingText: string;
+  readonly thinkingStarted?: boolean;
+  readonly thinkingEnded?: boolean;
+}
+
+/**
+ * Stateful parser for one streaming request. Implementations buffer across
+ * `feed()` calls so a tag split across chunk boundaries is stitched correctly.
+ */
+export interface ReasoningParser {
+  feed(textDelta: string): ParseChunk;
+  flush(): ParseChunk;
+}
+
+/**
+ * Inputs to parser selection. Comes from ModelInfo plus the resolved provider
+ * name. `chatTemplate` and `capabilities` may be undefined (cloud providers).
+ */
+export interface ParserSelectionContext {
+  readonly provider: ProviderName;
+  readonly modelId: string;
+  readonly chatTemplate?: string;
+  readonly capabilities?: readonly string[];
+}
+
+/**
+ * A factory that knows whether it can handle a given model and constructs
+ * fresh parser instances per request.
+ */
+export interface ReasoningParserFactory {
+  readonly id: string;
+  canHandle(ctx: ParserSelectionContext): boolean;
+  create(): ReasoningParser;
+}

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -146,4 +146,36 @@ describe("StreamProcessor", () => {
     expect(finalResponse.content).toBe("answer");
     expect(finalResponse.reasoning).toBe("deliberation");
   });
+
+  it("with no reasoningParser, text-delta events stream as today (regression)", async () => {
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+
+    const processor = new StreamProcessor(
+      {
+        providerName: "anthropic",
+        modelName: "claude",
+        hasReasoningEnabled: false,
+        startTime: Date.now(),
+      },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "Hello" };
+        yield { type: "text-delta", text: " <think> not parsed </think> world" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({ inputTokens: 5, outputTokens: 5, totalTokens: 10 }),
+    } as any;
+
+    const finalResponse = await processor.process(mockResult);
+    expect(finalResponse.content).toBe("Hello <think> not parsed </think> world");
+    expect(events.some((e) => e.type === "thinking_start")).toBe(false);
+  });
 });

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -178,4 +178,81 @@ describe("StreamProcessor", () => {
     expect(finalResponse.content).toBe("Hello <think> not parsed </think> world");
     expect(events.some((e) => e.type === "thinking_start")).toBe(false);
   });
+
+  it("with reasoningParser, splits inline <think> content into thinking_* and text_chunk events", async () => {
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+
+    const { TagPairParser } = await import("./reasoning/tag-pair-parser");
+
+    const processor = new StreamProcessor(
+      {
+        providerName: "llamacpp",
+        modelName: "qwen3-4b",
+        hasReasoningEnabled: true,
+        startTime: Date.now(),
+        reasoningParser: new TagPairParser(),
+      },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "<think>let me think</think>The answer is 4" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 5, totalTokens: 6 }),
+    } as any;
+
+    const finalResponse = await processor.process(mockResult);
+
+    expect(finalResponse.content).toBe("The answer is 4");
+
+    const thinkingStart = events.find((e) => e.type === "thinking_start");
+    const thinkingChunks = events.filter((e) => e.type === "thinking_chunk");
+    const thinkingComplete = events.find((e) => e.type === "thinking_complete");
+    const textChunks = events.filter((e) => e.type === "text_chunk");
+
+    expect(thinkingStart).toBeDefined();
+    expect(thinkingChunks.map((c) => c.content).join("")).toBe("let me think");
+    expect(thinkingComplete).toBeDefined();
+    expect(textChunks.map((c) => c.delta).join("")).toBe("The answer is 4");
+  });
+
+  it("with reasoningParser, suppresses thinking_start for whitespace-only blocks", async () => {
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+    const { TagPairParser } = await import("./reasoning/tag-pair-parser");
+
+    const processor = new StreamProcessor(
+      {
+        providerName: "llamacpp",
+        modelName: "qwen3-4b",
+        hasReasoningEnabled: false,
+        startTime: Date.now(),
+        reasoningParser: new TagPairParser(),
+      },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "<think>\n\n</think>The answer is 4" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 5, totalTokens: 6 }),
+    } as any;
+
+    await processor.process(mockResult);
+    expect(events.some((e) => e.type === "thinking_start")).toBe(false);
+    expect(events.some((e) => e.type === "thinking_chunk")).toBe(false);
+  });
 });

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -255,4 +255,41 @@ describe("StreamProcessor", () => {
     expect(events.some((e) => e.type === "thinking_start")).toBe(false);
     expect(events.some((e) => e.type === "thinking_chunk")).toBe(false);
   });
+
+  it("flushes the reasoningParser when the stream ends mid-thinking", async () => {
+    const events: any[] = [];
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      const chunk = Effect.runSync(eff);
+      events.push(...Chunk.toArray(chunk));
+    };
+    const { TagPairParser } = await import("./reasoning/tag-pair-parser");
+
+    const processor = new StreamProcessor(
+      {
+        providerName: "llamacpp",
+        modelName: "qwen3-4b",
+        hasReasoningEnabled: true,
+        startTime: Date.now(),
+        reasoningParser: new TagPairParser(),
+      },
+      emit,
+      mockLogger,
+    );
+
+    const mockResult = {
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "<think>truncated thought" };
+        yield { type: "finish", finishReason: "length" };
+      })(),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 5, totalTokens: 6 }),
+    } as any;
+
+    await processor.process(mockResult);
+
+    const thinkingChunks = events.filter((e) => e.type === "thinking_chunk");
+    const thinkingComplete = events.find((e) => e.type === "thinking_complete");
+
+    expect(thinkingChunks.map((c) => c.content).join("")).toBe("truncated thought");
+    expect(thinkingComplete).toBeDefined();
+  });
 });

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -206,8 +206,6 @@ export class StreamProcessor {
             if (typeof part.text === "string") {
               textChunk = part.text;
             } else if (Array.isArray(part.text)) {
-              // Extract text from structured content array
-              // e.g Mistral may return content as array of objects or strings
               const textArray = part.text as Array<unknown>;
               textChunk = textArray
                 .map((item: unknown) => {
@@ -217,7 +215,6 @@ export class StreamProcessor {
                       return String(itemData["text"]);
                     }
                     if (itemData["type"] === "reference") {
-                      // Skip reference items for now, could be enhanced to handle citations
                       return "";
                     }
                   }
@@ -225,30 +222,15 @@ export class StreamProcessor {
                 })
                 .join("");
             } else {
-              // Fallback: convert to string
               textChunk = String(part.text ?? "");
             }
 
-            // Emit text start on first chunk
-            if (!this.state.hasStartedText && textChunk.length > 0) {
-              const firstTokenLatency = Date.now() - this.config.startTime;
-              void this.logger.debug(
-                `[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`,
-              );
-              void this.emitEvent({ type: "text_start" });
-              this.state.hasStartedText = true;
-              this.recordFirstToken("text");
-            }
+            if (textChunk.length === 0) break;
 
-            // Emit text chunk
-            if (textChunk.length > 0) {
-              this.state.accumulatedText += textChunk;
-              void this.emitEvent({
-                type: "text_chunk",
-                delta: textChunk,
-                accumulated: this.state.accumulatedText,
-                sequence: this.state.textSequence++,
-              });
+            if (this.config.reasoningParser) {
+              this.routeParsedChunk(this.config.reasoningParser.feed(textChunk));
+            } else {
+              this.emitVisibleText(textChunk);
             }
             break;
           }
@@ -454,6 +436,58 @@ export class StreamProcessor {
       throw error;
     } finally {
       this.resolveCompletion();
+    }
+  }
+
+  private emitVisibleText(textChunk: string): void {
+    if (!this.state.hasStartedText) {
+      const firstTokenLatency = Date.now() - this.config.startTime;
+      void this.logger.debug(
+        `[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`,
+      );
+      void this.emitEvent({ type: "text_start" });
+      this.state.hasStartedText = true;
+      this.recordFirstToken("text");
+    }
+    this.state.accumulatedText += textChunk;
+    void this.emitEvent({
+      type: "text_chunk",
+      delta: textChunk,
+      accumulated: this.state.accumulatedText,
+      sequence: this.state.textSequence++,
+    });
+  }
+
+  private routeParsedChunk(chunk: import("./reasoning").ParseChunk): void {
+    if (chunk.thinkingStarted && this.state.reasoningSequence === 0) {
+      const firstReasoningLatency = Date.now() - this.config.startTime;
+      void this.logger.debug(
+        `[LLM Timing] 🧠 PARSER REASONING START after ${firstReasoningLatency}ms`,
+      );
+      void this.emitEvent({ type: "thinking_start", provider: this.config.providerName });
+      this.recordFirstToken("reasoning");
+    }
+    if (chunk.thinkingText.length > 0) {
+      this.state.accumulatedReasoning += chunk.thinkingText;
+      void this.emitEvent({
+        type: "thinking_chunk",
+        content: chunk.thinkingText,
+        sequence: this.state.reasoningSequence++,
+      });
+    }
+    if (chunk.thinkingEnded && this.state.reasoningSequence > 0 && !this.state.reasoningStreamCompleted) {
+      this.state.reasoningStreamCompleted = true;
+      void this.emitEvent({
+        type: "thinking_complete",
+        ...(this.state.reasoningTokens !== undefined && {
+          totalTokens: this.state.reasoningTokens,
+        }),
+      });
+      this.state.reasoningSequence = 0;
+      this.state.reasoningStreamCompleted = false;
+    }
+    if (chunk.visibleText.length > 0) {
+      this.emitVisibleText(chunk.visibleText);
     }
   }
 

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -447,9 +447,7 @@ export class StreamProcessor {
   private emitVisibleText(textChunk: string): void {
     if (!this.state.hasStartedText) {
       const firstTokenLatency = Date.now() - this.config.startTime;
-      void this.logger.debug(
-        `[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`,
-      );
+      void this.logger.debug(`[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`);
       void this.emitEvent({ type: "text_start" });
       this.state.hasStartedText = true;
       this.recordFirstToken("text");
@@ -485,7 +483,11 @@ export class StreamProcessor {
     // gate. The reasoningStreamCompleted toggle is kept symmetric with that handler
     // for consistency, even though emitEvent is synchronous and re-entrancy isn't
     // possible here.
-    if (chunk.thinkingEnded && this.state.reasoningSequence > 0 && !this.state.reasoningStreamCompleted) {
+    if (
+      chunk.thinkingEnded &&
+      this.state.reasoningSequence > 0 &&
+      !this.state.reasoningStreamCompleted
+    ) {
       this.state.reasoningStreamCompleted = true;
       void this.emitEvent({
         type: "thinking_complete",

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -167,6 +167,11 @@ export class StreamProcessor {
     void this.logger.debug(`[LLM Timing] 🔄 Starting to process fullStream...`);
     const streamProcessStart = Date.now();
     await this.processFullStream(result);
+
+    if (this.config.reasoningParser) {
+      this.routeParsedChunk(this.config.reasoningParser.flush());
+    }
+
     void this.logger.debug(
       `[LLM Timing] ✓ Stream processing completed in ${Date.now() - streamProcessStart}ms`,
     );

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -14,6 +14,7 @@ import type { LoggerService } from "@/core/interfaces/logger";
 import type { ChatCompletionResponse, StreamEvent } from "@/core/types";
 import { type LLMError } from "@/core/types/errors";
 import type { ToolCall } from "@/core/types/tools";
+import type { ReasoningParser } from "./reasoning";
 
 /**
  * Type for AI SDK StreamText result
@@ -41,6 +42,13 @@ interface StreamProcessorConfig {
   readonly toolDefinitionChars?: number;
   /** Number of tool definitions sent to the LLM. */
   readonly toolDefinitionCount?: number;
+  /**
+   * Optional client-side parser for reasoning tags in text-delta content.
+   * When set, text-delta chunks flow through parser.feed() instead of being
+   * emitted directly. Used for local providers (llamacpp, sometimes ollama)
+   * where reasoning arrives inline rather than as structured events.
+   */
+  readonly reasoningParser?: ReasoningParser;
 }
 
 /**

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -14,7 +14,7 @@ import type { LoggerService } from "@/core/interfaces/logger";
 import type { ChatCompletionResponse, StreamEvent } from "@/core/types";
 import { type LLMError } from "@/core/types/errors";
 import type { ToolCall } from "@/core/types/tools";
-import type { ReasoningParser } from "./reasoning";
+import type { ParseChunk, ReasoningParser } from "./reasoning";
 
 /**
  * Type for AI SDK StreamText result
@@ -463,7 +463,7 @@ export class StreamProcessor {
     });
   }
 
-  private routeParsedChunk(chunk: import("./reasoning").ParseChunk): void {
+  private routeParsedChunk(chunk: ParseChunk): void {
     if (chunk.thinkingStarted && this.state.reasoningSequence === 0) {
       const firstReasoningLatency = Date.now() - this.config.startTime;
       void this.logger.debug(
@@ -480,6 +480,11 @@ export class StreamProcessor {
         sequence: this.state.reasoningSequence++,
       });
     }
+    // Mirrors the reasoning-end handler above: reset reasoningSequence to 0 so a
+    // second thinking block in the same response can re-enter the thinking_start
+    // gate. The reasoningStreamCompleted toggle is kept symmetric with that handler
+    // for consistency, even though emitEvent is synchronous and re-entrancy isn't
+    // possible here.
     if (chunk.thinkingEnded && this.state.reasoningSequence > 0 && !this.state.reasoningStreamCompleted) {
       this.state.reasoningStreamCompleted = true;
       void this.emitEvent({


### PR DESCRIPTION
## Summary

- Local reasoning models (DeepSeek-R1, Qwen3/QwQ, Magistral, Phi-4-mini, SmolLM3, etc.) now render with a clean response area + collapsible thinking lane, matching the UX of cloud reasoning models. Today their `<think>...</think>` tags leak straight into the user-visible response when streaming through llama.cpp or ollama-without-`think:true`.
- Adds a self-claiming parser registry under `src/services/llm/reasoning/`. The first parser ships (`<think>` / `<thinking>` state machine); Harmony (gpt-oss) and Hermes/Gemma 4/Granite parsers slot in later by adding factories — no central pattern table to maintain.
- `ModelInfo` gains optional `chatTemplate` and `capabilities`. `model-fetcher.ts` populates them from llama.cpp `/props` (no extra HTTP call — already fetched today) and ollama `/api/show` (now always-fetched per model). `selectParser` runs once per streaming request in `AISDKService` and feeds an optional `ReasoningParser` into `StreamProcessor`, which routes `text-delta` chunks through `parser.feed()` and surfaces the existing `thinking_*` events.

This is sub-project 2 of a 5-piece umbrella initiative around first-class local LLM support. The other four (preflight UX, best-practice defaults, ollama model management, llama.cpp model management) are still queued.

Spec: `docs/superpowers/specs/2026-04-29-local-reasoning-tags-design.md`
Plan: `docs/superpowers/plans/2026-04-29-local-reasoning-tags.md`

## What's covered

- Client-side `<think>`/`<thinking>` parsing with split-tag stitching across stream chunks
- Whitespace-only `<think>\n\n</think>` (R1/Qwen3 reasoning-disabled signal) silently suppressed
- `flush()` end-of-stream cleanup for truncated thinking blocks
- Capability detection from chat-template content + ollama capabilities array — no per-model maintenance
- Mutual exclusion with structured `reasoning-*` events: cloud providers and ollama-with-`think:true` keep their existing path

## What's NOT covered (deferred)

- Harmony channel parsing for gpt-oss (Group 2)
- Hermes scratchpads, Gemma 4 channel-thought, Granite control-role (Group 3)
- Custom OpenAI-compatible endpoints with no template metadata (no parser engaged → behavior unchanged from today)

## Test plan

Automated:

- [x] 26 new unit tests under `src/services/llm/reasoning/` (parser state machine, factory `canHandle`, registry selection)
- [x] 4 new tests in `stream-processor.test.ts` covering parser-driven path + regression for no-parser path
- [x] 2 new tests in `model-fetcher.test.ts` for chat_template / capabilities propagation
- [x] Full suite: 1074 pass / 0 fail / 1 skip / 12 todo
- [x] `bun run typecheck` clean

Manual (please verify before merge):

- [ ] `llama-server -m <reasoning-model.gguf> --jinja --port 8080`, then in jazz: provider=llamacpp, send a prompt → verify thinking lane shows the chain-of-thought, response area is clean (no literal `<think>` tags)
- [ ] `ollama pull qwen3:8b` (or any thinking-capable model), then in jazz: provider=ollama, model=qwen3:8b, same prompt → verify same clean split
- [ ] Edit the agent to set `reasoning_effort: "disable"`, re-run → thinking lane is hidden but visible response is still clean (no leaked tags)
- [ ] Pick a non-reasoning local model (e.g. `llama3.1:8b`) and verify behavior is unchanged (no parser engaged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)