### PR TITLE
feat(workflow): expose per-run cost and token usage

### DIFF
--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -356,7 +356,7 @@ export function runWorkflowCommand(
 
     // Run the agent with the workflow prompt
     // maxIterations from workflow metadata is optional — omit for no limit
-    yield* AgentRunner.run({
+    const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       sessionId: `workflow-${workflowName}-${Date.now()}`,
@@ -366,10 +366,12 @@ export function runWorkflowCommand(
         : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
     }).pipe(
-      Effect.tap(() =>
+      Effect.tap((result) =>
         updateLatestRunRecord(workflowName, {
           completedAt: new Date().toISOString(),
           status: "completed",
+          ...(result.costUSD !== undefined ? { costUSD: result.costUSD } : {}),
+          ...(result.usage !== undefined ? { tokenUsage: result.usage } : {}),
         }).pipe(Effect.catchAll(() => Effect.void)),
       ),
       Effect.tapError((error) =>
@@ -383,6 +385,15 @@ export function runWorkflowCommand(
 
     yield* terminal.log("");
     yield* terminal.success(`Workflow completed: ${workflowName}`);
+
+    if (isNonInteractive) {
+      const summary = {
+        workflow: workflowName,
+        ...(runResult.costUSD !== undefined ? { costUSD: runResult.costUSD } : {}),
+        ...(runResult.usage !== undefined ? { tokenUsage: runResult.usage } : {}),
+      };
+      yield* terminal.log(`[JAZZ_SUMMARY] ${JSON.stringify(summary)}`);
+    }
   });
 }
 

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -479,6 +479,14 @@ export function executeAgentLoop(
         );
         yield* Ref.set(finalizeFiberRef, Option.some(finalizeFiber));
 
+        const inputPrice = modelMetadata?.inputPricePerMillion ?? 0;
+        const outputPrice = modelMetadata?.outputPricePerMillion ?? 0;
+        const costUSD =
+          inputPrice > 0 || outputPrice > 0
+            ? (runMetrics.totalPromptTokens / 1_000_000) * inputPrice +
+              (runMetrics.totalCompletionTokens / 1_000_000) * outputPrice
+            : undefined;
+
         return {
           ...response,
           messages: currentMessages,
@@ -486,6 +494,7 @@ export function executeAgentLoop(
             promptTokens: runMetrics.totalPromptTokens,
             completionTokens: runMetrics.totalCompletionTokens,
           },
+          ...(costUSD !== undefined ? { costUSD } : {}),
         };
       }),
     // Release: cleanup

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -173,6 +173,8 @@ export interface AgentResponse {
    * Used by the chat session to accumulate session cost for /cost.
    */
   readonly usage?: { readonly promptTokens: number; readonly completionTokens: number };
+  /** Total estimated cost for the full run in USD. Populated when model pricing is available. */
+  readonly costUSD?: number;
 }
 
 /**

--- a/src/core/workflows/run-history.ts
+++ b/src/core/workflows/run-history.ts
@@ -19,6 +19,8 @@ export interface WorkflowRunRecord {
   readonly status: "running" | "completed" | "failed" | "skipped";
   readonly error?: string;
   readonly triggeredBy: "manual" | "scheduled";
+  readonly costUSD?: number;
+  readonly tokenUsage?: { readonly promptTokens: number; readonly completionTokens: number };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Computes USD cost from models.dev input/output pricing at the end of each agent loop run
- Adds `costUSD?: number` to `AgentResponse` and `WorkflowRunRecord`
- Saves cost and token usage to run history on workflow completion
- Prints a `[JAZZ_SUMMARY] {...}` JSON line to stdout in non-interactive (CI) mode, allowing pipelines to parse cost and token stats without scraping rendered output

## Test plan

- [ ] Run a workflow locally with `--auto-approve` and verify `[JAZZ_SUMMARY]` line appears with `costUSD` and `tokenUsage`
- [ ] Confirm `run-history.json` records include `costUSD` and `tokenUsage` after a completed workflow run
- [ ] Verify no regression when model pricing is unavailable (cost omitted gracefully)