### PR TITLE
feat(agent): surface llm retry and slow-call status

### DIFF
--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -67,7 +67,6 @@ export function executeWithoutStreaming(
           ) => presentationService.presentStatus(message, level);
 
           const retryAttemptRef = yield* Ref.make(0);
-          yield* Ref.set(retryAttemptRef, 0);
           const batchRetrySchedule = makeUserVisibleLlmRetrySchedule(
             maxRetries,
             agent.name,

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -1,4 +1,8 @@
-import { Duration, Effect } from "effect";
+import { Cause, Duration, Effect, Ref } from "effect";
+import {
+  makeUserVisibleLlmRetrySchedule,
+  withLongRunningLlmNotice,
+} from "@/core/agent/execution/llm-retry-present";
 import { DEFAULT_MAX_LLM_RETRIES, LLM_TIMEOUT_SECONDS } from "@/core/constants/agent";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -9,7 +13,6 @@ import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-regi
 import type { ConversationMessages } from "@/core/types";
 import { LLMRateLimitError } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
-import { makeLLMRetrySchedule } from "@/core/utils/llm-error";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
 import type { RecursiveRunner } from "../context/summarizer";
 import { recordLLMRetry } from "../metrics/agent-run-metrics";
@@ -58,17 +61,45 @@ export function executeWithoutStreaming(
             reasoning_effort: reasoningEffort,
           };
 
+          const showAgentStatus = (
+            message: string,
+            level: "info" | "success" | "warning" | "error" | "progress",
+          ) => presentationService.presentStatus(message, level);
+
+          const retryAttemptRef = yield* Ref.make(0);
+          yield* Ref.set(retryAttemptRef, 0);
+          const batchRetrySchedule = makeUserVisibleLlmRetrySchedule(
+            maxRetries,
+            agent.name,
+            showAgentStatus,
+            retryAttemptRef,
+          );
+
           const completion = yield* Effect.retry(
-            Effect.gen(function* () {
-              try {
-                return yield* llmService.createChatCompletion(provider, llmOptions);
-              } catch (error) {
-                recordLLMRetry(runMetrics, error);
-                throw error;
-              }
-            }),
-            makeLLMRetrySchedule(maxRetries),
-          ).pipe(Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)));
+            withLongRunningLlmNotice(
+              agent.name,
+              showAgentStatus,
+              Effect.gen(function* () {
+                try {
+                  return yield* llmService.createChatCompletion(provider, llmOptions);
+                } catch (error) {
+                  recordLLMRetry(runMetrics, error);
+                  throw error;
+                }
+              }),
+            ),
+            batchRetrySchedule,
+          ).pipe(
+            Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+            Effect.tapError((error) =>
+              Cause.isTimeoutException(error)
+                ? showAgentStatus(
+                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                    "warning",
+                  )
+                : Effect.void,
+            ),
+          );
 
           return { completion, interrupted: false };
         });

--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -1,0 +1,53 @@
+import { Duration, Effect, Fiber, Ref, Schedule } from "effect";
+import { LLM_SLOW_MODEL_HINT_SECONDS } from "@/core/constants/agent";
+import { isRetryableLLMError, makeLLMRetrySchedule } from "@/core/utils/llm-error";
+
+export type PresentStatusFn = (
+  message: string,
+  level: "info" | "success" | "warning" | "error" | "progress",
+) => Effect.Effect<void, never>;
+
+export function withLongRunningLlmNotice<A, E, R>(
+  agentName: string,
+  presentStatus: PresentStatusFn,
+  body: Effect.Effect<A, E, R>,
+  slowHintAfterSeconds: number = LLM_SLOW_MODEL_HINT_SECONDS,
+): Effect.Effect<A, E, R> {
+  return Effect.gen(function* () {
+    const noticeFiber = yield* Effect.fork(
+      Effect.sleep(Duration.seconds(slowHintAfterSeconds)).pipe(
+        Effect.flatMap(() =>
+          presentStatus(
+            `${agentName} is taking longer than expected… still waiting on the model.`,
+            "progress",
+          ),
+        ),
+      ),
+    );
+    return yield* body.pipe(
+      Effect.ensuring(Fiber.interrupt(noticeFiber).pipe(Effect.catchAll(() => Effect.void))),
+    );
+  });
+}
+
+export function makeUserVisibleLlmRetrySchedule(
+  maxRetries: number,
+  agentName: string,
+  presentStatus: PresentStatusFn,
+  attemptRef: Ref.Ref<number>,
+) {
+  return makeLLMRetrySchedule(maxRetries).pipe(
+    Schedule.tapInput((error: unknown) =>
+      isRetryableLLMError(error)
+        ? Effect.gen(function* () {
+            yield* Ref.update(attemptRef, (count) => count + 1);
+            const attempt = yield* Ref.get(attemptRef);
+            yield* presentStatus(
+              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
+              "progress",
+            );
+          })
+        : Effect.void,
+    ),
+  );
+}

--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -24,9 +24,7 @@ export function withLongRunningLlmNotice<A, E, R>(
         ),
       ),
     );
-    return yield* body.pipe(
-      Effect.ensuring(Fiber.interrupt(noticeFiber).pipe(Effect.catchAll(() => Effect.void))),
-    );
+    return yield* body.pipe(Effect.ensuring(Fiber.interrupt(noticeFiber)));
   });
 }
 
@@ -40,8 +38,7 @@ export function makeUserVisibleLlmRetrySchedule(
     Schedule.tapInput((error: unknown) =>
       isRetryableLLMError(error)
         ? Effect.gen(function* () {
-            yield* Ref.update(attemptRef, (count) => count + 1);
-            const attempt = yield* Ref.get(attemptRef);
+            const attempt = yield* Ref.updateAndGet(attemptRef, (count) => count + 1);
             yield* presentStatus(
               `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
               "progress",

--- a/src/core/agent/execution/streaming-executor.test.ts
+++ b/src/core/agent/execution/streaming-executor.test.ts
@@ -56,6 +56,7 @@ const mockPresentationService = {
   formatCompletion: () => Effect.succeed(""),
   formatWarning: () => Effect.succeed(""),
   formatAgentResponse: () => Effect.succeed(""),
+  presentStatus: () => Effect.void,
 } as any;
 
 const mockToolRegistry = {

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -1,4 +1,8 @@
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Option, Ref, Stream } from "effect";
+import {
+  makeUserVisibleLlmRetrySchedule,
+  withLongRunningLlmNotice,
+} from "@/core/agent/execution/llm-retry-present";
 import { DEFAULT_MAX_LLM_RETRIES, LLM_TIMEOUT_SECONDS } from "@/core/constants/agent";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -16,7 +20,7 @@ import {
   LLMRequestError,
 } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
-import { isRetryableLLMError, makeLLMRetrySchedule } from "@/core/utils/llm-error";
+import { isRetryableLLMError } from "@/core/utils/llm-error";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
 import type { RecursiveRunner } from "../context/summarizer";
 import { recordFirstTokenLatency, recordLLMRetry } from "../metrics/agent-run-metrics";
@@ -104,32 +108,58 @@ export function executeWithStreaming(
             reasoning_effort: reasoningEffort,
           };
 
+          const showAgentStatus = (
+            message: string,
+            level: "info" | "success" | "warning" | "error" | "progress",
+          ) => presentationService.presentStatus(message, level);
+
+          const retryAttemptRef = yield* Ref.make(0);
+          yield* Ref.set(retryAttemptRef, 0);
+          const streamingRetrySchedule = makeUserVisibleLlmRetrySchedule(
+            maxRetries,
+            agent.name,
+            showAgentStatus,
+            retryAttemptRef,
+          );
+
           const streamingResult = yield* Effect.retry(
-            Effect.gen(function* () {
-              try {
-                return yield* llmService.createStreamingChatCompletion(provider, llmOptions);
-              } catch (error) {
-                recordLLMRetry(runMetrics, error);
-                if (
-                  error instanceof LLMRequestError ||
-                  error instanceof LLMRateLimitError ||
-                  error instanceof LLMAuthenticationError
-                ) {
-                  yield* logger.error("LLM request error", {
-                    provider,
-                    model: agent.config.llmModel,
-                    errorType: error._tag,
-                    message: error.message,
-                    agentId: agent.id,
-                    conversationId: actualConversationId,
-                  });
+            withLongRunningLlmNotice(
+              agent.name,
+              showAgentStatus,
+              Effect.gen(function* () {
+                try {
+                  return yield* llmService.createStreamingChatCompletion(provider, llmOptions);
+                } catch (error) {
+                  recordLLMRetry(runMetrics, error);
+                  if (
+                    error instanceof LLMRequestError ||
+                    error instanceof LLMRateLimitError ||
+                    error instanceof LLMAuthenticationError
+                  ) {
+                    yield* logger.error("LLM request error", {
+                      provider,
+                      model: agent.config.llmModel,
+                      errorType: error._tag,
+                      message: error.message,
+                      agentId: agent.id,
+                      conversationId: actualConversationId,
+                    });
+                  }
+                  throw error;
                 }
-                throw error;
-              }
-            }),
-            makeLLMRetrySchedule(maxRetries),
+              }),
+            ),
+            streamingRetrySchedule,
           ).pipe(
             Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+            Effect.tapError((error) =>
+              Cause.isTimeoutException(error)
+                ? showAgentStatus(
+                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                    "warning",
+                  )
+                : Effect.void,
+            ),
             Effect.catchIf(
               (error): error is LLMRequestError | LLMRateLimitError => isRetryableLLMError(error),
               (error) =>
@@ -142,17 +172,39 @@ export function executeWithStreaming(
                     agentId: agent.id,
                     conversationId: actualConversationId,
                   });
+                  const fallbackAttemptRef = yield* Ref.make(0);
+                  yield* Ref.set(fallbackAttemptRef, 0);
+                  const fallbackRetrySchedule = makeUserVisibleLlmRetrySchedule(
+                    maxRetries,
+                    agent.name,
+                    showAgentStatus,
+                    fallbackAttemptRef,
+                  );
                   const fallback = yield* Effect.retry(
-                    Effect.gen(function* () {
-                      try {
-                        return yield* llmService.createChatCompletion(provider, llmOptions);
-                      } catch (innerError) {
-                        recordLLMRetry(runMetrics, innerError);
-                        throw innerError;
-                      }
-                    }),
-                    makeLLMRetrySchedule(maxRetries),
-                  ).pipe(Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)));
+                    withLongRunningLlmNotice(
+                      agent.name,
+                      showAgentStatus,
+                      Effect.gen(function* () {
+                        try {
+                          return yield* llmService.createChatCompletion(provider, llmOptions);
+                        } catch (innerError) {
+                          recordLLMRetry(runMetrics, innerError);
+                          throw innerError;
+                        }
+                      }),
+                    ),
+                    fallbackRetrySchedule,
+                  ).pipe(
+                    Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                    Effect.tapError((innerError) =>
+                      Cause.isTimeoutException(innerError)
+                        ? showAgentStatus(
+                            `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                            "warning",
+                          )
+                        : Effect.void,
+                    ),
+                  );
                   return {
                     stream: Stream.empty,
                     response: Effect.succeed(fallback),

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -114,7 +114,6 @@ export function executeWithStreaming(
           ) => presentationService.presentStatus(message, level);
 
           const retryAttemptRef = yield* Ref.make(0);
-          yield* Ref.set(retryAttemptRef, 0);
           const streamingRetrySchedule = makeUserVisibleLlmRetrySchedule(
             maxRetries,
             agent.name,
@@ -173,7 +172,6 @@ export function executeWithStreaming(
                     conversationId: actualConversationId,
                   });
                   const fallbackAttemptRef = yield* Ref.make(0);
-                  yield* Ref.set(fallbackAttemptRef, 0);
                   const fallbackRetrySchedule = makeUserVisibleLlmRetrySchedule(
                     maxRetries,
                     agent.name,

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -34,6 +34,9 @@ export const MAX_RETRY_DELAY_SECONDS = 30;
 /** Total timeout for an LLM completion call, including all retries and backoff delays (15 min covers slow reasoning models) */
 export const LLM_TIMEOUT_SECONDS = 900;
 
+/** Show a slow-model hint if a single LLM attempt stays in flight this long without finishing */
+export const LLM_SLOW_MODEL_HINT_SECONDS = 45;
+
 export const HTTP_USER_AGENT = "Jazz/1.0 (https://github.com/lvndry/jazz)";
 export const WEB_FETCH_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";


### PR DESCRIPTION
## What and why

When the model or network is slow, or when Jazz automatically retries a failed LLM request, users had little in-terminal feedback that work was still happening. This change adds clear status lines so people see that Jazz is waiting, retrying, or has hit the overall time limit.

## Before this PR

- Long-running LLM calls could look idle until tokens arrived or the call failed.
- Automatic retries for transient errors happened in the background with no user-visible progress.
- Hitting the long overall LLM timeout could fail without an explicit, user-facing explanation in the presentation layer.

## After this PR

- After 45 seconds without a single attempt finishing, a progress message names the agent and states that Jazz is still waiting on the model.
- Each automatic retry for a retryable error shows a progress message with the attempt number (up to the configured maximum).
- If the step exceeds the maximum wait time for that request (including retries), a warning names the agent and suggests checking connectivity or trying again.

## Changes made

- `src/core/constants/agent.ts` — add `LLM_SLOW_MODEL_HINT_SECONDS` (45) to control when the slow-call hint appears.
- `src/core/agent/execution/llm-retry-present.ts` — new helpers: optional slow-call notice via a forked sleep fiber and cleanup; user-visible retry schedule built on the existing backoff with `Schedule.tapInput`.
- `src/core/agent/execution/streaming-executor.ts` — wrap streaming open and non-streaming fallback attempts with the slow hint; use the visible retry schedule; show a warning when `Cause.isTimeoutException` fires on the outer timeout.
- `src/core/agent/execution/batch-executor.ts` — same slow hint, visible retries, and timeout warning for non-streaming runs.
- `src/core/agent/execution/streaming-executor.test.ts` — add `presentStatus: () => Effect.void` to the mock presentation service so tests satisfy the interface.

## Impact

- More `presentStatus` traffic (`progress` and `warning`) during agent runs. Implementations that no-op or lightly log these calls should see no functional regression.
- Retry counts, backoff rules, and `LLM_TIMEOUT_SECONDS` are unchanged; only messaging is added.

## How to test

1. From the repo root, run `bun test src/core/agent/execution/streaming-executor.test.ts` and confirm all tests pass.
2. Run `bun run typecheck` and `bun run lint`.
3. Edge case: run a real agent against a model you can slow or interrupt (for example throttle network in your OS or use a mock provider) and confirm you see either the 45-second slow hint, a retry line after a transient failure, or the timeout warning if the overall budget is exceeded.

## Notes for reviewers

- Wording lives mainly in `llm-retry-present.ts` and in the timeout `tapError` branches in the two executors if you want product copy tweaks later.
