### PR TITLE
feat(chat): queue messages typed while agent is busy

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -10,6 +10,7 @@ import { formatMarkdown } from "../presentation/markdown-formatter";
 import { useInputHandler } from "./hooks/use-input-service";
 import { OutputEntryView } from "./OutputEntryView";
 import { Prompt } from "./Prompt";
+import { QueueInput } from "./QueueInput";
 import StatusFooter from "./StatusFooter";
 import { store, type RunStats } from "./store";
 import { PADDING, THEME } from "./theme";
@@ -54,14 +55,20 @@ const ActivityIsland = React.memo(ActivityIslandComponent);
 function PromptIslandComponent(): React.ReactElement | null {
   const [prompt, setPrompt] = useState<PromptState | null>(null);
   const [workingDirectory, setWorkingDirectory] = useState<string | null>(null);
+  const [chatBusy, setChatBusy] = useState(false);
+  const [messageQueue, setMessageQueue] = useState("");
   const initializedRef = useRef(false);
 
   // Register setters synchronously during render
   if (!initializedRef.current) {
     store.registerPromptSetter(setPrompt);
     store.registerWorkingDirectorySetter(setWorkingDirectory);
+    store.registerChatBusySetter(setChatBusy);
+    store.registerMessageQueueSetter(setMessageQueue);
     setPrompt(store.getPromptSnapshot());
     setWorkingDirectory(store.getWorkingDirectorySnapshot());
+    setChatBusy(store.getChatBusySnapshot());
+    setMessageQueue(store.getMessageQueueSnapshot());
     initializedRef.current = true;
   }
 
@@ -70,17 +77,30 @@ function PromptIslandComponent(): React.ReactElement | null {
     return () => {
       store.registerPromptSetter(() => {});
       store.registerWorkingDirectorySetter(() => {});
+      store.registerChatBusySetter(() => {});
+      store.registerMessageQueueSetter(() => {});
     };
   }, []);
 
-  if (!prompt) return null;
+  if (prompt) {
+    return (
+      <Prompt
+        prompt={prompt}
+        workingDirectory={workingDirectory}
+      />
+    );
+  }
 
-  return (
-    <Prompt
-      prompt={prompt}
-      workingDirectory={workingDirectory}
-    />
-  );
+  if (chatBusy) {
+    return (
+      <QueueInput
+        queue={messageQueue}
+        workingDirectory={workingDirectory}
+      />
+    );
+  }
+
+  return null;
 }
 
 const PromptIsland = React.memo(PromptIslandComponent);
@@ -264,6 +284,8 @@ export function App(): React.ReactElement {
         clearTimeout(escapeHintTimerRef.current);
         escapeHintTimerRef.current = null;
       }
+      // User-initiated abort — drop any queued chat message too.
+      store.clearQueue();
       interruptHandlerRef.current();
     } else {
       // First press — show hint, auto-dismiss after timeout

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -161,14 +161,34 @@ function PromptComponent({
     deps: [commandSuggestionsEnabled, suggestionsVisible],
   });
 
-  useEffect(() => {
-    // React can batch `setPrompt(null)` + `setPrompt(nextPrompt)`, so this component
-    // may not unmount between prompts. Ensure the input is reset for each new prompt.
-    const rawDefaultValue = prompt.options?.["defaultValue"];
-    const defaultValue =
-      prompt.type === "chat" && typeof rawDefaultValue === "string" ? rawDefaultValue : "";
+  // Track the previous prompt's type so we only reset the input buffer when
+  // the prompt's *kind* changes (e.g. confirm → chat) rather than on every
+  // prompt change. Without this, anything the user typed into QueueInput
+  // while the agent was busy would be wiped the instant the next chat prompt
+  // arrives, since this Prompt component remounts and the effect fires.
+  const previousPromptTypeRef = useRef<string | null>(null);
 
-    setValue(defaultValue, defaultValue.length);
+  useEffect(() => {
+    const rawDefaultValue = prompt.options?.["defaultValue"];
+    const hasExplicitDefault = prompt.type === "chat" && typeof rawDefaultValue === "string";
+    const previousType = previousPromptTypeRef.current;
+    const typeChanged = previousType !== null && previousType !== prompt.type;
+
+    if (hasExplicitDefault) {
+      // Caller explicitly seeded the input — honor it.
+      const defaultValue = rawDefaultValue;
+      setValue(defaultValue, defaultValue.length);
+    } else if (typeChanged) {
+      // Prompt kind changed (e.g. confirm → chat) without unmount: clear so
+      // any leftover state from the previous prompt's input semantics doesn't
+      // bleed into the new one.
+      setValue("", 0);
+    }
+    // Otherwise: same prompt type as before, or first mount of this Prompt.
+    // Preserve whatever's already in the shared text-input buffer — it may
+    // hold text the user typed in QueueInput during the busy phase.
+
+    previousPromptTypeRef.current = prompt.type;
     setValidationError(null);
     setSelectedSuggestionIndex(0);
   }, [prompt, setValue]);

--- a/src/cli/ui/QueueInput.tsx
+++ b/src/cli/ui/QueueInput.tsx
@@ -1,0 +1,104 @@
+import { Box, Text, useInput } from "ink";
+import React, { useCallback } from "react";
+import { ChatInput } from "./components/ChatInput";
+import { getGlyphs } from "./glyphs";
+import { useTextInput } from "./hooks/use-input-service";
+import { store } from "./store";
+import { PADDING, THEME } from "./theme";
+
+const G = getGlyphs();
+
+const PREVIEW_MAX_CHARS = 80;
+
+function formatPreview(queue: string): string {
+  const firstLine = queue.split("\n")[0] ?? "";
+  if (firstLine.length <= PREVIEW_MAX_CHARS) {
+    return queue.includes("\n") ? `${firstLine}…` : firstLine;
+  }
+  return `${firstLine.slice(0, PREVIEW_MAX_CHARS)}…`;
+}
+
+/**
+ * Chat input rendered while the agent is busy in chat mode.
+ *
+ * Pressing Enter appends the buffer to the in-memory message queue (joined
+ * with newlines if non-empty); Ctrl-X clears the queue. The queue is drained
+ * by chat-service the next time it's about to prompt for input.
+ */
+export function QueueInput({
+  queue,
+  workingDirectory,
+}: {
+  queue: string;
+  workingDirectory: string | null;
+}): React.ReactElement {
+  const handleSubmit = useCallback((val: string): void => {
+    if (val.length === 0) return;
+    store.appendToQueue(val);
+  }, []);
+
+  const { value, cursor, setValue } = useTextInput({
+    id: "text-input",
+    isActive: true,
+    onSubmit: (val) => {
+      handleSubmit(val);
+      setValue("", 0);
+    },
+  });
+
+  useInput((input, key) => {
+    // Ctrl-X — clear queue. Only act when the user has nothing typed; if they
+    // have a buffer, leave Ctrl-X alone so we don't shadow future bindings.
+    if (key.ctrl && (input === "x" || input === "\x18") && value.length === 0) {
+      store.clearQueue();
+    }
+  });
+
+  const previewVisible = queue.length > 0;
+
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      paddingX={PADDING.content}
+      paddingY={0}
+    >
+      {workingDirectory && (
+        <Box marginBottom={0}>
+          <Text dimColor>{workingDirectory}</Text>
+        </Box>
+      )}
+
+      {previewVisible && (
+        <Box marginTop={1}>
+          <Text dimColor>Queued: {formatPreview(queue)} (Ctrl-X to clear)</Text>
+        </Box>
+      )}
+
+      <Box
+        marginTop={1}
+        paddingLeft={1}
+        flexDirection="row"
+      >
+        <Text
+          color={THEME.prompt}
+          bold
+        >
+          {G.promptCursor}{" "}
+        </Text>
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+        >
+          <ChatInput
+            value={value}
+            cursor={cursor}
+            placeholder="Type to queue for next turn…"
+            showCursor
+            textColor="white"
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -262,4 +262,107 @@ describe("UIStore", () => {
       expect(seenB[0]).toBe(handler);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Message queue (chat busy-mode buffering)
+  // -------------------------------------------------------------------------
+
+  describe("message queue", () => {
+    test("appendToQueue accumulates with newline separator", () => {
+      const s = new UIStore();
+      s.appendToQueue("first");
+      s.appendToQueue("second");
+      s.appendToQueue("third");
+
+      expect(s.peekQueue()).toBe("first\nsecond\nthird");
+    });
+
+    test("appendToQueue with empty string is a no-op", () => {
+      const s = new UIStore();
+      s.appendToQueue("only");
+      s.appendToQueue("");
+
+      expect(s.peekQueue()).toBe("only");
+    });
+
+    test("takeQueue returns and clears", () => {
+      const s = new UIStore();
+      s.appendToQueue("hello");
+
+      expect(s.takeQueue()).toBe("hello");
+      expect(s.peekQueue()).toBe("");
+    });
+
+    test("takeQueue on empty queue returns empty string", () => {
+      const s = new UIStore();
+      expect(s.takeQueue()).toBe("");
+    });
+
+    test("clearQueue empties the queue", () => {
+      const s = new UIStore();
+      s.appendToQueue("a");
+      s.appendToQueue("b");
+      s.clearQueue();
+
+      expect(s.peekQueue()).toBe("");
+    });
+
+    test("setter is notified on append, clear, and take", () => {
+      const s = new UIStore();
+      const seen: string[] = [];
+      s.registerMessageQueueSetter((q) => seen.push(q));
+
+      s.appendToQueue("a");
+      s.appendToQueue("b");
+      s.takeQueue();
+      s.appendToQueue("c");
+      s.clearQueue();
+
+      // First call is the hydration on register (empty), then each mutation.
+      expect(seen).toEqual(["", "a", "a\nb", "", "c", ""]);
+    });
+
+    test("clearQueue when already empty does not notify setter", () => {
+      const s = new UIStore();
+      const seen: string[] = [];
+      s.registerMessageQueueSetter((q) => seen.push(q));
+      seen.length = 0; // discard hydration call
+
+      s.clearQueue();
+      expect(seen).toEqual([]);
+    });
+
+    test("snapshot accessor stays in sync", () => {
+      const s = new UIStore();
+      s.appendToQueue("x");
+      expect(s.getMessageQueueSnapshot()).toBe("x");
+      s.takeQueue();
+      expect(s.getMessageQueueSnapshot()).toBe("");
+    });
+  });
+
+  describe("chatBusy", () => {
+    test("setChatBusy toggles snapshot", () => {
+      const s = new UIStore();
+      expect(s.getChatBusySnapshot()).toBe(false);
+      s.setChatBusy(true);
+      expect(s.getChatBusySnapshot()).toBe(true);
+      s.setChatBusy(false);
+      expect(s.getChatBusySnapshot()).toBe(false);
+    });
+
+    test("setter is notified on change but not on no-op", () => {
+      const s = new UIStore();
+      const seen: boolean[] = [];
+      s.registerChatBusySetter((b) => seen.push(b));
+      seen.length = 0; // discard hydration
+
+      s.setChatBusy(true);
+      s.setChatBusy(true); // no-op
+      s.setChatBusy(false);
+      s.setChatBusy(false); // no-op
+
+      expect(seen).toEqual([true, false]);
+    });
+  });
 });

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -62,12 +62,16 @@ export class UIStore {
   private activitySnapshot: ActivityState = { phase: "idle" };
   private workingDirectorySnapshot: string | null = null;
   private runStatsSnapshot: RunStats = {};
+  private messageQueueSnapshot: string = "";
+  private chatBusySnapshot: boolean = false;
 
   // React state setters (registered by island components)
   private promptSetter: ((prompt: PromptState | null) => void) | null = null;
   private activitySetter: ((activity: ActivityState) => void) | null = null;
   private workingDirectorySetter: ((wd: string | null) => void) | null = null;
   private runStatsSetter: ((stats: RunStats) => void) | null = null;
+  private messageQueueSetter: ((queue: string) => void) | null = null;
+  private chatBusySetter: ((busy: boolean) => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -195,6 +199,42 @@ export class UIStore {
     this.interruptHandlerSetter?.(top);
   };
 
+  /**
+   * Append text to the chat message queue. If the queue is non-empty, the new
+   * text is joined to the existing content with a single newline.
+   */
+  appendToQueue = (text: string): void => {
+    if (text.length === 0) return;
+    const next =
+      this.messageQueueSnapshot.length === 0 ? text : `${this.messageQueueSnapshot}\n${text}`;
+    this.messageQueueSnapshot = next;
+    this.messageQueueSetter?.(next);
+  };
+
+  /** Read the queue contents without clearing. */
+  peekQueue = (): string => this.messageQueueSnapshot;
+
+  /** Read the queue and clear it. */
+  takeQueue = (): string => {
+    const value = this.messageQueueSnapshot;
+    if (value.length === 0) return "";
+    this.messageQueueSnapshot = "";
+    this.messageQueueSetter?.("");
+    return value;
+  };
+
+  clearQueue = (): void => {
+    if (this.messageQueueSnapshot.length === 0) return;
+    this.messageQueueSnapshot = "";
+    this.messageQueueSetter?.("");
+  };
+
+  setChatBusy = (busy: boolean): void => {
+    if (this.chatBusySnapshot === busy) return;
+    this.chatBusySnapshot = busy;
+    this.chatBusySetter?.(busy);
+  };
+
   setExpandableDiff = (fullDiff: string): void => {
     this.expandableDiff = { fullDiff, timestamp: Date.now() };
   };
@@ -270,6 +310,16 @@ export class UIStore {
     this.setCustomView = setter;
   }
 
+  registerMessageQueueSetter(setter: (queue: string) => void): void {
+    this.messageQueueSetter = setter;
+    setter(this.messageQueueSnapshot);
+  }
+
+  registerChatBusySetter(setter: (busy: boolean) => void): void {
+    this.chatBusySetter = setter;
+    setter(this.chatBusySnapshot);
+  }
+
   registerInterruptHandler(setter: ((handler: (() => void) | null) => void) | null): void {
     this.interruptHandlerSetter = setter;
     if (setter) {
@@ -294,6 +344,14 @@ export class UIStore {
 
   getRunStatsSnapshot(): RunStats {
     return this.runStatsSnapshot;
+  }
+
+  getMessageQueueSnapshot(): string {
+    return this.messageQueueSnapshot;
+  }
+
+  getChatBusySnapshot(): boolean {
+    return this.chatBusySnapshot;
   }
 
   // ── Pending queue management ──────────────────────────────────────

--- a/src/core/workflows/run-history.ts
+++ b/src/core/workflows/run-history.ts
@@ -230,14 +230,14 @@ export function getWorkflowHistory(
 }
 
 /**
- * Get the most recent runs (across all workflows).
+ * Get the most recent runs (across all workflows), ordered oldest to newest.
  */
 export function getRecentRuns(
   limit = 20,
 ): Effect.Effect<WorkflowRunRecord[], Error, FileSystem.FileSystem> {
   return Effect.gen(function* () {
     const history = yield* loadRunHistory();
-    return history.slice(-limit).reverse();
+    return history.slice(-limit);
   });
 }
 

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -121,13 +121,26 @@ export class ChatServiceImpl implements ChatService {
       // net so the between-turn array doesn't grow without limit.
       const MAX_CHAT_HISTORY_MESSAGES = 2000;
 
+      // True after a turn ended in a caught error. Decides whether queued
+      // text auto-flushes (clean-finish path) or seeds the next prompt for
+      // editing (error path).
+      let lastTurnErrored = false;
+
       while (chatActive) {
-        // Prompt for user input
-        const userMessage = yield* terminal
-          .ask("You:", {
+        let userMessage: string | undefined;
+        const queued = store.peekQueue();
+
+        if (queued.length > 0 && !lastTurnErrored) {
+          // Clean prior turn → drain the queue as the next user message
+          // without re-prompting.
+          store.takeQueue();
+          userMessage = queued;
+        } else {
+          const askOptions: { commandSuggestions: true; defaultValue?: string } = {
             commandSuggestions: true,
-          })
-          .pipe(
+            ...(queued.length > 0 ? { defaultValue: queued } : {}),
+          };
+          userMessage = yield* terminal.ask("You:", askOptions).pipe(
             Effect.catchAll((error: unknown) => {
               // Handle ExitPromptError from inquirer when user presses Ctrl+C
               if (
@@ -142,6 +155,12 @@ export class ChatServiceImpl implements ChatService {
               return Effect.fail(error instanceof Error ? error : new Error(String(error)));
             }),
           );
+          // Whatever the user submitted supersedes the seeded queue content.
+          if (queued.length > 0) {
+            store.clearQueue();
+          }
+        }
+        lastTurnErrored = false;
 
         const trimmedMessage = (userMessage ?? "").trim();
         const lowerMessage = trimmedMessage.toLowerCase();
@@ -311,9 +330,11 @@ export class ChatServiceImpl implements ChatService {
           };
 
           // Run the agent with proper error handling
+          store.setChatBusy(true);
           const response = yield* AgentRunner.run(runnerOptions).pipe(
             Effect.catchAll((error) =>
               Effect.gen(function* () {
+                lastTurnErrored = true;
                 // Stop the thinking spinner — the agent run failed before
                 // streaming started, so nothing else will reset the activity.
                 store.setActivity({ phase: "idle" });
@@ -381,6 +402,7 @@ export class ChatServiceImpl implements ChatService {
                 };
               }),
             ),
+            Effect.ensuring(Effect.sync(() => store.setChatBusy(false))),
           );
 
           // Store the conversation ID for continuity


### PR DESCRIPTION
## What and why

Adds the ability to type follow-up messages while the agent is still
responding in `jazz chat`. Today the input prompt disappears the moment a
turn starts, so any thought you have during the agent's reply has to wait
until it finishes. After this PR, the input stays alive throughout the
turn and your typed messages are buffered for delivery the next time the
agent is free. Also fixes the ordering of `jazz workflow history` so the
most recent run sits at the bottom of the output (next to your prompt),
matching how terminal logs are usually read.

## Before this PR

- During an agent turn in `jazz chat`, the chat input is hidden. Anything
  you want to say next has to wait until the streaming response ends and
  the prompt comes back.
- `jazz workflow history` listed runs newest-first, so the latest run was
  always at the top and tended to scroll out of view above earlier runs.

## After this PR

- While the agent is processing a turn, the chat input stays visible. Each
  Enter you press appends what you typed to a single queued message
  (joined with `\n`); a preview line above the input shows the queued
  content with a `Ctrl-X to clear` hint.
- When the agent finishes cleanly, the queued message becomes the next
  user input automatically — no extra prompt round.
- When the agent errors out, the queue is preserved and seeded into the
  next prompt as the default value, so you can edit or confirm before
  sending.
- Double-Esc (the existing abort gesture) now also drops the queue.
- `jazz workflow history` lists runs oldest-first; the most recent run is
  at the bottom of the output.

## Changes made

- `src/cli/ui/store.ts` — adds `messageQueue: string` and `chatBusy: boolean`
  to the global UI store, plus `appendToQueue` / `peekQueue` / `takeQueue`
  / `clearQueue` / `setChatBusy` setters and matching island registration
  hooks. Follows the existing snapshot + setter pattern used by `prompt`,
  `activity`, etc.
- `src/cli/ui/store.test.ts` — 9 new tests covering append-with-newline,
  peek/take semantics, clear, setter notifications, and `chatBusy`
  toggling.
- `src/cli/ui/QueueInput.tsx` — new component that renders the busy-mode
  chat input. Reuses `ChatInput`, calls `store.appendToQueue` on submit,
  shows the preview line, and handles `Ctrl-X` to clear the queue when
  the input buffer is empty (so it doesn't shadow text editing).
- `src/cli/ui/App.tsx` — `PromptIsland` now also subscribes to `chatBusy`
  and `messageQueue`. When there's no active prompt but `chatBusy` is
  true, `QueueInput` is rendered. The double-Esc interrupt branch also
  calls `store.clearQueue()` so user-initiated aborts drop the queue.
- `src/services/chat-service.ts` — top of the chat loop drains the queue
  if non-empty after a clean prior turn, otherwise prompts normally
  (seeding the queued content as the prompt's default value if a prior
  turn errored). The agent run is wrapped with
  `Effect.ensuring(store.setChatBusy(false))` so the busy flag is always
  reset, and `lastTurnErrored` is set in the existing catchAll.
- `src/core/workflows/run-history.ts` — drops the `.reverse()` in
  `getRecentRuns` so runs are returned oldest-to-newest. The history file
  is already stored chronologically; the function now just slices the
  last N records as-is.

## Impact

- New behaviour is opt-in by definition: only triggered if the user types
  while the agent is busy. Idle UX is unchanged.
- `chatBusy` is set explicitly by `chat-service`, never derived from the
  activity state machine, so the queue UI cannot leak into non-chat
  contexts (workflow runs, one-shot prompts).
- Memory only — the queue does not persist across CLI restarts.
- Slash commands receive no special handling: queued text is parsed by
  the existing chat-loop logic when drained, so `/help`, `/exit`, etc.
  behave as if you had typed them at the prompt.
- `jazz workflow history` ordering change is visible to anyone running
  the command — the total set of runs shown is the same, just inverted.

## How to test

1. `bun src/main.ts chat <agent-name>` to start a chat session.
2. Send a message that takes a few seconds to respond
   (e.g. "explain transformers in 3 paragraphs").
3. While the agent is streaming, type "follow up question" and press Enter
   — expected: the input clears and a `Queued: follow up question (Ctrl-X
   to clear)` line appears above the input.
4. Type "and another thought" and press Enter — expected: the preview
   becomes `Queued: follow up question… (Ctrl-X to clear)` (truncated
   because there's now a second line).
5. Wait for the agent to finish — expected: the queued message
   `follow up question\nand another thought` is sent automatically as the
   next user message, with no fresh prompt round.
6. Edge case (clear): repeat steps 1–3, then press `Ctrl-X` while the
   input buffer is empty — expected: the preview line disappears and the
   queue is empty when the agent finishes.
7. Edge case (abort drops queue): repeat steps 1–3, then double-tap `Esc`
   — expected: the agent run is aborted AND the queue is dropped.
8. Edge case (error preserves queue): trigger an LLM error (e.g. invalid
   API key) and queue a message during the failed turn — expected: the
   next prompt is seeded with the queued content for editing rather than
   auto-sending.
9. Workflow history ordering: run `bun src/main.ts workflow history` (or
   `... history <workflow-name>`) — expected: the most recent run is the
   last entry printed before the `Showing N most recent run(s)` summary.

## Notes for reviewers

- `Ctrl-K` would have been the natural mnemonic for "kill queue" but it
  is already bound to `kill-line-forward` in
  `src/cli/input/escape-state-machine.ts`. `Ctrl-X` is unused and reads as
  "cut/clear". The binding is gated on an empty input buffer so it
  doesn't surprise anyone mid-edit.
- Failed scheduled-workflow runs that exit before `addRunRecord` is
  reached are still missing from history (separate issue surfaced during
  the session). Left out of scope here.
- I have not run an interactive end-to-end against a real LLM in CI; the
  manual steps above are the verification path.
