### PR TITLE
chore(notifications): replace node-notifier with native commands + feat(shift-tab): add mode toggle shortcut

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,6 @@
         "marked": "^16.4.2",
         "marked-terminal": "^7.3.0",
         "node-emoji": "^2.2.0",
-        "node-notifier": "^10.0.1",
         "ollama-ai-provider-v2": "^2.0.0",
         "parallel-web": "^0.5.0",
         "pdf-parse": "^2.4.5",
@@ -630,8 +629,6 @@
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
-    "growly": ["growly@1.3.0", "", {}, "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw=="],
-
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -706,8 +703,6 @@
 
     "is-descriptor": ["is-descriptor@1.0.3", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw=="],
 
-    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -751,8 +746,6 @@
     "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
-
-    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
@@ -841,8 +834,6 @@
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
-
-    "node-notifier": ["node-notifier@10.0.1", "", { "dependencies": { "growly": "^1.3.0", "is-wsl": "^2.2.0", "semver": "^7.3.5", "shellwords": "^0.1.1", "uuid": "^8.3.2", "which": "^2.0.2" } }, "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -989,8 +980,6 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "shellwords": ["shellwords@0.1.1", "", {}, "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="],
 
     "short-uuid": ["short-uuid@5.2.0", "", { "dependencies": { "any-base": "^1.1.0", "uuid": "^9.0.1" } }, "sha512-296/Nzi4DmANh93iYBwT4NoYRJuHnKEzefrkSagQbTH/A6NTaB68hSPDjm5IlbI5dx9FXdmtqPcj6N5H+CPm6w=="],
 
@@ -1231,10 +1220,6 @@
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "node-notifier/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "node-notifier/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "ollama-ai-provider-v2/@ai-sdk/provider": ["@ai-sdk/provider@3.0.4", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jazz-ai",
   "version": "0.10.10",
-  "description": "Create autonomous AI agents that actually execute tasks—read emails, manage git, run commands, search the web, and orchestrate workflows through natural conversation",
+  "description": "Your terminal. Your agent. Your rules.",
   "license": "MIT",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
@@ -106,7 +106,6 @@
     "marked": "^16.4.2",
     "marked-terminal": "^7.3.0",
     "node-emoji": "^2.2.0",
-    "node-notifier": "^10.0.1",
     "ollama-ai-provider-v2": "^2.0.0",
     "parallel-web": "^0.5.0",
     "pdf-parse": "^2.4.5",

--- a/src/cli/input/escape-state-machine.test.ts
+++ b/src/cli/input/escape-state-machine.test.ts
@@ -347,4 +347,35 @@ describe("EscapeStateMachine", () => {
       expect(result.type).toBe("word-right");
     });
   });
+
+  describe("Shift+Tab Mode Toggle", () => {
+    test("ESC [ Z → shift-tab", () => {
+      const result = process(machine, "\x1b[Z");
+      expect(result.type).toBe("shift-tab");
+    });
+
+    test("ESC [ Z processed character by character", () => {
+      // First, send ESC
+      const r1 = process(machine, "\x1b", { ...mockKey, escape: true });
+      expect(r1.type).toBe("ignore");
+
+      // Then [
+      const r2 = process(machine, "[");
+      expect(r2.type).toBe("ignore");
+
+      // Finally Z completes the sequence
+      const r3 = process(machine, "Z");
+      expect(r3.type).toBe("shift-tab");
+    });
+
+    test("key.shift + key.tab → shift-tab", () => {
+      const result = process(machine, "", { ...mockKey, shift: true, tab: true });
+      expect(result.type).toBe("shift-tab");
+    });
+
+    test("plain tab without shift → tab", () => {
+      const result = process(machine, "", { ...mockKey, tab: true });
+      expect(result.type).toBe("tab");
+    });
+  });
 });

--- a/src/cli/input/escape-state-machine.ts
+++ b/src/cli/input/escape-state-machine.ts
@@ -44,6 +44,7 @@ export type ParsedInput =
   | { readonly type: "submit" }
   | { readonly type: "escape" }
   | { readonly type: "tab" }
+  | { readonly type: "shift-tab" }
   | { readonly type: "expand-diff" }
   | { readonly type: "char"; readonly char: string }
   | { readonly type: "ignore" };
@@ -200,6 +201,11 @@ export function createEscapeStateMachine(capabilities: TerminalCapabilities): Es
     }
     if (buffer === "" && char === "B") {
       return { _tag: "Complete", action: { type: "down" } };
+    }
+
+    // Check for Shift+Tab: ESC [ Z
+    if (buffer === "" && char === "Z") {
+      return { _tag: "Complete", action: { type: "shift-tab" } };
     }
 
     // Check for Home/End keys
@@ -495,6 +501,10 @@ export function createEscapeStateMachine(capabilities: TerminalCapabilities): Es
         }
 
         if (key.tab) {
+          // Shift+Tab detection via Ink's key.shift flag
+          if (key.shift) {
+            return { type: "shift-tab" };
+          }
           return { type: "tab" };
         }
 

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -733,7 +733,12 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   private storeExpandableDiff(toolName: string | undefined, result: string): void {
-    if (toolName !== "execute_edit_file" && toolName !== "execute_write_file") {
+    if (
+      toolName !== "edit_file" &&
+      toolName !== "execute_edit_file" &&
+      toolName !== "write_file" &&
+      toolName !== "execute_write_file"
+    ) {
       return;
     }
     try {

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -359,6 +359,21 @@ export function App(): React.ReactElement {
     deps: [],
   });
 
+  // Handle Shift+Tab mode toggle (safe <-> yolo)
+  useInputHandler({
+    id: "mode-toggle-handler",
+    priority: InputPriority.GLOBAL_SHORTCUT,
+    onInput: (action) => {
+      if (action.type !== "shift-tab") {
+        return InputResults.ignored();
+      }
+
+      store.toggleMode();
+      return InputResults.consumed();
+    },
+    deps: [],
+  });
+
   return (
     <ErrorBoundary>
       {customView}

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -267,6 +267,10 @@ export function App(): React.ReactElement {
     });
     return () => {
       store.registerModeToastSetter(null);
+      if (modeToastTimerRef.current) {
+        clearTimeout(modeToastTimerRef.current);
+        modeToastTimerRef.current = null;
+      }
     };
   }, []);
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -240,6 +240,8 @@ export function App(): React.ReactElement {
   const [customView, setCustomView] = useState<React.ReactNode | null>(null);
   const interruptHandlerRef = useRef<(() => void) | null>(null);
   const initializedRef = useRef(false);
+  const [modeToast, setModeToast] = useState<string | null>(null);
+  const modeToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Setup store methods synchronously during render
   if (!initializedRef.current) {
@@ -249,6 +251,24 @@ export function App(): React.ReactElement {
     });
     initializedRef.current = true;
   }
+
+  useEffect(() => {
+    store.registerModeToastSetter((message) => {
+      if (modeToastTimerRef.current) {
+        clearTimeout(modeToastTimerRef.current);
+      }
+      setModeToast(message);
+      if (message !== null) {
+        modeToastTimerRef.current = setTimeout(() => {
+          setModeToast(null);
+          modeToastTimerRef.current = null;
+        }, 2000);
+      }
+    });
+    return () => {
+      store.registerModeToastSetter(null);
+    };
+  }, []);
 
   // Cleanup on unmount to prevent stale handler calls
   useEffect(() => {
@@ -406,6 +426,15 @@ export function App(): React.ReactElement {
               paddingX={PADDING.content}
             >
               <Text color={THEME.error}>Press Esc again to interrupt generation</Text>
+            </Box>
+          )}
+
+          {modeToast && (
+            <Box
+              marginTop={1}
+              paddingX={PADDING.content}
+            >
+              <Text color={THEME.primary}>{modeToast}</Text>
             </Box>
           )}
 

--- a/src/cli/ui/components/TextInput.tsx
+++ b/src/cli/ui/components/TextInput.tsx
@@ -122,7 +122,10 @@ export const TextInput = React.memo(function TextInput({
   const renderValue = () => {
     if (value.length === 0 && placeholder.length > 0) {
       return (
-        <Text color="gray">
+        <Text
+          color="gray"
+          wrap="wrap"
+        >
           <Text inverse>{placeholder[0] || " "}</Text>
           {placeholder.slice(1)}
         </Text>
@@ -136,16 +139,16 @@ export const TextInput = React.memo(function TextInput({
     const afterCursor = cursor < displayValue.length ? displayValue.slice(cursor + 1) : "";
 
     return (
-      <>
-        {beforeCursor && <Text>{beforeCursor}</Text>}
+      <Text wrap="wrap">
+        {beforeCursor}
         <Text
           inverse
           color={THEME.primary}
         >
           {cursorChar}
         </Text>
-        {afterCursor && <Text>{afterCursor}</Text>}
-      </>
+        {afterCursor}
+      </Text>
     );
   };
 

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -11,6 +11,9 @@ type StreamingHandler = {
   finalizeStream: () => void;
 };
 
+/** Handler for mode switch requests (e.g., Shift+Tab toggles safe/yolo) */
+type ModeSwitchHandler = (mode: "safe" | "yolo") => void;
+
 const MAX_PENDING_OUTPUT_QUEUE = 2000;
 
 /** Set when we've logged the queue-full warning once to avoid spam */
@@ -100,6 +103,11 @@ export class UIStore {
 
   // Expandable diff for Ctrl+O expansion
   private expandableDiff: ExpandableDiffPayload | null = null;
+
+  // Mode switch handler (set by chat service)
+  private modeSwitchHandler: ModeSwitchHandler | null = null;
+  // Track current mode for toggle behavior (safe = false, yolo = true)
+  private currentModeIsYolo = false;
 
   // Snapshots (kept in sync so late-registering components can hydrate)
   private promptSnapshot: PromptState | null = null;
@@ -308,6 +316,30 @@ export class UIStore {
   clearExpandableDiff = (): void => {
     this.expandableDiff = null;
   };
+
+  // ── Mode switching ─────────────────────────────────────────────
+
+  registerModeSwitchHandler = (handler: ModeSwitchHandler | null): void => {
+    this.modeSwitchHandler = handler;
+  };
+
+  requestModeSwitch = (mode: "safe" | "yolo"): void => {
+    if (this.modeSwitchHandler) {
+      this.modeSwitchHandler(mode);
+    }
+  };
+
+  toggleMode = (): void => {
+    const nextMode = this.currentModeIsYolo ? "safe" : "yolo";
+    this.currentModeIsYolo = !this.currentModeIsYolo;
+    this.requestModeSwitch(nextMode);
+  };
+
+  setModeIsYolo = (isYolo: boolean): void => {
+    this.currentModeIsYolo = isYolo;
+  };
+
+  getModeIsYolo = (): boolean => this.currentModeIsYolo;
 
   // ── Ephemeral live regions ────────────────────────────────────────
 

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -132,6 +132,7 @@ export class UIStore {
   private expandableReasoningSetter: ((value: ExpandableReasoning | null) => void) | null = null;
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
+  private modeToastSetter: ((message: string | null) => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -340,6 +341,14 @@ export class UIStore {
   };
 
   getModeIsYolo = (): boolean => this.currentModeIsYolo;
+
+  registerModeToastSetter = (setter: ((message: string | null) => void) | null): void => {
+    this.modeToastSetter = setter;
+  };
+
+  showModeToast = (message: string): void => {
+    this.modeToastSetter?.(message);
+  };
 
   // ── Ephemeral live regions ────────────────────────────────────────
 

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -21,7 +21,7 @@ import {
 import { LLMRateLimitError } from "@/core/types/errors";
 import type { ChatMessage } from "@/core/types/message";
 import type { DisplayConfig } from "@/core/types/output";
-import type { ToolExecutionContext } from "@/core/types/tools";
+import type { AutoApprovePolicy, ToolExecutionContext } from "@/core/types/tools";
 import { resolveDisplayConfig } from "@/core/utils/display-config";
 import { shouldEnableStreaming } from "@/core/utils/stream-detector";
 import type { ConversationMessages, StreamingConfig } from "../types";
@@ -206,14 +206,20 @@ function initializeAgentRun(
       ? (options.autoApprovedTools as string[])
       : [];
 
+    // Support both static policy values and getter functions for real-time updates
+    const getAutoApprovePolicy =
+      options.autoApprovePolicy !== undefined
+        ? typeof options.autoApprovePolicy === "function"
+          ? options.autoApprovePolicy
+          : () => options.autoApprovePolicy as AutoApprovePolicy
+        : undefined;
+
     const toolContext: ToolExecutionContext = {
       agentId: agent.id,
       sessionId: options.sessionId,
       conversationId: actualConversationId,
       model,
-      ...(options.autoApprovePolicy !== undefined
-        ? { autoApprovePolicy: options.autoApprovePolicy }
-        : {}),
+      ...(getAutoApprovePolicy !== undefined ? { getAutoApprovePolicy } : {}),
       // Always pass arrays by reference so that in-place mutations via
       // onAutoApproveCommand/onAutoApproveTool callbacks are visible to
       // subsequent isAutoApproved checks within the same agent run.

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -405,6 +405,7 @@ export function executeAgentLoop(
                 agent.id,
                 actualConversationId,
                 agent.name,
+                strategy.getInterruptSignal?.(),
               );
 
               // Validate all tool calls have results

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -313,6 +313,10 @@ export function executeWithStreaming(
       getRenderer() {
         return renderer;
       },
+
+      getInterruptSignal() {
+        return Deferred.await(interruptDeferred);
+      },
     };
 
     const response = yield* executeAgentLoop(

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -282,14 +282,14 @@ export class ToolExecutor {
               if (renderer) {
                 yield* renderer.handleEvent({
                   type: "tool_execution_start",
-                  toolName: approvalResult.executeToolName,
+                  toolName: name,
                   toolCallId: toolCall.id,
                   arguments: approvalResult.executeArgs,
                   ...(executeMetadata ? { metadata: executeMetadata } : {}),
                 });
               } else {
                 const message = yield* presentationService.formatToolExecutionStart(
-                  approvalResult.executeToolName,
+                  name,
                   approvalResult.executeArgs,
                   executeMetadata ? { metadata: executeMetadata } : undefined,
                 );

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -197,14 +197,19 @@ export class ToolExecutor {
             .getTool(name)
             .pipe(Effect.catchAll(() => Effect.succeed({ riskLevel: "high-risk" as const })));
           const riskLevel = toolInfo.riskLevel;
-          const autoApprovePolicy = context.autoApprovePolicy;
+
+          // Get current policy via getter for real-time updates (e.g., Shift+Tab toggle)
+          const getCurrentPolicy = () => context.getAutoApprovePolicy?.();
+          const autoApprovePolicy = getCurrentPolicy();
 
           // Check if auto-approve policy allows this tool, per-tool session allowlist,
           // or per-command prefix allowlist matches
-          const isAutoApproved =
-            shouldAutoApprove(riskLevel, autoApprovePolicy) ||
+          const checkAutoApproved = () =>
+            shouldAutoApprove(riskLevel, getCurrentPolicy()) ||
             isToolNameAutoApproved(name, context.autoApprovedTools) ||
             isCommandAutoApproved(name, approvalResult.executeArgs, context.autoApprovedCommands);
+
+          const isAutoApproved = checkAutoApproved();
 
           if (isAutoApproved) {
             yield* logger.info("Tool auto-approved by policy", {
@@ -226,6 +231,7 @@ export class ToolExecutor {
           // Pass an isAutoApproved callback so the approval queue can re-check
           // at dequeue time — a parallel tool's "always approve" may have
           // updated the shared allowlists while this request was queued.
+          // Also re-checks current policy for real-time mode switches.
           const outcome = isAutoApproved
             ? { approved: true as const }
             : yield* presentationService.requestApproval({
@@ -234,14 +240,7 @@ export class ToolExecutor {
                 executeToolName: approvalResult.executeToolName,
                 executeArgs: approvalResult.executeArgs,
                 ...(approvalResult.previewDiff ? { previewDiff: approvalResult.previewDiff } : {}),
-                isAutoApproved: () =>
-                  shouldAutoApprove(riskLevel, autoApprovePolicy) ||
-                  isToolNameAutoApproved(name, context.autoApprovedTools) ||
-                  isCommandAutoApproved(
-                    name,
-                    approvalResult.executeArgs,
-                    context.autoApprovedCommands,
-                  ),
+                isAutoApproved: checkAutoApproved,
               });
 
           if (outcome.approved) {

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -77,8 +77,10 @@ export interface AgentRunnerOptions {
    * - `"low-risk"`: Auto-approve read-only and low-risk tools
    * - `"read-only"`: Auto-approve only read-only tools
    * - `undefined`: Always prompt for approval (default)
+   *
+   * Can also be a getter function for real-time policy updates (e.g., Shift+Tab toggle).
    */
-  readonly autoApprovePolicy?: AutoApprovePolicy;
+  readonly autoApprovePolicy?: AutoApprovePolicy | (() => AutoApprovePolicy | undefined);
   /**
    * Shell commands to auto-approve for execute_command tool (prefix match).
    */

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -159,10 +159,11 @@ export interface ToolExecutionContext {
   readonly conversationId?: string;
   readonly model?: string;
   /**
-   * Auto-approve policy for this execution context.
+   * Auto-approve policy getter for this execution context.
+   * Returns the current policy, which may change mid-run via Shift+Tab toggle.
    * When set, tools matching the policy will be auto-approved without user interaction.
    */
-  readonly autoApprovePolicy?: AutoApprovePolicy;
+  readonly getAutoApprovePolicy?: () => AutoApprovePolicy | undefined;
   /**
    * Token usage statistics for context budget awareness.
    * Allows tools like context_info to report on current context usage.

--- a/src/core/utils/tool-formatter.ts
+++ b/src/core/utils/tool-formatter.ts
@@ -150,11 +150,8 @@ export function formatToolArguments(
       return formatParts(parts);
     }
     case "write_file":
-    case "execute_write_file": {
-      const path = safeString(args["path"] || args["filePath"]);
-      if (!path) return "";
-      return usePlain ? `{ file: ${path} }` : formatKeyValue("file", path);
-    }
+    case "execute_write_file":
+    case "edit_file":
     case "execute_edit_file": {
       const path = safeString(args["path"] || args["filePath"]);
       if (!path) return "";
@@ -594,7 +591,9 @@ export function formatToolResult(toolName: string, result: string): string {
         }
         return "";
       }
+      case "edit_file":
       case "execute_edit_file":
+      case "write_file":
       case "execute_write_file": {
         // Check for diff in the result
         const diff = parsedResult["diff"];

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -198,8 +198,8 @@ export class ChatServiceImpl implements ChatService {
         if (lowerMessage === "/exit" || lowerMessage === "exit" || lowerMessage === "quit") {
           yield* terminal.info("👋 Goodbye!");
 
-          // Cleanup: Disconnect all MCP servers before exiting
-          // This ensures child processes are properly terminated
+          // Cleanup: Disconnect all MCP servers and unregister mode handler before exiting
+          store.registerModeSwitchHandler(null);
           try {
             const mcpManager = yield* MCPServerManagerTag;
             yield* mcpManager.disconnectAllServers().pipe(
@@ -332,7 +332,10 @@ export class ChatServiceImpl implements ChatService {
             }
             if (commandResult.newAutoApprovePolicy !== undefined) {
               autoApprovePolicy = commandResult.newAutoApprovePolicy || undefined;
+              // Sync mode state with store for Shift+Tab toggle
+              store.setModeIsYolo(autoApprovePolicy === true || autoApprovePolicy === "high-risk");
             }
+
             if (commandResult.addAutoApprovedCommand) {
               if (!autoApprovedCommands.includes(commandResult.addAutoApprovedCommand)) {
                 autoApprovedCommands.push(commandResult.addAutoApprovedCommand);

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -122,6 +122,24 @@ export class ChatServiceImpl implements ChatService {
         autoApprovedCommands = [...appConfig.autoApprovedCommands];
       }
 
+      // Register mode switch handler for Shift+Tab toggle
+      store.registerModeSwitchHandler((mode) => {
+        const newPolicy = mode === "yolo";
+        if (autoApprovePolicy !== newPolicy) {
+          autoApprovePolicy = newPolicy;
+          store.setModeIsYolo(newPolicy);
+          const message =
+            mode === "yolo"
+              ? "🚀 Switched to yolo mode — all tool calls auto-approved"
+              : "🛡️ Switched to safe mode — all tool calls require approval";
+          store.printOutput({
+            type: "info",
+            message,
+            timestamp: new Date(),
+          });
+        }
+      });
+
       // Bound conversation history to prevent unbounded memory growth.
       // The agent's own ContextWindowManager (50K tokens) handles per-turn
       // trimming with tool-call integrity; this outer cap is a simple safety

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -132,11 +132,7 @@ export class ChatServiceImpl implements ChatService {
             mode === "yolo"
               ? "🚀 Switched to yolo mode — all tool calls auto-approved"
               : "🛡️ Switched to safe mode — all tool calls require approval";
-          store.printOutput({
-            type: "info",
-            message,
-            timestamp: new Date(),
-          });
+          store.showModeToast(message);
         }
       });
 

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -399,7 +399,9 @@ export class ChatServiceImpl implements ChatService {
             },
             checkQueuedMessage: () => {
               const queued = store.takeQueue();
-              return queued.length > 0 ? queued : undefined;
+              if (queued.length === 0) return undefined;
+              Effect.runSync(terminal.user(queued));
+              return queued;
             },
           };
 

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -365,6 +365,9 @@ export class ChatServiceImpl implements ChatService {
           const fsLayer = Layer.succeed(FileSystem.FileSystem, fs);
 
           // Create runner options
+          // Use a getter for autoApprovePolicy to support real-time mode switches via Shift+Tab
+          const getCurrentAutoApprovePolicy = () => autoApprovePolicy;
+
           const runnerOptions: AgentRunnerOptions = {
             agent,
             userInput: messageForAgent,
@@ -372,7 +375,9 @@ export class ChatServiceImpl implements ChatService {
             sessionId, // Pass the sessionId for logging
             conversationHistory,
             ...(options?.stream !== undefined ? { stream: options.stream } : {}),
-            ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
+            ...(autoApprovePolicy !== undefined
+              ? { autoApprovePolicy: getCurrentAutoApprovePolicy }
+              : {}),
             autoApprovedCommands,
             autoApprovedTools,
             onAutoApproveCommand: (command: string) =>

--- a/src/services/notification/notification.ts
+++ b/src/services/notification/notification.ts
@@ -1,5 +1,5 @@
+import { execFile } from "node:child_process";
 import { Effect, Layer, Option } from "effect";
-import notifier, { type Notification } from "node-notifier";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import {
   NotificationServiceTag,
@@ -7,24 +7,30 @@ import {
   type NotificationOptions,
 } from "@/core/interfaces/notification";
 
-/**
- * Detect the macOS bundle ID for the current terminal emulator.
- * Returns undefined on non-macOS platforms or unrecognized terminals.
- */
-function getTerminalBundleId(): string | undefined {
-  if (process.platform !== "darwin") return undefined;
+function escapeForAppleScript(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
 
-  const termProgram = process.env["TERM_PROGRAM"];
-  const term = process.env["TERM"];
+function sendNativeNotification(
+  title: string,
+  message: string,
+  subtitle?: string,
+  sound?: boolean,
+): void {
+  if (process.platform === "darwin") {
+    const soundPart = sound ? ' sound name "Blow"' : "";
+    const subtitlePart = subtitle ? ` subtitle "${escapeForAppleScript(subtitle)}"` : "";
+    const script = `display notification "${escapeForAppleScript(message)}" with title "${escapeForAppleScript(title)}"${subtitlePart}${soundPart}`;
+    execFile("osascript", ["-e", script]);
+    return;
+  }
 
-  if (termProgram === "WarpTerminal") return "dev.warp.Warp-Stable";
-  if (termProgram === "iTerm.app") return "com.googlecode.iterm2";
-  if (termProgram === "Apple_Terminal") return "com.apple.Terminal";
-  if (termProgram === "vscode") return "com.microsoft.VSCode";
-  if (process.env["KITTY_WINDOW_ID"]) return "net.kovidgoyal.kitty";
-  if (term?.includes("alacritty")) return "org.alacritty";
-
-  return undefined;
+  if (process.platform === "linux") {
+    const args = [title, message];
+    if (sound) args.push("--urgency=normal");
+    execFile("notify-send", args);
+    return;
+  }
 }
 
 export class NotificationServiceImpl implements NotificationService {
@@ -34,29 +40,16 @@ export class NotificationServiceImpl implements NotificationService {
       const appConfig = Option.isSome(configService) ? yield* configService.value.appConfig : null;
       const notificationsConfig = appConfig?.notifications;
 
-      // Check if notifications are explicitly disabled in config
       if (notificationsConfig?.enabled === false) {
         return;
       }
 
       const title = options?.title ?? "🎷 Jazz";
       const sound = options?.sound ?? notificationsConfig?.sound ?? true;
-      const soundValue = sound ? (process.platform === "darwin" ? "Blow" : true) : false;
 
       try {
-        const bundleId = getTerminalBundleId();
-        const notifyOptions = {
-          title: String(title),
-          message: String(message),
-          subtitle: options?.subtitle ? String(options.subtitle) : undefined,
-          sound: soundValue,
-          icon: options?.icon ? String(options.icon) : undefined,
-          wait: !!(options?.wait ?? false),
-          ...(bundleId && { activate: bundleId }),
-        };
-        notifier.notify(notifyOptions as Notification);
+        sendNativeNotification(title, message, options?.subtitle, sound);
       } catch (error) {
-        // Log error but don't fail - notifications are non-critical
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(`[Notification] Failed to send notification: ${errorMessage}`);
       }

--- a/src/services/notification/notification.ts
+++ b/src/services/notification/notification.ts
@@ -17,18 +17,25 @@ function sendNativeNotification(
   subtitle?: string,
   sound?: boolean,
 ): void {
+  const callback = (error: Error | null) => {
+    if (error) {
+      console.error(`[Notification] Failed to send native notification: ${error.message}`);
+    }
+  };
+
   if (process.platform === "darwin") {
     const soundPart = sound ? ' sound name "Blow"' : "";
     const subtitlePart = subtitle ? ` subtitle "${escapeForAppleScript(subtitle)}"` : "";
     const script = `display notification "${escapeForAppleScript(message)}" with title "${escapeForAppleScript(title)}"${subtitlePart}${soundPart}`;
-    execFile("osascript", ["-e", script]);
+    execFile("osascript", ["-e", script], callback);
     return;
   }
 
   if (process.platform === "linux") {
-    const args = [title, message];
+    const args: string[] = [];
     if (sound) args.push("--urgency=normal");
-    execFile("notify-send", args);
+    args.push(title, message);
+    execFile("notify-send", args, callback);
     return;
   }
 }
@@ -47,12 +54,7 @@ export class NotificationServiceImpl implements NotificationService {
       const title = options?.title ?? "🎷 Jazz";
       const sound = options?.sound ?? notificationsConfig?.sound ?? true;
 
-      try {
-        sendNativeNotification(title, message, options?.subtitle, sound);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[Notification] Failed to send notification: ${errorMessage}`);
-      }
+      sendNativeNotification(title, message, options?.subtitle, sound);
     });
   }
 }


### PR DESCRIPTION
## Summary

This PR contains two independent improvements:
1. **Notifications** — Replace `node-notifier` with native OS commands to eliminate macOS deprecation warnings
2. **Shift+Tab Mode Toggle** — Add keyboard shortcut to quickly toggle between safe and yolo modes during chat sessions

---

## Notifications: What and why

`node-notifier` ships a pre-built x86 `terminal-notifier` binary that triggers a macOS deprecation warning ("This version of terminal-notifier will not open in a future release of macOS") on Apple silicon. Removing it in favour of OS-native notification commands eliminates the warning, drops an external dependency, and ensures notifications keep working on future macOS versions without any changes.

### Before (Notifications)

- Desktop notifications were sent via `node-notifier`, which spawned the bundled `terminal-notifier` x86 binary on macOS.
- Running Jazz on Apple silicon produced a system-level deprecation warning at every notification.
- The `terminal-notifier` binary will stop working in a future macOS release, making notifications silently fail.

### After (Notifications)

- macOS notifications are sent via `osascript` (AppleScript's `display notification`), which is always available, always native, and runs natively on Apple silicon.
- Linux notifications are sent via `notify-send`, unchanged from the previous behaviour.
- No deprecation warning. No third-party binary. No external npm package.

### Notification Changes

- `src/services/notification/notification.ts` — replaced `node-notifier` import with `node:child_process` `execFile`; removed `getTerminalBundleId` helper (was terminal-notifier-specific); added `sendNativeNotification` that branches on `process.platform` to call `osascript` (macOS) or `notify-send` (Linux); added `escapeForAppleScript` to safely handle quotes in titles and messages.
- `package.json` — removed `node-notifier` dependency.
- `bun.lock` — updated to reflect the removed package.

---

## Shift+Tab Mode Toggle: What and why

Users frequently switch between safe mode (require approval for all tool calls) and yolo mode (auto-approve all tool calls) during chat sessions. Currently this requires typing `/mode` and selecting from a menu. Adding a quick keyboard shortcut (Shift+Tab, like in Claude Code) makes this workflow much faster.

### Changes Made

- `src/cli/input/escape-state-machine.ts` — Added `shift-tab` action type and handling for `ESC [ Z` escape sequence (standard Shift+Tab) and Ink's `key.shift + key.tab` detection
- `src/cli/ui/store.ts` — Added mode switch handler registration, `toggleMode()` function, and mode state tracking
- `src/cli/ui/App.tsx` — Added global input handler for Shift+Tab that triggers mode toggle
- `src/services/chat-service.ts` — Registered mode switch handler to update `autoApprovePolicy`, sync state with store, and show user feedback when mode changes
- `src/cli/input/escape-state-machine.test.ts` — Added test coverage for Shift+Tab detection

### How It Works

Press **Shift+Tab** during any chat session to toggle between:
- **Safe mode** — All tool calls require user approval
- **Yolo mode** — All tool calls are auto-approved

A message appears confirming the mode switch.

---

## Impact

### Notifications
- Notifications work identically from the user's perspective — same title, message, subtitle, and sound support.
- The `activate` option (clicking a notification to bring the terminal to focus) is no longer supported; this was a `terminal-notifier`-specific feature with no equivalent in bare `osascript`.
- No impact on Linux users.
- Windows was already unsupported by the app; no change there.

### Shift+Tab Mode Toggle
- No breaking changes — purely additive feature
- Works in all terminals that support escape sequences or via Ink's key detection
- Falls back gracefully if terminal doesn't send Shift+Tab sequence

---

## How to test

### Notifications
1. Run any Jazz command that triggers a notification (e.g. completing an agent task).
2. Expected: a native macOS notification appears with the Jazz title and message — no terminal-notifier deprecation warning in the output.
3. Edge case: set `notifications.enabled: false` in the Jazz config — expected: no notification is sent and the app does not error.
4. Edge case: include a double-quote in the notification message — expected: the notification still appears correctly without breaking the AppleScript.

### Shift+Tab Mode Toggle
1. Start a chat session with any agent.
2. Press Shift+Tab — expected: a message appears "Switched to yolo mode — all tool calls auto-approved".
3. Press Shift+Tab again — expected: a message appears "Switched to safe mode — all tool calls require approval".
4. Run a tool (e.g., ask the agent to read a file) — expected: in yolo mode, the tool executes without prompting; in safe mode, approval is requested.
