### PR TITLE
chore: vscode default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "eamodio.gitlens",
-    "esbenp.prettier-vscode",
-    "mike-co.import-sorter"
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
   "eslint.format.enable": true,
   "eslint.useFlatConfig": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",


### PR DESCRIPTION
## Summary

- Use `esbenp.prettier-vscode` as the global default formatter — ESLint was set as the top-level default but can't format non-TS files (`.md`, `.yaml`, etc.); TS/TSX still go through ESLint via per-language overrides
- Add `editor.codeActionsOnSave` with `source.fixAll.eslint: "explicit"` so ESLint auto-fixes (import order, unused vars, etc.) run on save
- Remove `mike-co.import-sorter` from extension recommendations — conflicts with `eslint-plugin-import` which already handles import sorting

## Test plan

- [ ] Open a `.ts` file — ESLint formats on save
- [ ] Open a `.md` or `.yaml` file — Prettier formats on save without errors
- [ ] Make a lint-fixable change (e.g. wrong import order) — ESLint auto-fixes on save