### PR TITLE
feat(history): session storage and conversation history

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Format staged TypeScript/TSX files with prettier before committing.
+
+staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx)$')
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+echo "$staged" | xargs bun prettier --write --log-level warn
+echo "$staged" | xargs git add

--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent",
-  "model": "openrouter/free",
+  "model": "openai/gpt-oss-120b:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "openrouter/free",
+    "llmModel": "openai/gpt-oss-120b:free",
     "reasoningEffort": "medium",
     "tools": [
       "find",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -2,11 +2,11 @@
   "id": "pr-assistant",
   "name": "pr-assistant",
   "description": "Pull request assistant agent for /jazz PR comments",
-  "model": "openrouter/free",
+  "model": "openai/gpt-oss-120b:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "openrouter/free",
+    "llmModel": "openai/gpt-oss-120b:free",
     "reasoningEffort": "medium",
     "tools": [
       "find",

--- a/.github/jazz/agents/release-notes.json
+++ b/.github/jazz/agents/release-notes.json
@@ -2,11 +2,11 @@
   "id": "release-notes",
   "name": "release-notes",
   "description": "Release notes generator agent",
-  "model": "openrouter/free",
+  "model": "openai/gpt-oss-120b:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "openrouter/free",
+    "llmModel": "openai/gpt-oss-120b:free",
     "reasoningEffort": "medium",
     "tools": [
       "find",

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -135,25 +135,38 @@ If a comment doesn't pass all five, drop it. Volume is not the goal; signal is.
 
 ## Output Format
 
-### Wrapper rule — read this carefully
+Your output has **two mandatory blocks**, in this order:
 
-The very last thing you output MUST be a JSON array wrapped in a **FOUR-backtick** ` ````json ` fenced block. Four. Not three.
+1. A **`````markdown`** summary block — always required, never empty
+2. A **`````json`** inline-comments block — always required, may be `[]`
 
-Three backticks will silently corrupt your output: your `body` fields will routinely contain triple-backtick code samples (` ```diff `, ` ```ts `, etc.), and a triple-backtick outer fence collides with them. The downstream parser truncates at the first inner ` ``` ` and you get "Unterminated string in JSON at position …" — your entire review is discarded.
+### Block 1 — Markdown summary (always required)
 
-| ✅ DO (this is what works) | ❌ DON'T (this breaks parsing) |
+Write a human-readable review summary. This is posted as the top-level PR comment regardless of whether inline comments exist. It must never be empty.
+
+Include:
+- Which files you reviewed (a brief list or count)
+- Overall verdict: what looks good, what was changed and why it's correct, or what issues were found
+- If no inline issues: say so clearly and briefly explain what you checked
+
+### Block 2 — Inline comments (always required, may be `[]`)
+
+A JSON array of per-line review comments. Use `[]` when there are no inline findings — but Block 1 must still explain the review.
+
+**Four-backtick rule for both blocks.** Three backticks will corrupt your output: `body` fields routinely contain triple-backtick code samples, and a triple-backtick outer fence collides with them. Use four backticks for both outer wrappers.
+
+| ✅ DO | ❌ DON'T |
 |---|---|
-| `` ` ` ` ` json `` …4 backticks… `` ` ` ` ` `` | `` ` ` ` json `` …3 backticks… `` ` ` ` `` |
-
-Inside the four-backtick wrapper, your `body` fields can use normal three-backtick fences for code — they nest cleanly. **Only the outer wrapper is four backticks.**
-
-Do NOT output anything after the closing four-backtick fence — no commentary, no "let me know if…", no summary. The fence is the end.
+| `` ` ` ` ` markdown `` …summary… `` ` ` ` ` `` then `` ` ` ` ` json `` …array… `` ` ` ` ` `` | `` ` ` ` json `` …3 backticks… `` ` ` ` `` |
+| Inner code fences inside `body` use **three** backticks | Output anything after the closing JSON fence |
 
 When flagging issues, suggest concrete edits (code snippets or exact changes) when possible.
 
-### Example
+### Example (issues found)
 
-Each element of the array is one review comment tied to a specific file and line(s). Note the outer fence is four backticks; the inner ` ```ts ` is three.
+````markdown
+Reviewed 3 files. Found 2 issues: one null-dereference in `src/example.ts` and a suggestion in `src/utils.ts`.
+````
 
 ````json
 [
@@ -173,32 +186,40 @@ Each element of the array is one review comment tied to a specific file and line
 ]
 ````
 
+### Example (no issues)
+
+````markdown
+Reviewed 5 files (`src/cli/ui/store.ts`, `src/services/chat-service.ts`, and 3 others).
+
+Changes look correct: the `resetRunStats` call properly clears stale session data, the queue injection follows the existing tool-call loop pattern, and the AI SDK promise suppression is well-scoped to the error path only. No logic errors, type gaps, or edge cases missed.
+````
+
+````json
+[]
+````
+
 ### Self-check before emitting
 
-Before you write your final block, verify:
+1. Did you emit a `````markdown` block first? It must be non-empty.
+2. Did you emit a `````json` block second? The array may be `[]` but the block must be present.
+3. Both outer fences use **four** backticks. Count them.
+4. Inner code fences inside `body` use **three** backticks.
+5. Nothing after the closing JSON fence.
 
-1. The outer fence opens with **four** backticks + `json` and closes with **four** backticks. Count them.
-2. There is **no text after** the closing four-backtick fence.
-3. If a `body` field contains a code sample, that inner fence uses **three** backticks (not one, not four). Three is correct for nested code.
-
-Rules:
+### Inline comment field rules
 
 - `path`: relative file path from repo root (must exist in the diff)
 - `line`: line number; use the NEW version (RIGHT side) for added/modified files, or the OLD version (LEFT side) for deleted files
 - `start_line`: (optional) start line for multi-line block comments; omit for single-line
-- `side`: "RIGHT" for added/modified files (comment on new code); use "LEFT" or omit for deleted files (the CI workflow auto-detects removed files and uses LEFT)
-- `body`: markdown comment — include severity (Critical/Suggestion/Nice-to-have), explanation, and a concrete fix when possible
+- `side`: "RIGHT" for added/modified files; "LEFT" for deleted files
+- `body`: markdown — include severity (Critical/Suggestion/Nice-to-have), explanation, and a concrete fix when possible
 
 **CRITICAL — Line number accuracy:**
 
-The `line` field MUST reference a line that actually appears in the diff output. The GitHub API will reject comments on lines that are outside the diff hunks (changed lines + context lines). Before emitting a comment:
+The `line` field MUST reference a line that actually appears in the diff output. The GitHub API will reject comments on lines outside the diff hunks.
 
-1. **Verify the line is in the diff** — only comment on lines you can see in the `git_diff` output. If a line number does not appear in the diff hunks, do NOT use it.
-2. **Do NOT guess or extrapolate line numbers** — if the relevant code is not visible in the diff, either find the nearest diff line that provides enough context, or omit the comment entirely.
-3. **Prefer changed lines** — comment on added/modified lines (prefixed with `+` in the diff) whenever possible, as these are always valid targets.
-4. **Context lines are also valid** — unchanged lines shown in the diff hunk (no `+` or `-` prefix) can also be commented on.
-5. **Lines outside the diff are NOT valid** — even if the file is in the PR, lines that fall outside any hunk range will cause a "Line could not be resolved" API error.
-
-If you want to comment on code that is not in the diff (e.g., a pre-existing issue near the changed code), mention it in the `body` of a comment attached to the nearest valid diff line instead.
-
-If there are no issues, output an empty array: `[]`
+1. **Verify the line is in the diff** — only comment on lines visible in `git_diff` output.
+2. **Do NOT guess or extrapolate line numbers** — if the relevant code is not in the diff, attach the comment to the nearest valid diff line.
+3. **Prefer changed lines** — lines prefixed with `+` in the diff are always valid targets.
+4. **Context lines are also valid** — unchanged lines shown in the diff hunk can be commented on.
+5. **Lines outside the diff are NOT valid** — they cause a "Line could not be resolved" API error.

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -135,10 +135,12 @@ If a comment doesn't pass all five, drop it. Volume is not the goal; signal is.
 
 ## Output Format
 
-Your output has **two mandatory blocks**, in this order:
+**STOP — read this before writing any output.**
 
-1. A **`````markdown`** summary block — always required, never empty
-2. A **`````json`** inline-comments block — always required, may be `[]`
+Your output MUST contain exactly two fenced blocks in this order. Missing either block causes the review to silently fail. No exceptions.
+
+1. A **`````markdown`** summary block — **always required, never empty**, even when there are no issues
+2. A **`````json`** inline-comments block — **always required**, may be `[]`
 
 ### Block 1 — Markdown summary (always required)
 

--- a/.github/jazz/workflows/pr-assistant/WORKFLOW.md
+++ b/.github/jazz/workflows/pr-assistant/WORKFLOW.md
@@ -35,6 +35,7 @@ The requester said:
 5. If the request looks like a review request, prioritize correctness, security, and maintainability — and don't repeat issues already raised in prior `reviews` / `reviewComments`.
 6. If the request is asking for code changes, explain the exact files or functions that need to change and what to do. You cannot edit code or call GitHub yourself — describe the change instead.
 7. Keep the response concise, practical, and PR-ready.
+8. **Never return an empty response.** Even if the request is unclear or the diff is trivial, always produce a substantive answer: summarize what you found, explain what the PR does, or ask a clarifying question. A blank or one-word reply is not acceptable.
 
 ## Output Format — read this first
 

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -287,8 +287,14 @@ jobs:
               if (agent.model) modelLabel = `\n\n*Model: ${agent.model}*`;
             } catch (_) {}
 
-            // Prefer the agent's four-backtick fence; fall back to a
-            // last-occurrence scan of the three-backtick form so inner
+            // Extract the markdown summary block (Block 1) — always present per the workflow contract.
+            const extractFencedMarkdown = (text) => {
+              const fourFence = text.match(/````markdown\s*\n([\s\S]*?)\n?````/);
+              return fourFence ? fourFence[1].trim() : null;
+            };
+
+            // Extract the JSON inline-comments block (Block 2). Prefer four-backtick fence;
+            // fall back to last-occurrence scan of three-backtick form so inner
             // ```diff/```ts samples in `body` don't truncate the wrapper.
             const extractFencedJson = (text) => {
               const fourFence = text.match(/````json\s*\n([\s\S]*?)\n?````/);
@@ -302,6 +308,8 @@ jobs:
               return after.slice(0, close).trim();
             };
 
+            const markdownSummary = extractFencedMarkdown(output);
+
             let comments = [];
             const jsonText = extractFencedJson(output);
             if (jsonText) {
@@ -312,14 +320,18 @@ jobs:
               }
             }
 
+            // Build the review body from the agent's markdown summary when available,
+            // falling back to a generic message only when the agent produced nothing.
+            const summarySection = markdownSummary
+              ? markdownSummary
+              : '_No review summary produced._';
+
             if (!Array.isArray(comments) || comments.length === 0) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body: comments.length === 0
-                  ? `## Jazz Code Review\n\nNo issues found.${modelLabel}`
-                  : `## Jazz Code Review\n\n${output.slice(-60000) || '_No output from review._'}`
+                body: `## Jazz Code Review\n\n${summarySection}${modelLabel}`,
               });
               return;
             }
@@ -342,7 +354,7 @@ jobs:
 
             // Any comments that couldn't be posted inline become part of the review body
             const invalidComments = sanitized.filter(c => !validComments.includes(c));
-            let reviewBody = `## Jazz Code Review\n\nFound ${comments.length} comment(s).${modelLabel}`;
+            let reviewBody = `## Jazz Code Review\n\n${summarySection}${modelLabel}`;
             if (invalidComments.length > 0) {
               reviewBody += '\n\n### General Comments\n\n';
               reviewBody += invalidComments.map(c => `- ${c.body}`).join('\n');
@@ -602,7 +614,7 @@ jobs:
 
             const extracted = extractAnswer(output);
             let commentBody;
-            if (!extracted) {
+            if (!extracted || !extracted.body.trim()) {
               commentBody = `_The Jazz assistant didn't produce a usable answer. ` +
                 `See the [workflow run](${runUrl}) for details._`;
             } else if (extracted.strict) {

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -287,10 +287,15 @@ jobs:
               if (agent.model) modelLabel = `\n\n*Model: ${agent.model}*`;
             } catch (_) {}
 
-            // Extract the markdown summary block (Block 1) — always present per the workflow contract.
+            // Extract the markdown summary block (Block 1).
+            // Prefer four-backtick fence; fall back to three-backtick so weaker
+            // models that ignore the four-backtick rule still produce a summary.
             const extractFencedMarkdown = (text) => {
               const fourFence = text.match(/````markdown\s*\n([\s\S]*?)\n?````/);
-              return fourFence ? fourFence[1].trim() : null;
+              if (fourFence) return fourFence[1].trim();
+              const threeFence = text.match(/```markdown\s*\n([\s\S]*?)\n?```/);
+              if (threeFence) return threeFence[1].trim();
+              return null;
             };
 
             // Extract the JSON inline-comments block (Block 2). Prefer four-backtick fence;
@@ -320,11 +325,12 @@ jobs:
               }
             }
 
-            // Build the review body from the agent's markdown summary when available,
-            // falling back to a generic message only when the agent produced nothing.
+            // Build the review body from the agent's markdown summary when available.
+            // Fall back to a generated summary so the comment is never empty.
             const summarySection = markdownSummary
-              ? markdownSummary
-              : '_No review summary produced._';
+              || (Array.isArray(comments) && comments.length > 0
+                ? `Found ${comments.length} issue(s). See inline comments below.`
+                : 'No issues found.');
 
             if (!Array.isArray(comments) || comments.length === 0) {
               await github.rest.issues.createComment({

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dev": "bun --watch src/main.ts",
     "start": "bun dist/main.js",
     "cli": "bun src/main.ts",
+    "prepare": "git config core.hooksPath .githooks || true",
     "lint": "bun eslint src --cache",
     "lint:fix": "bun eslint src --fix --cache",
     "format": "bun prettier --write src",

--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -619,6 +619,7 @@ async function promptForAgentInfo(
         const result = await Effect.runPromise(
           terminal.ask(`Describe what this agent will do ${hint}:`, {
             ...descOptions,
+            placeholder: "(optional, press Enter to skip)",
           }),
         );
 

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -65,6 +65,18 @@ export function wizardCommand() {
         }
       }
 
+      // Check if any agent has saved conversation history
+      let hasConversationHistory = false;
+      for (const agent of agents) {
+        const history = yield* loadHistory(agent.id).pipe(
+          Effect.catchAll(() => Effect.succeed({ agentId: agent.id, conversations: [] })),
+        );
+        if (history.conversations.length > 0) {
+          hasConversationHistory = true;
+          break;
+        }
+      }
+
       // Build menu options dynamically
       const menuOptions: WizardMenuOption[] = [];
 
@@ -80,6 +92,9 @@ export function wizardCommand() {
           label: "New conversation",
           value: "new-conversation",
         });
+      }
+
+      if (hasConversationHistory) {
         menuOptions.push({
           label: "Resume conversation",
           value: "resume-conversation",
@@ -410,7 +425,7 @@ function resumeConversation(
     const selectedIdx = yield* terminal.select<string>("Select a conversation to resume:", {
       choices,
     });
-    if (!selectedIdx && selectedIdx !== "0") return;
+    if (selectedIdx === null || selectedIdx === undefined) return;
 
     const selected = entries[Number(selectedIdx)];
     if (!selected) return;

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -414,13 +414,10 @@ function resumeConversation(
     // Sort newest first
     entries.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
 
-    const choices = entries.map((entry, idx) => {
-      const date = new Date(entry.startedAt).toLocaleDateString();
-      return {
-        name: `[${entry.agent.name}] ${entry.title} (${date}, ${entry.messageCount} msgs)`,
-        value: String(idx),
-      };
-    });
+    const choices = entries.map((entry, idx) => ({
+      name: `${entry.title} · ${entry.agent.model}`,
+      value: String(idx),
+    }));
 
     const selectedIdx = yield* terminal.select<string>("Select a conversation to resume:", {
       choices,

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -5,7 +5,9 @@ import { AgentServiceTag } from "@/core/interfaces/agent-service";
 import { ChatServiceTag } from "@/core/interfaces/chat-service";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/index";
+import type { ChatMessage } from "@/core/types/message";
 import { sortAgents } from "@/core/utils/agent-sort";
+import { loadHistory } from "@/services/history/conversation-history-service";
 import { listAgentsCommand, deleteAgentCommand } from "./agent-management";
 import { configWizardCommand } from "./config-wizard";
 import { createAgentCommand } from "./create-agent";
@@ -19,6 +21,7 @@ import { WizardHome, type WizardMenuOption } from "../ui/WizardHome";
 type MenuAction =
   | "continue"
   | "new-conversation"
+  | "resume-conversation"
   | "create-agent"
   | "edit-agent"
   | "list-agents"
@@ -77,6 +80,10 @@ export function wizardCommand() {
           label: "New conversation",
           value: "new-conversation",
         });
+        menuOptions.push({
+          label: "Resume conversation",
+          value: "resume-conversation",
+        });
       }
 
       menuOptions.push({ label: "Create agent", value: "create-agent" });
@@ -119,6 +126,12 @@ export function wizardCommand() {
             yield* startChatWithAgent(selectedAgent, configService);
             yield* terminal.clear();
           }
+          break;
+        }
+
+        case "resume-conversation": {
+          yield* resumeConversation(agents, terminal, configService);
+          yield* terminal.clear();
           break;
         }
 
@@ -305,7 +318,11 @@ function selectAgent(
 /**
  * Start a chat session with an agent and save as last used
  */
-function startChatWithAgent(agent: Agent, configService: AgentConfigService) {
+function startChatWithAgent(
+  agent: Agent,
+  configService: AgentConfigService,
+  options?: { initialHistory?: ChatMessage[]; initialConversationTitle?: string },
+) {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
 
@@ -329,13 +346,79 @@ function startChatWithAgent(agent: Agent, configService: AgentConfigService) {
 
     // Start the chat session
     const chatService = yield* ChatServiceTag;
-    yield* chatService.startChatSession(agent).pipe(
+    yield* chatService.startChatSession(agent, options).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
           yield* terminal.error(`Chat session error: ${String(error)}`);
         }),
       ),
     );
+  });
+}
+
+/**
+ * Load all saved conversations across agents, show a selector, and resume the chosen one
+ */
+function resumeConversation(
+  agents: readonly Agent[],
+  terminal: TerminalService,
+  configService: AgentConfigService,
+) {
+  return Effect.gen(function* () {
+    type ConversationEntry = {
+      agent: Agent;
+      conversationId: string;
+      title: string;
+      startedAt: string;
+      messageCount: number;
+      messages: ChatMessage[];
+    };
+    const entries: ConversationEntry[] = [];
+
+    for (const agent of agents) {
+      const history = yield* loadHistory(agent.id).pipe(
+        Effect.catchAll(() => Effect.succeed({ agentId: agent.id, conversations: [] })),
+      );
+      for (const conv of history.conversations) {
+        entries.push({
+          agent,
+          conversationId: conv.conversationId,
+          title: conv.title,
+          startedAt: conv.startedAt,
+          messageCount: conv.messageCount,
+          messages: conv.messages,
+        });
+      }
+    }
+
+    if (entries.length === 0) {
+      yield* terminal.warn("No saved conversations found.");
+      return;
+    }
+
+    // Sort newest first
+    entries.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+
+    const choices = entries.map((entry, idx) => {
+      const date = new Date(entry.startedAt).toLocaleDateString();
+      return {
+        name: `[${entry.agent.name}] ${entry.title} (${date}, ${entry.messageCount} msgs)`,
+        value: String(idx),
+      };
+    });
+
+    const selectedIdx = yield* terminal.select<string>("Select a conversation to resume:", {
+      choices,
+    });
+    if (!selectedIdx && selectedIdx !== "0") return;
+
+    const selected = entries[Number(selectedIdx)];
+    if (!selected) return;
+
+    yield* startChatWithAgent(selected.agent, configService, {
+      initialHistory: selected.messages,
+      initialConversationTitle: selected.title,
+    });
   });
 }
 

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -233,6 +233,8 @@ export function reduceEvent(
       acc.lastAgentHeaderWritten = true;
       acc.currentProvider = event.provider;
       acc.currentModel = event.model;
+      acc.lastAppliedTextSequence = -1;
+      acc.isThinking = false;
 
       outputs.push({
         type: "info",

--- a/src/cli/ui/components/TextInput.tsx
+++ b/src/cli/ui/components/TextInput.tsx
@@ -57,6 +57,7 @@ export const TextInput = React.memo(function TextInput({
   const onSubmitRef = useRef(onSubmit);
   const validateRef = useRef(validate);
   const onCancelRef = useRef(onCancel);
+  const valueWhenValidationFailedRef = useRef<string | null>(null);
 
   // Keep refs up to date
   onSubmitRef.current = onSubmit;
@@ -69,10 +70,12 @@ export const TextInput = React.memo(function TextInput({
       const result = validateRef.current(val);
       if (result !== true) {
         setValidationError(typeof result === "string" ? result : "Invalid input");
+        valueWhenValidationFailedRef.current = val;
         return;
       }
     }
     setValidationError(null);
+    valueWhenValidationFailedRef.current = null;
     onSubmitRef.current(val);
   }, []);
 
@@ -104,10 +107,14 @@ export const TextInput = React.memo(function TextInput({
     }
   });
 
-  // Clear validation error when user types
   useEffect(() => {
-    if (validationError && value !== "") {
+    const snapshot = valueWhenValidationFailedRef.current;
+    if (validationError === null || snapshot === null) {
+      return;
+    }
+    if (value !== snapshot) {
       setValidationError(null);
+      valueWhenValidationFailedRef.current = null;
     }
   }, [value, validationError]);
 

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -210,9 +210,15 @@ export class UIStore {
    * incremental updates (e.g. tokens-in-context after every LLM call,
    * costUSD only after we've resolved pricing).
    */
+  resetRunStats = (initial: RunStats = {}): void => {
+    this.runStatsSnapshot = initial;
+    if (this.runStatsSetter) {
+      this.runStatsSetter(initial);
+    }
+  };
+
   updateRunStats = (patch: Partial<RunStats>): void => {
     const next: RunStats = { ...this.runStatsSnapshot, ...patch };
-    // Bail out if nothing changed (cheap by-key check).
     let changed = false;
     for (const k of Object.keys(patch) as (keyof RunStats)[]) {
       if (this.runStatsSnapshot[k] !== next[k]) {

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -6,6 +6,21 @@ import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { DEFAULT_PROMPT } from "./prompts/default/system";
 import { SKILLS_INSTRUCTIONS } from "./prompts/shared";
 
+function formatUtcOffsetLabel(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset();
+  if (offsetMinutes === 0) {
+    return "UTC";
+  }
+  const sign = offsetMinutes > 0 ? "+" : "-";
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const hours = Math.floor(absoluteMinutes / 60);
+  const minutes = absoluteMinutes % 60;
+  if (minutes === 0) {
+    return `UTC${sign}${hours}`;
+  }
+  return `UTC${sign}${hours}:${String(minutes).padStart(2, "0")}`;
+}
+
 export interface AgentPersona {
   readonly name: string;
   readonly description: string;
@@ -91,12 +106,14 @@ export class AgentPromptBuilder {
   > {
     return Effect.sync(() => {
       const now = new Date();
-      const currentDate = now.toLocaleDateString("en-US", {
+      const calendarDate = now.toLocaleDateString("en-US", {
         weekday: "long",
         year: "numeric",
         month: "long",
         day: "numeric",
       });
+      const timeZoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const currentDate = `${calendarDate} (${formatUtcOffsetLabel(now)}, ${timeZoneId})`;
       const platform = os.platform();
       const release = os.release();
       const machine = os.machine();

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -406,6 +406,11 @@ export function executeAgentLoop(
                 toolCalls: completion.toolCalls,
                 toolResults: Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
               };
+
+              const queuedMessage = options.checkQueuedMessage?.();
+              if (queuedMessage) {
+                currentMessages.push({ role: "user", content: queuedMessage });
+              }
               continue;
             }
 

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -98,6 +98,14 @@ export interface AgentRunnerOptions {
    * from the approval prompt.
    */
   readonly onAutoApproveTool?: (toolName: string) => void;
+  /**
+   * Optional callback polled between tool-call batches (before the next LLM
+   * call) to inject a queued user message into the running conversation.
+   * When it returns a non-empty string, that string is appended as a user
+   * message so the agent can incorporate mid-run guidance immediately.
+   * Not called for internal (sub-agent) runs.
+   */
+  readonly checkQueuedMessage?: () => string | undefined;
 }
 
 /**

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -10,6 +10,9 @@ export const TOOL_TIMEOUT_MS = 3 * 60 * 1000;
 /** Maximum number of workflow run history records to keep */
 export const MAX_RUN_HISTORY_RECORDS = 100;
 
+/** Maximum number of conversation history records to keep per agent */
+export const MAX_CONVERSATION_HISTORY_PER_AGENT = 5;
+
 /** Default maximum age for workflow catch-up runs in seconds (24 hours) */
 export const DEFAULT_MAX_CATCH_UP_AGE_SECONDS = 60 * 60 * 24;
 

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -2,6 +2,7 @@ import type { FileSystem } from "@effect/platform";
 import { Context, Effect } from "effect";
 import type { SkillService } from "@/core/skills/skill-service";
 import type { Agent } from "@/core/types/index";
+import type { ChatMessage } from "@/core/types/message";
 import type { WorkflowService } from "@/core/workflows/workflow-service";
 import { AgentConfigServiceTag } from "./agent-config";
 import type { AgentService } from "./agent-service";
@@ -33,6 +34,8 @@ export interface ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      initialHistory?: ChatMessage[];
+      initialConversationTitle?: string;
     },
   ) => Effect.Effect<
     void,

--- a/src/core/utils/runtime-detection.ts
+++ b/src/core/utils/runtime-detection.ts
@@ -78,6 +78,16 @@ export function getGlobalUserDataDirectory(): string {
 }
 
 /**
+ * Get the directory where Jazz stores per-agent conversation history.
+ *
+ * - Global install: ~/.jazz/history
+ * - Development:    ./.jazz/history
+ */
+export function getHistoryDirectory(): string {
+  return path.join(getUserDataDirectory(), "history");
+}
+
+/**
  * Get the jazz-ai package's root directory (where package.json lives).
  *
  * This is used to locate built-in assets (skills, templates, etc.) that ship

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -205,7 +205,11 @@ export class ChatServiceImpl implements ChatService {
           continue;
         }
 
-        if (conversationTitle === null && trimmedMessage.length > 0 && !trimmedMessage.startsWith("/")) {
+        if (
+          conversationTitle === null &&
+          trimmedMessage.length > 0 &&
+          !trimmedMessage.startsWith("/")
+        ) {
           conversationTitle = trimmedMessage.slice(0, 80);
         }
 
@@ -247,6 +251,7 @@ export class ChatServiceImpl implements ChatService {
 
             if (commandResult.newConversationId !== undefined) {
               conversationId = commandResult.newConversationId;
+              conversationTitle = null;
               sessionUsage = { promptTokens: 0, completionTokens: 0 };
               // Initialize the new conversation
               const fileSystemContext = yield* FileSystemContextServiceTag;

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -40,6 +40,7 @@ import {
   bumpPromotionThreshold,
   type CommandApprovalRecord,
 } from "./command-approval-tracker";
+import { saveConversation, type ConversationRecord } from "./history/conversation-history-service";
 
 /**
  * Chat service implementation for managing interactive chat sessions with AI agents
@@ -107,6 +108,8 @@ export class ChatServiceImpl implements ChatService {
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
+      const startedAt = sessionStartedAt.toISOString();
+      let conversationTitle: string | null = null;
 
       // Load persistent auto-approved commands from config
       const configService = yield* AgentConfigServiceTag;
@@ -200,6 +203,10 @@ export class ChatServiceImpl implements ChatService {
             "(Tip) Type a message and press Enter, '/help' for commands, or '/exit' to quit.",
           );
           continue;
+        }
+
+        if (conversationTitle === null && trimmedMessage.length > 0 && !trimmedMessage.startsWith("/")) {
+          conversationTitle = trimmedMessage.slice(0, 80);
         }
 
         let messageForAgent = userMessage;
@@ -503,6 +510,25 @@ export class ChatServiceImpl implements ChatService {
             }
           }
         });
+      }
+
+      if (conversationTitle !== null && conversationHistory.length > 0) {
+        const record: ConversationRecord = {
+          conversationId,
+          title: conversationTitle,
+          agentId: agent.id,
+          startedAt,
+          endedAt: new Date().toISOString(),
+          messageCount: conversationHistory.length,
+          messages: conversationHistory,
+        };
+        const fs = yield* FileSystem.FileSystem;
+        const fsLayer = Layer.succeed(FileSystem.FileSystem, fs);
+        yield* saveConversation(record).pipe(
+          Effect.catchAll(() => Effect.void),
+          Effect.provide(fsLayer),
+          Effect.forkDaemon,
+        );
       }
     }).pipe(Effect.catchAll(() => Effect.void));
   }

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -285,6 +285,7 @@ export class ChatServiceImpl implements ChatService {
               conversationHistory = commandResult.newHistory;
               // Reset logged message count when history is cleared (e.g., /new command)
               loggedMessageCount = 0;
+              conversationTitle = null;
             }
             if (commandResult.newAutoApprovePolicy !== undefined) {
               autoApprovePolicy = commandResult.newAutoApprovePolicy || undefined;

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -102,6 +102,8 @@ export class ChatServiceImpl implements ChatService {
       // Errors are handled gracefully inside setupAgent - conversation continues even if some MCPs fail
       yield* setupAgent(agent, sessionId);
 
+      store.resetRunStats({ provider: agent.config.llmProvider, model: agent.config.llmModel });
+
       let chatActive = true;
       let conversationHistory: ChatMessage[] = options?.initialHistory ?? [];
       let loggedMessageCount = 0;
@@ -365,6 +367,10 @@ export class ChatServiceImpl implements ChatService {
               if (!autoApprovedTools.includes(toolName)) {
                 autoApprovedTools.push(toolName);
               }
+            },
+            checkQueuedMessage: () => {
+              const queued = store.takeQueue();
+              return queued.length > 0 ? queued : undefined;
             },
           };
 

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -50,6 +50,8 @@ export class ChatServiceImpl implements ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      initialHistory?: ChatMessage[];
+      initialConversationTitle?: string;
     },
   ): Effect.Effect<
     void,
@@ -101,7 +103,7 @@ export class ChatServiceImpl implements ChatService {
       yield* setupAgent(agent, sessionId);
 
       let chatActive = true;
-      let conversationHistory: ChatMessage[] = [];
+      let conversationHistory: ChatMessage[] = options?.initialHistory ?? [];
       let loggedMessageCount = 0;
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
@@ -109,7 +111,7 @@ export class ChatServiceImpl implements ChatService {
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
       let startedAt = sessionStartedAt.toISOString();
-      let conversationTitle: string | null = null;
+      let conversationTitle: string | null = options?.initialConversationTitle ?? null;
 
       // Load persistent auto-approved commands from config
       const configService = yield* AgentConfigServiceTag;

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -309,6 +309,9 @@ export class ChatServiceImpl implements ChatService {
               loggedMessageCount = 0;
               conversationTitle = null;
             }
+            if (commandResult.resetStartedAt) {
+              startedAt = new Date().toISOString();
+            }
             if (commandResult.newAutoApprovePolicy !== undefined) {
               autoApprovePolicy = commandResult.newAutoApprovePolicy || undefined;
             }

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -108,7 +108,7 @@ export class ChatServiceImpl implements ChatService {
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
-      const startedAt = sessionStartedAt.toISOString();
+      let startedAt = sessionStartedAt.toISOString();
       let conversationTitle: string | null = null;
 
       // Load persistent auto-approved commands from config
@@ -249,9 +249,27 @@ export class ChatServiceImpl implements ChatService {
               context,
             );
 
+            if (
+              commandResult.saveCurrentHistory &&
+              conversationTitle !== null &&
+              conversationHistory.length > 0
+            ) {
+              const record: ConversationRecord = {
+                conversationId,
+                title: conversationTitle,
+                agentId: agent.id,
+                startedAt,
+                endedAt: new Date().toISOString(),
+                messageCount: conversationHistory.length,
+                messages: conversationHistory,
+              };
+              yield* saveConversation(record).pipe(Effect.catchAll(() => Effect.void));
+            }
+
             if (commandResult.newConversationId !== undefined) {
               conversationId = commandResult.newConversationId;
               conversationTitle = null;
+              startedAt = new Date().toISOString();
               sessionUsage = { promptTokens: 0, completionTokens: 0 };
               // Initialize the new conversation
               const fileSystemContext = yield* FileSystemContextServiceTag;
@@ -528,13 +546,7 @@ export class ChatServiceImpl implements ChatService {
           messageCount: conversationHistory.length,
           messages: conversationHistory,
         };
-        const fs = yield* FileSystem.FileSystem;
-        const fsLayer = Layer.succeed(FileSystem.FileSystem, fs);
-        yield* saveConversation(record).pipe(
-          Effect.catchAll(() => Effect.void),
-          Effect.provide(fsLayer),
-          Effect.forkDaemon,
-        );
+        yield* saveConversation(record).pipe(Effect.catchAll(() => Effect.void));
       }
     }).pipe(Effect.catchAll(() => Effect.void));
   }

--- a/src/services/chat/commands/constants.ts
+++ b/src/services/chat/commands/constants.ts
@@ -21,6 +21,7 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "mcp", description: "Show MCP server status and connections" },
   { name: "mode", description: "Switch between safe mode and yolo mode for tool approvals" },
   { name: "model", description: "Show or change model and reasoning effort" },
+  { name: "resume", description: "Browse and resume a past conversation" },
   { name: "new", description: "Start a new conversation (clear context)" },
   { name: "skills", description: "List and view available skills" },
   { name: "stats", description: "Show session statistics and usage summary" },

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
+import type { Agent } from "@/core/types/agent";
+import type { ChatMessage } from "@/core/types/message";
+import { saveConversation } from "@/services/history/conversation-history-service";
+import { handleSpecialCommand } from "./handler";
+import type { CommandContext } from "./types";
+
+let tmpDir = "";
+
+mock.module("@/core/utils/runtime-detection", () => ({
+  getHistoryDirectory: () => tmpDir,
+  getUserDataDirectory: () => tmpDir,
+  getGlobalUserDataDirectory: () => tmpDir,
+  getPackageRootDirectory: () => null,
+  getBuiltinSkillsDirectory: () => null,
+  getGlobalSkillsDirectory: () => tmpDir,
+  getAgentsSkillsDirectory: () => tmpDir,
+  getBuiltinPersonasDirectory: () => null,
+  getBuiltinWorkflowsDirectory: () => null,
+  getGlobalWorkflowsDirectory: () => tmpDir,
+  isRunningFromGlobalInstall: () => false,
+  isRunningInDevelopmentMode: () => false,
+  findExecutablePathViaShell: () => Effect.succeed(null),
+  detectPackageManagerFromPath: () => null,
+  getJazzSchedulerInvocation: () => Effect.succeed([]),
+}));
+
+const TEST_AGENT_ID = "test-agent-resume";
+
+const testAgent: Agent = {
+  id: TEST_AGENT_ID,
+  name: "Test Agent",
+  description: "Test agent for resume command tests",
+  model: "openai/gpt-4",
+  config: {
+    persona: "default",
+    llmProvider: "openai",
+    llmModel: "gpt-4",
+    tools: [],
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const testRecord = {
+  conversationId: "conv-to-resume",
+  title: "A past conversation",
+  agentId: TEST_AGENT_ID,
+  startedAt: new Date(Date.now() - 3600_000).toISOString(),
+  endedAt: new Date(Date.now() - 3000_000).toISOString(),
+  messageCount: 2,
+  messages: [
+    { role: "user" as const, content: "Hello" },
+    { role: "assistant" as const, content: "Hi there" },
+  ] as ChatMessage[],
+};
+
+function runEffect<A>(eff: Effect.Effect<A, unknown, NodeFileSystem.NodeFileSystem["Type"]>) {
+  return Effect.runPromise(eff.pipe(Effect.provide(NodeFileSystem.layer)));
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-resume-handler-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("handleSpecialCommand resume", () => {
+  test("sets resetStartedAt on the result when a conversation is successfully resumed", async () => {
+    await runEffect(saveConversation(testRecord, tmpDir));
+
+    const mockTerminal: Partial<TerminalService> = {
+      select: mock(() => Effect.succeed("conv-to-resume")),
+      success: mock(() => Effect.void),
+      log: mock(() => Effect.succeed(undefined)),
+      info: mock(() => Effect.void),
+    };
+
+    const terminalLayer = Layer.succeed(
+      TerminalServiceTag,
+      mockTerminal as unknown as TerminalService,
+    );
+    const testLayer = Layer.merge(terminalLayer, NodeFileSystem.layer);
+
+    const context: CommandContext = {
+      agent: testAgent,
+      conversationId: "current-conv-id",
+      conversationHistory: [],
+      sessionId: "test-session",
+      sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionStartedAt: new Date(Date.now() - 1800_000),
+    };
+
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "resume", args: [] }, context).pipe(
+        Effect.provide(testLayer),
+      ),
+    );
+
+    expect(result.resetStartedAt).toBe(true);
+  });
+});

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -100,9 +100,7 @@ describe("handleSpecialCommand resume", () => {
     };
 
     const result = await Effect.runPromise(
-      handleSpecialCommand({ type: "resume", args: [] }, context).pipe(
-        Effect.provide(testLayer),
-      ),
+      handleSpecialCommand({ type: "resume", args: [] }, context).pipe(Effect.provide(testLayer)),
     );
 
     expect(result.resetStartedAt).toBe(true);

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
 import * as fmt from "@/cli/utils/list-format";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
@@ -35,6 +36,7 @@ import { getModelsDevMetadata } from "@/core/utils/models-dev-client";
 import { WorkflowServiceTag, type WorkflowService } from "@/core/workflows/workflow-service";
 import type { WorkflowMetadata } from "@/core/workflows/workflow-service";
 import { groupWorkflows } from "@/core/workflows/workflow-utils";
+import { loadHistory } from "@/services/history/conversation-history-service";
 import { generateConversationId } from "../session";
 import type { CommandContext, CommandResult, SpecialCommand } from "./types";
 
@@ -61,6 +63,7 @@ export function handleSpecialCommand(
   | SkillService
   | WorkflowService
   | MCPServerManager
+  | FileSystem.FileSystem
 > {
   const { agent, conversationId, conversationHistory, sessionId } = context;
 
@@ -131,6 +134,9 @@ export function handleSpecialCommand(
           context.persistedAutoApprovedCommands,
           context.autoApprovedTools,
         );
+
+      case "resume":
+        return yield* handleResumeCommand(terminal, agent);
 
       case "clear":
         return yield* handleClearCommand(terminal, agent);
@@ -255,6 +261,7 @@ function handleHelpCommand(terminal: TerminalService): Effect.Effect<CommandResu
         fmt.commandRow("/stats", "Show session statistics"),
         fmt.commandRow("/mcp", "Show MCP server status"),
         fmt.commandRow("/mode", "Switch approval modes"),
+        fmt.commandRow("/resume", "Browse and resume a past conversation"),
         fmt.commandRow("/help", "Show this help message"),
         fmt.commandRow("/exit", "Exit the chat"),
       ].join("\n"),
@@ -1021,6 +1028,73 @@ function handleUnknownCommand(
     yield* terminal.info("Type '/help' to see available commands.");
     yield* terminal.log("");
     return { shouldContinue: true };
+  });
+}
+
+function handleResumeCommand(
+  terminal: TerminalService,
+  agent: CommandContext["agent"],
+): Effect.Effect<CommandResult, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const fsLayer = Layer.succeed(FileSystem.FileSystem, fs);
+
+    const history = yield* loadHistory(agent.id).pipe(
+      Effect.provide(fsLayer),
+      Effect.catchAll(() => Effect.succeed({ agentId: agent.id, conversations: [] })),
+    );
+
+    if (history.conversations.length === 0) {
+      yield* terminal.info("No past conversations found for this agent.");
+      yield* terminal.log("");
+      return { shouldContinue: true };
+    }
+
+    const choices = history.conversations.map((conv) => {
+      const date = new Date(conv.startedAt);
+      const dateStr = date.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      return {
+        name: `${conv.title}  (${dateStr}, ${conv.messageCount} messages)`,
+        value: conv.conversationId,
+      };
+    });
+
+    const selectedId = yield* terminal.select<string>("Select a conversation to resume:", {
+      choices,
+    });
+
+    if (!selectedId) {
+      yield* terminal.log("Resume cancelled");
+      yield* terminal.log("");
+      return { shouldContinue: true };
+    }
+
+    const selected = history.conversations.find((c) => c.conversationId === selectedId);
+    if (!selected) {
+      return { shouldContinue: true };
+    }
+
+    const resumeSystemMessage = {
+      role: "system" as const,
+      content: `Resuming conversation from ${new Date(selected.startedAt).toLocaleString()}: ${selected.title}`,
+    };
+
+    const systemMessage = selected.messages.find((m) => m.role === "system");
+    const otherMessages = selected.messages.filter((m) => m.role !== "system");
+    const newHistory = [
+      ...(systemMessage ? [systemMessage] : []),
+      resumeSystemMessage,
+      ...otherMessages,
+    ];
+
+    yield* terminal.success(`Resumed: ${selected.title}`);
+    yield* terminal.log("");
+    return { shouldContinue: true, newHistory };
   });
 }
 

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { FileSystem } from "@effect/platform";
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import * as fmt from "@/cli/utils/list-format";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
@@ -1036,11 +1036,7 @@ function handleResumeCommand(
   agent: CommandContext["agent"],
 ): Effect.Effect<CommandResult, Error, FileSystem.FileSystem> {
   return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const fsLayer = Layer.succeed(FileSystem.FileSystem, fs);
-
     const history = yield* loadHistory(agent.id).pipe(
-      Effect.provide(fsLayer),
       Effect.catchAll(() => Effect.succeed({ agentId: agent.id, conversations: [] })),
     );
 

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -184,6 +184,7 @@ function handleNewCommand(
       shouldContinue: true,
       newConversationId: generateConversationId(),
       newHistory: [],
+      saveCurrentHistory: true,
     };
   });
 }
@@ -232,6 +233,7 @@ function handleForkCommand(
       shouldContinue: true,
       newConversationId: generateConversationId(),
       newHistory,
+      saveCurrentHistory: true,
     };
   });
 }
@@ -1090,7 +1092,7 @@ function handleResumeCommand(
 
     yield* terminal.success(`Resumed: ${selected.title}`);
     yield* terminal.log("");
-    return { shouldContinue: true, newHistory };
+    return { shouldContinue: true, newHistory, saveCurrentHistory: true };
   });
 }
 

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1092,7 +1092,7 @@ function handleResumeCommand(
 
     yield* terminal.success(`Resumed: ${selected.title}`);
     yield* terminal.log("");
-    return { shouldContinue: true, newHistory, saveCurrentHistory: true };
+    return { shouldContinue: true, newHistory, saveCurrentHistory: true, resetStartedAt: true };
   });
 }
 

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -54,6 +54,8 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "mcp", args };
     case "mode":
       return { type: "mode", args };
+    case "resume":
+      return { type: "resume", args };
     default:
       return { type: "unknown", args: [command, ...args] };
   }

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -53,6 +53,8 @@ export interface CommandResult {
   addAutoApprovedCommand?: string;
   /** Command prefix to remove from auto-approved commands list */
   removeAutoApprovedCommand?: string;
+  /** Save current conversation history before resetting state */
+  saveCurrentHistory?: boolean;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -24,6 +24,7 @@ export type CommandType =
   | "stats"
   | "mcp"
   | "mode"
+  | "resume"
   | "unknown";
 
 /**

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -55,6 +55,8 @@ export interface CommandResult {
   removeAutoApprovedCommand?: string;
   /** Save current conversation history before resetting state */
   saveCurrentHistory?: boolean;
+  /** Reset the startedAt timestamp to now (used when resuming a saved conversation) */
+  resetStartedAt?: boolean;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */

--- a/src/services/history/conversation-history-service.test.ts
+++ b/src/services/history/conversation-history-service.test.ts
@@ -1,9 +1,9 @@
-import * as path from "node:path";
-import * as os from "node:os";
 import * as fs from "node:fs";
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { Effect, Layer } from "effect";
+import * as os from "node:os";
+import * as path from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Effect } from "effect";
 import type { ChatMessage } from "@/core/types/message";
 import {
   saveConversation,

--- a/src/services/history/conversation-history-service.test.ts
+++ b/src/services/history/conversation-history-service.test.ts
@@ -39,6 +39,16 @@ function makeRecord(overrides: Partial<ConversationRecord> = {}): ConversationRe
 }
 
 describe("saveConversation", () => {
+  test("creates history directory and file when neither exists yet", async () => {
+    const nonExistentDir = path.join(tmpDir, "nested", "history");
+    const record = makeRecord();
+    await runEffect(saveConversation(record, nonExistentDir));
+    const historyPath = path.join(nonExistentDir, `${record.agentId}.json`);
+    expect(fs.existsSync(historyPath)).toBe(true);
+    const data = JSON.parse(fs.readFileSync(historyPath, "utf-8"));
+    expect(data.conversations).toHaveLength(1);
+  });
+
   test("creates history file on first save", async () => {
     const record = makeRecord();
     await runEffect(saveConversation(record, tmpDir));

--- a/src/services/history/conversation-history-service.test.ts
+++ b/src/services/history/conversation-history-service.test.ts
@@ -1,0 +1,82 @@
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Effect, Layer } from "effect";
+import { NodeFileSystem } from "@effect/platform-node";
+import type { ChatMessage } from "@/core/types/message";
+import {
+  saveConversation,
+  loadHistory,
+  type ConversationRecord,
+} from "./conversation-history-service";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-history-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function runEffect<A>(eff: Effect.Effect<A, unknown, NodeFileSystem.NodeFileSystem["Type"]>) {
+  return Effect.runPromise(eff.pipe(Effect.provide(NodeFileSystem.layer)));
+}
+
+function makeRecord(overrides: Partial<ConversationRecord> = {}): ConversationRecord {
+  return {
+    conversationId: "conv-1",
+    title: "Hello world",
+    agentId: "agent-1",
+    startedAt: new Date().toISOString(),
+    endedAt: new Date().toISOString(),
+    messageCount: 1,
+    messages: [{ role: "user", content: "Hello world" } as ChatMessage],
+    ...overrides,
+  };
+}
+
+describe("saveConversation", () => {
+  test("creates history file on first save", async () => {
+    const record = makeRecord();
+    await runEffect(saveConversation(record, tmpDir));
+    const historyPath = path.join(tmpDir, `${record.agentId}.json`);
+    expect(fs.existsSync(historyPath)).toBe(true);
+    const data = JSON.parse(fs.readFileSync(historyPath, "utf-8"));
+    expect(data.conversations).toHaveLength(1);
+    expect(data.conversations[0].conversationId).toBe("conv-1");
+  });
+
+  test("prepends new conversation, newest first", async () => {
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-1" }), tmpDir));
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-2" }), tmpDir));
+    const { conversations } = await runEffect(loadHistory("agent-1", tmpDir));
+    expect(conversations[0].conversationId).toBe("conv-2");
+    expect(conversations[1].conversationId).toBe("conv-1");
+  });
+
+  test("evicts oldest when count exceeds 5", async () => {
+    for (let i = 1; i <= 6; i++) {
+      await runEffect(saveConversation(makeRecord({ conversationId: `conv-${i}` }), tmpDir));
+    }
+    const { conversations } = await runEffect(loadHistory("agent-1", tmpDir));
+    expect(conversations).toHaveLength(5);
+    expect(conversations.map((c) => c.conversationId)).not.toContain("conv-1");
+  });
+});
+
+describe("loadHistory", () => {
+  test("returns empty conversations array when file does not exist", async () => {
+    const { conversations } = await runEffect(loadHistory("no-such-agent", tmpDir));
+    expect(conversations).toEqual([]);
+  });
+
+  test("returns empty conversations array when file is corrupt", async () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "agent-1.json"), "not-json");
+    const { conversations } = await runEffect(loadHistory("agent-1", tmpDir));
+    expect(conversations).toEqual([]);
+  });
+});

--- a/src/services/history/conversation-history-service.ts
+++ b/src/services/history/conversation-history-service.ts
@@ -142,18 +142,25 @@ export function saveConversation(
   record: ConversationRecord,
   dir?: string,
 ): Effect.Effect<void, Error, FileSystem.FileSystem> {
-  return withLock(
-    record.agentId,
-    dir,
-    Effect.gen(function* () {
-      const history = yield* readHistory(record.agentId, dir);
-      const updated = [record, ...history.conversations].slice(
-        0,
-        MAX_CONVERSATION_HISTORY_PER_AGENT,
-      );
-      yield* writeHistory({ agentId: record.agentId, conversations: updated }, dir);
-    }),
-  );
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const historyDir = dir ?? getHistoryDirectory();
+    yield* fs
+      .makeDirectory(historyDir, { recursive: true })
+      .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+    yield* withLock(
+      record.agentId,
+      dir,
+      Effect.gen(function* () {
+        const history = yield* readHistory(record.agentId, dir);
+        const updated = [record, ...history.conversations].slice(
+          0,
+          MAX_CONVERSATION_HISTORY_PER_AGENT,
+        );
+        yield* writeHistory({ agentId: record.agentId, conversations: updated }, dir);
+      }),
+    );
+  });
 }
 
 export function loadHistory(

--- a/src/services/history/conversation-history-service.ts
+++ b/src/services/history/conversation-history-service.ts
@@ -7,8 +7,8 @@ import {
   FILE_LOCK_TIMEOUT_MS,
   MAX_CONVERSATION_HISTORY_PER_AGENT,
 } from "@/core/constants/agent";
-import { getHistoryDirectory } from "@/core/utils/runtime-detection";
 import type { ChatMessage } from "@/core/types/message";
+import { getHistoryDirectory } from "@/core/utils/runtime-detection";
 
 export interface ConversationRecord {
   readonly conversationId: string;
@@ -33,18 +33,14 @@ function getLockPath(agentId: string, dir?: string): string {
   return path.join(dir ?? getHistoryDirectory(), `${agentId}.lock`);
 }
 
-function acquireLock(
-  lockPath: string,
-): Effect.Effect<void, Error, FileSystem.FileSystem> {
+function acquireLock(lockPath: string): Effect.Effect<void, Error, FileSystem.FileSystem> {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     for (let attempt = 0; attempt < FILE_LOCK_MAX_RETRIES; attempt++) {
-      const acquired = yield* fs
-        .makeDirectory(lockPath, { recursive: false })
-        .pipe(
-          Effect.map(() => true),
-          Effect.catchAll(() => Effect.succeed(false)),
-        );
+      const acquired = yield* fs.makeDirectory(lockPath, { recursive: false }).pipe(
+        Effect.map(() => true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
       if (acquired) return;
 
       const statResult = yield* fs.stat(lockPath).pipe(Effect.option);
@@ -91,23 +87,25 @@ function readHistory(
     const fs = yield* FileSystem.FileSystem;
     const filePath = getAgentHistoryPath(agentId, dir);
 
-    const content = yield* fs.readFileString(filePath).pipe(
-      Effect.catchAll((e) =>
-        e && typeof e === "object" && "_tag" in e &&
-        (e as { _tag: string })._tag === "SystemError" &&
-        (e as { reason?: string }).reason === "NotFound"
-          ? Effect.succeed("")
-          : Effect.fail(e instanceof Error ? e : new Error(String(e))),
-      ),
-    );
+    const content = yield* fs
+      .readFileString(filePath)
+      .pipe(
+        Effect.catchAll((e) =>
+          e &&
+          typeof e === "object" &&
+          "_tag" in e &&
+          (e as { _tag: string })._tag === "SystemError" &&
+          (e as { reason?: string }).reason === "NotFound"
+            ? Effect.succeed("")
+            : Effect.fail(e instanceof Error ? e : new Error(String(e))),
+        ),
+      );
 
     if (content === "") return { agentId, conversations: [] };
 
     try {
       const parsed = JSON.parse(content) as AgentConversationHistory;
-      return Array.isArray(parsed?.conversations)
-        ? parsed
-        : { agentId, conversations: [] };
+      return Array.isArray(parsed?.conversations) ? parsed : { agentId, conversations: [] };
     } catch {
       return { agentId, conversations: [] };
     }

--- a/src/services/history/conversation-history-service.ts
+++ b/src/services/history/conversation-history-service.ts
@@ -1,0 +1,166 @@
+import * as path from "node:path";
+import { FileSystem } from "@effect/platform";
+import { Effect, Option } from "effect";
+import {
+  FILE_LOCK_MAX_RETRIES,
+  FILE_LOCK_RETRY_DELAY_MS,
+  FILE_LOCK_TIMEOUT_MS,
+  MAX_CONVERSATION_HISTORY_PER_AGENT,
+} from "@/core/constants/agent";
+import { getHistoryDirectory } from "@/core/utils/runtime-detection";
+import type { ChatMessage } from "@/core/types/message";
+
+export interface ConversationRecord {
+  readonly conversationId: string;
+  readonly title: string;
+  readonly agentId: string;
+  readonly startedAt: string;
+  readonly endedAt: string | null;
+  readonly messageCount: number;
+  readonly messages: ChatMessage[];
+}
+
+export interface AgentConversationHistory {
+  readonly agentId: string;
+  readonly conversations: ConversationRecord[];
+}
+
+function getAgentHistoryPath(agentId: string, dir?: string): string {
+  return path.join(dir ?? getHistoryDirectory(), `${agentId}.json`);
+}
+
+function getLockPath(agentId: string, dir?: string): string {
+  return path.join(dir ?? getHistoryDirectory(), `${agentId}.lock`);
+}
+
+function acquireLock(
+  lockPath: string,
+): Effect.Effect<void, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    for (let attempt = 0; attempt < FILE_LOCK_MAX_RETRIES; attempt++) {
+      const acquired = yield* fs
+        .makeDirectory(lockPath, { recursive: false })
+        .pipe(
+          Effect.map(() => true),
+          Effect.catchAll(() => Effect.succeed(false)),
+        );
+      if (acquired) return;
+
+      const statResult = yield* fs.stat(lockPath).pipe(Effect.option);
+      const stat = Option.getOrNull(statResult);
+      const mtimeMs = Option.match(stat?.mtime ?? Option.none(), {
+        onNone: () => 0,
+        onSome: (d) => d.getTime(),
+      });
+      if (stat && Date.now() - mtimeMs > FILE_LOCK_TIMEOUT_MS) {
+        yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
+        continue;
+      }
+      yield* Effect.sleep(FILE_LOCK_RETRY_DELAY_MS);
+    }
+    return yield* Effect.fail(new Error("Failed to acquire history lock after retries"));
+  });
+}
+
+function releaseLock(lockPath: string): Effect.Effect<void, never, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
+
+function withLock<A, E, R>(
+  agentId: string,
+  dir: string | undefined,
+  operation: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | Error, R | FileSystem.FileSystem> {
+  const lockPath = getLockPath(agentId, dir);
+  return Effect.acquireUseRelease(
+    acquireLock(lockPath),
+    () => operation,
+    () => releaseLock(lockPath),
+  );
+}
+
+function readHistory(
+  agentId: string,
+  dir?: string,
+): Effect.Effect<AgentConversationHistory, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const filePath = getAgentHistoryPath(agentId, dir);
+
+    const content = yield* fs.readFileString(filePath).pipe(
+      Effect.catchAll((e) =>
+        e && typeof e === "object" && "_tag" in e &&
+        (e as { _tag: string })._tag === "SystemError" &&
+        (e as { reason?: string }).reason === "NotFound"
+          ? Effect.succeed("")
+          : Effect.fail(e instanceof Error ? e : new Error(String(e))),
+      ),
+    );
+
+    if (content === "") return { agentId, conversations: [] };
+
+    try {
+      const parsed = JSON.parse(content) as AgentConversationHistory;
+      return Array.isArray(parsed?.conversations)
+        ? parsed
+        : { agentId, conversations: [] };
+    } catch {
+      return { agentId, conversations: [] };
+    }
+  });
+}
+
+function writeHistory(
+  data: AgentConversationHistory,
+  dir?: string,
+): Effect.Effect<void, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const filePath = getAgentHistoryPath(data.agentId, dir);
+    const directory = path.dirname(filePath);
+    const tmpPath = path.join(
+      directory,
+      `.history-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+    );
+
+    yield* fs
+      .makeDirectory(directory, { recursive: true })
+      .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+    yield* fs
+      .writeFileString(tmpPath, JSON.stringify(data, null, 2))
+      .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+    yield* fs.rename(tmpPath, filePath).pipe(
+      Effect.tapError(() => fs.remove(tmpPath).pipe(Effect.catchAll(() => Effect.void))),
+      Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+    );
+  });
+}
+
+export function saveConversation(
+  record: ConversationRecord,
+  dir?: string,
+): Effect.Effect<void, Error, FileSystem.FileSystem> {
+  return withLock(
+    record.agentId,
+    dir,
+    Effect.gen(function* () {
+      const history = yield* readHistory(record.agentId, dir);
+      const updated = [record, ...history.conversations].slice(
+        0,
+        MAX_CONVERSATION_HISTORY_PER_AGENT,
+      );
+      yield* writeHistory({ agentId: record.agentId, conversations: updated }, dir);
+    }),
+  );
+}
+
+export function loadHistory(
+  agentId: string,
+  dir?: string,
+): Effect.Effect<AgentConversationHistory, Error, FileSystem.FileSystem> {
+  return readHistory(agentId, dir);
+}

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -1231,6 +1231,7 @@ class AISDKService implements LLMService {
             ) => void,
           ) => {
             void (async (): Promise<void> => {
+              let streamTextResult: Awaited<ReturnType<typeof streamText>> | undefined;
               try {
                 const streamTextStart = Date.now();
                 void this.logger.debug(
@@ -1263,7 +1264,7 @@ class AISDKService implements LLMService {
                   );
                 }
 
-                const result = streamText({
+                streamTextResult = streamText({
                   model,
                   messages: coreMessages,
                   ...(typeof options.temperature === "number"
@@ -1275,6 +1276,7 @@ class AISDKService implements LLMService {
                   abortSignal: abortController.signal,
                   stopWhen: stepCountIs(DEFAULT_MAX_ITERATIONS),
                 });
+                const result = streamTextResult;
 
                 void this.logger.debug(
                   `[LLM Timing] ✓ streamText returned (initialization) in ${Date.now() - streamTextStart}ms`,
@@ -1314,6 +1316,17 @@ class AISDKService implements LLMService {
                 // Close the stream
                 processor.close();
               } catch (error) {
+                // Suppress unhandled rejections on the AI SDK's internal
+                // DelayedPromise properties (usage, finishReason, steps).
+                // When the stream fails these all reject, but we only await
+                // them in the success path, so they'd otherwise surface as
+                // Bun unhandled-rejection dumps.
+                if (streamTextResult) {
+                  void Promise.resolve(streamTextResult.usage).catch(() => {});
+                  void Promise.resolve(streamTextResult.finishReason).catch(() => {});
+                  void Promise.resolve(streamTextResult.steps).catch(() => {});
+                }
+
                 const llmError = convertToLLMError(error, providerName);
 
                 const errorDetails: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

- Adds per-agent conversation history persistence (`~/.jazz/history/{agentId}.json`) — last 5 conversations per agent, atomic writes with file locking
- Saves conversations automatically on chat exit, with title derived from first user message
- Adds `/resume` slash command to browse and restore past conversations with full message history

## Changes

- `src/services/history/conversation-history-service.ts` — new storage service (`saveConversation`, `loadHistory`) following the same atomic-write + mkdir-lock pattern as `run-history.ts`
- `src/core/constants/agent.ts` — `MAX_CONVERSATION_HISTORY_PER_AGENT = 5`
- `src/core/utils/runtime-detection.ts` — `getHistoryDirectory()` helper
- `src/services/chat-service.ts` — captures title on first user message; saves conversation on exit; resets title on `/new`, `/fork`, `/resume`
- `src/services/chat/commands/` — `/resume` wired into types, constants, parser, and handler

## Test Plan

- [ ] Start a chat session, send a message, `/exit` → verify `~/.jazz/history/{agentId}.json` is created with the conversation
- [ ] Start a new session, type `/resume` → list shows the saved conversation with title, date, message count
- [ ] Select a conversation → history is restored and the model responds with full prior context
- [ ] Type `/new` then send a message, `/exit` → new conversation saved with correct title (not the old one)
- [ ] `bun test` — 1152 tests, 0 failures