### PR TITLE
fix(agent): bump DEFAULT_MAX_LLM_RETRIES from 3 to 8

### DIFF
--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -26,7 +26,7 @@ export const FILE_LOCK_MAX_RETRIES = 10;
 export const FILE_LOCK_RETRY_DELAY_MS = 100;
 
 /** Default maximum number of LLM API retries on transient failures */
-export const DEFAULT_MAX_LLM_RETRIES = 3;
+export const DEFAULT_MAX_LLM_RETRIES = 8;
 
 /** Maximum delay between LLM retry attempts in seconds (caps exponential backoff) */
 export const MAX_RETRY_DELAY_SECONDS = 30;

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -26,7 +26,7 @@ export const FILE_LOCK_MAX_RETRIES = 10;
 export const FILE_LOCK_RETRY_DELAY_MS = 100;
 
 /** Default maximum number of LLM API retries on transient failures */
-export const DEFAULT_MAX_LLM_RETRIES = 8;
+export const DEFAULT_MAX_LLM_RETRIES = 10;
 
 /** Maximum delay between LLM retry attempts in seconds (caps exponential backoff) */
 export const MAX_RETRY_DELAY_SECONDS = 30;


### PR DESCRIPTION
## Summary

- Increases `DEFAULT_MAX_LLM_RETRIES` from 3 to 8
- The LLM-request timeout is computed as `Math.max(120, maxRetries × MAX_RETRY_DELAY_SECONDS + 30)` — with 3 retries this evaluates to exactly **120 s (2 min)**, which is too tight for slow providers and causes CI failures
- With 8 retries the timeout becomes **270 s (4.5 min)**, and agents get more attempts on transient rate-limit / network errors

## Test plan

- [ ] Confirm CI "Generate release notes" job no longer hits `TimeoutException` after merge
- [ ] Verify agent runs still respect per-config `maxRetries` overrides (unchanged logic in `agent-runner.ts`)