### PR TITLE
feat(web-search): auto-detect provider API keys from environment variables

### DIFF
--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -315,7 +315,7 @@ function selectAgent(
 
     const choices = sorted.map((agent) => {
       return {
-        name: `${agent.name} - ${agent.description || agent.config.persona || "default"}`,
+        name: `${agent.name} - ${agent.model} - ${agent.description || agent.config.persona || "default"}`,
         value: agent.id,
       };
     });

--- a/src/core/agent/tools/web-search-tools.ts
+++ b/src/core/agent/tools/web-search-tools.ts
@@ -50,6 +50,30 @@ export const DEFAULT_MAX_RESULTS = 50;
 
 export type WebSearchProviderName = (typeof WEB_SEARCH_PROVIDERS)[number]["value"];
 
+const PROVIDER_ENV_VARS: Record<WebSearchProviderName, string> = {
+  brave: "BRAVE_API_KEY",
+  tavily: "TAVILY_API_KEY",
+  exa: "EXA_API_KEY",
+  parallel: "PARALLEL_API_KEY",
+  perplexity: "PERPLEXITY_API_KEY",
+};
+
+const PROVIDER_DETECTION_ORDER: WebSearchProviderName[] = [
+  "brave",
+  "tavily",
+  "exa",
+  "parallel",
+  "perplexity",
+];
+
+function detectProviderFromEnv(): { provider: WebSearchProviderName; apiKey: string } | null {
+  for (const provider of PROVIDER_DETECTION_ORDER) {
+    const apiKey = process.env[PROVIDER_ENV_VARS[provider]];
+    if (apiKey) return { provider, apiKey };
+  }
+  return null;
+}
+
 export function createWebSearchTool(): ReturnType<
   typeof defineTool<AgentConfigService | LoggerService, WebSearchArgs>
 > {
@@ -121,37 +145,40 @@ export function createWebSearchTool(): ReturnType<
         // Get web search config
         const appConfig = yield* config.appConfig;
         const webSearchConfig: WebSearchConfig | undefined = appConfig.web_search;
-        const selectedProvider = webSearchConfig?.provider;
+        let selectedProvider = webSearchConfig?.provider;
+        let resolvedApiKey: string | undefined;
 
-        // If no external provider is configured, the AI SDK service will handle
-        // using the provider-native web search (if available). This tool handler
-        // should only execute when an external provider (Parallel, Exa, Tavily) is selected.
-        if (!selectedProvider) {
-          return {
-            success: false,
-            result: null,
-            error:
-              "No external web search provider configured. If your LLM provider supports built-in web search, it will be used automatically. Otherwise, please configure an external provider (Parallel, Exa, Tavily, Brave, or Perplexity) in settings.",
-          };
-        }
-
-        const getApiKey = (
-          providerName: string,
-        ): Effect.Effect<string, never, AgentConfigService> =>
-          Effect.gen(function* () {
-            return yield* config.getOrElse(`web_search.${providerName}.api_key`, "");
+        if (selectedProvider) {
+          resolvedApiKey = yield* Effect.gen(function* () {
+            return yield* config.getOrElse(`web_search.${selectedProvider}.api_key`, "");
           });
-
-        // Get API key for the selected provider
-        const apiKey = yield* getApiKey(selectedProvider);
-
-        if (!apiKey) {
-          return {
-            success: false,
-            result: null,
-            error: `No API key configured for ${selectedProvider}. Please configure 'web_search.${selectedProvider}.api_key' in settings.`,
-          };
+          if (!resolvedApiKey) {
+            const envKey = process.env[PROVIDER_ENV_VARS[selectedProvider]];
+            if (envKey) {
+              resolvedApiKey = envKey;
+            } else {
+              return {
+                success: false,
+                result: null,
+                error: `No API key configured for ${selectedProvider}. Set 'web_search.${selectedProvider}.api_key' in settings or the ${PROVIDER_ENV_VARS[selectedProvider]} environment variable.`,
+              };
+            }
+          }
+        } else {
+          const detected = detectProviderFromEnv();
+          if (!detected) {
+            return {
+              success: false,
+              result: null,
+              error:
+                "No web search provider configured. Set one of: BRAVE_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PARALLEL_API_KEY, or PERPLEXITY_API_KEY as an environment variable, or configure a provider in settings.",
+            };
+          }
+          selectedProvider = detected.provider;
+          resolvedApiKey = detected.apiKey;
         }
+
+        const apiKey = resolvedApiKey;
 
         // Map provider name to execution function
         const executorMap: Record<

--- a/src/core/agent/tools/web-search-tools.ts
+++ b/src/core/agent/tools/web-search-tools.ts
@@ -31,7 +31,7 @@ export interface WebSearchResult {
   readonly totalResults: number;
   readonly query: string;
   readonly timestamp: string;
-  readonly provider: "exa" | "parallel" | "tavily" | "brave" | "perplexity";
+  readonly provider: WebSearchProviderName;
 }
 
 /**
@@ -146,16 +146,14 @@ export function createWebSearchTool(): ReturnType<
         const appConfig = yield* config.appConfig;
         const webSearchConfig: WebSearchConfig | undefined = appConfig.web_search;
         let selectedProvider = webSearchConfig?.provider;
-        let resolvedApiKey: string | undefined;
+        let apiKey: string | undefined;
 
         if (selectedProvider) {
-          resolvedApiKey = yield* Effect.gen(function* () {
-            return yield* config.getOrElse(`web_search.${selectedProvider}.api_key`, "");
-          });
-          if (!resolvedApiKey) {
+          apiKey = yield* config.getOrElse(`web_search.${selectedProvider}.api_key`, "");
+          if (!apiKey) {
             const envKey = process.env[PROVIDER_ENV_VARS[selectedProvider]];
             if (envKey) {
-              resolvedApiKey = envKey;
+              apiKey = envKey;
             } else {
               return {
                 success: false,
@@ -167,22 +165,20 @@ export function createWebSearchTool(): ReturnType<
         } else {
           const detected = detectProviderFromEnv();
           if (!detected) {
+            const envVarList = Object.values(PROVIDER_ENV_VARS).join(", ");
             return {
               success: false,
               result: null,
-              error:
-                "No web search provider configured. Set one of: BRAVE_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PARALLEL_API_KEY, or PERPLEXITY_API_KEY as an environment variable, or configure a provider in settings.",
+              error: `No web search provider configured. Set one of: ${envVarList} as an environment variable, or configure a provider in settings.`,
             };
           }
           selectedProvider = detected.provider;
-          resolvedApiKey = detected.apiKey;
+          apiKey = detected.apiKey;
         }
-
-        const apiKey = resolvedApiKey;
 
         // Map provider name to execution function
         const executorMap: Record<
-          "exa" | "parallel" | "tavily" | "brave" | "perplexity",
+          WebSearchProviderName,
           (
             args: WebSearchArgs,
             apiKey: string,


### PR DESCRIPTION
## Summary

- When no web search provider is configured in settings, automatically scan well-known environment variables (`BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `PARALLEL_API_KEY`, `PERPLEXITY_API_KEY`) in priority order and use the first one found
- When a provider is explicitly configured but has no API key in settings, fall back to the corresponding env var before erroring
- Improves CI/GitHub Actions ergonomics: just add a secret (e.g. `BRAVE_API_KEY`) and pass it in the workflow `env:` block — no config file setup needed

## Test plan

- [ ] Set `BRAVE_API_KEY` in env with no config → web search uses Brave
- [ ] Set multiple provider env vars → first in priority order wins (`brave > tavily > exa > parallel > perplexity`)
- [ ] Configure provider in settings with no key, set matching env var → uses env var key
- [ ] No provider configured, no env vars → error message lists all accepted env var names