### PR TITLE
fix(agent): recover gracefully from LLM request timeouts

### DIFF
--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -213,8 +213,6 @@ export function executeAgentLoop(
               lastUserMessage: lastUserContent,
             });
 
-            // Get completion via strategy — catch LLM request timeouts and inject a
-            // recovery prompt so the agent can write partial results instead of crashing.
             const maybeResult = yield* strategy.getCompletion(currentMessages, i).pipe(
               Effect.map(Option.some),
               Effect.catchAll((error) =>
@@ -225,15 +223,12 @@ export function executeAgentLoop(
             );
 
             if (Option.isNone(maybeResult)) {
-              yield* logger.warn("LLM request timed out — injecting recovery prompt", {
+              yield* logger.warn("LLM request timed out", {
                 agentId: agent.id,
                 conversationId: actualConversationId,
                 iteration: i + 1,
               });
-              yield* presentationService.presentWarning(
-                agent.name,
-                "LLM request timed out — injecting recovery prompt",
-              );
+              yield* presentationService.presentWarning(agent.name, "LLM request timed out");
               currentMessages.push({
                 role: "user",
                 content:

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber, Option, Ref } from "effect";
+import { Cause, Effect, Fiber, Option, Ref } from "effect";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
 import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 import { type AgentConfigService } from "@/core/interfaces/agent-config";
@@ -213,8 +213,36 @@ export function executeAgentLoop(
               lastUserMessage: lastUserContent,
             });
 
-            // Get completion via strategy
-            const result = yield* strategy.getCompletion(currentMessages, i);
+            // Get completion via strategy — catch LLM request timeouts and inject a
+            // recovery prompt so the agent can write partial results instead of crashing.
+            const maybeResult = yield* strategy.getCompletion(currentMessages, i).pipe(
+              Effect.map(Option.some),
+              Effect.catchAll((error) =>
+                Cause.isTimeoutException(error)
+                  ? Effect.succeed(Option.none())
+                  : Effect.fail(error),
+              ),
+            );
+
+            if (Option.isNone(maybeResult)) {
+              yield* logger.warn("LLM request timed out — injecting recovery prompt", {
+                agentId: agent.id,
+                conversationId: actualConversationId,
+                iteration: i + 1,
+              });
+              yield* presentationService.presentWarning(
+                agent.name,
+                "LLM request timed out — injecting recovery prompt",
+              );
+              currentMessages.push({
+                role: "user",
+                content:
+                  "The previous LLM request timed out. Please provide the best response you can based on what you have gathered so far.",
+              });
+              continue;
+            }
+
+            const result = maybeResult.value;
 
             if (result.interrupted) {
               const completion = result.completion;

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -172,6 +172,7 @@ export function executeAgentLoop(
         let finished = false;
         let interrupted = false;
         let iterationsUsed = 0;
+        let consecutiveTimeouts = 0;
 
         for (let i = 0; i < maxIterations; i++) {
           yield* Effect.sync(() => beginIteration(runMetrics, i + 1));
@@ -223,12 +224,25 @@ export function executeAgentLoop(
             );
 
             if (Option.isNone(maybeResult)) {
-              yield* logger.warn("LLM request timed out", {
+              consecutiveTimeouts++;
+              yield* logger.warn("LLM request timed out — injecting recovery prompt", {
                 agentId: agent.id,
                 conversationId: actualConversationId,
                 iteration: i + 1,
+                consecutiveTimeouts,
               });
-              yield* presentationService.presentWarning(agent.name, "LLM request timed out");
+              if (consecutiveTimeouts > 1) {
+                yield* presentationService.presentWarning(
+                  agent.name,
+                  "LLM request timed out twice in a row — stopping",
+                );
+                finished = true;
+                break;
+              }
+              yield* presentationService.presentWarning(
+                agent.name,
+                "LLM request timed out — injecting recovery prompt",
+              );
               currentMessages.push({
                 role: "user",
                 content:
@@ -236,6 +250,8 @@ export function executeAgentLoop(
               });
               continue;
             }
+
+            consecutiveTimeouts = 0;
 
             const result = maybeResult.value;
 


### PR DESCRIPTION
## Summary

- `Effect.timeout` on LLM requests (10-min default) was raising an uncaught `TimeoutException` that crashed the entire workflow before it could produce any output
- Catches `TimeoutException` via `Cause.isTimeoutException` in `executeAgentLoop`, injects a recovery prompt, and continues the loop instead of propagating the failure
- Applies to both the main agent and subagents (which share the same loop via `runRecursive`)

## Behavior change

**Before:** LLM request timeout → `TimeoutException` propagates uncaught → workflow crash, no output written

**After:** LLM request timeout → warning displayed → recovery prompt injected (*"The previous LLM request timed out. Please provide the best response you can based on what you have gathered so far."*) → loop continues → agent wraps up with whatever it collected

## Test plan

- [ ] Trigger a workflow with a model/prompt that is likely to hit the 10-min LLM timeout
- [ ] Verify the workflow emits a warning instead of crashing
- [ ] Verify the agent produces partial output rather than nothing