### PR TITLE
fix(llm): suppress AI SDK system-in-messages warning

### DIFF
--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -1054,6 +1054,7 @@ class AISDKService implements LLMService {
         const result = await generateText({
           model,
           messages: coreMessages,
+          allowSystemInMessages: true,
           ...(typeof options.temperature === "number" ? { temperature: options.temperature } : {}),
           ...(tools ? { tools } : {}),
           ...(requestedToolChoice ? { toolChoice: requestedToolChoice } : {}),
@@ -1288,6 +1289,7 @@ class AISDKService implements LLMService {
                 streamTextResult = streamText({
                   model,
                   messages: coreMessages,
+                  allowSystemInMessages: true,
                   ...(typeof options.temperature === "number"
                     ? { temperature: options.temperature }
                     : {}),


### PR DESCRIPTION
## What and why

The AI SDK emits a security warning whenever system messages appear in the `messages` array rather than the dedicated `system` option. Jazz intentionally places system messages in `messages` to attach provider-level cache-control options (e.g. `cacheControl: { type: "ephemeral" }` for Anthropic/OpenRouter, `promptCacheKey` for OpenAI). Adding `allowSystemInMessages: true` tells the SDK this placement is deliberate, eliminating the noisy warning without altering any runtime behaviour.

## Before this PR

Every call to `generateText` and `streamText` would emit this warning to stderr:

> AI SDK Warning: System messages in the prompt or messages fields can be a security risk because they may enable prompt injection attacks. Use the system option instead when possible. Set allowSystemInMessages to true to suppress this warning, or false to throw an error.

## After this PR

The warning is silenced. System messages continue to be passed in `messages` with their per-provider caching `providerOptions` intact, so prompt-cache cost and latency benefits are preserved.

## Changes made

- `src/services/llm/ai-sdk-service.ts` — Added `allowSystemInMessages: true` to both the `generateText` call (non-streaming path) and the `streamText` call (streaming path).

## Impact

No behaviour change for end users or providers. The only observable difference is the absence of the warning in logs and stderr output. Prompt caching for Anthropic, OpenAI, and OpenRouter is unaffected.

## How to test

1. Run Jazz with any Anthropic or OpenAI model and send a message.
2. Confirm no "AI SDK Warning: System messages…" line appears in the output or logs.
3. Edge case — enable debug logging (`--log-level debug`) and verify system messages are still being sent with `providerOptions` caching hints in the message conversion debug output.
