### PR TITLE
perf(cli): adaptive buffering for tables and code blocks

### DIFF
--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -269,6 +269,114 @@ describe("InkStreamingRenderer", () => {
         store.appendStream = originalAppend;
       }
     });
+
+    test("adaptive: defers flush while inside an open code fence", async () => {
+      const calls: { delta: string }[] = [];
+      const originalAppend = store.appendStream;
+      store.appendStream = (kind, delta): void => {
+        if (kind === "response") calls.push({ delta });
+        originalAppend(kind, delta);
+      };
+      try {
+        const renderer = new InkStreamingRenderer(
+          "TestAgent",
+          false,
+          {
+            showThinking: true,
+            showToolExecution: true,
+            mode: "rendered",
+            colorProfile: "full",
+          },
+          { textBufferMs: 20 },
+          0,
+        );
+        emitStreamStart(renderer);
+        Effect.runSync(renderer.handleEvent({ type: "text_start" }));
+
+        // Stream the opening of a code fence — buffer ends inside an open
+        // structure, so the adaptive heuristic should defer the flush.
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "Here:\n```ts\nconst x =",
+            accumulated: "Here:\n```ts\nconst x =",
+            sequence: 0,
+          }),
+        );
+
+        // After one buffer window: the deferral should keep the buffer pending.
+        await new Promise((r) => setTimeout(r, 35));
+        expect(calls).toHaveLength(0);
+
+        // Close the fence — open structure resolves, next flush window emits.
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: " 1;\n```\nDone.",
+            accumulated: "Here:\n```ts\nconst x = 1;\n```\nDone.",
+            sequence: 1,
+          }),
+        );
+        await new Promise((r) => setTimeout(r, 35));
+        expect(calls.length).toBeGreaterThan(0);
+        const merged = calls.map((c) => c.delta).join("");
+        expect(merged).toContain("```ts");
+        expect(merged).toContain("Done.");
+      } finally {
+        store.appendStream = originalAppend;
+      }
+    });
+
+    test("adaptive: cap forces flush after MAX_ADAPTIVE_WAIT_MS even if structure stays open", async () => {
+      // Cover the runaway-open-structure case by directly calling flush()
+      // after the buffer window: flush() short-circuits adaptive deferral
+      // unconditionally, which is the same path the real runtime uses on
+      // complete / reset / abort. The MAX_ADAPTIVE_WAIT_MS cap covers the
+      // mid-stream timer-driven case; verifying it requires waiting 2s+
+      // which is wasteful in unit tests.
+      const calls: { delta: string }[] = [];
+      const originalAppend = store.appendStream;
+      store.appendStream = (kind, delta): void => {
+        if (kind === "response") calls.push({ delta });
+        originalAppend(kind, delta);
+      };
+      try {
+        const renderer = new InkStreamingRenderer(
+          "TestAgent",
+          false,
+          {
+            showThinking: true,
+            showToolExecution: true,
+            mode: "rendered",
+            colorProfile: "full",
+          },
+          { textBufferMs: 20 },
+          0,
+        );
+        emitStreamStart(renderer);
+        Effect.runSync(renderer.handleEvent({ type: "text_start" }));
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "text_chunk",
+            delta: "```ts\nconst x = 1\n",
+            accumulated: "```ts\nconst x = 1\n",
+            sequence: 0,
+          }),
+        );
+
+        // Code fence still open after the buffer window — adaptive defers.
+        await new Promise((r) => setTimeout(r, 35));
+        expect(calls).toHaveLength(0);
+
+        // Manual flush (the path used by complete/reset/abort) bypasses
+        // the deferral and emits everything synchronously.
+        Effect.runSync(renderer.flush());
+        expect(calls.length).toBeGreaterThan(0);
+        expect(calls[0]!.delta).toContain("```ts");
+      } finally {
+        store.appendStream = originalAppend;
+      }
+    });
   });
 
   describe("thinking phase", () => {

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -38,6 +38,7 @@ import {
   wrapToWidth,
   getTerminalWidth,
 } from "./markdown-formatter";
+import { isInsideOpenStructure } from "./markdown-split";
 import { AgentResponseCard } from "../ui/AgentResponseCard";
 import { store } from "../ui/store";
 import { CHALK_THEME, PADDING, PADDING_BUDGET, THEME } from "../ui/theme";
@@ -102,6 +103,25 @@ export class InkStreamingRenderer implements StreamingRenderer {
   /** Default buffer cadence — visible "live typing" without burning CPU. */
   private static readonly DEFAULT_TEXT_BUFFER_MS = 80;
 
+  /**
+   * Cumulative response text seen this turn — used to detect whether the
+   * stream is currently "inside" an open markdown structure (code fence,
+   * table). When it is, the next live-area flush is deferred so partial
+   * tables and code blocks don't render with shifting column widths or
+   * recoloring. Reset on text_start / complete / reset / flush.
+   */
+  private cumulativeResponseText = "";
+
+  /**
+   * Wall-clock when adaptive deferral started for the current run of buffered
+   * deltas. Capped at MAX_ADAPTIVE_WAIT_MS so a long fenceless code block
+   * doesn't make the live area silent for many seconds.
+   */
+  private adaptiveDeferStartedAt: number | null = null;
+
+  /** Max time to defer the live-area flush while inside an open structure. */
+  private static readonly MAX_ADAPTIVE_WAIT_MS = 2000;
+
   constructor(
     private readonly agentName: string,
     private readonly showMetrics: boolean,
@@ -128,13 +148,49 @@ export class InkStreamingRenderer implements StreamingRenderer {
       return;
     }
 
+    if (kind === "response") {
+      this.cumulativeResponseText += delta;
+    }
+
     this.streamBuffer.push({ kind, delta });
     if (this.streamFlushTimeoutId !== null) return;
 
+    this.scheduleBufferFlush(this.textBufferMs);
+  }
+
+  /**
+   * Schedule a flush. The handler checks the open-structure heuristic before
+   * flushing: if we're mid-table or mid-code-fence (and within the adaptive
+   * wait cap), reschedule for another `textBufferMs` window so partial
+   * structured content doesn't render incrementally.
+   */
+  private scheduleBufferFlush(delayMs: number): void {
     this.streamFlushTimeoutId = setTimeout(() => {
       this.streamFlushTimeoutId = null;
+
+      if (this.shouldDeferForOpenStructure()) {
+        this.scheduleBufferFlush(this.textBufferMs);
+        return;
+      }
+
+      this.adaptiveDeferStartedAt = null;
       this.flushStreamBuffer();
-    }, this.textBufferMs);
+    }, delayMs);
+  }
+
+  /**
+   * True when the next flush should be deferred because the cumulative
+   * response text ends inside an open markdown structure. Capped by
+   * MAX_ADAPTIVE_WAIT_MS so a runaway open structure (e.g. a 200-line code
+   * block) doesn't keep the live area silent indefinitely.
+   */
+  private shouldDeferForOpenStructure(): boolean {
+    if (!isInsideOpenStructure(this.cumulativeResponseText)) return false;
+    if (this.adaptiveDeferStartedAt === null) {
+      this.adaptiveDeferStartedAt = Date.now();
+      return true;
+    }
+    return Date.now() - this.adaptiveDeferStartedAt < InkStreamingRenderer.MAX_ADAPTIVE_WAIT_MS;
   }
 
   /**
@@ -147,6 +203,8 @@ export class InkStreamingRenderer implements StreamingRenderer {
       clearTimeout(this.streamFlushTimeoutId);
       this.streamFlushTimeoutId = null;
     }
+    // Manual flush short-circuits adaptive deferral — drop the wait timer.
+    this.adaptiveDeferStartedAt = null;
     if (this.streamBuffer.length === 0) return;
     const buffered = this.streamBuffer;
     this.streamBuffer = [];
@@ -182,6 +240,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       this.acc.lastAppliedTextSequence = -1;
       this.seenLength = 0;
       this.hasStreamedText = false;
+      this.cumulativeResponseText = "";
       this.lastUpdateTime = 0;
       this.pendingActivity = null;
       if (this.updateTimeoutId) {
@@ -298,6 +357,10 @@ export class InkStreamingRenderer implements StreamingRenderer {
         // Reset stream-text bookkeeping for the new response stream.
         this.seenLength = 0;
         this.hasStreamedText = false;
+        // The cumulative response text only matters within a single
+        // response stream — drop it so the open-structure heuristic sees
+        // a clean buffer for the new turn.
+        this.cumulativeResponseText = "";
       }
 
       if (event.type === "text_chunk") {
@@ -357,6 +420,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
     // text_start fires before the next text_chunk.
     this.seenLength = 0;
     this.hasStreamedText = false;
+    this.cumulativeResponseText = "";
   }
 
   /** Compute the new portion of the accumulated stream text, based on seenLength. */

--- a/src/cli/presentation/markdown-split.ts
+++ b/src/cli/presentation/markdown-split.ts
@@ -83,6 +83,33 @@ export function findLastSafeSplitPoint(text: string): number {
 }
 
 /**
+ * True when the text is "still inside" a markdown structure that should be
+ * rendered as a unit (code fence, table) rather than progressively chunk-by-chunk.
+ *
+ * Used by the streaming renderer for adaptive buffering: when streamed text
+ * ends inside an open structure, the renderer defers the next live-area flush
+ * (up to a cap) so partial tables and code blocks don't render incrementally
+ * with shifting column widths or syntax-highlighting reflow.
+ *
+ * Conservative — false positives just mean the live area updates a beat later
+ * than the baseline cadence; false negatives let partial structures render.
+ */
+export function isInsideOpenStructure(text: string): boolean {
+  // Open fenced code block?
+  if (findLastUnmatchedFenceStart(text) !== null) return true;
+
+  // Open table: the last non-empty line looks like a table row (`| ... |`),
+  // and we haven't yet seen the next line (no trailing newline → row is in
+  // flight). Plain `|` characters in normal prose don't trip this — we
+  // require the line to *start* with a pipe.
+  const lastNewlineIndex = text.lastIndexOf("\n");
+  const lastLine = lastNewlineIndex === -1 ? text : text.slice(lastNewlineIndex + 1);
+  if (lastLine.trimStart().startsWith("|")) return true;
+
+  return false;
+}
+
+/**
  * Earliest offset still inside an unclosed structure. Split must be ≤ this.
  * For text with no open structures, returns text.length.
  */


### PR DESCRIPTION
## What and why

Builds on the `textBufferMs` baseline (#216) to fix a specific UX
issue with structured content during streaming. When the LLM is
emitting a markdown table or a code block, the buffered ~80ms
flushes still render the partial structure to the live area —
column widths shift as new cells arrive, syntax highlighting
reflows, and the result feels visually noisy.

This PR adds a small adaptive layer on top: when the cumulative
response text ends inside an open structure, defer the next
live-area flush by another buffer window (up to a 2s cap). When the
structure closes, the next flush emits the full content cleanly.
The cap means a runaway open structure (a 200-line code block, a
table that streams over multiple seconds) never makes the live area
silent for more than 2 seconds.

## Before this PR

- A markdown table arriving over 6 chunks showed: `| col1 | col2`
  → `| col1 | col2 |\n|-----` → `| col1 | col2 |\n|-----|----`
  → … each step a separate render with the table renderer trying to
  lay out an incomplete grid. Visible jitter.
- A code block streamed token-by-token rendered with progressively
  reflowing syntax highlighting as new identifiers crossed line
  boundaries.

## After this PR

- While the cumulative response text ends inside an open structure
  (code fence detected via the existing `findLastUnmatchedFenceStart`,
  or open table row detected via `lastLine.trimStart().startsWith("|")`),
  the buffer flush is deferred for another `textBufferMs` window.
- Once the structure closes (closing fence, or last line is no
  longer a table row), the next flush emits all queued deltas.
- 2s adaptive cap: if the structure stays open longer than that,
  the heuristic stops deferring and falls back to the baseline
  cadence. Avoids the "silent live area for 30 seconds" failure
  mode for large code blocks.
- Manual flush paths (`complete`, `reset`, `flush`, abort,
  `SETTLE_BEFORE` events) all short-circuit the deferral
  unconditionally — a closing turn never hangs on the heuristic.

## Changes made

- `src/cli/presentation/markdown-split.ts` — exports a new
  `isInsideOpenStructure(text: string): boolean`. Checks for an
  unclosed code fence (delegates to the existing
  `findLastUnmatchedFenceStart`) or a last-line-starts-with-`|`
  open table row.
- `src/cli/presentation/ink-presentation-service.ts` — adds
  `cumulativeResponseText` (running concatenation per turn),
  `adaptiveDeferStartedAt` (wall-clock for the cap), and
  `MAX_ADAPTIVE_WAIT_MS = 2000`. Refactored the timer setup into
  `scheduleBufferFlush(delayMs)` whose handler checks
  `shouldDeferForOpenStructure()` before dispatching to
  `flushStreamBuffer()`. Reset on `text_start`, `handleComplete`,
  `reset`, and inside `flushStreamBuffer` (which is called by every
  manual-flush path).
- `src/cli/presentation/ink-presentation-service.test.ts` — two new
  tests: the open-fence defer-then-resolve flow, and the manual
  `flush()` bypass.

## Impact

- Visible only during structured-content streaming. Plain prose is
  unaffected because `isInsideOpenStructure` returns false the moment
  the last line is plain text.
- No CLI surface changes. No config changes. The 2s cap is a
  constant, not user-tunable.
- Adaptive deferral runs *on top of* `textBufferMs`, not instead of
  it. Setting `textBufferMs: 0` (the opt-out path used in the
  existing tests) keeps the synchronous-emit behavior for unit
  testing.

## How to test

1. `bun src/main.ts chat <agent>`.
2. Ask the agent to produce a long markdown table (e.g. "list 8
   programming languages with creator and year as a markdown
   table"). Watch the live area:
   - Expected (after this PR): the table appears in a few clean
     batches as rows complete, not a per-cell flicker.
3. Ask for a fenced code block of moderate size (e.g. "show me a
   30-line TypeScript function"). Expected: the code appears in
   1–3 batches with stable syntax highlighting, not a per-token
   reflow.
4. Edge case (cap fires): ask for a very large code block (e.g.
   "paste 200 lines of Python noise without any newlines outside
   the fence"). Expected: visible content arrives every ~2s
   instead of going silent until the fence closes.
5. Edge case (interrupt mid-defer): start a long streaming code
   block, double-tap Esc partway through. Expected: any deferred
   buffer flushes via the abort path; nothing is lost.
6. Edge case (plain prose): hold a normal conversation, no tables
   or code. Streaming should feel identical to #216 (~80ms
   cadence).

## Notes for reviewers

- The 2s cap is a guess based on "long enough to avoid jitter on
  big code blocks, short enough that a stuck stream doesn't feel
  hung". Easy to tune later if needed.
- The table heuristic is intentionally lenient — any line starting
  with `|` triggers it. False positives (someone writing prose with
  a leading `|`) just mean a one-buffer-window delay; harmless.
- I considered also detecting open lists (`-`, `*`, `1.`), but
  lists generally render fine progressively — column-width-style
  layout isn't a concern. Skipped to avoid unnecessary deferral.
- The cumulative text only tracks `kind === "response"`. Reasoning
  goes through the same buffer but doesn't get the adaptive
  treatment because reasoning is shown in a bounded panel where
  partial rendering is expected. (Tied to #213's ephemeral panels
  feature, but works fine without it on main today.)
