### PR TITLE
fix(workflow): record failed scheduled runs and surface them on startup

### DIFF
--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -3,6 +3,7 @@ import { NodeFileSystem } from "@effect/platform-node";
 import { Cause, Duration, Effect, Exit, Fiber, Layer, Option } from "effect";
 import { autoCheckForUpdate } from "./cli/auto-update";
 import { promptInteractiveCatchUp } from "./cli/catch-up-prompt";
+import { promptFailedRunsWarning } from "./cli/failed-run-prompt";
 import { CLIPresentationServiceLayer } from "./cli/presentation/cli-presentation-service";
 import { InkPresentationServiceLayer } from "./cli/presentation/ink-presentation-service";
 import { createToolRegistrationLayer } from "./core/agent/tools/register-tools";
@@ -236,6 +237,11 @@ export function runCliEffect<R, E extends JazzError | Error>(
       // Interactive prompt for catch-up - asks user if they want to run missed workflows
       // Runs selected workflows in background, then continues with the original command
       yield* promptInteractiveCatchUp();
+
+      // Surface scheduled workflows whose most recent run ended in failure
+      // (agent missing, quota exceeded, network error, etc.). One-shot info
+      // line — does not block the command.
+      yield* promptFailedRunsWarning();
     }
 
     const fiber = yield* Effect.fork(autoCheckForUpdate().pipe(Effect.zipRight(effect)));

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -242,10 +242,34 @@ export function runWorkflowCommand(
     yield* terminal.heading(`🚀 Running workflow: ${workflowName}`);
     yield* terminal.log("");
 
+    // Record the run start as early as possible. Until this lands every
+    // failed scheduled run (e.g. agent not found) exited before reaching
+    // addRunRecord, so the run history showed nothing and the catch-up
+    // logic kept treating the slot as a missed run.
+    const startedAt = new Date().toISOString();
+    const triggeredBy = isSchedulerTriggered ? ("scheduled" as const) : ("manual" as const);
+    yield* addRunRecord({
+      workflowName,
+      startedAt,
+      status: "running",
+      triggeredBy,
+    }).pipe(Effect.catchAll(() => Effect.void));
+
+    // Helper: mark the just-opened "running" record as failed. Called on
+    // every early-exit error path so failures show up in `jazz workflow
+    // history` and the next-startup warning surfaces them to the user.
+    const markFailed = (errorMessage: string) =>
+      updateLatestRunRecord(workflowName, {
+        completedAt: new Date().toISOString(),
+        status: "failed",
+        error: errorMessage,
+      }).pipe(Effect.catchAll(() => Effect.void));
+
     // Load the workflow
     const workflow = yield* workflowService.loadWorkflow(workflowName).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
+          yield* markFailed(`Workflow not found: ${workflowName}`);
           yield* terminal.error(`Workflow not found: ${workflowName}`);
           yield* terminal.info("Run 'jazz workflow list' to see available workflows.");
           return yield* Effect.fail(error);
@@ -266,24 +290,24 @@ export function runWorkflowCommand(
     } else {
       // In non-interactive mode (--auto-approve), fail immediately if agent not found
       if (isNonInteractive) {
+        const errorMessage = `Agent '${agentIdentifier}' not found. Scheduled workflows require a valid agent — update the workflow or re-schedule with an existing agent.`;
+        yield* markFailed(errorMessage);
         yield* terminal.error(`Agent '${agentIdentifier}' not found.`);
         yield* terminal.info(
           "Scheduled workflows require a valid agent. Update the workflow or create the agent.",
         );
-        return yield* Effect.fail(
-          new Error(`Agent '${agentIdentifier}' not found for non-interactive workflow execution`),
-        );
+        return yield* Effect.fail(new Error(errorMessage));
       }
 
       // Agent not found - list available agents and let user choose
       const allAgents = yield* listAllAgents();
 
       if (allAgents.length === 0) {
+        const errorMessage = "No agents available. Create an agent first with: jazz agent create";
+        yield* markFailed(errorMessage);
         yield* terminal.error("No agents available.");
         yield* terminal.info("Create an agent first with: jazz agent create");
-        return yield* Effect.fail(
-          new Error("No agents available. Create an agent first with: jazz agent create"),
-        );
+        return yield* Effect.fail(new Error(errorMessage));
       }
 
       if (agentIdentifier !== "default") {
@@ -299,6 +323,12 @@ export function runWorkflowCommand(
         "Select an agent to run this workflow:",
       );
       if (!selectedAgent) {
+        // User cancelled the picker. Mark the record skipped so it doesn't
+        // sit as a stale "running" entry forever.
+        yield* updateLatestRunRecord(workflowName, {
+          completedAt: new Date().toISOString(),
+          status: "skipped",
+        }).pipe(Effect.catchAll(() => Effect.void));
         yield* terminal.info("Workflow cancelled.");
         return;
       }
@@ -323,15 +353,6 @@ export function runWorkflowCommand(
       agent: agent.name,
       autoApprove: autoApprovePolicy,
     });
-
-    // Record the run start
-    const startedAt = new Date().toISOString();
-    yield* addRunRecord({
-      workflowName,
-      startedAt,
-      status: "running",
-      triggeredBy: isSchedulerTriggered ? "scheduled" : "manual",
-    }).pipe(Effect.catchAll(() => Effect.void)); // Don't fail if history tracking fails
 
     // Run the agent with the workflow prompt
     // maxIterations from workflow metadata is optional — omit for no limit

--- a/src/cli/failed-run-prompt.ts
+++ b/src/cli/failed-run-prompt.ts
@@ -1,0 +1,86 @@
+import * as path from "node:path";
+import { Effect } from "effect";
+import { TerminalServiceTag } from "@/core/interfaces/terminal";
+import { getGlobalUserDataDirectory } from "@/core/utils/runtime-detection";
+import {
+  getRunHistoryFilePath,
+  loadRunHistory,
+  type WorkflowRunRecord,
+} from "@/core/workflows/run-history";
+import { SchedulerServiceTag } from "@/core/workflows/scheduler-service";
+
+/**
+ * If the most recent run of any *scheduled* workflow ended in `failed`, show
+ * a one-shot warning on jazz startup so the user notices silent regressions
+ * (e.g. the agent the workflow was scheduled with was deleted, or the model
+ * is rate-limited / out of quota). Points the user at the run-history file
+ * and the per-workflow log.
+ *
+ * Pairs with the early `addRunRecord({ status: "running" })` move in
+ * `cli/commands/workflow.ts` — without that, scheduled runs that fail at
+ * agent lookup never reach the history at all and this prompt has nothing
+ * to surface.
+ */
+export function promptFailedRunsWarning() {
+  return Effect.gen(function* () {
+    if (!process.stdout.isTTY) return;
+
+    const scheduler = yield* SchedulerServiceTag;
+    const scheduled = yield* scheduler
+      .listScheduled()
+      .pipe(Effect.catchAll(() => Effect.succeed([] as const)));
+
+    if (scheduled.length === 0) return;
+
+    const history = yield* loadRunHistory().pipe(
+      Effect.catchAll(() => Effect.succeed([] as WorkflowRunRecord[])),
+    );
+
+    if (history.length === 0) return;
+
+    const scheduledNames = new Set(scheduled.map((s) => s.workflowName));
+
+    // Find the latest record (by completedAt ?? startedAt) for each scheduled
+    // workflow, and keep only those whose latest is "failed".
+    type Latest = { record: WorkflowRunRecord; ts: number };
+    const latestByWorkflow = new Map<string, Latest>();
+    for (const record of history) {
+      if (!scheduledNames.has(record.workflowName)) continue;
+      const ts = Date.parse(record.completedAt ?? record.startedAt);
+      if (!Number.isFinite(ts)) continue;
+      const existing = latestByWorkflow.get(record.workflowName);
+      if (!existing || ts > existing.ts) {
+        latestByWorkflow.set(record.workflowName, { record, ts });
+      }
+    }
+
+    const failed: WorkflowRunRecord[] = [];
+    for (const { record } of latestByWorkflow.values()) {
+      if (record.status === "failed") failed.push(record);
+    }
+
+    if (failed.length === 0) return;
+
+    const terminal = yield* TerminalServiceTag;
+    const logsDir = path.join(getGlobalUserDataDirectory(), "logs");
+    const historyPath = getRunHistoryFilePath();
+
+    yield* terminal.log("");
+    yield* terminal.warn(
+      `${failed.length} scheduled workflow${failed.length > 1 ? "s" : ""} ${
+        failed.length > 1 ? "have" : "has"
+      } failed on the last run:`,
+    );
+    for (const record of failed) {
+      const summary = record.error ? record.error.split("\n")[0] : "no error message recorded";
+      yield* terminal.log(`   • ${record.workflowName} — ${summary}`);
+    }
+    yield* terminal.log("");
+    yield* terminal.log(`   Run history: ${historyPath}`);
+    yield* terminal.log(`   Logs:        ${logsDir}/<workflow>.log`);
+    yield* terminal.log(
+      `   Triage:      jazz workflow history <workflow>  →  inspect, then re-schedule if needed`,
+    );
+    yield* terminal.log("");
+  }).pipe(Effect.catchAll(() => Effect.void));
+}

--- a/src/cli/failed-run-prompt.ts
+++ b/src/cli/failed-run-prompt.ts
@@ -40,13 +40,17 @@ export function promptFailedRunsWarning() {
 
     const scheduledNames = new Set(scheduled.map((s) => s.workflowName));
 
-    // Find the latest record (by completedAt ?? startedAt) for each scheduled
-    // workflow, and keep only those whose latest is "failed".
+    // Find the latest *attempt* per scheduled workflow, and keep only those
+    // whose latest attempt failed. We sort on `startedAt` (not completedAt)
+    // because runs can overlap — e.g. a long-running catch-up that finishes
+    // after a quick failure that started later. Sorting on completedAt would
+    // pick the long-running one as "latest" even though a more recent
+    // attempt exists.
     type Latest = { record: WorkflowRunRecord; ts: number };
     const latestByWorkflow = new Map<string, Latest>();
     for (const record of history) {
       if (!scheduledNames.has(record.workflowName)) continue;
-      const ts = Date.parse(record.completedAt ?? record.startedAt);
+      const ts = Date.parse(record.startedAt);
       if (!Number.isFinite(ts)) continue;
       const existing = latestByWorkflow.get(record.workflowName);
       if (!existing || ts > existing.ts) {


### PR DESCRIPTION
## What and why

When a scheduled workflow's daily run failed because the agent it was
scheduled with had been deleted (or for any other reason that aborts
before the agent runs), nothing about the failure ever made it into
`jazz workflow history`. The catch-up logic kept thinking the slot was
"missed" because the last successful run was ages ago. Users saw "my
workflows always need to catch up; they never run automatically" and
had no trail to find out what was actually breaking.

This PR fixes both halves of that experience:

1. **Failed scheduled runs now show up in history**, with a real error
   message, by recording the run as soon as we commit to executing it
   and marking it `failed` on every early-exit error path.
2. **Jazz tells you on startup** when a scheduled workflow's most
   recent run ended in failure, names the workflow, points at the
   run-history file and the log directory.

## Before this PR

- A scheduled run that died at the agent-not-found check exited
  *before* the existing `addRunRecord` call. `jazz workflow history`
  showed nothing.
- Because no record was written, the catch-up decision in
  `src/core/workflows/catch-up.ts:96` kept looking back to the last
  successful run; today's slot was always "missed".
- The user was prompted to catch up the same workflows day after day.
  No indication anywhere that the daily 8 AM fire was actually firing
  and dying in milliseconds.
- The `~/.jazz/logs/<workflow>.error.log` had the real error
  (`Agent 'xyz' not found`), but you had to know it existed and tail
  it to find out.

## After this PR

- A scheduled run records `{ status: "running", triggeredBy:
  "scheduled" }` immediately on entry. If the agent isn't found, the
  code calls `updateLatestRunRecord({ status: "failed", error: ... })`
  before exiting. Same for "no agents available" and "workflow not
  found". User-cancellation at the agent picker marks the record
  `skipped` so it doesn't linger as a stale "running" entry.
- `jazz workflow history <name>` now shows the daily failures with
  their error messages — no need to dig into log files.
- On every interactive `jazz` startup, after the catch-up prompt
  passes, a one-shot info line appears if any scheduled workflow's
  most recent run was a failure:

  ```
  ⚠ 1 scheduled workflow has failed on the last run:
     • tech-digest — Agent 'iVzRGTWoKDAgDxPexVVi8Q' not found. …

     Run history: /Users/foo/.jazz/run-history.json
     Logs:        /Users/foo/.jazz/logs/<workflow>.log
     Triage:      jazz workflow history <workflow>  →  inspect, then re-schedule if needed
  ```

  The warning is informational, not interactive — it does not block
  the command you typed.

## Changes made

- `src/cli/commands/workflow.ts` — In `runWorkflowCommand`, move the
  `addRunRecord({ status: "running" })` call from after the agent
  lookup to right after the scheduled-skip-recent guard. Add a
  `markFailed(errorMessage)` helper that calls
  `updateLatestRunRecord` with `status: "failed"` and a meaningful
  error message; call it on every early-exit error path
  (workflow-not-found, agent-not-found in non-interactive, no
  agents available). On user-cancellation at the agent picker, mark
  the record `skipped` instead of leaving it `running`.
- `src/cli/failed-run-prompt.ts` (new) — Sibling of
  `catch-up-prompt.ts`. Reads scheduled workflows + run history,
  picks the latest record per scheduled workflow, surfaces a warning
  for any whose latest is `failed`. Skips silently in non-TTY mode
  and on any error. Points at run-history.json and the logs
  directory.
- `src/app-layer.ts` — Wires `promptFailedRunsWarning` immediately
  after the existing `promptInteractiveCatchUp` call, gated on the
  same `JAZZ_DISABLE_CATCH_UP` / `skipCatchUp` flags.

## Impact

- New noise on jazz startup is bounded: only fires when a scheduled
  workflow's *most recent* run actually failed. Healthy schedules
  produce zero output. Once the user re-schedules / fixes the issue,
  the next successful run replaces "failed" with "completed" and the
  warning is gone.
- The "catch-up" semantic does not change: if a scheduled run failed
  today at 8 AM, the catch-up prompt may still offer it as a missed
  run (because the failed record means the run didn't *complete*,
  even though it tried). The new warning is additive — it surfaces
  the failure independently so users understand *why* catch-up keeps
  re-offering things.
- Manual workflow runs (`jazz workflow run <name>`) also benefit
  from earlier recording. A manual run that aborts at the agent
  picker now appears as `skipped` in history, which is more accurate
  than not appearing at all.
- No CLI surface changes. No config changes.

## How to test

1. **Repro the original symptom on a fresh checkout (pre-fix
   behavior):**
   - Schedule a workflow with `jazz workflow schedule <name>`,
     pick any agent.
   - Edit `~/.jazz/schedules/<name>.json` and set `"agent"` to a
     bogus value like `"deadbeef"`.
   - Edit `~/Library/LaunchAgents/com.jazz.workflow.<name>.plist`
     similarly so the daily run will hit "Agent not found".
   - On a pre-fix build, wait for the schedule to fire (or trigger
     RunAtLoad by `launchctl unload && launchctl load` the plist).
     Confirm `~/.jazz/logs/<name>.error.log` shows
     `Agent 'deadbeef' not found.` but `jazz workflow history
     <name>` is empty for that day.
2. **Verify the fix:**
   - Build and install this branch (or `bun src/main.ts`).
   - Re-trigger the failing run (e.g. `bun src/main.ts workflow
     run <name> --auto-approve --scheduled`).
   - Run `bun src/main.ts workflow history <name>` — expected: a
     record `✗ failed` with the agent-not-found error message in
     the `Error:` line.
3. **Verify the startup warning:**
   - With the failed record in history (from step 2), run any
     interactive `bun src/main.ts` command (e.g. `chat <agent>`).
   - Expected: after the catch-up prompt, a one-shot warning:
     `⚠ 1 scheduled workflow has failed on the last run` followed
     by the workflow name, error summary, and pointers.
4. **Edge case (warning only fires for scheduled):** trigger a
   manual workflow failure (`workflow run <name>` with no agent
   selected → cancel). Confirm the next startup does NOT show the
   failure warning (it's scheduled-only).
5. **Edge case (transient → recovered):** fix the agent ID, run the
   workflow successfully via `workflow run --auto-approve`. Confirm
   the next startup no longer warns (the latest record is now
   `completed`).
6. **Edge case (non-TTY):** pipe `bun src/main.ts agent list | cat`
   — expected: no warning text leaked into the piped output.

## Notes for reviewers

- The warning intentionally does not block. We considered making it
  interactive ("would you like to re-schedule now?") but that
  conflates with the catch-up flow that already exists. The current
  one-shot warning + triage hint feels lighter; we can layer
  interactive remediation in later if it's useful.
- "First line of the error message" is the chosen summary format
  because LLM/auth errors often run multiple lines with stack
  fragments. Truncating to the first line keeps the warning
  scannable. Full error stays in `run-history.json`.
- Manual runs also get earlier recording. This was a deliberate
  consistency choice — same code path, same record semantics.
