### PR TITLE
feat(openrouter): native web_search and web_fetch server tool support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@effect/platform": "^0.90.10",
         "@effect/platform-node": "^0.96.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@openrouter/ai-sdk-provider": "^2.2.3",
+        "@openrouter/ai-sdk-provider": "^2.9.0",
         "@perplexity-ai/perplexity_ai": "^0.27.0",
         "@tavily/core": "^0.7.3",
         "@toon-format/toon": "^2.1.0",
@@ -204,7 +204,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.2.3", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-NovC+BaCfEeJwhToDrs8JeDYXXlJdEyz7lcxkjtyePSE4eoAKik872SyDK0MzXKcz8MRkv7XlNhPI6zz4TQp0g=="],
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.0", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Seva+NCa0WUQnJIUE5GzHsUv1WTIeyqwz0ELl2VtS6NP+eF+77yCXGFVOMbvoCM7QMjlnhv7931e89R+8pJdcQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@effect/platform": "^0.90.10",
     "@effect/platform-node": "^0.96.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@openrouter/ai-sdk-provider": "^2.2.3",
+    "@openrouter/ai-sdk-provider": "^2.9.0",
     "@perplexity-ai/perplexity_ai": "^0.27.0",
     "@tavily/core": "^0.7.3",
     "@toon-format/toon": "^2.1.0",

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -72,14 +72,18 @@ export class ToolExecutor {
               duration: timeoutMs,
               onTimeout: () => {
                 const timeoutMinutes = Math.round(timeoutMs / 60000);
-                return new Error(
-                  `Tool '${name}' timed out after ${timeoutMinutes} minutes. The operation took too long to complete.`,
-                );
+                return new Error(`Operation timed out after '${timeoutMinutes}m'`);
               },
             }),
             Effect.catchAll((error) => {
-              if (error instanceof Error && error.message.includes("timed out")) {
-                void logger.warn(`Tool timeout: ${error.message}`);
+              const message = error instanceof Error ? error.message : String(error);
+              if (message.includes("timed out")) {
+                void logger.warn(`Tool timeout: ${name}: ${message}`);
+                return Effect.succeed({
+                  success: false,
+                  result: null,
+                  error: message,
+                } satisfies ToolExecutionResult);
               }
               return Effect.fail(error);
             }),

--- a/src/core/agent/tools/http-tools.ts
+++ b/src/core/agent/tools/http-tools.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
+import { HTTP_USER_AGENT } from "@/core/constants/agent";
 import type { Tool } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
 import { defineTool } from "./base-tool";
@@ -391,7 +392,7 @@ export function createHttpRequestTool(): Tool<never> {
           } satisfies ToolExecutionResult;
         }
 
-        ensureHeader(headerMap, "User-Agent", "Jazz/1.0 (https://github.com/lvndry/jazz)");
+        ensureHeader(headerMap, "User-Agent", HTTP_USER_AGENT);
         ensureHeader(
           headerMap,
           "Accept",

--- a/src/core/agent/tools/register-tools.ts
+++ b/src/core/agent/tools/register-tools.ts
@@ -22,6 +22,7 @@ import { createSkillTools } from "./skill-tools";
 import { createSubagentTools } from "./subagent-tools";
 import { createListTodosTool, createManageTodosTool } from "./todo-tools";
 import { userInteractionTools } from "./user-interaction-tools";
+import { createWebFetchTool } from "./web-fetch-tools";
 import { createWebSearchTool } from "./web-search-tools";
 
 /**
@@ -646,9 +647,8 @@ export function registerSearchTools(): Effect.Effect<void, Error, ToolRegistry> 
     const registry = yield* ToolRegistryTag;
     const registerTool = registry.registerForCategory(WEB_SEARCH_CATEGORY);
 
-    const webSearchTool = createWebSearchTool();
-
-    yield* registerTool(webSearchTool);
+    yield* registerTool(createWebSearchTool());
+    yield* registerTool(createWebFetchTool());
   });
 }
 

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -1,11 +1,11 @@
 import { Effect } from "effect";
 import { z } from "zod";
+import { HTTP_USER_AGENT } from "@/core/constants/agent";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
 import { defineTool, makeZodValidator } from "./base-tool";
 
 const DEFAULT_MAX_CONTENT_LENGTH = 50_000;
-const USER_AGENT = "Mozilla/5.0 (compatible; Jazz CLI)";
 
 const SUPPORTED_CONTENT_TYPES = [
   "text/html",
@@ -51,7 +51,7 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         const response = yield* Effect.tryPromise({
           try: (signal) =>
             fetch(args.url, {
-              headers: { "User-Agent": USER_AGENT },
+              headers: { "User-Agent": HTTP_USER_AGENT },
               signal,
             }),
           catch: (error) =>

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -56,15 +56,21 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         }
 
         const contentType = response.headers.get("content-type") ?? "";
-        if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
+        const isSupported =
+          contentType.includes("text/html") ||
+          contentType.includes("text/plain") ||
+          contentType.includes("application/json") ||
+          contentType.includes("application/xml") ||
+          contentType.includes("text/xml");
+        if (!isSupported) {
           return {
             success: false,
             result: null,
-            error: `Unsupported content type "${contentType}" for ${args.url} — only text/html and text/plain are supported`,
+            error: `Unsupported content type "${contentType}" for ${args.url}`,
           } satisfies ToolExecutionResult;
         }
 
-        const html = yield* Effect.tryPromise({
+        const body = yield* Effect.tryPromise({
           try: () => response.text(),
           catch: (error) =>
             new Error(
@@ -72,20 +78,26 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
             ),
         });
 
-        const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
-        const title = titleMatch?.[1]?.trim() ?? "";
+        const isHtml = contentType.includes("text/html");
+        let title = "";
+        let content: string;
 
-        const text = html
-          .replace(/<script\b[^<]*(?:(?!<\/script\s*>)<[^<]*)*<\/script\s*>/gi, " ")
-          .replace(/<style\b[^<]*(?:(?!<\/style\s*>)<[^<]*)*<\/style\s*>/gi, " ")
-          .replace(/<[^>]+>/g, " ")
-          .replace(/\s+/g, " ")
-          .trim()
-          .slice(0, maxLength);
+        if (isHtml) {
+          title = body.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]?.trim() ?? "";
+          content = body
+            .replace(/<script\b[^<]*(?:(?!<\/script\b[^>]*>)<[^<]*)*<\/script\b[^>]*>/gi, " ")
+            .replace(/<style\b[^<]*(?:(?!<\/style\b[^>]*>)<[^<]*)*<\/style\b[^>]*>/gi, " ")
+            .replace(/<[^>]+>/g, " ")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, maxLength);
+        } else {
+          content = body.slice(0, maxLength);
+        }
 
         return {
           success: true,
-          result: { url: args.url, title, content: text },
+          result: { url: args.url, title, content },
         } satisfies ToolExecutionResult;
       }),
     createSummary: (result: ToolExecutionResult) => {

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -1,0 +1,87 @@
+import { Effect } from "effect";
+import { z } from "zod";
+import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
+import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
+import { defineTool, makeZodValidator } from "./base-tool";
+
+const DEFAULT_MAX_CONTENT_LENGTH = 50_000;
+
+const webFetchSchema = z
+  .object({
+    url: z.string().url().describe("The URL to fetch content from"),
+    max_length: z
+      .number()
+      .int()
+      .min(1)
+      .max(200_000)
+      .optional()
+      .describe(`Max content length in characters (default: ${DEFAULT_MAX_CONTENT_LENGTH})`),
+  })
+  .strict();
+
+type WebFetchArgs = z.infer<typeof webFetchSchema>;
+
+export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService, WebFetchArgs>> {
+  return defineTool<LoggerService, WebFetchArgs>({
+    name: "web_fetch",
+    description: "Fetch and extract text content from a URL.",
+    tags: ["web", "fetch"],
+    parameters: webFetchSchema,
+    validate: makeZodValidator(webFetchSchema),
+    handler: (args: WebFetchArgs, _context: ToolExecutionContext) =>
+      Effect.gen(function* () {
+        const logger = yield* LoggerServiceTag;
+        const maxLength = args.max_length ?? DEFAULT_MAX_CONTENT_LENGTH;
+
+        yield* logger.debug(`[Web Fetch] Fetching ${args.url}`);
+
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            fetch(args.url, {
+              headers: { "User-Agent": "Mozilla/5.0 (compatible; Jazz CLI)" },
+            }),
+          catch: (error) =>
+            new Error(
+              `Failed to fetch ${args.url}: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        });
+
+        if (!response.ok) {
+          return {
+            success: false,
+            result: null,
+            error: `HTTP ${response.status} ${response.statusText} for ${args.url}`,
+          } satisfies ToolExecutionResult;
+        }
+
+        const html = yield* Effect.tryPromise({
+          try: () => response.text(),
+          catch: (error) =>
+            new Error(
+              `Failed to read response body: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        });
+
+        const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+        const title = titleMatch?.[1]?.trim() ?? "";
+
+        const text = html
+          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ")
+          .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, maxLength);
+
+        return {
+          success: true,
+          result: { url: args.url, title, content: text },
+        } satisfies ToolExecutionResult;
+      }),
+    createSummary: (result: ToolExecutionResult) => {
+      if (!result.success || !result.result) return undefined;
+      const res = result.result as { url: string; title: string; content: string };
+      return `Fetched ${res.url}${res.title ? ` — "${res.title}"` : ""} (${res.content.length} chars)`;
+    },
+  });
+}

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -6,6 +6,18 @@ import { defineTool, makeZodValidator } from "./base-tool";
 
 const DEFAULT_MAX_CONTENT_LENGTH = 50_000;
 
+const SUPPORTED_CONTENT_TYPES = [
+  "text/html",
+  "text/plain",
+  "application/json",
+  "application/xml",
+  "text/xml",
+] as const;
+
+function isSupportedContentType(contentType: string): boolean {
+  return SUPPORTED_CONTENT_TYPES.some((type) => contentType.includes(type));
+}
+
 const webFetchSchema = z
   .object({
     url: z.string().url().describe("The URL to fetch content from"),
@@ -56,13 +68,7 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         }
 
         const contentType = response.headers.get("content-type") ?? "";
-        const isSupported =
-          contentType.includes("text/html") ||
-          contentType.includes("text/plain") ||
-          contentType.includes("application/json") ||
-          contentType.includes("application/xml") ||
-          contentType.includes("text/xml");
-        if (!isSupported) {
+        if (!isSupportedContentType(contentType)) {
           return {
             success: false,
             result: null,

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -36,9 +36,10 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         yield* logger.debug(`[Web Fetch] Fetching ${args.url}`);
 
         const response = yield* Effect.tryPromise({
-          try: () =>
+          try: (signal) =>
             fetch(args.url, {
               headers: { "User-Agent": "Mozilla/5.0 (compatible; Jazz CLI)" },
+              signal,
             }),
           catch: (error) =>
             new Error(
@@ -51,6 +52,15 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
             success: false,
             result: null,
             error: `HTTP ${response.status} ${response.statusText} for ${args.url}`,
+          } satisfies ToolExecutionResult;
+        }
+
+        const contentType = response.headers.get("content-type") ?? "";
+        if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
+          return {
+            success: false,
+            result: null,
+            error: `Unsupported content type "${contentType}" for ${args.url} — only text/html and text/plain are supported`,
           } satisfies ToolExecutionResult;
         }
 

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
-import { HTTP_USER_AGENT } from "@/core/constants/agent";
+import { WEB_FETCH_USER_AGENT } from "@/core/constants/agent";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
 import { defineTool, makeZodValidator } from "./base-tool";
@@ -51,7 +51,7 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         const response = yield* Effect.tryPromise({
           try: (signal) =>
             fetch(args.url, {
-              headers: { "User-Agent": HTTP_USER_AGENT },
+              headers: { "User-Agent": WEB_FETCH_USER_AGENT },
               signal,
             }),
           catch: (error) =>

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -5,6 +5,7 @@ import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
 import { defineTool, makeZodValidator } from "./base-tool";
 
 const DEFAULT_MAX_CONTENT_LENGTH = 50_000;
+const USER_AGENT = "Mozilla/5.0 (compatible; Jazz CLI)";
 
 const SUPPORTED_CONTENT_TYPES = [
   "text/html",
@@ -50,7 +51,7 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         const response = yield* Effect.tryPromise({
           try: (signal) =>
             fetch(args.url, {
-              headers: { "User-Agent": "Mozilla/5.0 (compatible; Jazz CLI)" },
+              headers: { "User-Agent": USER_AGENT },
               signal,
             }),
           catch: (error) =>

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -66,8 +66,8 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
         const title = titleMatch?.[1]?.trim() ?? "";
 
         const text = html
-          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ")
-          .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ")
+          .replace(/<script\b[^<]*(?:(?!<\/script\s*>)<[^<]*)*<\/script\s*>/gi, " ")
+          .replace(/<style\b[^<]*(?:(?!<\/style\s*>)<[^<]*)*<\/style\s*>/gi, " ")
           .replace(/<[^>]+>/g, " ")
           .replace(/\s+/g, " ")
           .trim()

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -30,3 +30,5 @@ export const DEFAULT_MAX_LLM_RETRIES = 3;
 
 /** Maximum delay between LLM retry attempts in seconds (caps exponential backoff) */
 export const MAX_RETRY_DELAY_SECONDS = 30;
+
+export const HTTP_USER_AGENT = "Jazz/1.0 (https://github.com/lvndry/jazz)";

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -32,3 +32,5 @@ export const DEFAULT_MAX_LLM_RETRIES = 3;
 export const MAX_RETRY_DELAY_SECONDS = 30;
 
 export const HTTP_USER_AGENT = "Jazz/1.0 (https://github.com/lvndry/jazz)";
+export const WEB_FETCH_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -40,9 +40,11 @@ import { xai, type XaiProviderOptions } from "@ai-sdk/xai";
 import { minimax } from "vercel-minimax-ai-provider";
 import {
   createOpenRouter,
+  openrouter as openrouterDefaultInstance,
   type OpenRouterProviderOptions,
   type OpenRouterProviderSettings,
 } from "@openrouter/ai-sdk-provider";
+import { createProviderToolFactory } from "@ai-sdk/provider-utils";
 import {
   gateway,
   generateText,
@@ -324,6 +326,12 @@ function getProviderNativeWebSearchTool(
         }
         return null;
       }
+      case "openrouter": {
+        if (typeof openrouterDefaultInstance.tools?.webSearch === "function") {
+          return openrouterDefaultInstance.tools.webSearch({}) as unknown as ToolSet[string];
+        }
+        return null;
+      }
       default:
         return null;
     }
@@ -335,6 +343,22 @@ function getProviderNativeWebSearchTool(
     }
     return null;
   }
+}
+
+const openrouterWebFetchTool = createProviderToolFactory<unknown, { url?: string }>({
+  id: "openrouter.web_fetch",
+  inputSchema: z.object({ url: z.string().optional() }),
+});
+
+/**
+ * Get provider-native web fetch tool if supported by the provider.
+ * Currently only OpenRouter supports server-side web fetch.
+ */
+function getProviderNativeWebFetchTool(providerName: ProviderName): ToolSet[string] | null {
+  if (providerName.toLowerCase() === "openrouter") {
+    return openrouterWebFetchTool({}) as unknown as ToolSet[string];
+  }
+  return null;
 }
 
 /**
@@ -959,6 +983,19 @@ class AISDKService implements LLMService {
           `[Web Search] web_search tool available but may fail: provider ${providerName} has no native support and no external provider configured`,
         );
         // Keep Jazz's web_search tool but it will return an error when called
+      }
+    }
+
+    // Handle the special case for web_fetch.
+    const hasWebFetch = requestedTools.some((t) => t.function.name === "web_fetch");
+    if (hasWebFetch) {
+      const providerNativeWebFetch = getProviderNativeWebFetchTool(providerName);
+      if (providerNativeWebFetch) {
+        void this.logger.debug(
+          `[Web Fetch] Using provider-native web fetch tool for ${providerName}`,
+        );
+        tools["web_fetch"] = providerNativeWebFetch;
+        providerNativeToolNames.add("web_fetch");
       }
     }
 

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -345,9 +345,9 @@ function getProviderNativeWebSearchTool(
   }
 }
 
-const openrouterWebFetchTool = createProviderToolFactory<unknown, { url?: string }>({
+const openrouterWebFetchTool = createProviderToolFactory<unknown, Record<string, never>>({
   id: "openrouter.web_fetch",
-  inputSchema: z.object({ url: z.string().optional() }),
+  inputSchema: z.object({ url: z.string().url().describe("The URL to fetch content from") }),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Upgrades `@openrouter/ai-sdk-provider` from `2.2.3` → `2.9.0`, which adds `openrouter.tools.webSearch()` factory
- Wires `openrouter:web_search` as a provider-native tool — OpenRouter agents now show **Built-in** as a web search option in the config wizard
- Adds `openrouter:web_fetch` native server tool via `createProviderToolFactory` from `@ai-sdk/provider-utils`, used automatically when the provider is OpenRouter
- Adds a client-side `web_fetch` Jazz tool (fetches URL, strips HTML) as a fallback for all other providers
- Registers `web_fetch` in `WEB_SEARCH_CATEGORY` alongside `web_search` — agents with Web Search tools enabled get `web_fetch` too

## Test plan

- [ ] Create an agent with OpenRouter as the provider and Web Search enabled — confirm **Built-in** appears as an option
- [ ] Confirm selecting Built-in sets no external provider and the agent uses `openrouter:web_search` server-side
- [ ] Confirm `web_fetch` appears as a tool in the Web Search category for OpenRouter agents
- [ ] Confirm `web_fetch` falls back to client-side fetch for non-OpenRouter providers
- [ ] `bun test` passes (1198 tests)
- [ ] `bun run typecheck` clean