### PR TITLE
perf(cli): buffer streaming deltas to ~80ms cadence

### DIFF
--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -18,6 +18,9 @@ describe("InkStreamingRenderer", () => {
   let lastRenderer: InkStreamingRenderer | null = null;
 
   function createRenderer() {
+    // textBufferMs: 0 disables stream-delta buffering so appendStream calls
+    // are synchronous, matching the assertions in this test file. Production
+    // uses ~80ms buffering by default.
     const renderer = new InkStreamingRenderer(
       "TestAgent",
       false,
@@ -27,7 +30,7 @@ describe("InkStreamingRenderer", () => {
         mode: "rendered",
         colorProfile: "full",
       },
-      undefined,
+      { textBufferMs: 0 },
       0,
     );
     lastRenderer = renderer;
@@ -161,6 +164,113 @@ describe("InkStreamingRenderer", () => {
     });
   });
 
+  describe("text buffering (textBufferMs)", () => {
+    test("text deltas are coalesced and flushed once per buffer window", async () => {
+      const calls: { kind: string; delta: string }[] = [];
+      const originalAppend = store.appendStream;
+      store.appendStream = (kind, delta): void => {
+        calls.push({ kind, delta });
+        originalAppend(kind, delta);
+      };
+      try {
+        // 30ms buffer keeps the test fast.
+        const renderer = new InkStreamingRenderer(
+          "TestAgent",
+          false,
+          {
+            showThinking: true,
+            showToolExecution: true,
+            mode: "rendered",
+            colorProfile: "full",
+          },
+          { textBufferMs: 30 },
+          0,
+        );
+        emitStreamStart(renderer);
+        Effect.runSync(renderer.handleEvent({ type: "text_start" }));
+
+        // Three back-to-back chunks within one buffer window.
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "Hel",
+            accumulated: "Hel",
+            sequence: 0,
+          }),
+        );
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "lo, ",
+            accumulated: "Hello, ",
+            sequence: 1,
+          }),
+        );
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "world",
+            accumulated: "Hello, world",
+            sequence: 2,
+          }),
+        );
+
+        // Before the timer fires, nothing has gone to appendStream.
+        expect(calls).toHaveLength(0);
+
+        // Wait past the buffer window for the flush.
+        await new Promise((r) => setTimeout(r, 50));
+
+        // All three chunks coalesced into a single appendStream call.
+        const responseCalls = calls.filter((c) => c.kind === "response");
+        expect(responseCalls).toHaveLength(1);
+        expect(responseCalls[0]!.delta).toBe("Hello, world");
+      } finally {
+        store.appendStream = originalAppend;
+      }
+    });
+
+    test("flush() drains buffered deltas synchronously", () => {
+      const calls: { kind: string; delta: string }[] = [];
+      const originalAppend = store.appendStream;
+      store.appendStream = (kind, delta): void => {
+        calls.push({ kind, delta });
+        originalAppend(kind, delta);
+      };
+      try {
+        const renderer = new InkStreamingRenderer(
+          "TestAgent",
+          false,
+          {
+            showThinking: true,
+            showToolExecution: true,
+            mode: "rendered",
+            colorProfile: "full",
+          },
+          { textBufferMs: 1000 }, // long window
+          0,
+        );
+        emitStreamStart(renderer);
+        Effect.runSync(renderer.handleEvent({ type: "text_start" }));
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "buffered",
+            accumulated: "buffered",
+            sequence: 0,
+          }),
+        );
+
+        expect(calls).toHaveLength(0);
+        Effect.runSync(renderer.flush());
+        expect(calls).toHaveLength(1);
+        expect(calls[0]!.delta).toBe("buffered");
+      } finally {
+        store.appendStream = originalAppend;
+      }
+    });
+  });
+
   describe("thinking phase", () => {
     test("thinking_start transitions to thinking activity", async () => {
       const renderer = createRenderer();
@@ -183,7 +293,7 @@ describe("InkStreamingRenderer", () => {
           mode: "rendered",
           colorProfile: "full",
         },
-        undefined,
+        { textBufferMs: 0 },
         0,
       );
       emitStreamStart(renderer);

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -85,15 +85,93 @@ export class InkStreamingRenderer implements StreamingRenderer {
   private toolTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
   private static readonly TOOL_WARNING_MS = 30_000;
 
+  /**
+   * Buffered streaming deltas, flushed at `textBufferMs` cadence. Without
+   * buffering, every token (~60–80/sec) triggers a React re-render of the
+   * live area; with it the live area updates at the buffer cadence
+   * (e.g. ~12 fps at 80ms), giving a "line-by-line" feel similar to
+   * claude.ai instead of a frantic chunk-by-chunk one.
+   *
+   * Stored as an in-order array so reasoning and response deltas keep their
+   * arrival order at flush time. Empty arrays bypass setTimeout overhead.
+   */
+  private streamBuffer: { kind: "response" | "reasoning"; delta: string }[] = [];
+  private streamFlushTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private readonly textBufferMs: number;
+
+  /** Default buffer cadence — visible "live typing" without burning CPU. */
+  private static readonly DEFAULT_TEXT_BUFFER_MS = 80;
+
   constructor(
     private readonly agentName: string,
     private readonly showMetrics: boolean,
     private readonly displayConfig: DisplayConfig,
-    _streamingConfig?: { textBufferMs?: number },
+    streamingConfig?: { textBufferMs?: number },
     throttleMs?: number,
   ) {
     this.updateThrottleMs = throttleMs ?? 60;
+    this.textBufferMs =
+      streamingConfig?.textBufferMs ?? InkStreamingRenderer.DEFAULT_TEXT_BUFFER_MS;
     this.acc = createAccumulator(agentName);
+  }
+
+  /**
+   * Append a streaming delta to the in-memory buffer. Schedules a flush
+   * within `textBufferMs` if one isn't already pending. With
+   * `textBufferMs: 0` the delta flushes synchronously, matching the
+   * pre-buffering behavior for callers that opt out.
+   */
+  private bufferStreamDelta(kind: "response" | "reasoning", delta: string): void {
+    if (delta.length === 0) return;
+    if (this.textBufferMs <= 0) {
+      store.appendStream(kind, delta);
+      return;
+    }
+
+    this.streamBuffer.push({ kind, delta });
+    if (this.streamFlushTimeoutId !== null) return;
+
+    this.streamFlushTimeoutId = setTimeout(() => {
+      this.streamFlushTimeoutId = null;
+      this.flushStreamBuffer();
+    }, this.textBufferMs);
+  }
+
+  /**
+   * Flush any buffered streaming deltas immediately. Called whenever we
+   * need on-screen content to be in sync (kind transitions, completion,
+   * abort, reset, etc.) so we never lose a tail.
+   */
+  private flushStreamBuffer(): void {
+    if (this.streamFlushTimeoutId !== null) {
+      clearTimeout(this.streamFlushTimeoutId);
+      this.streamFlushTimeoutId = null;
+    }
+    if (this.streamBuffer.length === 0) return;
+    const buffered = this.streamBuffer;
+    this.streamBuffer = [];
+
+    // Coalesce consecutive same-kind chunks into single appendStream calls
+    // so the scrollback adapter sees one append per kind-run instead of N.
+    let runKind: "response" | "reasoning" | null = null;
+    let runText = "";
+    for (const { kind, delta } of buffered) {
+      if (runKind === null) {
+        runKind = kind;
+        runText = delta;
+        continue;
+      }
+      if (kind === runKind) {
+        runText += delta;
+      } else {
+        store.appendStream(runKind, runText);
+        runKind = kind;
+        runText = delta;
+      }
+    }
+    if (runKind !== null && runText.length > 0) {
+      store.appendStream(runKind, runText);
+    }
   }
 
   reset(): Effect.Effect<void, never> {
@@ -111,6 +189,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         this.updateTimeoutId = null;
       }
       this.clearAllToolTimeouts();
+      this.flushStreamBuffer();
       store.finalizeStream();
       store.setActivity({ phase: "idle" });
       store.setInterruptHandler(null);
@@ -125,6 +204,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       }
       this.pendingActivity = null;
       this.clearAllToolTimeouts();
+      this.flushStreamBuffer();
       store.finalizeStream();
       store.setActivity({ phase: "idle" });
       store.setInterruptHandler(null);
@@ -165,6 +245,9 @@ export class InkStreamingRenderer implements StreamingRenderer {
   handleEvent(event: StreamEvent): Effect.Effect<void, never> {
     return Effect.sync(() => {
       if (InkStreamingRenderer.SETTLE_BEFORE.has(event.type)) {
+        // Flush any in-flight buffered deltas BEFORE finalizing the stream
+        // so they land in the slice that's about to settle, not the next one.
+        this.flushStreamBuffer();
         store.finalizeStream();
       }
 
@@ -183,7 +266,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
           });
         }
         if (event.type === "thinking_chunk") {
-          store.appendStream("reasoning", event.content);
+          this.bufferStreamDelta("reasoning", event.content);
         }
       }
 
@@ -220,7 +303,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       if (event.type === "text_chunk") {
         const delta = this.consumeTextDelta(event);
         if (delta.length > 0) {
-          store.appendStream("response", delta);
+          this.bufferStreamDelta("response", delta);
           this.hasStreamedText = true;
         }
       }
@@ -256,6 +339,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       this.pendingActivity = null;
     }
 
+    this.flushStreamBuffer();
     store.finalizeStream();
 
     if (!this.hasStreamedText) {


### PR DESCRIPTION
## What and why

Streaming in `jazz chat` currently re-renders the live area on every
token from the model. With typical LLM output around 60–80 tokens/sec,
that means 60–80 React re-renders per second of the streaming buffer.
The visible result is a frantic chunk-by-chunk feel; the invisible
result is high CPU and (per the project's own
`PreWrappedText.tsx:10-14` warning) increased risk of Yoga
miscalculating layout under load.

claude.ai renders at roughly line cadence — visibly streaming, but
much smoother. This PR brings jazz to the same range by wiring up the
already-documented-but-unused `streamingConfig.textBufferMs` setting:
deltas are buffered in-memory and flushed at a configurable cadence
(default 80ms ≈ 12 fps) instead of per-token. Same-kind consecutive
deltas are coalesced into a single `store.appendStream` call so the
scrollback adapter does fewer state updates too.

## Before this PR

- `text_chunk` and `thinking_chunk` events called `store.appendStream`
  synchronously inside `InkStreamingRenderer.handleEvent`, one call
  per delta.
- React re-rendered the live area on every token.
- The `streamingConfig.textBufferMs` field existed in the type system
  (`src/core/types/streaming.ts:113` documents a default of 50ms) and
  was wired through the agent runner / streaming executor, but the
  renderer accepted it as `_streamingConfig` (note the underscore)
  and ignored it. So the documented buffering was never actually
  applied.

## After this PR

- The renderer holds an in-memory `streamBuffer` array; `text_chunk`
  and `thinking_chunk` push into it instead of calling `appendStream`
  directly.
- A single `setTimeout(flushStreamBuffer, textBufferMs)` flushes the
  buffer; new pushes coalesce into the next window if a flush is
  already pending.
- On flush, consecutive same-kind deltas merge into one
  `store.appendStream(kind, mergedText)` call. So if 6 response
  tokens arrive in 80ms, the scrollback adapter sees one append
  instead of six.
- Lifecycle events (`SETTLE_BEFORE` set, `complete`, `flush()`,
  `reset()`) all call `flushStreamBuffer()` *before* the surrounding
  finalize/finalize-stream work, so a tail in the buffer at a phase
  boundary still lands in the correct slice.
- `textBufferMs: 0` is an explicit opt-out path (used by existing
  unit tests that assert synchronous `appendStream` semantics) — it
  routes deltas straight through with zero overhead.
- Default value: 80ms (renderer constant
  `DEFAULT_TEXT_BUFFER_MS`). Configurable via
  `appConfig.output.streaming.textBufferMs` per the existing wiring.

## Changes made

- `src/cli/presentation/ink-presentation-service.ts`
  - Added `streamBuffer`, `streamFlushTimeoutId`, `textBufferMs`
    fields and a `DEFAULT_TEXT_BUFFER_MS = 80` constant.
  - Constructor parameter renamed from `_streamingConfig` to
    `streamingConfig` and the value is now read.
  - New private methods `bufferStreamDelta(kind, delta)` and
    `flushStreamBuffer()` — the second coalesces consecutive
    same-kind chunks into single `appendStream` calls.
  - `handleEvent` calls `bufferStreamDelta` instead of
    `appendStream` for both `text_chunk` and `thinking_chunk`.
  - Every `SETTLE_BEFORE` event now calls `flushStreamBuffer`
    before `store.finalizeStream` so buffered text lands in the
    closing slice.
  - `handleComplete`, `flush`, and `reset` flush the buffer too.
- `src/cli/presentation/ink-presentation-service.test.ts`
  - `createRenderer()` factory now passes `{ textBufferMs: 0 }` so
    existing assertions about synchronous `appendStream` behavior
    keep working without rewrites.
  - `when showThinking is false` test that constructs its own
    renderer also passes `{ textBufferMs: 0 }`.
  - Two new tests under `describe("text buffering (textBufferMs)")`:
    - Multiple chunks within one window coalesce into a single
      `appendStream` call.
    - `flush()` drains buffered deltas synchronously even with a
      long buffer window.

## Impact

- **Visible**: streaming text now appears in batches of ~80ms of
  tokens at a time, smoother and more readable than per-token
  flicker. Long single tokens (a multi-character word arriving on
  its own) still feel snappy.
- **CPU**: live-area React re-renders drop from ~60–80/sec to ~12/sec
  during streaming. Markdown formatting on the pending tail
  (which is stateless and runs every render) drops by the same
  factor.
- **No semantics change for end-of-turn output**: the final
  authoritative response is still printed at `complete`, just
  drained from the buffer first.
- **Out of scope for this PR but logical follow-up**: adaptive
  buffering — hold the flush longer while we're inside an open
  code fence or markdown table (use `computeOpenStructureFloor`
  in `markdown-split.ts`) so structured content renders cleanly
  instead of progressively. Captured as a follow-up task.

## How to test

1. Build: `bun src/main.ts chat <agent>`.
2. Send a prompt that triggers a long streaming response (e.g.
   "explain the Linux scheduler in 5 paragraphs").
3. **Expected**: the response visibly streams in chunks roughly
   matching short phrases / line fragments, not a per-character
   flutter. CPU impact (Activity Monitor / `top`) should be lower
   than before.
4. **Edge case (no buffering)**: set
   `output.streaming.textBufferMs: 0` in your config (or
   `~/.jazz/config.json`) and re-run. You should see the previous
   per-token behavior. Confirm the output is still correct.
5. **Edge case (long buffer)**: set
   `output.streaming.textBufferMs: 1000` in config and re-run.
   You should see chunks roughly once per second; the response
   completes correctly and the final text is identical to a normal
   run.
6. **Edge case (interrupted mid-buffer)**: start a long prompt,
   double-tap Esc to interrupt while the model is still streaming.
   Expected: any buffered tail is flushed (visible) before the
   stream finalizes; nothing is lost.
7. **Edge case (kind transition)**: ask a reasoning-capable agent
   a question that produces both reasoning and a response.
   Confirm the dim reasoning block ends cleanly before the bright
   response begins; no buffered reasoning text leaks into the
   response slice.

## Notes for reviewers

- The default of 80ms was picked by feel against the user's
  reference of "claude.ai line-by-line cadence". Configurable per
  user; we can tune the default later based on feedback.
- The buffer is per-renderer-instance, not global. A nested
  sub-agent (which gets its own renderer) has its own independent
  buffer — important once #213 (ephemeral panels) lands and
  sub-agents stream into separate live regions.
- I tested at 0ms, 30ms (in unit tests), and 80ms (manually).
  Behavior is consistent: 0ms is identical to pre-PR; >0ms
  exhibits the coalescing.
- Coalescing assumes nothing else writes to scrollback's pending
  between buffered chunks of the same kind — true today since
  these are the only `appendStream` callers in the renderer.
