### PR TITLE
feat(agent): add unlimited mode for autonomous 24/7 operation

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -127,22 +127,31 @@ function registerAgentCommands(program: Command): void {
     .description("Start a chat with an AI agent by ID or name")
     .option("--stream", "Force streaming mode (real-time output)")
     .option("--no-stream", "Disable streaming mode")
+    .option(
+      "--unlimited",
+      "Lift all per-run guardrails (iteration cap, retries, timeouts) for this run",
+    )
+    .option("--no-unlimited", "Force unlimited mode off for this run, even if enabled in config")
     .action(
       (
         agentIdentifier: string,
         options: {
           stream?: boolean;
           noStream?: boolean;
+          unlimited?: boolean;
+          noUnlimited?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
+        const unlimitedOverride =
+          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
-          chatWithAIAgentCommand(
-            agentIdentifier,
-            streamOption !== undefined ? { stream: streamOption } : {},
-          ),
+          chatWithAIAgentCommand(agentIdentifier, {
+            ...(streamOption !== undefined ? { stream: streamOption } : {}),
+            ...(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
@@ -344,17 +353,30 @@ function registerWorkflowCommands(program: Command): void {
       "--scheduled",
       "Indicates this run was triggered by the system scheduler (launchd/cron)",
     )
+    .option("--unlimited", "Lift all per-run guardrails for this run")
+    .option("--no-unlimited", "Force unlimited mode off for this run")
     .action(
       (
         name: string,
-        options: { autoApprove?: boolean; agent?: string; scheduled?: boolean },
+        options: {
+          autoApprove?: boolean;
+          agent?: string;
+          scheduled?: boolean;
+          unlimited?: boolean;
+          noUnlimited?: boolean;
+        },
         command: Command,
       ) => {
         const opts = program.opts<CliOptions>();
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
+        const unlimitedOverride =
+          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
-          runWorkflowCommand(name, options),
+          runWorkflowCommand(name, {
+            ...options,
+            ...(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
@@ -404,13 +426,20 @@ function registerWorkflowCommands(program: Command): void {
   workflowCommand
     .command("catchup")
     .description("List workflows that missed a scheduled run, select which to run, then run them")
-    .action(() => {
+    .option("--unlimited", "Lift all per-run guardrails for this run")
+    .option("--no-unlimited", "Force unlimited mode off for this run")
+    .action((options: { unlimited?: boolean; noUnlimited?: boolean }) => {
       const opts = program.opts<CliOptions>();
-      runCliEffect(catchupWorkflowCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
+      const unlimitedOverride =
+        options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+      runCliEffect(
+        catchupWorkflowCommand(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+        {
+          verbose: opts.verbose,
+          debug: opts.debug,
+          configPath: opts.config,
+        },
+      );
     });
 
   workflowCommand

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -139,14 +139,13 @@ function registerAgentCommands(program: Command): void {
           stream?: boolean;
           noStream?: boolean;
           unlimited?: boolean;
-          noUnlimited?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
         const unlimitedOverride =
-          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+          options.unlimited === false ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
           chatWithAIAgentCommand(agentIdentifier, {
             ...(streamOption !== undefined ? { stream: streamOption } : {}),
@@ -363,7 +362,6 @@ function registerWorkflowCommands(program: Command): void {
           agent?: string;
           scheduled?: boolean;
           unlimited?: boolean;
-          noUnlimited?: boolean;
         },
         command: Command,
       ) => {
@@ -371,7 +369,7 @@ function registerWorkflowCommands(program: Command): void {
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
         const unlimitedOverride =
-          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+          options.unlimited === false ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
           runWorkflowCommand(name, {
             ...options,
@@ -428,10 +426,10 @@ function registerWorkflowCommands(program: Command): void {
     .description("List workflows that missed a scheduled run, select which to run, then run them")
     .option("--unlimited", "Lift all per-run guardrails for this run")
     .option("--no-unlimited", "Force unlimited mode off for this run")
-    .action((options: { unlimited?: boolean; noUnlimited?: boolean }) => {
+    .action((options: { unlimited?: boolean }) => {
       const opts = program.opts<CliOptions>();
       const unlimitedOverride =
-        options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+        options.unlimited === false ? false : options.unlimited === true ? true : undefined;
       runCliEffect(
         catchupWorkflowCommand(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
         {

--- a/src/cli/commands/chat-agent.ts
+++ b/src/cli/commands/chat-agent.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { ChatServiceTag } from "@/core/interfaces/chat-service";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { TerminalServiceTag } from "@/core/interfaces/terminal";
@@ -22,9 +23,13 @@ export function chatWithAIAgentCommand(
   agentIdentifier: string,
   options?: {
     stream?: boolean;
+    unlimitedOverride?: boolean;
   },
 ) {
   return Effect.gen(function* () {
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const resolvedUnlimited = options?.unlimitedOverride ?? appConfig.unlimited ?? false;
     const normalizedIdentifier = agentIdentifier.trim();
 
     if (normalizedIdentifier.length === 0) {
@@ -81,7 +86,7 @@ export function chatWithAIAgentCommand(
 
     // Start the chat session using the chat service
     const chatService = yield* ChatServiceTag;
-    yield* chatService.startChatSession(agent, options).pipe(
+    yield* chatService.startChatSession(agent, { ...options, unlimited: resolvedUnlimited }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
           const logger = yield* LoggerServiceTag;

--- a/src/cli/commands/config-wizard.ts
+++ b/src/cli/commands/config-wizard.ts
@@ -20,6 +20,7 @@ type ConfigMenuAction =
   | "output-display"
   | "logging"
   | "notifications"
+  | "unlimited"
   | "back";
 
 /**
@@ -36,6 +37,7 @@ export function configWizardCommand() {
         { label: "Output & Display", value: "output-display" },
         { label: "Logging", value: "logging" },
         { label: "Notifications", value: "notifications" },
+        { label: "Unlimited Mode", value: "unlimited" },
         { label: "Back to Main Menu", value: "back" },
       ];
 
@@ -60,6 +62,10 @@ export function configWizardCommand() {
         }
         case "notifications": {
           yield* configureNotifications();
+          break;
+        }
+        case "unlimited": {
+          yield* configureUnlimited();
           break;
         }
         case "back": {
@@ -368,6 +374,24 @@ function configureNotifications() {
 
       yield* terminal.log("");
     }
+  });
+}
+
+function configureUnlimited() {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const current = appConfig.unlimited ?? false;
+
+    const nextValue = yield* terminal.confirm(
+      "Enable unlimited mode by default? (no iteration, retry, or timeout caps — recommended only for trusted long-running setups)",
+      current,
+    );
+
+    yield* configService.set("unlimited", nextValue);
+    yield* terminal.success(`Unlimited mode ${nextValue ? "enabled" : "disabled"}.`);
+    yield* terminal.log("");
   });
 }
 

--- a/src/cli/commands/config.test.ts
+++ b/src/cli/commands/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { coerceConfigValue } from "./config";
+
+describe("coerceConfigValue", () => {
+  it("coerces 'true' to boolean true", () => {
+    expect(coerceConfigValue("true")).toBe(true);
+  });
+
+  it("coerces 'false' to boolean false", () => {
+    expect(coerceConfigValue("false")).toBe(false);
+  });
+
+  it("leaves other strings unchanged", () => {
+    expect(coerceConfigValue("hello")).toBe("hello");
+    expect(coerceConfigValue("")).toBe("");
+    expect(coerceConfigValue("123")).toBe("123");
+  });
+});

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -13,6 +13,17 @@ import { ConfigCard } from "../ui/ConfigCard";
  */
 
 /**
+ * Coerces string values from CLI/terminal input to their proper types.
+ * Needed because argv and terminal.ask always yield strings, so "false" would
+ * otherwise be stored as the truthy string "false" instead of the boolean false.
+ */
+export function coerceConfigValue(raw: string): string | boolean | number {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return raw;
+}
+
+/**
  * List all configuration values
  */
 export function listConfigCommand(): Effect.Effect<
@@ -155,9 +166,11 @@ export function setConfigCommand(
       }
 
       const answer = yield* terminal.ask(`Enter value for ${targetKey}:`);
-      yield* terminal.info(`Setting config: ${targetKey} = ${answer}`);
-      yield* configService.set(targetKey, answer);
-      yield* terminal.success(`Config set: ${targetKey} = ${answer}`);
+      if (answer === undefined) return;
+      const coercedAnswer = coerceConfigValue(answer);
+      yield* terminal.info(`Setting config: ${targetKey} = ${coercedAnswer}`);
+      yield* configService.set(targetKey, coercedAnswer);
+      yield* terminal.success(`Config set: ${targetKey} = ${coercedAnswer}`);
       return;
     }
 
@@ -179,8 +192,9 @@ export function setConfigCommand(
       );
     }
 
-    yield* terminal.info(`Setting config: ${targetKey} = ${value}`);
-    yield* configService.set(targetKey, value);
-    yield* terminal.success(`Config set: ${targetKey} = ${value}`);
+    const coercedValue = coerceConfigValue(value);
+    yield* terminal.info(`Setting config: ${targetKey} = ${coercedValue}`);
+    yield* configService.set(targetKey, coercedValue);
+    yield* terminal.success(`Config set: ${targetKey} = ${coercedValue}`);
   });
 }

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -194,6 +194,7 @@ export function runWorkflowCommand(
     autoApprove?: boolean;
     agent?: string;
     scheduled?: boolean;
+    unlimitedOverride?: boolean;
   },
 ) {
   return Effect.gen(function* () {
@@ -357,8 +358,8 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // maxIterations from workflow metadata is honored unless appConfig.unlimited is on
-    const unlimitedMode = appConfig.unlimited ?? false;
+    // maxIterations from workflow metadata is honored unless unlimited mode is on
+    const unlimitedMode = options?.unlimitedOverride ?? appConfig.unlimited ?? false;
     const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
@@ -564,7 +565,7 @@ export function unscheduleWorkflowCommand(workflowName: string) {
 /**
  * List workflows that need catch-up, let user select which to run, then run them.
  */
-export function catchupWorkflowCommand() {
+export function catchupWorkflowCommand(options: { unlimitedOverride?: boolean } = {}) {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
 
@@ -624,7 +625,11 @@ export function catchupWorkflowCommand() {
     yield* terminal.info(`Running catch-up for ${entriesToRun.length} workflow(s)...`);
     yield* terminal.log("");
 
-    yield* runCatchUpForWorkflows(entriesToRun);
+    yield* runCatchUpForWorkflows(entriesToRun, {
+      ...(options.unlimitedOverride !== undefined
+        ? { unlimitedOverride: options.unlimitedOverride }
+        : {}),
+    });
 
     yield* terminal.log("");
     yield* terminal.success("Catch-up finished.");

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -6,6 +6,7 @@ import { store } from "@/cli/ui/store";
 import { THEME } from "@/cli/ui/theme";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { TerminalServiceTag } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/agent";
@@ -199,6 +200,8 @@ export function runWorkflowCommand(
     const terminal = yield* TerminalServiceTag;
     const workflowService = yield* WorkflowServiceTag;
     const logger = yield* LoggerServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
 
     const isNonInteractive = options?.autoApprove === true;
     const isSchedulerTriggered = options?.scheduled === true;
@@ -354,16 +357,17 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // Run the agent with the workflow prompt
-    // maxIterations from workflow metadata is optional — omit for no limit
+    // maxIterations from workflow metadata is honored unless appConfig.unlimited is on
+    const unlimitedMode = appConfig.unlimited ?? false;
     const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       sessionId: `workflow-${workflowName}-${Date.now()}`,
       conversationId: `workflow-${workflowName}-${Date.now()}`,
-      ...(workflow.metadata.maxIterations != null
+      ...(workflow.metadata.maxIterations != null && !unlimitedMode
         ? { maxIterations: workflow.metadata.maxIterations }
         : {}),
+      unlimited: unlimitedMode,
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
     }).pipe(
       Effect.tap((result) =>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -113,15 +113,13 @@ const PromptIsland = React.memo(PromptIslandComponent);
 // ============================================================================
 
 function StatusFooterIslandComponent(): React.ReactElement | null {
-  // RunStats is the footer's primary content — model · tokens · cost.
-  // The working directory is rendered by the prompt island already, so
-  // we don't duplicate it here (avoids conflicting with the prompt's
-  // single-slot wd setter).
   const [runStats, setRunStats] = React.useState<RunStats>({});
+  const [unlimited, setUnlimited] = React.useState<boolean>(store.getUnlimitedActive());
   const initializedRef = useRef(false);
 
   if (!initializedRef.current) {
     store.registerRunStatsSetter(setRunStats);
+    store.registerUnlimitedSetter(setUnlimited);
     setRunStats(store.getRunStatsSnapshot());
     initializedRef.current = true;
   }
@@ -129,6 +127,7 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
   useEffect(() => {
     return () => {
       store.registerRunStatsSetter(() => {});
+      store.registerUnlimitedSetter(null);
     };
   }, []);
 
@@ -137,6 +136,7 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
       status={null}
       workingDirectory={null}
       runStats={runStats}
+      unlimited={unlimited}
     />
   );
 }

--- a/src/cli/ui/StatusFooter.tsx
+++ b/src/cli/ui/StatusFooter.tsx
@@ -67,16 +67,18 @@ function StatusFooter({
   status,
   workingDirectory,
   runStats,
+  unlimited,
 }: {
   status: string | null;
   workingDirectory: string | null;
   runStats: RunStats;
+  unlimited: boolean;
 }) {
   const hasRunStats =
     runStats.model !== undefined ||
     runStats.tokensInContext !== undefined ||
     runStats.costUSD !== undefined;
-  const hasContent = status || workingDirectory || hasRunStats;
+  const hasContent = status || workingDirectory || hasRunStats || unlimited;
   if (!hasContent) return null;
 
   const homeDir = process.env["HOME"];
@@ -110,6 +112,7 @@ function StatusFooter({
       width="100%"
     >
       <Box flexShrink={1}>
+        {unlimited && <Text color={THEME.warning}>[unlimited] </Text>}
         {status ? (
           <AnimatedEllipsis
             label={status}

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -108,6 +108,7 @@ export class UIStore {
   private modeSwitchHandler: ModeSwitchHandler | null = null;
   // Track current mode for toggle behavior (safe = false, yolo = true)
   private currentModeIsYolo = false;
+  private currentUnlimitedActive = false;
 
   // Snapshots (kept in sync so late-registering components can hydrate)
   private promptSnapshot: PromptState | null = null;
@@ -133,6 +134,7 @@ export class UIStore {
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
+  private unlimitedSetter: ((active: boolean) => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -349,6 +351,20 @@ export class UIStore {
   showModeToast = (message: string): void => {
     this.modeToastSetter?.(message);
   };
+
+  // ── Unlimited mode indicator ─────────────────────────────────────────────
+
+  registerUnlimitedSetter = (setter: ((active: boolean) => void) | null): void => {
+    this.unlimitedSetter = setter;
+    if (setter) setter(this.currentUnlimitedActive);
+  };
+
+  setUnlimitedActive = (active: boolean): void => {
+    this.currentUnlimitedActive = active;
+    this.unlimitedSetter?.(active);
+  };
+
+  getUnlimitedActive = (): boolean => this.currentUnlimitedActive;
 
   // ── Ephemeral live regions ────────────────────────────────────────
 

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -254,6 +254,7 @@ function initializeAgentRun(
       model,
       connectedMCPServers,
       maxRetries: Math.max(0, Math.floor(appConfig.maxRetries ?? DEFAULT_MAX_LLM_RETRIES)),
+      unlimited: options.unlimited ?? false,
       knownSkills: relevantSkills,
     };
   });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -659,4 +659,64 @@ describe("executeAgentLoop with unlimited", () => {
       ToolExecutor.executeToolCalls = originalExecute;
     }
   });
+
+  it("sets parentUnlimited on the tool execution context when unlimited is true", async () => {
+    let capturedContext: any = null;
+    let iteration = 0;
+
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () => {
+        iteration++;
+        if (iteration === 1) {
+          return Effect.succeed({
+            completion: {
+              id: "c1",
+              model: "gpt-4",
+              content: "",
+              toolCalls: [
+                {
+                  id: "call_1",
+                  type: "function" as const,
+                  function: { name: "test_tool", arguments: "{}" },
+                },
+              ],
+            },
+            interrupted: false,
+          });
+        }
+        return Effect.succeed({
+          completion: { id: "c2", model: "gpt-4", content: "Done" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    try {
+      ToolExecutor.executeToolCalls = mock((_toolCalls: any[], context: any) => {
+        capturedContext = context;
+        return Effect.succeed([
+          { toolCallId: "call_1", name: "test_tool", result: "ok", success: true },
+        ]);
+      });
+
+      await Effect.runPromise(
+        executeAgentLoop(
+          makeOptions({ unlimited: true }),
+          makeRunContext(),
+          displayConfig,
+          strategy,
+          runRecursive,
+        ).pipe(Effect.provide(TestLayer)),
+      );
+
+      expect(capturedContext?.parentUnlimited).toBe(true);
+    } finally {
+      ToolExecutor.executeToolCalls = originalExecute;
+    }
+  });
 });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -582,3 +582,79 @@ describe("detectMeltdown", () => {
     expect(detectMeltdown([...diverse, ...meltdown])).toBe(true);
   });
 });
+
+describe("buildBudgetPressureMessage with unlimited", () => {
+  it("returns null at every threshold when unlimited is true", () => {
+    expect(buildBudgetPressureMessage(700, 1000, true)).toBeNull();
+    expect(buildBudgetPressureMessage(950, 1000, true)).toBeNull();
+    expect(buildBudgetPressureMessage(999, 1000, true)).toBeNull();
+  });
+
+  it("still emits pressure messages when unlimited is false", () => {
+    expect(buildBudgetPressureMessage(70, 100, false)?.content).toContain("WARNING");
+    expect(buildBudgetPressureMessage(95, 100, false)?.content).toContain("CRITICAL");
+  });
+});
+
+describe("executeAgentLoop with unlimited", () => {
+  it("ignores maxIterations when unlimited is true", async () => {
+    let callCount = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () => {
+        callCount++;
+        if (callCount <= 3) {
+          return Effect.succeed({
+            completion: {
+              id: `c${callCount}`,
+              model: "gpt-4",
+              content: "",
+              toolCalls: [
+                {
+                  id: `call_${callCount}`,
+                  type: "function" as const,
+                  function: { name: "test_tool", arguments: "{}" },
+                },
+              ],
+            },
+            interrupted: false,
+          });
+        }
+        return Effect.succeed({
+          completion: { id: "c-final", model: "gpt-4", content: "Done beyond limit" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
+      Effect.succeed(
+        toolCalls.map((tc: any) => ({
+          toolCallId: tc.id,
+          name: tc.function.name,
+          result: "ok",
+          success: true,
+        })),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 2, unlimited: true }),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(result.content).toBe("Done beyond limit");
+    expect(callCount).toBeGreaterThanOrEqual(4);
+
+    ToolExecutor.executeToolCalls = originalExecute;
+  });
+});

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -631,30 +631,32 @@ describe("executeAgentLoop with unlimited", () => {
     };
 
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
-      Effect.succeed(
-        toolCalls.map((tc: any) => ({
-          toolCallId: tc.id,
-          name: tc.function.name,
-          result: "ok",
-          success: true,
-        })),
-      ),
-    );
+    try {
+      ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
+        Effect.succeed(
+          toolCalls.map((tc: any) => ({
+            toolCallId: tc.id,
+            name: tc.function.name,
+            result: "ok",
+            success: true,
+          })),
+        ),
+      );
 
-    const result = await Effect.runPromise(
-      executeAgentLoop(
-        makeOptions({ maxIterations: 2, unlimited: true }),
-        makeRunContext(),
-        displayConfig,
-        strategy,
-        runRecursive,
-      ).pipe(Effect.provide(TestLayer)),
-    );
+      const result = await Effect.runPromise(
+        executeAgentLoop(
+          makeOptions({ maxIterations: 2, unlimited: true }),
+          makeRunContext(),
+          displayConfig,
+          strategy,
+          runRecursive,
+        ).pipe(Effect.provide(TestLayer)),
+      );
 
-    expect(result.content).toBe("Done beyond limit");
-    expect(callCount).toBeGreaterThanOrEqual(4);
-
-    ToolExecutor.executeToolCalls = originalExecute;
+      expect(result.content).toBe("Done beyond limit");
+      expect(callCount).toBe(4);
+    } finally {
+      ToolExecutor.executeToolCalls = originalExecute;
+    }
   });
 });

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -390,6 +390,7 @@ export function executeAgentLoop(
                 conversationMessages: currentMessages,
                 parentAgent: agent,
                 parentMaxIterations: maxIterations,
+                parentUnlimited: unlimited,
                 compactConversation: (compacted: readonly ChatMessage[]) => {
                   currentMessages = [
                     currentMessages[0],

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -408,6 +408,7 @@ export function executeAgentLoop(
                 actualConversationId,
                 agent.name,
                 strategy.getInterruptSignal?.(),
+                unlimited,
               );
 
               // Validate all tool calls have results

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -38,7 +38,9 @@ import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../type
 export function buildBudgetPressureMessage(
   iteration: number,
   maxIterations: number,
+  unlimited: boolean = false,
 ): { role: "user"; content: string } | null {
+  if (unlimited) return null;
   const pct = iteration / maxIterations;
   if (pct >= 0.9) {
     return {
@@ -179,7 +181,7 @@ export function executeAgentLoop(
     // Use: main loop
     ({ logger, finalizeFiberRef }) =>
       Effect.gen(function* () {
-        const { agent, maxIterations: maxIter } = options;
+        const { agent, maxIterations: maxIter, unlimited = false } = options;
         const maxIterations = maxIter ?? DEFAULT_MAX_ITERATIONS;
         const presentationService = yield* PresentationServiceTag;
         const { actualConversationId, context, tools, messages, runMetrics, provider, model } =
@@ -219,7 +221,7 @@ export function executeAgentLoop(
         let iterationsUsed = 0;
         const recentToolCalls: TrackedToolCall[] = [];
 
-        for (let i = 0; i < maxIterations; i++) {
+        for (let i = 0; unlimited || i < maxIterations; i++) {
           yield* Effect.sync(() => beginIteration(runMetrics, i + 1));
           try {
             if (!options.internal && strategy.shouldShowThinking) {
@@ -255,7 +257,7 @@ export function executeAgentLoop(
               lastUserMessage: lastUserContent,
             });
 
-            const budgetMsg = buildBudgetPressureMessage(i + 1, maxIterations);
+            const budgetMsg = buildBudgetPressureMessage(i + 1, maxIterations, unlimited);
             const messagesForLLM = budgetMsg
               ? ([...currentMessages, budgetMsg] as typeof currentMessages)
               : currentMessages;
@@ -366,7 +368,7 @@ export function executeAgentLoop(
                 recentToolCalls.splice(0, recentToolCalls.length - MELTDOWN_WINDOW_SIZE);
               }
 
-              if (detectMeltdown(recentToolCalls)) {
+              if (!unlimited && detectMeltdown(recentToolCalls)) {
                 yield* logger.warn("Meltdown detected — injecting recovery signal", {
                   agentId: agent.id,
                   recentTools: recentToolCalls.slice(-10).map((tc) => tc.name),

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -73,6 +73,7 @@ export function executeWithoutStreaming(
             agent.name,
             showAgentStatus,
             retryAttemptRef,
+            runContext.unlimited ?? false,
           );
 
           const completion = yield* Effect.retry(

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -76,7 +76,7 @@ export function executeWithoutStreaming(
             runContext.unlimited ?? false,
           );
 
-          const completion = yield* Effect.retry(
+          const batchCall = Effect.retry(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
@@ -90,17 +90,21 @@ export function executeWithoutStreaming(
               }),
             ),
             batchRetrySchedule,
-          ).pipe(
-            Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-            Effect.tapError((error) =>
-              Cause.isTimeoutException(error)
-                ? showAgentStatus(
-                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                    "warning",
-                  )
-                : Effect.void,
-            ),
           );
+          const batchCallWithTimeout = runContext.unlimited
+            ? batchCall
+            : batchCall.pipe(
+                Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                Effect.tapError((error) =>
+                  Cause.isTimeoutException(error)
+                    ? showAgentStatus(
+                        `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                        "warning",
+                      )
+                    : Effect.void,
+                ),
+              );
+          const completion = yield* batchCallWithTimeout;
 
           return { completion, interrupted: false };
         });

--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -33,14 +33,16 @@ export function makeUserVisibleLlmRetrySchedule(
   agentName: string,
   presentStatus: PresentStatusFn,
   attemptRef: Ref.Ref<number>,
+  unlimited: boolean = false,
 ) {
-  return makeLLMRetrySchedule(maxRetries).pipe(
+  return makeLLMRetrySchedule(maxRetries, unlimited).pipe(
     Schedule.tapInput((error: unknown) =>
       isRetryableLLMError(error)
         ? Effect.gen(function* () {
             const attempt = yield* Ref.updateAndGet(attemptRef, (count) => count + 1);
+            const tail = unlimited ? "" : ` of up to ${maxRetries}`;
             yield* presentStatus(
-              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
+              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt}${tail})…`,
               "progress",
             );
           })

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -120,6 +120,7 @@ export function executeWithStreaming(
             agent.name,
             showAgentStatus,
             retryAttemptRef,
+            runContext.unlimited ?? false,
           );
 
           const streamingResult = yield* Effect.retry(
@@ -178,6 +179,7 @@ export function executeWithStreaming(
                     agent.name,
                     showAgentStatus,
                     fallbackAttemptRef,
+                    runContext.unlimited ?? false,
                   );
                   const fallback = yield* Effect.retry(
                     withLongRunningLlmNotice(

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -123,7 +123,7 @@ export function executeWithStreaming(
             runContext.unlimited ?? false,
           );
 
-          const streamingResult = yield* Effect.retry(
+          const streamingCall = Effect.retry(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
@@ -151,16 +151,21 @@ export function executeWithStreaming(
               }),
             ),
             streamingRetrySchedule,
-          ).pipe(
-            Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-            Effect.tapError((error) =>
-              Cause.isTimeoutException(error)
-                ? showAgentStatus(
-                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                    "warning",
-                  )
-                : Effect.void,
-            ),
+          );
+          const streamingCallWithTimeout = runContext.unlimited
+            ? streamingCall
+            : streamingCall.pipe(
+                Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                Effect.tapError((error) =>
+                  Cause.isTimeoutException(error)
+                    ? showAgentStatus(
+                        `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                        "warning",
+                      )
+                    : Effect.void,
+                ),
+              );
+          const streamingResult = yield* streamingCallWithTimeout.pipe(
             Effect.catchIf(
               (error): error is LLMRequestError | LLMRateLimitError => isRetryableLLMError(error),
               (error) =>
@@ -181,7 +186,7 @@ export function executeWithStreaming(
                     fallbackAttemptRef,
                     runContext.unlimited ?? false,
                   );
-                  const fallback = yield* Effect.retry(
+                  const fallbackCall = Effect.retry(
                     withLongRunningLlmNotice(
                       agent.name,
                       showAgentStatus,
@@ -195,17 +200,21 @@ export function executeWithStreaming(
                       }),
                     ),
                     fallbackRetrySchedule,
-                  ).pipe(
-                    Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-                    Effect.tapError((innerError) =>
-                      Cause.isTimeoutException(innerError)
-                        ? showAgentStatus(
-                            `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                            "warning",
-                          )
-                        : Effect.void,
-                    ),
                   );
+                  const fallbackCallWithTimeout = runContext.unlimited
+                    ? fallbackCall
+                    : fallbackCall.pipe(
+                        Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                        Effect.tapError((innerError) =>
+                          Cause.isTimeoutException(innerError)
+                            ? showAgentStatus(
+                                `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                                "warning",
+                              )
+                            : Effect.void,
+                        ),
+                      );
+                  const fallback = yield* fallbackCallWithTimeout;
                   return {
                     stream: Stream.empty,
                     response: Effect.succeed(fallback),

--- a/src/core/agent/execution/tool-executor.test.ts
+++ b/src/core/agent/execution/tool-executor.test.ts
@@ -262,6 +262,50 @@ describe("ToolExecutor.executeToolCall", () => {
   });
 });
 
+describe("ToolExecutor.executeTool unlimited mode", () => {
+  it("does not apply a timeout when unlimited is true", async () => {
+    const mockToolRegistry = {
+      getTool: () =>
+        Effect.succeed({
+          name: "slow_tool",
+          timeoutMs: 50,
+          longRunning: false,
+          approvalExecuteToolName: undefined,
+        }),
+      executeTool: () =>
+        Effect.sleep("200 millis").pipe(
+          Effect.as({ success: true, result: { data: "completed" } }),
+        ),
+    } as unknown as ToolRegistry;
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(FileSystem.FileSystem, emptyFs),
+      Layer.succeed(TerminalServiceTag, emptyTerminal),
+      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(LLMServiceTag, emptyLlm),
+      Layer.succeed(MCPServerManagerTag, emptyMcp),
+    );
+
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "slow_tool",
+        {},
+        { agentId: "agent-1", conversationId: "conv-123", sessionId: "sess-1" },
+        undefined,
+        true,
+      ).pipe(Effect.provide(testLayer)) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ data: "completed" });
+  });
+});
+
 describe("ToolExecutor.executeToolCalls", () => {
   it("should execute multiple tool calls", async () => {
     const mockToolRegistry = {

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -42,6 +42,7 @@ export class ToolExecutor {
     args: Record<string, unknown>,
     context: ToolExecutionContext,
     overrideTimeoutMs?: number,
+    unlimited: boolean = false,
   ): Effect.Effect<
     ToolExecutionResult,
     ToolNotFoundError | Error,
@@ -63,6 +64,10 @@ export class ToolExecutor {
         if (timeoutMs === undefined && !toolMeta?.longRunning) {
           timeoutMs = TOOL_TIMEOUT_MS;
         }
+      }
+
+      if (unlimited) {
+        timeoutMs = undefined;
       }
 
       const execution = registry.executeTool(name, args, context);
@@ -106,6 +111,7 @@ export class ToolExecutor {
     agentId: string,
     conversationId: string,
     toolsRequiringApproval: ReadonlySet<string>,
+    unlimited: boolean = false,
   ): Effect.Effect<
     { toolCallId: string; result: unknown; success: boolean; name: string },
     Error,
@@ -182,7 +188,13 @@ export class ToolExecutor {
         }
 
         // Execute tool — pass pre-fetched timeout to avoid redundant getTool lookup
-        let result = yield* ToolExecutor.executeTool(name, args, context, toolMeta?.timeoutMs);
+        let result = yield* ToolExecutor.executeTool(
+          name,
+          args,
+          context,
+          toolMeta?.timeoutMs,
+          unlimited,
+        );
         let toolDuration = Date.now() - toolStartTime;
         let finalToolName = name;
 
@@ -306,6 +318,8 @@ export class ToolExecutor {
               approvalResult.executeToolName,
               approvalResult.executeArgs,
               context,
+              undefined,
+              unlimited,
             );
             toolDuration = Date.now() - executeStartTime;
             finalToolName = approvalResult.executeToolName;
@@ -442,6 +456,7 @@ export class ToolExecutor {
     conversationId: string,
     agentName: string,
     interruptSignal?: Effect.Effect<void, never>,
+    unlimited: boolean = false,
   ): Effect.Effect<
     Array<{ toolCallId: string; result: unknown; name: string; success: boolean }>,
     Error,
@@ -531,6 +546,7 @@ export class ToolExecutor {
               agentId,
               conversationId,
               approvalSet,
+              unlimited,
             ),
           ),
         ),

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -138,6 +138,7 @@ ${args.task}`;
             sessionId: context.sessionId ?? context.conversationId ?? `session-${Date.now()}`,
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
             maxIterations: context.parentMaxIterations ?? DEFAULT_MAX_ITERATIONS,
+            unlimited: context.parentUnlimited ?? false,
             ephemeralRegionId: regionId,
           }).pipe(
             Effect.tapError(() =>

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -59,6 +59,12 @@ export interface AgentRunnerOptions {
    */
   readonly maxIterations?: number;
   /**
+   * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
+   * nudges, meltdown detection, tool timeouts, LLM retry cap. Propagates to
+   * spawned subagents. Default false.
+   */
+  readonly unlimited?: boolean;
+  /**
    * Full conversation history to date, including prior assistant, user, and tool messages.
    * Use this to preserve context across turns (e.g., approval flows, multi-step tasks).
    */
@@ -203,6 +209,7 @@ export interface AgentRunContext {
   readonly model: string;
   readonly connectedMCPServers: readonly string[];
   readonly maxRetries?: number;
+  readonly unlimited?: boolean;
   readonly knownSkills: readonly {
     readonly name: string;
     readonly description: string;

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -60,8 +60,8 @@ export interface AgentRunnerOptions {
   readonly maxIterations?: number;
   /**
    * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
-   * nudges, meltdown detection, tool timeouts, LLM retry cap. Propagates to
-   * spawned subagents. Default false.
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, and per-call LLM
+   * timeout. Propagates to spawned subagents. Default false.
    */
   readonly unlimited?: boolean;
   /**

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -34,6 +34,7 @@ export interface ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      unlimited?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
     },

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -21,9 +21,9 @@ export interface AppConfig {
   readonly maxRetries?: number;
   /**
    * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
-   * nudges, meltdown detection, tool timeouts, LLM retry cap, and workflow
-   * `maxIterations` metadata are all ignored. Intended for trusted long-running
-   * setups. Default false.
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, per-call LLM
+   * timeout, and workflow `maxIterations` metadata are all ignored. Intended
+   * for trusted long-running setups. Default false.
    */
   readonly unlimited?: boolean;
 }

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -19,6 +19,13 @@ export interface AppConfig {
   readonly telemetry?: TelemetryConfig;
   /** Maximum number of retries for transient LLM API failures. Defaults to 3. */
   readonly maxRetries?: number;
+  /**
+   * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, and workflow
+   * `maxIterations` metadata are all ignored. Intended for trusted long-running
+   * setups. Default false.
+   */
+  readonly unlimited?: boolean;
 }
 
 export interface NotificationsConfig {

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -188,6 +188,11 @@ export interface ToolExecutionContext {
    */
   readonly parentMaxIterations?: number;
   /**
+   * Whether the parent agent is in unlimited mode. Subagents inherit this so
+   * every guardrail (iteration cap, retries, timeouts) is lifted for them too.
+   */
+  readonly parentUnlimited?: boolean;
+  /**
    * Callback to replace conversation messages with compacted versions.
    * Used by summarize_context to actually update the executor's message array.
    */

--- a/src/core/utils/llm-error.test.ts
+++ b/src/core/utils/llm-error.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Ref } from "effect";
+import { LLMRateLimitError, LLMRequestError } from "@/core/types/errors";
+import { isRetryableLLMError, makeLLMRetrySchedule } from "./llm-error";
+
+const instantClock = {
+  currentTimeMillis: Effect.succeed(0),
+  currentTimeNanos: Effect.succeed(BigInt(0)),
+  sleep: (_duration: unknown) => Effect.void,
+};
+
+function withInstantClock<A, E>(effect: Effect.Effect<A, E>) {
+  return Effect.withClock(instantClock)(effect);
+}
+
+function countRetryAttempts(schedule: ReturnType<typeof makeLLMRetrySchedule>, error: unknown) {
+  return withInstantClock(
+    Effect.gen(function* () {
+      const countRef = yield* Ref.make(0);
+      yield* Effect.retry(
+        Effect.gen(function* () {
+          yield* Ref.update(countRef, (count) => count + 1);
+          return yield* Effect.fail(error);
+        }),
+        schedule,
+      ).pipe(Effect.catchAll(() => Effect.void));
+      const total = yield* Ref.get(countRef);
+      return total - 1;
+    }).pipe(
+      Effect.timeout("5 seconds"),
+      Effect.catchAll(() => Effect.succeed(-1)),
+    ),
+  );
+}
+
+const retryableError = new LLMRateLimitError({ message: "rate limited", provider: "openai" });
+const nonRetryableError = new LLMRequestError({ message: "bad request", statusCode: 400 });
+
+describe("isRetryableLLMError", () => {
+  it("returns true for LLMRateLimitError", () => {
+    expect(isRetryableLLMError(retryableError)).toBe(true);
+  });
+
+  it("returns false for non-retryable LLMRequestError (4xx)", () => {
+    expect(isRetryableLLMError(nonRetryableError)).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    expect(isRetryableLLMError(new Error("generic"))).toBe(false);
+  });
+});
+
+describe("makeLLMRetrySchedule", () => {
+  it("bounded mode: retries exactly maxRetries times on retryable error", async () => {
+    const maxRetries = 3;
+    const schedule = makeLLMRetrySchedule(maxRetries, false);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, retryableError));
+    expect(retryCount).toBe(maxRetries);
+  });
+
+  it("bounded mode: does not retry on non-retryable error", async () => {
+    const schedule = makeLLMRetrySchedule(5, false);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, nonRetryableError));
+    expect(retryCount).toBe(0);
+  });
+
+  it("unlimited mode: retries more than maxRetries times on retryable error", async () => {
+    const maxRetries = 3;
+    const extraRetries = maxRetries + 5;
+    const schedule = makeLLMRetrySchedule(maxRetries, true);
+    const retryCount = await Effect.runPromise(
+      withInstantClock(
+        Effect.gen(function* () {
+          const countRef = yield* Ref.make(0);
+          yield* Effect.retry(
+            Effect.gen(function* () {
+              const count = yield* Ref.updateAndGet(countRef, (n) => n + 1);
+              if (count > extraRetries) return yield* Effect.void;
+              return yield* Effect.fail(retryableError);
+            }),
+            schedule,
+          ).pipe(Effect.catchAll(() => Effect.void));
+          const total = yield* Ref.get(countRef);
+          return total - 1;
+        }),
+      ),
+    );
+    expect(retryCount).toBe(extraRetries);
+  });
+
+  it("unlimited mode: still does not retry on non-retryable error", async () => {
+    const schedule = makeLLMRetrySchedule(5, true);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, nonRetryableError));
+    expect(retryCount).toBe(0);
+  });
+
+  it("default second parameter behaves as bounded", async () => {
+    const maxRetries = 2;
+    const schedule = makeLLMRetrySchedule(maxRetries);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, retryableError));
+    expect(retryCount).toBe(maxRetries);
+  });
+});

--- a/src/core/utils/llm-error.ts
+++ b/src/core/utils/llm-error.ts
@@ -263,12 +263,18 @@ export function isRetryableLLMError(error: unknown): boolean {
  * Exponential backoff schedule for LLM retries, delay capped at MAX_RETRY_DELAY_SECONDS.
  * Only retries on transient errors (rate limits, connection failures, 5xx).
  */
-export function makeLLMRetrySchedule(maxRetries: number) {
-  return Schedule.exponential("1 second").pipe(
+export function makeLLMRetrySchedule(maxRetries: number, unlimited: boolean = false) {
+  const base = Schedule.exponential("1 second").pipe(
     Schedule.modifyDelay((_, delay) =>
       Duration.min(delay, Duration.seconds(MAX_RETRY_DELAY_SECONDS)),
     ),
-    Schedule.intersect(Schedule.recurs(maxRetries)),
     Schedule.whileInput((error: unknown) => isRetryableLLMError(error)),
+  );
+  if (unlimited) {
+    return base;
+  }
+  return base.pipe(
+    Schedule.intersect(Schedule.recurs(maxRetries)),
+    Schedule.map(([delay]) => delay),
   );
 }

--- a/src/core/workflows/catch-up.ts
+++ b/src/core/workflows/catch-up.ts
@@ -172,6 +172,11 @@ interface RunCatchUpOptions {
    * are written, which would cause the catch-up prompt to reappear.
    */
   readonly recordsPreCreated?: boolean;
+  /**
+   * CLI-level override for unlimited mode. When set, takes precedence over
+   * appConfig.unlimited. Undefined means fall back to appConfig.unlimited.
+   */
+  readonly unlimitedOverride?: boolean;
 }
 
 /**
@@ -191,7 +196,7 @@ export function runCatchUpForWorkflows(
     const workflowService = yield* WorkflowServiceTag;
     const configService = yield* AgentConfigServiceTag;
     const appConfig = yield* configService.appConfig;
-    const unlimitedMode = appConfig.unlimited ?? false;
+    const unlimitedMode = options.unlimitedOverride ?? appConfig.unlimited ?? false;
     const now = new Date();
 
     // Only load history and re-check decisions when records were not pre-created.

--- a/src/core/workflows/catch-up.ts
+++ b/src/core/workflows/catch-up.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { DEFAULT_MAX_CATCH_UP_AGE_SECONDS } from "@/core/constants/agent";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { normalizeCronExpression } from "@/core/utils/cron-utils";
 import {
@@ -188,6 +189,9 @@ export function runCatchUpForWorkflows(
   return Effect.gen(function* () {
     const logger = yield* LoggerServiceTag;
     const workflowService = yield* WorkflowServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const unlimitedMode = appConfig.unlimited ?? false;
     const now = new Date();
 
     // Only load history and re-check decisions when records were not pre-created.
@@ -267,7 +271,10 @@ export function runCatchUpForWorkflows(
         userInput: workflowContent.prompt,
         sessionId: runId,
         conversationId: runId,
-        ...(workflow.maxIterations != null ? { maxIterations: workflow.maxIterations } : {}),
+        ...(workflow.maxIterations != null && !unlimitedMode
+          ? { maxIterations: workflow.maxIterations }
+          : {}),
+        unlimited: unlimitedMode,
         ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       }).pipe(
         Effect.tap(() =>

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -110,6 +110,7 @@ export class ChatServiceImpl implements ChatService {
       let loggedMessageCount = 0;
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
+      let unlimited: boolean = options?.unlimited ?? false;
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
@@ -256,6 +257,7 @@ export class ChatServiceImpl implements ChatService {
               sessionId,
               sessionUsage,
               sessionStartedAt,
+              unlimited,
               ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
               ...(autoApprovedCommands.length > 0 ? { autoApprovedCommands } : {}),
               ...(latestConfig.autoApprovedCommands?.length
@@ -332,6 +334,10 @@ export class ChatServiceImpl implements ChatService {
               // Sync mode state with store for Shift+Tab toggle
               store.setModeIsYolo(autoApprovePolicy === true || autoApprovePolicy === "high-risk");
             }
+            if (commandResult.newUnlimited !== undefined) {
+              unlimited = commandResult.newUnlimited;
+              // Store sync (store.setUnlimitedActive) is added in Task 12.
+            }
 
             if (commandResult.addAutoApprovedCommand) {
               if (!autoApprovedCommands.includes(commandResult.addAutoApprovedCommand)) {
@@ -371,6 +377,7 @@ export class ChatServiceImpl implements ChatService {
             conversationId,
             sessionId, // Pass the sessionId for logging
             conversationHistory,
+            unlimited,
             ...(options?.stream !== undefined ? { stream: options.stream } : {}),
             ...(autoApprovePolicy !== undefined
               ? { autoApprovePolicy: getCurrentAutoApprovePolicy }

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -111,6 +111,7 @@ export class ChatServiceImpl implements ChatService {
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
       let unlimited: boolean = options?.unlimited ?? false;
+      store.setUnlimitedActive(unlimited);
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
@@ -336,7 +337,7 @@ export class ChatServiceImpl implements ChatService {
             }
             if (commandResult.newUnlimited !== undefined) {
               unlimited = commandResult.newUnlimited;
-              // Store sync (store.setUnlimitedActive) is added in Task 12.
+              store.setUnlimitedActive(unlimited);
             }
 
             if (commandResult.addAutoApprovedCommand) {

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -50,6 +50,7 @@ export class ChatServiceImpl implements ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      unlimited?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
     },

--- a/src/services/chat/commands/constants.ts
+++ b/src/services/chat/commands/constants.ts
@@ -27,6 +27,10 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "stats", description: "Show session statistics and usage summary" },
   { name: "switch", description: "Switch to a different agent in the same conversation" },
   { name: "tools", description: "List all agent tools by category" },
+  {
+    name: "unlimited",
+    description: "Toggle unlimited mode (no iteration, retry, or timeout caps) for this session",
+  },
   { name: "workflows", description: "List workflows or send action (e.g. create) to the agent" },
 ] as const;
 

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -73,6 +73,91 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+describe("/unlimited", () => {
+  function makeUnlimitedContext(unlimited?: boolean): CommandContext {
+    return {
+      agent: testAgent,
+      conversationId: "current-conv-id",
+      conversationHistory: [],
+      sessionId: "test-session",
+      sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionStartedAt: new Date(),
+      unlimited,
+    };
+  }
+
+  function makeTerminalLayer() {
+    const mockTerminal: Partial<TerminalService> = {
+      success: mock(() => Effect.void),
+      info: mock(() => Effect.void),
+      error: mock(() => Effect.void),
+      log: mock(() => Effect.succeed(undefined)),
+    };
+    return {
+      layer: Layer.merge(
+        Layer.succeed(TerminalServiceTag, mockTerminal as unknown as TerminalService),
+        NodeFileSystem.layer,
+      ),
+    };
+  }
+
+  test("reports OFF when current state is false and no args given", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: [] }, context).pipe(Effect.provide(layer)),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+
+  test("reports ON when current state is true and no args given", async () => {
+    const context = makeUnlimitedContext(true);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: [] }, context).pipe(Effect.provide(layer)),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+
+  test("enables unlimited mode with /unlimited on", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["on"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBe(true);
+  });
+
+  test("disables unlimited mode with /unlimited off", async () => {
+    const context = makeUnlimitedContext(true);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["off"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBe(false);
+  });
+
+  test("rejects unknown arguments without changing state", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["maybe"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+});
+
 describe("handleSpecialCommand resume", () => {
   test("sets resetStartedAt on the result when a conversation is successfully resumed", async () => {
     await runEffect(saveConversation(testRecord, tmpDir));

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -135,6 +135,9 @@ export function handleSpecialCommand(
           context.autoApprovedTools,
         );
 
+      case "unlimited":
+        return yield* handleUnlimitedCommand(terminal, command.args, context.unlimited);
+
       case "resume":
         return yield* handleResumeCommand(terminal, agent);
 
@@ -1725,6 +1728,41 @@ function handleCostCommand(
     }
 
     yield* terminal.log(fmt.blank());
+    return { shouldContinue: true };
+  });
+}
+
+function handleUnlimitedCommand(
+  terminal: TerminalService,
+  args: string[],
+  currentUnlimited?: boolean,
+): Effect.Effect<CommandResult, never, never> {
+  return Effect.gen(function* () {
+    const arg = args[0]?.toLowerCase();
+
+    if (arg === "on") {
+      yield* terminal.success("Unlimited mode ENABLED — no iteration, retry, or timeout caps");
+      yield* terminal.log("");
+      return { shouldContinue: true, newUnlimited: true };
+    }
+
+    if (arg === "off") {
+      yield* terminal.success("Unlimited mode DISABLED — standard guardrails restored");
+      yield* terminal.log("");
+      return { shouldContinue: true, newUnlimited: false };
+    }
+
+    if (arg) {
+      yield* terminal.error(`Unknown argument: ${arg}`);
+      yield* terminal.info("Usage: /unlimited [on|off]");
+      yield* terminal.log("");
+      return { shouldContinue: true };
+    }
+
+    const state = currentUnlimited ? "ON" : "OFF";
+    yield* terminal.info(`Unlimited mode: ${state}`);
+    yield* terminal.info("Usage: /unlimited on  |  /unlimited off");
+    yield* terminal.log("");
     return { shouldContinue: true };
   });
 }

--- a/src/services/chat/commands/parser.test.ts
+++ b/src/services/chat/commands/parser.test.ts
@@ -74,6 +74,24 @@ describe("parseSpecialCommand", () => {
       expect(result.type).toBe("mcp");
       expect(result.args).toEqual([]);
     });
+
+    it("should parse /unlimited command", () => {
+      const result = parseSpecialCommand("/unlimited");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual([]);
+    });
+
+    it("should parse /unlimited on", () => {
+      const result = parseSpecialCommand("/unlimited on");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual(["on"]);
+    });
+
+    it("should parse /unlimited off", () => {
+      const result = parseSpecialCommand("/unlimited off");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual(["off"]);
+    });
   });
 
   describe("commands with arguments", () => {

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -56,6 +56,8 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "mode", args };
     case "resume":
       return { type: "resume", args };
+    case "unlimited":
+      return { type: "unlimited", args };
     default:
       return { type: "unknown", args: [command, ...args] };
   }

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -25,6 +25,7 @@ export type CommandType =
   | "mcp"
   | "mode"
   | "resume"
+  | "unlimited"
   | "unknown";
 
 /**
@@ -57,6 +58,8 @@ export interface CommandResult {
   saveCurrentHistory?: boolean;
   /** Reset the startedAt timestamp to now (used when resuming a saved conversation) */
   resetStartedAt?: boolean;
+  /** New unlimited state set by /unlimited command (true/false to set; undefined to leave unchanged). */
+  newUnlimited?: boolean;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */
@@ -85,4 +88,6 @@ export interface CommandContext {
   persistedAutoApprovedCommands?: readonly string[];
   /** Currently auto-approved tool names for this session (for /mode display). */
   autoApprovedTools?: readonly string[];
+  /** Current unlimited mode state (for /unlimited display). */
+  unlimited?: boolean;
 }

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -102,4 +102,28 @@ describe("AgentConfigService", () => {
     expect(parsed.mcpServers.testServer).toEqual({ enabled: false });
     expect(parsed.mcpServers.testServer.command).toBeUndefined();
   });
+
+  it("should round-trip unlimited flag through save and load", async () => {
+    let written = "";
+    const capturingFS = {
+      ...mockFS,
+      writeFileString: mock((_path: string, content: string) => {
+        written = content;
+        return Effect.void;
+      }),
+      readFileString: mock(() => Effect.succeed(written)),
+    } as unknown as FileSystem;
+
+    const configPath = "/tmp/jazz-unlimited-test.json";
+    const configWithUnlimited: AppConfig = {
+      ...initialConfig,
+      unlimited: true,
+    };
+    const service = new AgentConfigServiceImpl(configWithUnlimited, {}, configPath, capturingFS);
+
+    await Effect.runPromise(service.set("unlimited", true));
+
+    const reloaded = await Effect.runPromise(service.get<boolean>("unlimited"));
+    expect(reloaded).toBe(true);
+  });
 });

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -1,7 +1,8 @@
-import { type FileSystem } from "@effect/platform/FileSystem";
+import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
-import { Effect } from "effect";
-import { AgentConfigServiceImpl } from "./config";
+import { Effect, Layer } from "effect";
+import { AgentConfigServiceImpl, createConfigLayer } from "./config";
+import { AgentConfigServiceTag } from "../core/interfaces/agent-config";
 import { type AppConfig } from "../core/types/index";
 
 // Mock FileSystem
@@ -35,7 +36,7 @@ const mockFS = {
   truncate: mock(() => Effect.void),
   utimes: mock(() => Effect.void),
   writeFile: mock(() => Effect.void),
-} as unknown as FileSystem;
+} as unknown as FileSystem.FileSystem;
 
 describe("AgentConfigService", () => {
   const initialConfig: AppConfig = {
@@ -112,7 +113,7 @@ describe("AgentConfigService", () => {
         return Effect.void;
       }),
       readFileString: mock(() => Effect.succeed(written)),
-    } as unknown as FileSystem;
+    } as unknown as FileSystem.FileSystem;
 
     const configPath = "/tmp/jazz-unlimited-test.json";
     const configWithUnlimited: AppConfig = {
@@ -123,7 +124,34 @@ describe("AgentConfigService", () => {
 
     await Effect.runPromise(service.set("unlimited", true));
 
+    expect(JSON.parse(written).unlimited).toBe(true);
+
     const reloaded = await Effect.runPromise(service.get<boolean>("unlimited"));
     expect(reloaded).toBe(true);
+  });
+
+  it("should load unlimited flag from config file via mergeConfig", async () => {
+    const configPath = "/tmp/jazz-unlimited-load-test.json";
+    const fileContent = JSON.stringify({ unlimited: true });
+
+    const loadFS = {
+      ...mockFS,
+      exists: mock((path: string) => Effect.succeed(path === configPath)),
+      readFileString: mock((path: string) =>
+        path === configPath ? Effect.succeed(fileContent) : Effect.succeed(""),
+      ),
+    } as unknown as FileSystem.FileSystem;
+
+    const fsLayer = Layer.succeed(FileSystem.FileSystem, loadFS);
+    const configLayer = createConfigLayer(false, configPath);
+
+    const unlimitedValue = await Effect.runPromise(
+      Effect.gen(function* () {
+        const config = yield* AgentConfigServiceTag;
+        return yield* config.get<boolean>("unlimited");
+      }).pipe(Effect.provide(configLayer), Effect.provide(fsLayer)),
+    );
+
+    expect(unlimitedValue).toBe(true);
   });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -326,6 +326,7 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.autoApprovedCommands && {
       autoApprovedCommands: override.autoApprovedCommands,
     }),
+    ...(override.unlimited !== undefined && { unlimited: override.unlimited }),
   };
 }
 


### PR DESCRIPTION
## What and why

Adds an opt-in "unlimited mode" that lifts every per-run guardrail in Jazz — iteration cap, budget-pressure nudges, meltdown detection, per-tool timeouts, per-call LLM timeout, LLM retry cap, and workflow-level `maxIterations` metadata. The use case is running Jazz autonomously over long horizons (24/7 background workflows, "run my company" style operation) where the default safety rails are too aggressive. The mode is fully opt-in and propagates to spawned subagents, so a single switch governs the whole agent graph.

## Before this PR

- Every agent run was capped at `DEFAULT_MAX_ITERATIONS = 80` reasoning steps; longer runs were forced to type `continue` to resume.
- Budget pressure messages were injected at 70% and 90% of the cap, biasing the model toward "wrap up now."
- Meltdown detection aborted any run that made identical tool calls 4+ times in a 10-call window.
- Each tool execution had a hard 3-minute timeout; a longer external call returned a timeout error.
- Each LLM call had a hard 15-minute timeout; long reasoning chains failed.
- LLM retries were capped at 10 attempts on transient errors; an outage past that window aborted the run.
- Workflows could pin their own `maxIterations`, which always took precedence.

There was no single switch to turn off these guardrails for users who explicitly wanted unbounded operation.

## After this PR

`unlimited` mode is a global boolean activated by any of three paths (CLI flag > config > false at startup; `/unlimited on|off` toggles within a session):

- **CLI flag:** `jazz agent chat <agent> --unlimited` (or `--no-unlimited` to disable for one run, even if config has it on). Same flag is available on `jazz workflow run` and `jazz workflow catchup`.
- **Config field:** `jazz config set unlimited true` (persistent) or via the new "Unlimited Mode" entry in `jazz config wizard`.
- **Slash command:** `/unlimited` (status), `/unlimited on`, `/unlimited off` inside a chat session.

When the mode is on:

- The agent loop runs unbounded; budget-pressure messages are suppressed; meltdown detection does not abort.
- Tool calls run without the 3-minute timeout.
- Each LLM call runs without the 15-minute timeout.
- LLM retries are unbounded (the existing exponential backoff capped at `MAX_RETRY_DELAY_SECONDS` still applies, so retries are not a hot loop).
- Workflow-level `maxIterations` metadata is ignored.
- Spawned subagents inherit the flag via `parentUnlimited`.
- A subtle `[unlimited]` chip in the status footer makes the mode visible at a glance.

## Changes made

**Schema & types**
- `src/core/types/config.ts` — adds `AppConfig.unlimited?: boolean` with JSDoc enumerating every lifted guardrail.
- `src/core/agent/types.ts` — adds `unlimited?: boolean` to `AgentRunnerOptions` and `AgentRunContext`.
- `src/core/types/tools.ts` — adds `parentUnlimited?: boolean` to `ToolExecutionContext` for subagent inheritance.
- `src/core/interfaces/chat-service.ts` — adds `unlimited?: boolean` to `ChatService.startChatSession` options.
- `src/services/chat/commands/types.ts` — adds `"unlimited"` to `CommandType`, `newUnlimited?: boolean` to `CommandResult`, `unlimited?: boolean` to `CommandContext`.

**Guardrail lifts**
- `src/core/agent/execution/agent-loop.ts` — `for` loop becomes `for (let i = 0; unlimited || i < maxIterations; i++)`; `buildBudgetPressureMessage` accepts an `unlimited` parameter and short-circuits to null; `detectMeltdown` is gated by `!unlimited`. `parentUnlimited` is populated on the tool execution context.
- `src/core/agent/execution/tool-executor.ts` — `executeTool`, `executeToolCall`, `executeToolCalls` accept an `unlimited` parameter; when true, `timeoutMs` is forced to `undefined` so the no-timeout branch runs.
- `src/core/utils/llm-error.ts` — `makeLLMRetrySchedule(maxRetries, unlimited)` drops the `Schedule.recurs(maxRetries)` cap when unlimited; the `whileInput(isRetryableLLMError)` filter and exponential backoff cap stay in both modes.
- `src/core/agent/execution/llm-retry-present.ts` — `makeUserVisibleLlmRetrySchedule` accepts `unlimited` and omits "of up to N" from the status message.
- `src/core/agent/execution/streaming-executor.ts`, `batch-executor.ts` — at each LLM call site, the `Effect.timeout(LLM_TIMEOUT_SECONDS)` wrapper is applied only when `runContext.unlimited` is false. Retry schedule and user-visible schedule receive `runContext.unlimited`.
- `src/core/agent/tools/subagent-tools.ts` — `AgentRunner.runRecursive` is given `unlimited: context.parentUnlimited ?? false`.
- `src/core/workflows/catch-up.ts`, `src/cli/commands/workflow.ts` — workflow `maxIterations` metadata is dropped when `appConfig.unlimited` (or the `--unlimited` flag override) is true; `unlimited` is passed to `AgentRunner.run`. `RunCatchUpOptions` accepts an `unlimitedOverride?: boolean`.

**Activation surfaces**
- `src/cli/cli-app.ts` — adds `--unlimited` / `--no-unlimited` to `agent chat`, `workflow run`, `workflow catchup`. Parses Commander.js's collapsed `unlimited` boolean correctly (the initial implementation used `noUnlimited` which Commander never sets; the fix in 5c22d74 reads `options.unlimited === false` for the negation).
- `src/cli/commands/chat-agent.ts` — resolves `resolvedUnlimited = options.unlimitedOverride ?? appConfig.unlimited ?? false` and threads it into the chat session.
- `src/cli/commands/workflow.ts` — `runWorkflowCommand` and `catchupWorkflowCommand` accept `unlimitedOverride` and resolve precedence.
- `src/cli/commands/config.ts` — adds a `coerceConfigValue` helper that maps the string `"true"`/`"false"` to real booleans so `jazz config set unlimited false` actually stores `false`, not the truthy string `"false"`.
- `src/cli/commands/config-wizard.ts` — adds a top-level "Unlimited Mode" menu entry with a single Y/N confirm prompt.
- `src/services/config.ts` — adds `unlimited` to `mergeConfig` so a user's `unlimited: true` survives the config-file load path.
- `src/services/chat-service.ts` — adds a session-local `let unlimited`, seeds it from CLI/config, threads it into `CommandContext` and `AgentRunnerOptions`, and updates it on `commandResult.newUnlimited`.
- `src/services/chat/commands/constants.ts`, `parser.ts`, `handler.ts` — adds `/unlimited` to the slash-command registry, parser, and handler with on/off/status branches.

**UI**
- `src/cli/ui/store.ts` — adds `currentUnlimitedActive`, `registerUnlimitedSetter`, `setUnlimitedActive`, `getUnlimitedActive`.
- `src/cli/ui/StatusFooter.tsx` — renders a `[unlimited]` chip in `THEME.warning` color when the mode is active.
- `src/cli/ui/App.tsx` — wires `StatusFooterIslandComponent` to the new store API.

**Tests**
- New: `src/core/utils/llm-error.test.ts` (retry schedule bounded vs unlimited), `src/cli/commands/config.test.ts` (`coerceConfigValue`), plus `bun:test` blocks added to `agent-loop.test.ts`, `tool-executor.test.ts`, `config.test.ts`, `parser.test.ts`, `handler.test.ts`. The integration test for the iteration cap uses a `try/finally` block to guard mock teardown.

## Impact

- **Default behavior is unchanged.** Every new field is optional with a `false` default; every guardrail check still fires unless `unlimited` is explicitly true.
- **Performance:** no measurable cost for users who don't enable the mode. When enabled, runs can use more tokens (no automatic abort) and run longer (no time cap). This is by design.
- **Risk surface for users who enable unlimited mode:** a stuck tool or LLM call will hang until Ctrl+C; a model that loops on identical tool calls will burn tokens without an automatic abort; a permanently-down LLM provider will retry indefinitely (backoff still capped, so not a hot loop). Scheduled workflows in particular could miss the next run if a previous one hangs. These tradeoffs are accepted by the design.
- **No breaking API changes.** All new fields are additive and optional. Existing callers that don't pass `unlimited` get the default behavior.
- **Out of scope (intentional):** no daily-quota / cost-warning heuristics, no environment-variable activation, no per-tool unlimited overrides, no auto-persistence of the slash command toggle.

## How to test

Run the full check suite first:

```
bun test          # 1242 pass / 0 fail
bun run typecheck # clean
bun run lint      # clean
bun run build     # bundles
```

**1. CLI flag (happy path):**
```
./dist/main.js agent chat --help
```
Expected: both `--unlimited` and `--no-unlimited` appear in the options list. Same for `workflow run --help` and `workflow catchup --help`.

**2. Config round-trip (the boolean-coercion fix):**
```
./dist/main.js config set unlimited true
./dist/main.js config get unlimited   # → true
./dist/main.js config set unlimited false
./dist/main.js config get unlimited   # → false
```
Inspect `~/.config/jazz/config.json` (or your configured path) — the value should be the JSON boolean `false`, not the string `"false"`. (Pre-fix, the string would be stored and `if (appConfig.unlimited)` would evaluate truthy because non-empty strings are truthy.)

**3. Flag override edge case:**
With `unlimited: true` already in config, run:
```
./dist/main.js agent chat <agent> --no-unlimited
```
Expected: the session does NOT have the `[unlimited]` chip in the footer, and standard guardrails apply for the run. (Pre-fix, `--no-unlimited` was silently ignored because the code read `opts.noUnlimited` which Commander never sets.)

**4. Slash command toggle:**
Inside a chat session:
- Type `/unlimited` → reports current state and usage.
- Type `/unlimited on` → confirmation message; `[unlimited]` chip appears in the footer.
- Type `/unlimited off` → chip disappears.
- Type `/unlimited maybe` → error + usage message.

**5. Edge case — workflow `maxIterations` is dropped:**
Create a workflow with `maxIterations: 30` in its metadata. Enable unlimited mode via config. Run `jazz workflow run <name>`. The agent should not stop at iteration 30; it should run until the strategy returns no further tool calls.

**6. Edge case — subagent inheritance:**
With `unlimited: true` and an agent that delegates to subagents via the `spawn_subagent` tool, confirm the subagent runs receive `unlimited: true` (visible in metrics: `iterationsUsed` for the subagent can exceed the default cap). Covered by the propagation test in `agent-loop.test.ts`.

## Notes for reviewers

- The spec and plan are local-only at `docs/superpowers/specs/2026-05-25-unlimited-mode-design.md` and `docs/superpowers/plans/2026-05-25-unlimited-mode.md` (gitignored per CLAUDE.md). Happy to share their content separately if useful.
- During implementation, two correctness bugs surfaced in code review and were fixed before merge: (a) `mergeConfig` did not forward `unlimited` on load (commit `47e0f95`); (b) `setConfigCommand` stored boolean flags as strings (commit `27e6f3c`). Both fixes also indirectly help future boolean config fields.
- The `Schedule.intersect(Schedule.recurs(maxRetries))` removal in `makeLLMRetrySchedule` uses `Schedule.map(([delay]) => delay)` on the bounded branch to unify the schedule's output type with the unbounded branch. The `recurs(N)` AND-semantics still terminate the bounded schedule at exactly N attempts.
- The status-footer chip placement leans on existing `THEME.warning` (yellow). If you'd prefer a different color or symbol, that's a one-line change in `StatusFooter.tsx`.
