### PR TITLE
feat(cli): add jazz run one-shot command for headless/webhook use

### DIFF
--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -221,6 +221,13 @@ export function runCliEffect<R, E extends JazzError | Error>(
      * doesn't also trigger catch-up execution for scheduled workflows.
      */
     readonly skipCatchUp?: boolean | undefined;
+    /**
+     * Skip the periodic "update available" notice on startup.
+     *
+     * Intended for machine-readable commands like `jazz run`, where the notice
+     * box would otherwise corrupt the clean stdout payload.
+     */
+    readonly skipUpdateCheck?: boolean | undefined;
   } = {},
 ): void {
   const cliOptionsLayer = Layer.succeed(CLIOptionsTag, {
@@ -244,7 +251,10 @@ export function runCliEffect<R, E extends JazzError | Error>(
       yield* promptFailedRunsWarning();
     }
 
-    const fiber = yield* Effect.fork(autoCheckForUpdate().pipe(Effect.zipRight(effect)));
+    const shouldSkipUpdateCheck =
+      process.env["JAZZ_DISABLE_UPDATE_CHECK"] === "1" || options.skipUpdateCheck === true;
+    const startupCheck = shouldSkipUpdateCheck ? Effect.void : autoCheckForUpdate();
+    const fiber = yield* Effect.fork(startupCheck.pipe(Effect.zipRight(effect)));
     let signalCount = 0;
     type SignalName = "SIGINT" | "SIGTERM";
 

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -38,6 +38,7 @@ import {
   catchupWorkflowCommand,
   workflowHistoryCommand,
 } from "./commands/workflow";
+import { parsePositiveInt } from "./utils/option-parsers";
 
 /**
  * CLI Application setup and command registration
@@ -52,16 +53,6 @@ interface CliOptions {
   config?: string;
   output?: string;
   tui?: boolean;
-}
-
-function parsePositiveInt(label: string) {
-  return (raw: string): number => {
-    const value = Number.parseInt(raw, 10);
-    if (!Number.isFinite(value) || value <= 0) {
-      throw new Error(`${label} must be a positive integer (got "${raw}").`);
-    }
-    return value;
-  };
 }
 
 /**

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -127,22 +127,31 @@ function registerAgentCommands(program: Command): void {
     .description("Start a chat with an AI agent by ID or name")
     .option("--stream", "Force streaming mode (real-time output)")
     .option("--no-stream", "Disable streaming mode")
+    .option(
+      "--unlimited",
+      "Lift all per-run guardrails (iteration cap, retries, timeouts) for this run",
+    )
+    .option("--no-unlimited", "Force unlimited mode off for this run, even if enabled in config")
     .action(
       (
         agentIdentifier: string,
         options: {
           stream?: boolean;
           noStream?: boolean;
+          unlimited?: boolean;
+          noUnlimited?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
+        const unlimitedOverride =
+          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
-          chatWithAIAgentCommand(
-            agentIdentifier,
-            streamOption !== undefined ? { stream: streamOption } : {},
-          ),
+          chatWithAIAgentCommand(agentIdentifier, {
+            ...(streamOption !== undefined ? { stream: streamOption } : {}),
+            ...(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
@@ -344,17 +353,30 @@ function registerWorkflowCommands(program: Command): void {
       "--scheduled",
       "Indicates this run was triggered by the system scheduler (launchd/cron)",
     )
+    .option("--unlimited", "Lift all per-run guardrails for this run")
+    .option("--no-unlimited", "Force unlimited mode off for this run")
     .action(
       (
         name: string,
-        options: { autoApprove?: boolean; agent?: string; scheduled?: boolean },
+        options: {
+          autoApprove?: boolean;
+          agent?: string;
+          scheduled?: boolean;
+          unlimited?: boolean;
+          noUnlimited?: boolean;
+        },
         command: Command,
       ) => {
         const opts = program.opts<CliOptions>();
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
+        const unlimitedOverride =
+          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
-          runWorkflowCommand(name, options),
+          runWorkflowCommand(name, {
+            ...options,
+            ...(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
@@ -404,13 +426,20 @@ function registerWorkflowCommands(program: Command): void {
   workflowCommand
     .command("catchup")
     .description("List workflows that missed a scheduled run, select which to run, then run them")
-    .action(() => {
+    .option("--unlimited", "Lift all per-run guardrails for this run")
+    .option("--no-unlimited", "Force unlimited mode off for this run")
+    .action((options: { unlimited?: boolean; noUnlimited?: boolean }) => {
       const opts = program.opts<CliOptions>();
-      runCliEffect(catchupWorkflowCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
+      const unlimitedOverride =
+        options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+      runCliEffect(
+        catchupWorkflowCommand(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+        {
+          verbose: opts.verbose,
+          debug: opts.debug,
+          configPath: opts.config,
+        },
+      );
     });
 
   workflowCommand

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -139,14 +139,13 @@ function registerAgentCommands(program: Command): void {
           stream?: boolean;
           noStream?: boolean;
           unlimited?: boolean;
-          noUnlimited?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
         const unlimitedOverride =
-          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+          options.unlimited === false ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
           chatWithAIAgentCommand(agentIdentifier, {
             ...(streamOption !== undefined ? { stream: streamOption } : {}),
@@ -363,7 +362,6 @@ function registerWorkflowCommands(program: Command): void {
           agent?: string;
           scheduled?: boolean;
           unlimited?: boolean;
-          noUnlimited?: boolean;
         },
         command: Command,
       ) => {
@@ -371,7 +369,7 @@ function registerWorkflowCommands(program: Command): void {
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
         const unlimitedOverride =
-          options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+          options.unlimited === false ? false : options.unlimited === true ? true : undefined;
         runCliEffect(
           runWorkflowCommand(name, {
             ...options,
@@ -428,10 +426,10 @@ function registerWorkflowCommands(program: Command): void {
     .description("List workflows that missed a scheduled run, select which to run, then run them")
     .option("--unlimited", "Lift all per-run guardrails for this run")
     .option("--no-unlimited", "Force unlimited mode off for this run")
-    .action((options: { unlimited?: boolean; noUnlimited?: boolean }) => {
+    .action((options: { unlimited?: boolean }) => {
       const opts = program.opts<CliOptions>();
       const unlimitedOverride =
-        options.noUnlimited === true ? false : options.unlimited === true ? true : undefined;
+        options.unlimited === false ? false : options.unlimited === true ? true : undefined;
       runCliEffect(
         catchupWorkflowCommand(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
         {

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -25,6 +25,7 @@ import {
   editPersonaCommand,
   deletePersonaCommand,
 } from "./commands/persona";
+import { isApprovalPolicyFlag, runAgentOnceCommand } from "./commands/run-agent";
 import { updateCommand } from "./commands/update";
 import { wizardCommand } from "./commands/wizard";
 import {
@@ -51,6 +52,100 @@ interface CliOptions {
   config?: string;
   output?: string;
   tui?: boolean;
+}
+
+function parsePositiveInt(label: string) {
+  return (raw: string): number => {
+    const value = Number.parseInt(raw, 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`${label} must be a positive integer (got "${raw}").`);
+    }
+    return value;
+  };
+}
+
+/**
+ * Register the one-shot `run` command — non-interactive agent invocation for
+ * scripts and webhook handlers.
+ */
+function registerRunCommand(program: Command): void {
+  program
+    .command("run [prompt]")
+    .description(
+      "Run an agent once non-interactively (for scripts/webhooks). Prompt comes from the argument or piped stdin; the answer goes to stdout, all chatter to stderr.",
+    )
+    .requiredOption("--agent <agentId>", "Agent ID or name to run")
+    .option("--json", "Emit a single JSON envelope { ok, answer, costUSD, tokenUsage, toolCalls }")
+    .option(
+      "--approval-policy <policy>",
+      "Auto-approve tools up to a risk level: read-only | low-risk | high-risk (high-risk approves everything). Tools above the level are declined.",
+    )
+    .option(
+      "--timeout <ms>",
+      "Abort the run after this many milliseconds",
+      parsePositiveInt("--timeout"),
+    )
+    .option(
+      "--max-iterations <n>",
+      "Maximum agent reasoning iterations for this run",
+      parsePositiveInt("--max-iterations"),
+    )
+    .option("--unlimited", "Lift all per-run guardrails (iteration cap, retries, timeouts)")
+    .option("--no-unlimited", "Force unlimited mode off for this run, even if enabled in config")
+    .action(
+      (
+        prompt: string | undefined,
+        options: {
+          agent: string;
+          json?: boolean;
+          approvalPolicy?: string;
+          timeout?: number;
+          maxIterations?: number;
+          unlimited?: boolean;
+        },
+      ) => {
+        const opts = program.opts<CliOptions>();
+        const json = options.json === true;
+
+        if (options.approvalPolicy !== undefined && !isApprovalPolicyFlag(options.approvalPolicy)) {
+          const message = `Invalid --approval-policy "${options.approvalPolicy}". Expected read-only, low-risk, or high-risk.`;
+          if (json) {
+            process.stdout.write(`${JSON.stringify({ ok: false, error: message, costUSD: 0 })}\n`);
+          } else {
+            process.stderr.write(`${message}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Force plain terminal so Ink never mounts and writes to stdout; the
+        // one-shot presentation layer keeps stdout clean for the payload.
+        process.env["JAZZ_NO_TUI"] = "1";
+
+        const unlimitedOverride =
+          options.unlimited === false ? false : options.unlimited === true ? true : undefined;
+
+        runCliEffect(
+          runAgentOnceCommand(options.agent, prompt, {
+            json,
+            ...(options.approvalPolicy !== undefined && isApprovalPolicyFlag(options.approvalPolicy)
+              ? { approvalPolicy: options.approvalPolicy }
+              : {}),
+            ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+            ...(options.maxIterations !== undefined
+              ? { maxIterations: options.maxIterations }
+              : {}),
+            ...(unlimitedOverride !== undefined ? { unlimitedOverride } : {}),
+          }),
+          {
+            verbose: opts.verbose,
+            debug: opts.debug,
+            configPath: opts.config,
+          },
+          { skipCatchUp: true, skipUpdateCheck: true },
+        );
+      },
+    );
 }
 
 /**
@@ -501,6 +596,7 @@ export function createCLIApp(): Effect.Effect<Command, never> {
     });
 
     // Register all commands
+    registerRunCommand(program);
     registerAgentCommands(program);
     registerPersonaCommands(program);
     registerConfigCommands(program);

--- a/src/cli/commands/chat-agent.ts
+++ b/src/cli/commands/chat-agent.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { ChatServiceTag } from "@/core/interfaces/chat-service";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { TerminalServiceTag } from "@/core/interfaces/terminal";
@@ -22,9 +23,13 @@ export function chatWithAIAgentCommand(
   agentIdentifier: string,
   options?: {
     stream?: boolean;
+    unlimitedOverride?: boolean;
   },
 ) {
   return Effect.gen(function* () {
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const resolvedUnlimited = options?.unlimitedOverride ?? appConfig.unlimited ?? false;
     const normalizedIdentifier = agentIdentifier.trim();
 
     if (normalizedIdentifier.length === 0) {
@@ -81,7 +86,7 @@ export function chatWithAIAgentCommand(
 
     // Start the chat session using the chat service
     const chatService = yield* ChatServiceTag;
-    yield* chatService.startChatSession(agent, options).pipe(
+    yield* chatService.startChatSession(agent, { ...options, unlimited: resolvedUnlimited }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
           const logger = yield* LoggerServiceTag;

--- a/src/cli/commands/config-wizard.ts
+++ b/src/cli/commands/config-wizard.ts
@@ -20,6 +20,7 @@ type ConfigMenuAction =
   | "output-display"
   | "logging"
   | "notifications"
+  | "unlimited"
   | "back";
 
 /**
@@ -36,6 +37,7 @@ export function configWizardCommand() {
         { label: "Output & Display", value: "output-display" },
         { label: "Logging", value: "logging" },
         { label: "Notifications", value: "notifications" },
+        { label: "Unlimited Mode", value: "unlimited" },
         { label: "Back to Main Menu", value: "back" },
       ];
 
@@ -60,6 +62,10 @@ export function configWizardCommand() {
         }
         case "notifications": {
           yield* configureNotifications();
+          break;
+        }
+        case "unlimited": {
+          yield* configureUnlimited();
           break;
         }
         case "back": {
@@ -368,6 +374,24 @@ function configureNotifications() {
 
       yield* terminal.log("");
     }
+  });
+}
+
+function configureUnlimited() {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const current = appConfig.unlimited ?? false;
+
+    const nextValue = yield* terminal.confirm(
+      "Enable unlimited mode by default? (no iteration, retry, or timeout caps — recommended only for trusted long-running setups)",
+      current,
+    );
+
+    yield* configService.set("unlimited", nextValue);
+    yield* terminal.success(`Unlimited mode ${nextValue ? "enabled" : "disabled"}.`);
+    yield* terminal.log("");
   });
 }
 

--- a/src/cli/commands/config.test.ts
+++ b/src/cli/commands/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { coerceConfigValue } from "./config";
+
+describe("coerceConfigValue", () => {
+  it("coerces 'true' to boolean true", () => {
+    expect(coerceConfigValue("true")).toBe(true);
+  });
+
+  it("coerces 'false' to boolean false", () => {
+    expect(coerceConfigValue("false")).toBe(false);
+  });
+
+  it("leaves other strings unchanged", () => {
+    expect(coerceConfigValue("hello")).toBe("hello");
+    expect(coerceConfigValue("")).toBe("");
+    expect(coerceConfigValue("123")).toBe("123");
+  });
+});

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -13,6 +13,17 @@ import { ConfigCard } from "../ui/ConfigCard";
  */
 
 /**
+ * Coerces string values from CLI/terminal input to their proper types.
+ * Needed because argv and terminal.ask always yield strings, so "false" would
+ * otherwise be stored as the truthy string "false" instead of the boolean false.
+ */
+export function coerceConfigValue(raw: string): string | boolean | number {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return raw;
+}
+
+/**
  * List all configuration values
  */
 export function listConfigCommand(): Effect.Effect<
@@ -155,9 +166,11 @@ export function setConfigCommand(
       }
 
       const answer = yield* terminal.ask(`Enter value for ${targetKey}:`);
-      yield* terminal.info(`Setting config: ${targetKey} = ${answer}`);
-      yield* configService.set(targetKey, answer);
-      yield* terminal.success(`Config set: ${targetKey} = ${answer}`);
+      if (answer === undefined) return;
+      const coercedAnswer = coerceConfigValue(answer);
+      yield* terminal.info(`Setting config: ${targetKey} = ${coercedAnswer}`);
+      yield* configService.set(targetKey, coercedAnswer);
+      yield* terminal.success(`Config set: ${targetKey} = ${coercedAnswer}`);
       return;
     }
 
@@ -179,8 +192,9 @@ export function setConfigCommand(
       );
     }
 
-    yield* terminal.info(`Setting config: ${targetKey} = ${value}`);
-    yield* configService.set(targetKey, value);
-    yield* terminal.success(`Config set: ${targetKey} = ${value}`);
+    const coercedValue = coerceConfigValue(value);
+    yield* terminal.info(`Setting config: ${targetKey} = ${coercedValue}`);
+    yield* configService.set(targetKey, coercedValue);
+    yield* terminal.success(`Config set: ${targetKey} = ${coercedValue}`);
   });
 }

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatOneShotError,
+  formatOneShotResult,
+  isApprovalPolicyFlag,
+  type OneShotSuccess,
+} from "./run-agent";
+
+const baseResult: OneShotSuccess = {
+  answer: "Hello from the agent",
+  costUSD: 0.0012,
+  tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+  toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
+};
+
+describe("formatOneShotResult", () => {
+  it("plain mode emits only the trimmed answer with a trailing newline", () => {
+    const output = formatOneShotResult({ ...baseResult, answer: "  Hello  \n\n" }, { json: false });
+    expect(output).toBe("Hello\n");
+  });
+
+  it("plain mode does not include header, footer, or JSON envelope keys", () => {
+    const output = formatOneShotResult(baseResult, { json: false });
+    expect(output).not.toContain("◉");
+    expect(output).not.toContain("completed");
+    expect(output).not.toContain('"ok"');
+  });
+
+  it("json mode emits exactly one single-line envelope", () => {
+    const output = formatOneShotResult(baseResult, { json: true });
+    expect(output.endsWith("\n")).toBe(true);
+    expect(output.trimEnd().includes("\n")).toBe(false);
+    expect(JSON.parse(output)).toEqual({
+      ok: true,
+      answer: "Hello from the agent",
+      costUSD: 0.0012,
+      tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
+    });
+  });
+});
+
+describe("formatOneShotError", () => {
+  it("plain mode emits the message with a trailing newline", () => {
+    expect(formatOneShotError("Agent not found", { json: false })).toBe("Agent not found\n");
+  });
+
+  it("json mode emits an ok:false envelope including costUSD", () => {
+    expect(JSON.parse(formatOneShotError("boom", { json: true }, 0.5))).toEqual({
+      ok: false,
+      error: "boom",
+      costUSD: 0.5,
+    });
+  });
+
+  it("json mode defaults costUSD to 0", () => {
+    expect(JSON.parse(formatOneShotError("boom", { json: true })).costUSD).toBe(0);
+  });
+});
+
+describe("isApprovalPolicyFlag", () => {
+  it("accepts the three risk levels", () => {
+    expect(isApprovalPolicyFlag("read-only")).toBe(true);
+    expect(isApprovalPolicyFlag("low-risk")).toBe(true);
+    expect(isApprovalPolicyFlag("high-risk")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isApprovalPolicyFlag("all")).toBe(false);
+    expect(isApprovalPolicyFlag("")).toBe(false);
+  });
+});

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -1,0 +1,221 @@
+import { Duration, Effect } from "effect";
+import { AgentRunner } from "@/core/agent/agent-runner";
+import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
+import { OneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
+import { AgentNotFoundError } from "@/core/types/errors";
+import type { AutoApprovePolicy } from "@/core/types/tools";
+import { CommonSuggestions, getErrorMessage } from "@/core/utils/error-handler";
+
+/**
+ * One-shot, non-interactive agent invocation — designed to be driven from
+ * scripts and webhook handlers (Slack, Google Chat, etc.).
+ *
+ * Unlike `jazz agent chat` (an interactive REPL) and `jazz workflow run` (a
+ * fixed, file-defined prompt), this command takes a dynamic prompt, runs a
+ * single turn, and prints a clean payload to stdout. All operational noise
+ * (status notices, tool chatter, the `◉ Agent:` header, the `✔ completed`
+ * footer) is routed to stderr so stdout carries only the answer (plain mode)
+ * or exactly one JSON object (`--json`).
+ */
+
+export interface OneShotTokenUsage {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+  readonly totalTokens: number;
+}
+
+export interface OneShotToolCall {
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: string;
+}
+
+export interface OneShotSuccess {
+  readonly answer: string;
+  readonly costUSD: number;
+  readonly tokenUsage: OneShotTokenUsage;
+  readonly toolCalls: readonly OneShotToolCall[];
+}
+
+export interface OneShotOutputOptions {
+  readonly json: boolean;
+}
+
+/**
+ * Format a successful run for stdout.
+ *
+ * Plain mode returns just the trimmed answer (raw markdown, ready to be
+ * translated to Slack mrkdwn / Google Chat formatting downstream). JSON mode
+ * returns exactly one single-line envelope.
+ */
+export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutputOptions): string {
+  if (!options.json) {
+    return `${result.answer.trim()}\n`;
+  }
+
+  return `${JSON.stringify({
+    ok: true,
+    answer: result.answer,
+    costUSD: result.costUSD,
+    tokenUsage: result.tokenUsage,
+    toolCalls: result.toolCalls,
+  })}\n`;
+}
+
+/** Format a failure (plain message to stderr, or JSON envelope to stdout in --json mode). */
+export function formatOneShotError(
+  message: string,
+  options: OneShotOutputOptions,
+  costUSD = 0,
+): string {
+  return options.json
+    ? `${JSON.stringify({ ok: false, error: message, costUSD })}\n`
+    : `${message}\n`;
+}
+
+const VALID_APPROVAL_POLICIES = ["read-only", "low-risk", "high-risk"] as const;
+export type ApprovalPolicyFlag = (typeof VALID_APPROVAL_POLICIES)[number];
+
+export function isApprovalPolicyFlag(value: string): value is ApprovalPolicyFlag {
+  return (VALID_APPROVAL_POLICIES as readonly string[]).includes(value);
+}
+
+export interface RunAgentOnceOptions {
+  readonly json: boolean;
+  readonly approvalPolicy?: ApprovalPolicyFlag | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly maxIterations?: number | undefined;
+  readonly unlimitedOverride?: boolean | undefined;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    process.stdin.on("error", reject);
+  });
+}
+
+const writeStdout = (message: string): Effect.Effect<void, never> =>
+  Effect.sync(() => {
+    process.stdout.write(message);
+  });
+
+const failOneShot = (
+  message: string,
+  options: OneShotOutputOptions,
+  costUSD = 0,
+): Effect.Effect<void, never> =>
+  Effect.sync(() => {
+    const formatted = formatOneShotError(message, options, costUSD);
+    // JSON mode keeps the single-object stdout contract; plain mode sends the
+    // human-readable error to stderr so stdout stays empty on failure.
+    if (options.json) {
+      process.stdout.write(formatted);
+    } else {
+      process.stderr.write(formatted);
+    }
+    process.exitCode = 1;
+  });
+
+/**
+ * Run an agent once against a dynamic prompt and print a clean payload.
+ *
+ * The prompt comes from the positional argument or, when absent, piped stdin —
+ * webhook text is untrusted and stdin avoids shell-escaping it.
+ */
+export function runAgentOnceCommand(
+  agentIdentifier: string,
+  promptArg: string | undefined,
+  options: RunAgentOnceOptions,
+) {
+  const outputOptions: OneShotOutputOptions = { json: options.json };
+
+  return Effect.gen(function* () {
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const resolvedUnlimited = options.unlimitedOverride ?? appConfig.unlimited ?? false;
+
+    const normalizedIdentifier = agentIdentifier.trim();
+    if (normalizedIdentifier.length === 0) {
+      return yield* failOneShot("No agent specified. Use --agent <agentId>.", outputOptions);
+    }
+
+    let prompt = promptArg ?? "";
+    if (prompt.trim().length === 0 && !process.stdin.isTTY) {
+      prompt = yield* Effect.tryPromise({
+        try: () => readStdin(),
+        catch: () => new Error("Failed to read prompt from stdin."),
+      }).pipe(Effect.catchAll(() => Effect.succeed("")));
+    }
+    if (prompt.trim().length === 0) {
+      return yield* failOneShot(
+        "No prompt provided. Pass it as an argument or pipe it via stdin.",
+        outputOptions,
+      );
+    }
+
+    const agent = yield* getAgentByIdentifier(normalizedIdentifier).pipe(
+      Effect.catchTag("StorageNotFoundError", () =>
+        Effect.fail(
+          new AgentNotFoundError({
+            agentId: normalizedIdentifier,
+            suggestion: CommonSuggestions.checkAgentExists(normalizedIdentifier),
+          }),
+        ),
+      ),
+    );
+
+    const autoApprovePolicy: AutoApprovePolicy | undefined = options.approvalPolicy;
+    const runId = `run-${agent.id}-${Date.now()}`;
+    const runEffect = AgentRunner.run({
+      agent,
+      userInput: prompt,
+      sessionId: runId,
+      conversationId: runId,
+      unlimited: resolvedUnlimited,
+      ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
+      ...(options.maxIterations != null && !resolvedUnlimited
+        ? { maxIterations: options.maxIterations }
+        : {}),
+    });
+
+    const runResult = yield* options.timeoutMs != null && !resolvedUnlimited
+      ? runEffect.pipe(
+          Effect.timeoutFail({
+            duration: Duration.millis(options.timeoutMs),
+            onTimeout: () => new Error(`Run exceeded the ${options.timeoutMs}ms timeout.`),
+          }),
+        )
+      : runEffect;
+
+    const promptTokens = runResult.usage?.promptTokens ?? 0;
+    const completionTokens = runResult.usage?.completionTokens ?? 0;
+    const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
+      id: toolCall.id,
+      name: toolCall.function.name,
+      arguments: toolCall.function.arguments,
+    }));
+
+    yield* writeStdout(
+      formatOneShotResult(
+        {
+          answer: runResult.content,
+          costUSD: runResult.costUSD ?? 0,
+          tokenUsage: {
+            promptTokens,
+            completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          toolCalls,
+        },
+        outputOptions,
+      ),
+    );
+  }).pipe(
+    Effect.catchAll((error) => failOneShot(getErrorMessage(error), outputOptions)),
+    Effect.provide(OneShotPresentationServiceLayer),
+  );
+}

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -194,6 +194,7 @@ export function runWorkflowCommand(
     autoApprove?: boolean;
     agent?: string;
     scheduled?: boolean;
+    unlimitedOverride?: boolean;
   },
 ) {
   return Effect.gen(function* () {
@@ -357,8 +358,8 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // maxIterations from workflow metadata is honored unless appConfig.unlimited is on
-    const unlimitedMode = appConfig.unlimited ?? false;
+    // maxIterations from workflow metadata is honored unless unlimited mode is on
+    const unlimitedMode = options?.unlimitedOverride ?? appConfig.unlimited ?? false;
     const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
@@ -564,7 +565,7 @@ export function unscheduleWorkflowCommand(workflowName: string) {
 /**
  * List workflows that need catch-up, let user select which to run, then run them.
  */
-export function catchupWorkflowCommand() {
+export function catchupWorkflowCommand(options: { unlimitedOverride?: boolean } = {}) {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
 
@@ -624,7 +625,11 @@ export function catchupWorkflowCommand() {
     yield* terminal.info(`Running catch-up for ${entriesToRun.length} workflow(s)...`);
     yield* terminal.log("");
 
-    yield* runCatchUpForWorkflows(entriesToRun);
+    yield* runCatchUpForWorkflows(entriesToRun, {
+      ...(options.unlimitedOverride !== undefined
+        ? { unlimitedOverride: options.unlimitedOverride }
+        : {}),
+    });
 
     yield* terminal.log("");
     yield* terminal.success("Catch-up finished.");

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -6,6 +6,7 @@ import { store } from "@/cli/ui/store";
 import { THEME } from "@/cli/ui/theme";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { TerminalServiceTag } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/agent";
@@ -199,6 +200,8 @@ export function runWorkflowCommand(
     const terminal = yield* TerminalServiceTag;
     const workflowService = yield* WorkflowServiceTag;
     const logger = yield* LoggerServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
 
     const isNonInteractive = options?.autoApprove === true;
     const isSchedulerTriggered = options?.scheduled === true;
@@ -354,16 +357,17 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // Run the agent with the workflow prompt
-    // maxIterations from workflow metadata is optional — omit for no limit
+    // maxIterations from workflow metadata is honored unless appConfig.unlimited is on
+    const unlimitedMode = appConfig.unlimited ?? false;
     const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       sessionId: `workflow-${workflowName}-${Date.now()}`,
       conversationId: `workflow-${workflowName}-${Date.now()}`,
-      ...(workflow.metadata.maxIterations != null
+      ...(workflow.metadata.maxIterations != null && !unlimitedMode
         ? { maxIterations: workflow.metadata.maxIterations }
         : {}),
+      unlimited: unlimitedMode,
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
     }).pipe(
       Effect.tap((result) =>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -113,15 +113,13 @@ const PromptIsland = React.memo(PromptIslandComponent);
 // ============================================================================
 
 function StatusFooterIslandComponent(): React.ReactElement | null {
-  // RunStats is the footer's primary content — model · tokens · cost.
-  // The working directory is rendered by the prompt island already, so
-  // we don't duplicate it here (avoids conflicting with the prompt's
-  // single-slot wd setter).
   const [runStats, setRunStats] = React.useState<RunStats>({});
+  const [unlimited, setUnlimited] = React.useState<boolean>(store.getUnlimitedActive());
   const initializedRef = useRef(false);
 
   if (!initializedRef.current) {
     store.registerRunStatsSetter(setRunStats);
+    store.registerUnlimitedSetter(setUnlimited);
     setRunStats(store.getRunStatsSnapshot());
     initializedRef.current = true;
   }
@@ -129,6 +127,7 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
   useEffect(() => {
     return () => {
       store.registerRunStatsSetter(() => {});
+      store.registerUnlimitedSetter(null);
     };
   }, []);
 
@@ -137,6 +136,7 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
       status={null}
       workingDirectory={null}
       runStats={runStats}
+      unlimited={unlimited}
     />
   );
 }

--- a/src/cli/ui/StatusFooter.tsx
+++ b/src/cli/ui/StatusFooter.tsx
@@ -67,16 +67,18 @@ function StatusFooter({
   status,
   workingDirectory,
   runStats,
+  unlimited,
 }: {
   status: string | null;
   workingDirectory: string | null;
   runStats: RunStats;
+  unlimited: boolean;
 }) {
   const hasRunStats =
     runStats.model !== undefined ||
     runStats.tokensInContext !== undefined ||
     runStats.costUSD !== undefined;
-  const hasContent = status || workingDirectory || hasRunStats;
+  const hasContent = status || workingDirectory || hasRunStats || unlimited;
   if (!hasContent) return null;
 
   const homeDir = process.env["HOME"];
@@ -110,6 +112,7 @@ function StatusFooter({
       width="100%"
     >
       <Box flexShrink={1}>
+        {unlimited && <Text color={THEME.warning}>[unlimited] </Text>}
         {status ? (
           <AnimatedEllipsis
             label={status}

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -108,6 +108,7 @@ export class UIStore {
   private modeSwitchHandler: ModeSwitchHandler | null = null;
   // Track current mode for toggle behavior (safe = false, yolo = true)
   private currentModeIsYolo = false;
+  private currentUnlimitedActive = false;
 
   // Snapshots (kept in sync so late-registering components can hydrate)
   private promptSnapshot: PromptState | null = null;
@@ -133,6 +134,7 @@ export class UIStore {
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
+  private unlimitedSetter: ((active: boolean) => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -349,6 +351,20 @@ export class UIStore {
   showModeToast = (message: string): void => {
     this.modeToastSetter?.(message);
   };
+
+  // ── Unlimited mode indicator ─────────────────────────────────────────────
+
+  registerUnlimitedSetter = (setter: ((active: boolean) => void) | null): void => {
+    this.unlimitedSetter = setter;
+    if (setter) setter(this.currentUnlimitedActive);
+  };
+
+  setUnlimitedActive = (active: boolean): void => {
+    this.currentUnlimitedActive = active;
+    this.unlimitedSetter?.(active);
+  };
+
+  getUnlimitedActive = (): boolean => this.currentUnlimitedActive;
 
   // ── Ephemeral live regions ────────────────────────────────────────
 

--- a/src/cli/utils/option-parsers.test.ts
+++ b/src/cli/utils/option-parsers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { parsePositiveInt } from "./option-parsers";
+
+describe("parsePositiveInt", () => {
+  const parse = parsePositiveInt("--timeout");
+
+  it("parses a positive integer string", () => {
+    expect(parse("5000")).toBe(5000);
+    expect(parse("1")).toBe(1);
+  });
+
+  it("ignores trailing non-numeric characters like parseInt", () => {
+    expect(parse("30s")).toBe(30);
+  });
+
+  it("throws on zero, negatives, and non-numeric input", () => {
+    expect(() => parse("0")).toThrow('--timeout must be a positive integer (got "0").');
+    expect(() => parse("-3")).toThrow("--timeout must be a positive integer");
+    expect(() => parse("abc")).toThrow("--timeout must be a positive integer");
+  });
+
+  it("uses the provided label in the error message", () => {
+    expect(() => parsePositiveInt("--max-iterations")("x")).toThrow(
+      "--max-iterations must be a positive integer",
+    );
+  });
+});

--- a/src/cli/utils/option-parsers.ts
+++ b/src/cli/utils/option-parsers.ts
@@ -1,0 +1,22 @@
+/**
+ * Commander.js option parsers shared across CLI command definitions.
+ */
+
+/**
+ * Build a Commander option parser that accepts only positive integers.
+ *
+ * Commander passes option values as raw strings; this validates and coerces
+ * them, throwing a clear error (which Commander surfaces to the user) when the
+ * value is not a positive integer.
+ *
+ * @param label - The flag name used in the error message (e.g. "--timeout").
+ */
+export function parsePositiveInt(label: string) {
+  return (raw: string): number => {
+    const value = Number.parseInt(raw, 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`${label} must be a positive integer (got "${raw}").`);
+    }
+    return value;
+  };
+}

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -254,6 +254,7 @@ function initializeAgentRun(
       model,
       connectedMCPServers,
       maxRetries: Math.max(0, Math.floor(appConfig.maxRetries ?? DEFAULT_MAX_LLM_RETRIES)),
+      unlimited: options.unlimited ?? false,
       knownSkills: relevantSkills,
     };
   });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -659,4 +659,64 @@ describe("executeAgentLoop with unlimited", () => {
       ToolExecutor.executeToolCalls = originalExecute;
     }
   });
+
+  it("sets parentUnlimited on the tool execution context when unlimited is true", async () => {
+    let capturedContext: any = null;
+    let iteration = 0;
+
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () => {
+        iteration++;
+        if (iteration === 1) {
+          return Effect.succeed({
+            completion: {
+              id: "c1",
+              model: "gpt-4",
+              content: "",
+              toolCalls: [
+                {
+                  id: "call_1",
+                  type: "function" as const,
+                  function: { name: "test_tool", arguments: "{}" },
+                },
+              ],
+            },
+            interrupted: false,
+          });
+        }
+        return Effect.succeed({
+          completion: { id: "c2", model: "gpt-4", content: "Done" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    try {
+      ToolExecutor.executeToolCalls = mock((_toolCalls: any[], context: any) => {
+        capturedContext = context;
+        return Effect.succeed([
+          { toolCallId: "call_1", name: "test_tool", result: "ok", success: true },
+        ]);
+      });
+
+      await Effect.runPromise(
+        executeAgentLoop(
+          makeOptions({ unlimited: true }),
+          makeRunContext(),
+          displayConfig,
+          strategy,
+          runRecursive,
+        ).pipe(Effect.provide(TestLayer)),
+      );
+
+      expect(capturedContext?.parentUnlimited).toBe(true);
+    } finally {
+      ToolExecutor.executeToolCalls = originalExecute;
+    }
+  });
 });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -582,3 +582,79 @@ describe("detectMeltdown", () => {
     expect(detectMeltdown([...diverse, ...meltdown])).toBe(true);
   });
 });
+
+describe("buildBudgetPressureMessage with unlimited", () => {
+  it("returns null at every threshold when unlimited is true", () => {
+    expect(buildBudgetPressureMessage(700, 1000, true)).toBeNull();
+    expect(buildBudgetPressureMessage(950, 1000, true)).toBeNull();
+    expect(buildBudgetPressureMessage(999, 1000, true)).toBeNull();
+  });
+
+  it("still emits pressure messages when unlimited is false", () => {
+    expect(buildBudgetPressureMessage(70, 100, false)?.content).toContain("WARNING");
+    expect(buildBudgetPressureMessage(95, 100, false)?.content).toContain("CRITICAL");
+  });
+});
+
+describe("executeAgentLoop with unlimited", () => {
+  it("ignores maxIterations when unlimited is true", async () => {
+    let callCount = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () => {
+        callCount++;
+        if (callCount <= 3) {
+          return Effect.succeed({
+            completion: {
+              id: `c${callCount}`,
+              model: "gpt-4",
+              content: "",
+              toolCalls: [
+                {
+                  id: `call_${callCount}`,
+                  type: "function" as const,
+                  function: { name: "test_tool", arguments: "{}" },
+                },
+              ],
+            },
+            interrupted: false,
+          });
+        }
+        return Effect.succeed({
+          completion: { id: "c-final", model: "gpt-4", content: "Done beyond limit" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
+      Effect.succeed(
+        toolCalls.map((tc: any) => ({
+          toolCallId: tc.id,
+          name: tc.function.name,
+          result: "ok",
+          success: true,
+        })),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 2, unlimited: true }),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(result.content).toBe("Done beyond limit");
+    expect(callCount).toBeGreaterThanOrEqual(4);
+
+    ToolExecutor.executeToolCalls = originalExecute;
+  });
+});

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -631,30 +631,32 @@ describe("executeAgentLoop with unlimited", () => {
     };
 
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
-      Effect.succeed(
-        toolCalls.map((tc: any) => ({
-          toolCallId: tc.id,
-          name: tc.function.name,
-          result: "ok",
-          success: true,
-        })),
-      ),
-    );
+    try {
+      ToolExecutor.executeToolCalls = mock((toolCalls: any[]) =>
+        Effect.succeed(
+          toolCalls.map((tc: any) => ({
+            toolCallId: tc.id,
+            name: tc.function.name,
+            result: "ok",
+            success: true,
+          })),
+        ),
+      );
 
-    const result = await Effect.runPromise(
-      executeAgentLoop(
-        makeOptions({ maxIterations: 2, unlimited: true }),
-        makeRunContext(),
-        displayConfig,
-        strategy,
-        runRecursive,
-      ).pipe(Effect.provide(TestLayer)),
-    );
+      const result = await Effect.runPromise(
+        executeAgentLoop(
+          makeOptions({ maxIterations: 2, unlimited: true }),
+          makeRunContext(),
+          displayConfig,
+          strategy,
+          runRecursive,
+        ).pipe(Effect.provide(TestLayer)),
+      );
 
-    expect(result.content).toBe("Done beyond limit");
-    expect(callCount).toBeGreaterThanOrEqual(4);
-
-    ToolExecutor.executeToolCalls = originalExecute;
+      expect(result.content).toBe("Done beyond limit");
+      expect(callCount).toBe(4);
+    } finally {
+      ToolExecutor.executeToolCalls = originalExecute;
+    }
   });
 });

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -390,6 +390,7 @@ export function executeAgentLoop(
                 conversationMessages: currentMessages,
                 parentAgent: agent,
                 parentMaxIterations: maxIterations,
+                parentUnlimited: unlimited,
                 compactConversation: (compacted: readonly ChatMessage[]) => {
                   currentMessages = [
                     currentMessages[0],

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -408,6 +408,7 @@ export function executeAgentLoop(
                 actualConversationId,
                 agent.name,
                 strategy.getInterruptSignal?.(),
+                unlimited,
               );
 
               // Validate all tool calls have results

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -38,7 +38,9 @@ import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../type
 export function buildBudgetPressureMessage(
   iteration: number,
   maxIterations: number,
+  unlimited: boolean = false,
 ): { role: "user"; content: string } | null {
+  if (unlimited) return null;
   const pct = iteration / maxIterations;
   if (pct >= 0.9) {
     return {
@@ -179,7 +181,7 @@ export function executeAgentLoop(
     // Use: main loop
     ({ logger, finalizeFiberRef }) =>
       Effect.gen(function* () {
-        const { agent, maxIterations: maxIter } = options;
+        const { agent, maxIterations: maxIter, unlimited = false } = options;
         const maxIterations = maxIter ?? DEFAULT_MAX_ITERATIONS;
         const presentationService = yield* PresentationServiceTag;
         const { actualConversationId, context, tools, messages, runMetrics, provider, model } =
@@ -219,7 +221,7 @@ export function executeAgentLoop(
         let iterationsUsed = 0;
         const recentToolCalls: TrackedToolCall[] = [];
 
-        for (let i = 0; i < maxIterations; i++) {
+        for (let i = 0; unlimited || i < maxIterations; i++) {
           yield* Effect.sync(() => beginIteration(runMetrics, i + 1));
           try {
             if (!options.internal && strategy.shouldShowThinking) {
@@ -255,7 +257,7 @@ export function executeAgentLoop(
               lastUserMessage: lastUserContent,
             });
 
-            const budgetMsg = buildBudgetPressureMessage(i + 1, maxIterations);
+            const budgetMsg = buildBudgetPressureMessage(i + 1, maxIterations, unlimited);
             const messagesForLLM = budgetMsg
               ? ([...currentMessages, budgetMsg] as typeof currentMessages)
               : currentMessages;
@@ -366,7 +368,7 @@ export function executeAgentLoop(
                 recentToolCalls.splice(0, recentToolCalls.length - MELTDOWN_WINDOW_SIZE);
               }
 
-              if (detectMeltdown(recentToolCalls)) {
+              if (!unlimited && detectMeltdown(recentToolCalls)) {
                 yield* logger.warn("Meltdown detected — injecting recovery signal", {
                   agentId: agent.id,
                   recentTools: recentToolCalls.slice(-10).map((tc) => tc.name),

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -73,6 +73,7 @@ export function executeWithoutStreaming(
             agent.name,
             showAgentStatus,
             retryAttemptRef,
+            runContext.unlimited ?? false,
           );
 
           const completion = yield* Effect.retry(

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -76,7 +76,7 @@ export function executeWithoutStreaming(
             runContext.unlimited ?? false,
           );
 
-          const completion = yield* Effect.retry(
+          const batchCall = Effect.retry(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
@@ -90,17 +90,21 @@ export function executeWithoutStreaming(
               }),
             ),
             batchRetrySchedule,
-          ).pipe(
-            Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-            Effect.tapError((error) =>
-              Cause.isTimeoutException(error)
-                ? showAgentStatus(
-                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                    "warning",
-                  )
-                : Effect.void,
-            ),
           );
+          const batchCallWithTimeout = runContext.unlimited
+            ? batchCall
+            : batchCall.pipe(
+                Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                Effect.tapError((error) =>
+                  Cause.isTimeoutException(error)
+                    ? showAgentStatus(
+                        `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                        "warning",
+                      )
+                    : Effect.void,
+                ),
+              );
+          const completion = yield* batchCallWithTimeout;
 
           return { completion, interrupted: false };
         });

--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -33,14 +33,16 @@ export function makeUserVisibleLlmRetrySchedule(
   agentName: string,
   presentStatus: PresentStatusFn,
   attemptRef: Ref.Ref<number>,
+  unlimited: boolean = false,
 ) {
-  return makeLLMRetrySchedule(maxRetries).pipe(
+  return makeLLMRetrySchedule(maxRetries, unlimited).pipe(
     Schedule.tapInput((error: unknown) =>
       isRetryableLLMError(error)
         ? Effect.gen(function* () {
             const attempt = yield* Ref.updateAndGet(attemptRef, (count) => count + 1);
+            const tail = unlimited ? "" : ` of up to ${maxRetries}`;
             yield* presentStatus(
-              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
+              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt}${tail})…`,
               "progress",
             );
           })

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -120,6 +120,7 @@ export function executeWithStreaming(
             agent.name,
             showAgentStatus,
             retryAttemptRef,
+            runContext.unlimited ?? false,
           );
 
           const streamingResult = yield* Effect.retry(
@@ -178,6 +179,7 @@ export function executeWithStreaming(
                     agent.name,
                     showAgentStatus,
                     fallbackAttemptRef,
+                    runContext.unlimited ?? false,
                   );
                   const fallback = yield* Effect.retry(
                     withLongRunningLlmNotice(

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -123,7 +123,7 @@ export function executeWithStreaming(
             runContext.unlimited ?? false,
           );
 
-          const streamingResult = yield* Effect.retry(
+          const streamingCall = Effect.retry(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
@@ -151,16 +151,21 @@ export function executeWithStreaming(
               }),
             ),
             streamingRetrySchedule,
-          ).pipe(
-            Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-            Effect.tapError((error) =>
-              Cause.isTimeoutException(error)
-                ? showAgentStatus(
-                    `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                    "warning",
-                  )
-                : Effect.void,
-            ),
+          );
+          const streamingCallWithTimeout = runContext.unlimited
+            ? streamingCall
+            : streamingCall.pipe(
+                Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                Effect.tapError((error) =>
+                  Cause.isTimeoutException(error)
+                    ? showAgentStatus(
+                        `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                        "warning",
+                      )
+                    : Effect.void,
+                ),
+              );
+          const streamingResult = yield* streamingCallWithTimeout.pipe(
             Effect.catchIf(
               (error): error is LLMRequestError | LLMRateLimitError => isRetryableLLMError(error),
               (error) =>
@@ -181,7 +186,7 @@ export function executeWithStreaming(
                     fallbackAttemptRef,
                     runContext.unlimited ?? false,
                   );
-                  const fallback = yield* Effect.retry(
+                  const fallbackCall = Effect.retry(
                     withLongRunningLlmNotice(
                       agent.name,
                       showAgentStatus,
@@ -195,17 +200,21 @@ export function executeWithStreaming(
                       }),
                     ),
                     fallbackRetrySchedule,
-                  ).pipe(
-                    Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
-                    Effect.tapError((innerError) =>
-                      Cause.isTimeoutException(innerError)
-                        ? showAgentStatus(
-                            `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
-                            "warning",
-                          )
-                        : Effect.void,
-                    ),
                   );
+                  const fallbackCallWithTimeout = runContext.unlimited
+                    ? fallbackCall
+                    : fallbackCall.pipe(
+                        Effect.timeout(Duration.seconds(LLM_TIMEOUT_SECONDS)),
+                        Effect.tapError((innerError) =>
+                          Cause.isTimeoutException(innerError)
+                            ? showAgentStatus(
+                                `${agent.name} exceeded the maximum wait time for this step (including retries). Check connectivity or try again.`,
+                                "warning",
+                              )
+                            : Effect.void,
+                        ),
+                      );
+                  const fallback = yield* fallbackCallWithTimeout;
                   return {
                     stream: Stream.empty,
                     response: Effect.succeed(fallback),

--- a/src/core/agent/execution/tool-executor.test.ts
+++ b/src/core/agent/execution/tool-executor.test.ts
@@ -262,6 +262,50 @@ describe("ToolExecutor.executeToolCall", () => {
   });
 });
 
+describe("ToolExecutor.executeTool unlimited mode", () => {
+  it("does not apply a timeout when unlimited is true", async () => {
+    const mockToolRegistry = {
+      getTool: () =>
+        Effect.succeed({
+          name: "slow_tool",
+          timeoutMs: 50,
+          longRunning: false,
+          approvalExecuteToolName: undefined,
+        }),
+      executeTool: () =>
+        Effect.sleep("200 millis").pipe(
+          Effect.as({ success: true, result: { data: "completed" } }),
+        ),
+    } as unknown as ToolRegistry;
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(FileSystem.FileSystem, emptyFs),
+      Layer.succeed(TerminalServiceTag, emptyTerminal),
+      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(LLMServiceTag, emptyLlm),
+      Layer.succeed(MCPServerManagerTag, emptyMcp),
+    );
+
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "slow_tool",
+        {},
+        { agentId: "agent-1", conversationId: "conv-123", sessionId: "sess-1" },
+        undefined,
+        true,
+      ).pipe(Effect.provide(testLayer)) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ data: "completed" });
+  });
+});
+
 describe("ToolExecutor.executeToolCalls", () => {
   it("should execute multiple tool calls", async () => {
     const mockToolRegistry = {

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -42,6 +42,7 @@ export class ToolExecutor {
     args: Record<string, unknown>,
     context: ToolExecutionContext,
     overrideTimeoutMs?: number,
+    unlimited: boolean = false,
   ): Effect.Effect<
     ToolExecutionResult,
     ToolNotFoundError | Error,
@@ -63,6 +64,10 @@ export class ToolExecutor {
         if (timeoutMs === undefined && !toolMeta?.longRunning) {
           timeoutMs = TOOL_TIMEOUT_MS;
         }
+      }
+
+      if (unlimited) {
+        timeoutMs = undefined;
       }
 
       const execution = registry.executeTool(name, args, context);
@@ -106,6 +111,7 @@ export class ToolExecutor {
     agentId: string,
     conversationId: string,
     toolsRequiringApproval: ReadonlySet<string>,
+    unlimited: boolean = false,
   ): Effect.Effect<
     { toolCallId: string; result: unknown; success: boolean; name: string },
     Error,
@@ -182,7 +188,13 @@ export class ToolExecutor {
         }
 
         // Execute tool — pass pre-fetched timeout to avoid redundant getTool lookup
-        let result = yield* ToolExecutor.executeTool(name, args, context, toolMeta?.timeoutMs);
+        let result = yield* ToolExecutor.executeTool(
+          name,
+          args,
+          context,
+          toolMeta?.timeoutMs,
+          unlimited,
+        );
         let toolDuration = Date.now() - toolStartTime;
         let finalToolName = name;
 
@@ -306,6 +318,8 @@ export class ToolExecutor {
               approvalResult.executeToolName,
               approvalResult.executeArgs,
               context,
+              undefined,
+              unlimited,
             );
             toolDuration = Date.now() - executeStartTime;
             finalToolName = approvalResult.executeToolName;
@@ -442,6 +456,7 @@ export class ToolExecutor {
     conversationId: string,
     agentName: string,
     interruptSignal?: Effect.Effect<void, never>,
+    unlimited: boolean = false,
   ): Effect.Effect<
     Array<{ toolCallId: string; result: unknown; name: string; success: boolean }>,
     Error,
@@ -531,6 +546,7 @@ export class ToolExecutor {
               agentId,
               conversationId,
               approvalSet,
+              unlimited,
             ),
           ),
         ),

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -138,6 +138,7 @@ ${args.task}`;
             sessionId: context.sessionId ?? context.conversationId ?? `session-${Date.now()}`,
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
             maxIterations: context.parentMaxIterations ?? DEFAULT_MAX_ITERATIONS,
+            unlimited: context.parentUnlimited ?? false,
             ephemeralRegionId: regionId,
           }).pipe(
             Effect.tapError(() =>

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -59,6 +59,12 @@ export interface AgentRunnerOptions {
    */
   readonly maxIterations?: number;
   /**
+   * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
+   * nudges, meltdown detection, tool timeouts, LLM retry cap. Propagates to
+   * spawned subagents. Default false.
+   */
+  readonly unlimited?: boolean;
+  /**
    * Full conversation history to date, including prior assistant, user, and tool messages.
    * Use this to preserve context across turns (e.g., approval flows, multi-step tasks).
    */
@@ -203,6 +209,7 @@ export interface AgentRunContext {
   readonly model: string;
   readonly connectedMCPServers: readonly string[];
   readonly maxRetries?: number;
+  readonly unlimited?: boolean;
   readonly knownSkills: readonly {
     readonly name: string;
     readonly description: string;

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -60,8 +60,8 @@ export interface AgentRunnerOptions {
   readonly maxIterations?: number;
   /**
    * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
-   * nudges, meltdown detection, tool timeouts, LLM retry cap. Propagates to
-   * spawned subagents. Default false.
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, and per-call LLM
+   * timeout. Propagates to spawned subagents. Default false.
    */
   readonly unlimited?: boolean;
   /**

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -34,6 +34,7 @@ export interface ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      unlimited?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
     },

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -1,0 +1,168 @@
+import { Effect, Layer, Option } from "effect";
+import { DEFAULT_DISPLAY_CONFIG } from "@/core/agent/types";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
+import type {
+  PresentationService,
+  StreamingRenderer,
+  StreamingRendererConfig,
+} from "@/core/interfaces/presentation";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { StreamEvent } from "@/core/types/streaming";
+import type { ApprovalRequest, ApprovalOutcome } from "@/core/types/tools";
+import { resolveDisplayConfig } from "@/core/utils/display-config";
+
+/**
+ * Presentation service for headless, one-shot agent runs (`jazz run`).
+ *
+ * Keeps stdout clean for a machine-readable payload: nothing the agent loop
+ * emits reaches stdout. Operational chatter (status, warnings, stray writes)
+ * is routed to stderr instead. Interactive prompts cannot be answered without
+ * a human, so:
+ *  - approvals are DECLINED (the run's `autoApprovePolicy` already auto-approved
+ *    everything it was allowed to; anything still asking is above the policy
+ *    threshold and is refused rather than blanket-approved),
+ *  - user-input / file-picker requests return empty.
+ *
+ * This differs from QuietPresentationService, which blanket-approves every tool
+ * and is meant for trusted background runs.
+ */
+class OneShotPresentationService implements PresentationService {
+  constructor(_displayConfig = DEFAULT_DISPLAY_CONFIG) {}
+
+  presentThinking(_agentName: string, _isFirstIteration: boolean): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentCompletion(_agentName: string): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentWarning(agentName: string, message: string): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      process.stderr.write(`⚠ ${agentName}: ${message}\n`);
+    });
+  }
+
+  presentAgentResponse(_agentName: string, _content: string): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  renderMarkdown(markdown: string): Effect.Effect<string, never> {
+    return Effect.succeed(markdown);
+  }
+
+  formatToolArguments(_toolName: string, args?: Record<string, unknown>): string {
+    if (!args || Object.keys(args).length === 0) return "";
+    return ` ${JSON.stringify(args)}`;
+  }
+
+  formatToolResult(_toolName: string, result: string): string {
+    return result;
+  }
+
+  formatToolExecutionStart(
+    _toolName: string,
+    _args?: Record<string, unknown>,
+    _options?: { readonly metadata?: Record<string, unknown> },
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolExecutionComplete(
+    _summary: string | null,
+    _durationMs: number,
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolExecutionError(
+    _errorMessage: string,
+    _durationMs: number,
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolsDetected(
+    _agentName: string,
+    _toolNames: readonly string[],
+    _toolsRequiringApproval: readonly string[],
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  createStreamingRenderer(
+    _config: StreamingRendererConfig,
+  ): Effect.Effect<StreamingRenderer, never> {
+    const noopRenderer: StreamingRenderer = {
+      handleEvent: (_event: StreamEvent) => Effect.void,
+      setInterruptHandler: (_handler: (() => void) | null) => Effect.void,
+      reset: () => Effect.void,
+      flush: () => Effect.void,
+    };
+    return Effect.succeed(noopRenderer);
+  }
+
+  writeOutput(message: string): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      process.stderr.write(message);
+    });
+  }
+
+  writeBlankLine(): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentStatus(
+    message: string,
+    level: "info" | "success" | "warning" | "error" | "progress",
+  ): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      const prefixes: Record<typeof level, string> = {
+        info: "ℹ",
+        success: "✓",
+        warning: "⚠",
+        error: "✗",
+        progress: "⏳",
+      };
+      process.stderr.write(`${prefixes[level]} ${message}\n`);
+    });
+  }
+
+  requestApproval(request: ApprovalRequest): Effect.Effect<ApprovalOutcome, never> {
+    // Headless: no human to approve. Decline, but steer the model away from the
+    // default "ask the user to try again" recovery (there is no user) and toward
+    // either an allowed tool or a clear explanation of what it could not do.
+    const userMessage =
+      `The "${request.toolName}" tool requires approval and was automatically declined ` +
+      `because this is a non-interactive run. Do not ask the user to approve or retry — ` +
+      `there is no one to respond. Either accomplish the task using tools that do not ` +
+      `require approval, or clearly explain what could not be done and why.`;
+    return Effect.succeed({ approved: false, userMessage });
+  }
+
+  signalToolExecutionStarted(): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  requestUserInput(): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  requestFilePicker(): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+}
+
+/**
+ * Layer providing the one-shot presentation service for `jazz run`.
+ */
+export const OneShotPresentationServiceLayer = Layer.effect(
+  PresentationServiceTag,
+  Effect.gen(function* () {
+    const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
+    const displayConfig = Option.isSome(configServiceOption)
+      ? resolveDisplayConfig(yield* configServiceOption.value.appConfig)
+      : DEFAULT_DISPLAY_CONFIG;
+    return new OneShotPresentationService(displayConfig);
+  }),
+);

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -21,9 +21,9 @@ export interface AppConfig {
   readonly maxRetries?: number;
   /**
    * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
-   * nudges, meltdown detection, tool timeouts, LLM retry cap, and workflow
-   * `maxIterations` metadata are all ignored. Intended for trusted long-running
-   * setups. Default false.
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, per-call LLM
+   * timeout, and workflow `maxIterations` metadata are all ignored. Intended
+   * for trusted long-running setups. Default false.
    */
   readonly unlimited?: boolean;
 }

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -19,6 +19,13 @@ export interface AppConfig {
   readonly telemetry?: TelemetryConfig;
   /** Maximum number of retries for transient LLM API failures. Defaults to 3. */
   readonly maxRetries?: number;
+  /**
+   * If true, every per-run guardrail is lifted: iteration cap, budget-pressure
+   * nudges, meltdown detection, tool timeouts, LLM retry cap, and workflow
+   * `maxIterations` metadata are all ignored. Intended for trusted long-running
+   * setups. Default false.
+   */
+  readonly unlimited?: boolean;
 }
 
 export interface NotificationsConfig {

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -188,6 +188,11 @@ export interface ToolExecutionContext {
    */
   readonly parentMaxIterations?: number;
   /**
+   * Whether the parent agent is in unlimited mode. Subagents inherit this so
+   * every guardrail (iteration cap, retries, timeouts) is lifted for them too.
+   */
+  readonly parentUnlimited?: boolean;
+  /**
    * Callback to replace conversation messages with compacted versions.
    * Used by summarize_context to actually update the executor's message array.
    */

--- a/src/core/utils/error-handler.ts
+++ b/src/core/utils/error-handler.ts
@@ -494,6 +494,21 @@ export function formatError(error: JazzError): string {
 }
 
 /**
+ * Extract a concise, single-line human message from any error.
+ *
+ * JazzError types carry their detail in structured fields (often with an empty
+ * `.message`), so fall back to the suggestion engine's message for those.
+ * Useful for machine-readable surfaces (e.g. `jazz run --json`) that need a
+ * meaningful string without the full decorated multi-line output.
+ */
+export function getErrorMessage(error: JazzError | Error): string {
+  if ("_tag" in error && typeof (error as { _tag: unknown })._tag === "string") {
+    return generateSuggestions(error).message;
+  }
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+/**
  * Enhanced error handler that provides actionable suggestions
  *
  * Handles both JazzError types (with structured suggestions) and generic Error objects.

--- a/src/core/utils/llm-error.test.ts
+++ b/src/core/utils/llm-error.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Ref } from "effect";
+import { LLMRateLimitError, LLMRequestError } from "@/core/types/errors";
+import { isRetryableLLMError, makeLLMRetrySchedule } from "./llm-error";
+
+const instantClock = {
+  currentTimeMillis: Effect.succeed(0),
+  currentTimeNanos: Effect.succeed(BigInt(0)),
+  sleep: (_duration: unknown) => Effect.void,
+};
+
+function withInstantClock<A, E>(effect: Effect.Effect<A, E>) {
+  return Effect.withClock(instantClock)(effect);
+}
+
+function countRetryAttempts(schedule: ReturnType<typeof makeLLMRetrySchedule>, error: unknown) {
+  return withInstantClock(
+    Effect.gen(function* () {
+      const countRef = yield* Ref.make(0);
+      yield* Effect.retry(
+        Effect.gen(function* () {
+          yield* Ref.update(countRef, (count) => count + 1);
+          return yield* Effect.fail(error);
+        }),
+        schedule,
+      ).pipe(Effect.catchAll(() => Effect.void));
+      const total = yield* Ref.get(countRef);
+      return total - 1;
+    }).pipe(
+      Effect.timeout("5 seconds"),
+      Effect.catchAll(() => Effect.succeed(-1)),
+    ),
+  );
+}
+
+const retryableError = new LLMRateLimitError({ message: "rate limited", provider: "openai" });
+const nonRetryableError = new LLMRequestError({ message: "bad request", statusCode: 400 });
+
+describe("isRetryableLLMError", () => {
+  it("returns true for LLMRateLimitError", () => {
+    expect(isRetryableLLMError(retryableError)).toBe(true);
+  });
+
+  it("returns false for non-retryable LLMRequestError (4xx)", () => {
+    expect(isRetryableLLMError(nonRetryableError)).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    expect(isRetryableLLMError(new Error("generic"))).toBe(false);
+  });
+});
+
+describe("makeLLMRetrySchedule", () => {
+  it("bounded mode: retries exactly maxRetries times on retryable error", async () => {
+    const maxRetries = 3;
+    const schedule = makeLLMRetrySchedule(maxRetries, false);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, retryableError));
+    expect(retryCount).toBe(maxRetries);
+  });
+
+  it("bounded mode: does not retry on non-retryable error", async () => {
+    const schedule = makeLLMRetrySchedule(5, false);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, nonRetryableError));
+    expect(retryCount).toBe(0);
+  });
+
+  it("unlimited mode: retries more than maxRetries times on retryable error", async () => {
+    const maxRetries = 3;
+    const extraRetries = maxRetries + 5;
+    const schedule = makeLLMRetrySchedule(maxRetries, true);
+    const retryCount = await Effect.runPromise(
+      withInstantClock(
+        Effect.gen(function* () {
+          const countRef = yield* Ref.make(0);
+          yield* Effect.retry(
+            Effect.gen(function* () {
+              const count = yield* Ref.updateAndGet(countRef, (n) => n + 1);
+              if (count > extraRetries) return yield* Effect.void;
+              return yield* Effect.fail(retryableError);
+            }),
+            schedule,
+          ).pipe(Effect.catchAll(() => Effect.void));
+          const total = yield* Ref.get(countRef);
+          return total - 1;
+        }),
+      ),
+    );
+    expect(retryCount).toBe(extraRetries);
+  });
+
+  it("unlimited mode: still does not retry on non-retryable error", async () => {
+    const schedule = makeLLMRetrySchedule(5, true);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, nonRetryableError));
+    expect(retryCount).toBe(0);
+  });
+
+  it("default second parameter behaves as bounded", async () => {
+    const maxRetries = 2;
+    const schedule = makeLLMRetrySchedule(maxRetries);
+    const retryCount = await Effect.runPromise(countRetryAttempts(schedule, retryableError));
+    expect(retryCount).toBe(maxRetries);
+  });
+});

--- a/src/core/utils/llm-error.ts
+++ b/src/core/utils/llm-error.ts
@@ -263,12 +263,18 @@ export function isRetryableLLMError(error: unknown): boolean {
  * Exponential backoff schedule for LLM retries, delay capped at MAX_RETRY_DELAY_SECONDS.
  * Only retries on transient errors (rate limits, connection failures, 5xx).
  */
-export function makeLLMRetrySchedule(maxRetries: number) {
-  return Schedule.exponential("1 second").pipe(
+export function makeLLMRetrySchedule(maxRetries: number, unlimited: boolean = false) {
+  const base = Schedule.exponential("1 second").pipe(
     Schedule.modifyDelay((_, delay) =>
       Duration.min(delay, Duration.seconds(MAX_RETRY_DELAY_SECONDS)),
     ),
-    Schedule.intersect(Schedule.recurs(maxRetries)),
     Schedule.whileInput((error: unknown) => isRetryableLLMError(error)),
+  );
+  if (unlimited) {
+    return base;
+  }
+  return base.pipe(
+    Schedule.intersect(Schedule.recurs(maxRetries)),
+    Schedule.map(([delay]) => delay),
   );
 }

--- a/src/core/workflows/catch-up.ts
+++ b/src/core/workflows/catch-up.ts
@@ -172,6 +172,11 @@ interface RunCatchUpOptions {
    * are written, which would cause the catch-up prompt to reappear.
    */
   readonly recordsPreCreated?: boolean;
+  /**
+   * CLI-level override for unlimited mode. When set, takes precedence over
+   * appConfig.unlimited. Undefined means fall back to appConfig.unlimited.
+   */
+  readonly unlimitedOverride?: boolean;
 }
 
 /**
@@ -191,7 +196,7 @@ export function runCatchUpForWorkflows(
     const workflowService = yield* WorkflowServiceTag;
     const configService = yield* AgentConfigServiceTag;
     const appConfig = yield* configService.appConfig;
-    const unlimitedMode = appConfig.unlimited ?? false;
+    const unlimitedMode = options.unlimitedOverride ?? appConfig.unlimited ?? false;
     const now = new Date();
 
     // Only load history and re-check decisions when records were not pre-created.

--- a/src/core/workflows/catch-up.ts
+++ b/src/core/workflows/catch-up.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { DEFAULT_MAX_CATCH_UP_AGE_SECONDS } from "@/core/constants/agent";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { normalizeCronExpression } from "@/core/utils/cron-utils";
 import {
@@ -188,6 +189,9 @@ export function runCatchUpForWorkflows(
   return Effect.gen(function* () {
     const logger = yield* LoggerServiceTag;
     const workflowService = yield* WorkflowServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const unlimitedMode = appConfig.unlimited ?? false;
     const now = new Date();
 
     // Only load history and re-check decisions when records were not pre-created.
@@ -267,7 +271,10 @@ export function runCatchUpForWorkflows(
         userInput: workflowContent.prompt,
         sessionId: runId,
         conversationId: runId,
-        ...(workflow.maxIterations != null ? { maxIterations: workflow.maxIterations } : {}),
+        ...(workflow.maxIterations != null && !unlimitedMode
+          ? { maxIterations: workflow.maxIterations }
+          : {}),
+        unlimited: unlimitedMode,
         ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       }).pipe(
         Effect.tap(() =>

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -110,6 +110,7 @@ export class ChatServiceImpl implements ChatService {
       let loggedMessageCount = 0;
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
+      let unlimited: boolean = options?.unlimited ?? false;
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
@@ -256,6 +257,7 @@ export class ChatServiceImpl implements ChatService {
               sessionId,
               sessionUsage,
               sessionStartedAt,
+              unlimited,
               ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
               ...(autoApprovedCommands.length > 0 ? { autoApprovedCommands } : {}),
               ...(latestConfig.autoApprovedCommands?.length
@@ -332,6 +334,10 @@ export class ChatServiceImpl implements ChatService {
               // Sync mode state with store for Shift+Tab toggle
               store.setModeIsYolo(autoApprovePolicy === true || autoApprovePolicy === "high-risk");
             }
+            if (commandResult.newUnlimited !== undefined) {
+              unlimited = commandResult.newUnlimited;
+              // Store sync (store.setUnlimitedActive) is added in Task 12.
+            }
 
             if (commandResult.addAutoApprovedCommand) {
               if (!autoApprovedCommands.includes(commandResult.addAutoApprovedCommand)) {
@@ -371,6 +377,7 @@ export class ChatServiceImpl implements ChatService {
             conversationId,
             sessionId, // Pass the sessionId for logging
             conversationHistory,
+            unlimited,
             ...(options?.stream !== undefined ? { stream: options.stream } : {}),
             ...(autoApprovePolicy !== undefined
               ? { autoApprovePolicy: getCurrentAutoApprovePolicy }

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -111,6 +111,7 @@ export class ChatServiceImpl implements ChatService {
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
       let unlimited: boolean = options?.unlimited ?? false;
+      store.setUnlimitedActive(unlimited);
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
       const sessionStartedAt = new Date();
@@ -336,7 +337,7 @@ export class ChatServiceImpl implements ChatService {
             }
             if (commandResult.newUnlimited !== undefined) {
               unlimited = commandResult.newUnlimited;
-              // Store sync (store.setUnlimitedActive) is added in Task 12.
+              store.setUnlimitedActive(unlimited);
             }
 
             if (commandResult.addAutoApprovedCommand) {

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -50,6 +50,7 @@ export class ChatServiceImpl implements ChatService {
     agent: Agent,
     options?: {
       stream?: boolean;
+      unlimited?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
     },

--- a/src/services/chat/commands/constants.ts
+++ b/src/services/chat/commands/constants.ts
@@ -27,6 +27,10 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "stats", description: "Show session statistics and usage summary" },
   { name: "switch", description: "Switch to a different agent in the same conversation" },
   { name: "tools", description: "List all agent tools by category" },
+  {
+    name: "unlimited",
+    description: "Toggle unlimited mode (no iteration, retry, or timeout caps) for this session",
+  },
   { name: "workflows", description: "List workflows or send action (e.g. create) to the agent" },
 ] as const;
 

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -73,6 +73,91 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+describe("/unlimited", () => {
+  function makeUnlimitedContext(unlimited?: boolean): CommandContext {
+    return {
+      agent: testAgent,
+      conversationId: "current-conv-id",
+      conversationHistory: [],
+      sessionId: "test-session",
+      sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionStartedAt: new Date(),
+      unlimited,
+    };
+  }
+
+  function makeTerminalLayer() {
+    const mockTerminal: Partial<TerminalService> = {
+      success: mock(() => Effect.void),
+      info: mock(() => Effect.void),
+      error: mock(() => Effect.void),
+      log: mock(() => Effect.succeed(undefined)),
+    };
+    return {
+      layer: Layer.merge(
+        Layer.succeed(TerminalServiceTag, mockTerminal as unknown as TerminalService),
+        NodeFileSystem.layer,
+      ),
+    };
+  }
+
+  test("reports OFF when current state is false and no args given", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: [] }, context).pipe(Effect.provide(layer)),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+
+  test("reports ON when current state is true and no args given", async () => {
+    const context = makeUnlimitedContext(true);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: [] }, context).pipe(Effect.provide(layer)),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+
+  test("enables unlimited mode with /unlimited on", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["on"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBe(true);
+  });
+
+  test("disables unlimited mode with /unlimited off", async () => {
+    const context = makeUnlimitedContext(true);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["off"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBe(false);
+  });
+
+  test("rejects unknown arguments without changing state", async () => {
+    const context = makeUnlimitedContext(false);
+    const { layer } = makeTerminalLayer();
+    const result = await Effect.runPromise(
+      handleSpecialCommand({ type: "unlimited", args: ["maybe"] }, context).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    expect(result.shouldContinue).toBe(true);
+    expect(result.newUnlimited).toBeUndefined();
+  });
+});
+
 describe("handleSpecialCommand resume", () => {
   test("sets resetStartedAt on the result when a conversation is successfully resumed", async () => {
     await runEffect(saveConversation(testRecord, tmpDir));

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -135,6 +135,9 @@ export function handleSpecialCommand(
           context.autoApprovedTools,
         );
 
+      case "unlimited":
+        return yield* handleUnlimitedCommand(terminal, command.args, context.unlimited);
+
       case "resume":
         return yield* handleResumeCommand(terminal, agent);
 
@@ -1725,6 +1728,41 @@ function handleCostCommand(
     }
 
     yield* terminal.log(fmt.blank());
+    return { shouldContinue: true };
+  });
+}
+
+function handleUnlimitedCommand(
+  terminal: TerminalService,
+  args: string[],
+  currentUnlimited?: boolean,
+): Effect.Effect<CommandResult, never, never> {
+  return Effect.gen(function* () {
+    const arg = args[0]?.toLowerCase();
+
+    if (arg === "on") {
+      yield* terminal.success("Unlimited mode ENABLED — no iteration, retry, or timeout caps");
+      yield* terminal.log("");
+      return { shouldContinue: true, newUnlimited: true };
+    }
+
+    if (arg === "off") {
+      yield* terminal.success("Unlimited mode DISABLED — standard guardrails restored");
+      yield* terminal.log("");
+      return { shouldContinue: true, newUnlimited: false };
+    }
+
+    if (arg) {
+      yield* terminal.error(`Unknown argument: ${arg}`);
+      yield* terminal.info("Usage: /unlimited [on|off]");
+      yield* terminal.log("");
+      return { shouldContinue: true };
+    }
+
+    const state = currentUnlimited ? "ON" : "OFF";
+    yield* terminal.info(`Unlimited mode: ${state}`);
+    yield* terminal.info("Usage: /unlimited on  |  /unlimited off");
+    yield* terminal.log("");
     return { shouldContinue: true };
   });
 }

--- a/src/services/chat/commands/parser.test.ts
+++ b/src/services/chat/commands/parser.test.ts
@@ -74,6 +74,24 @@ describe("parseSpecialCommand", () => {
       expect(result.type).toBe("mcp");
       expect(result.args).toEqual([]);
     });
+
+    it("should parse /unlimited command", () => {
+      const result = parseSpecialCommand("/unlimited");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual([]);
+    });
+
+    it("should parse /unlimited on", () => {
+      const result = parseSpecialCommand("/unlimited on");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual(["on"]);
+    });
+
+    it("should parse /unlimited off", () => {
+      const result = parseSpecialCommand("/unlimited off");
+      expect(result.type).toBe("unlimited");
+      expect(result.args).toEqual(["off"]);
+    });
   });
 
   describe("commands with arguments", () => {

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -56,6 +56,8 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "mode", args };
     case "resume":
       return { type: "resume", args };
+    case "unlimited":
+      return { type: "unlimited", args };
     default:
       return { type: "unknown", args: [command, ...args] };
   }

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -25,6 +25,7 @@ export type CommandType =
   | "mcp"
   | "mode"
   | "resume"
+  | "unlimited"
   | "unknown";
 
 /**
@@ -57,6 +58,8 @@ export interface CommandResult {
   saveCurrentHistory?: boolean;
   /** Reset the startedAt timestamp to now (used when resuming a saved conversation) */
   resetStartedAt?: boolean;
+  /** New unlimited state set by /unlimited command (true/false to set; undefined to leave unchanged). */
+  newUnlimited?: boolean;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */
@@ -85,4 +88,6 @@ export interface CommandContext {
   persistedAutoApprovedCommands?: readonly string[];
   /** Currently auto-approved tool names for this session (for /mode display). */
   autoApprovedTools?: readonly string[];
+  /** Current unlimited mode state (for /unlimited display). */
+  unlimited?: boolean;
 }

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -102,4 +102,28 @@ describe("AgentConfigService", () => {
     expect(parsed.mcpServers.testServer).toEqual({ enabled: false });
     expect(parsed.mcpServers.testServer.command).toBeUndefined();
   });
+
+  it("should round-trip unlimited flag through save and load", async () => {
+    let written = "";
+    const capturingFS = {
+      ...mockFS,
+      writeFileString: mock((_path: string, content: string) => {
+        written = content;
+        return Effect.void;
+      }),
+      readFileString: mock(() => Effect.succeed(written)),
+    } as unknown as FileSystem;
+
+    const configPath = "/tmp/jazz-unlimited-test.json";
+    const configWithUnlimited: AppConfig = {
+      ...initialConfig,
+      unlimited: true,
+    };
+    const service = new AgentConfigServiceImpl(configWithUnlimited, {}, configPath, capturingFS);
+
+    await Effect.runPromise(service.set("unlimited", true));
+
+    const reloaded = await Effect.runPromise(service.get<boolean>("unlimited"));
+    expect(reloaded).toBe(true);
+  });
 });

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -1,7 +1,8 @@
-import { type FileSystem } from "@effect/platform/FileSystem";
+import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
-import { Effect } from "effect";
-import { AgentConfigServiceImpl } from "./config";
+import { Effect, Layer } from "effect";
+import { AgentConfigServiceImpl, createConfigLayer } from "./config";
+import { AgentConfigServiceTag } from "../core/interfaces/agent-config";
 import { type AppConfig } from "../core/types/index";
 
 // Mock FileSystem
@@ -35,7 +36,7 @@ const mockFS = {
   truncate: mock(() => Effect.void),
   utimes: mock(() => Effect.void),
   writeFile: mock(() => Effect.void),
-} as unknown as FileSystem;
+} as unknown as FileSystem.FileSystem;
 
 describe("AgentConfigService", () => {
   const initialConfig: AppConfig = {
@@ -112,7 +113,7 @@ describe("AgentConfigService", () => {
         return Effect.void;
       }),
       readFileString: mock(() => Effect.succeed(written)),
-    } as unknown as FileSystem;
+    } as unknown as FileSystem.FileSystem;
 
     const configPath = "/tmp/jazz-unlimited-test.json";
     const configWithUnlimited: AppConfig = {
@@ -123,7 +124,34 @@ describe("AgentConfigService", () => {
 
     await Effect.runPromise(service.set("unlimited", true));
 
+    expect(JSON.parse(written).unlimited).toBe(true);
+
     const reloaded = await Effect.runPromise(service.get<boolean>("unlimited"));
     expect(reloaded).toBe(true);
+  });
+
+  it("should load unlimited flag from config file via mergeConfig", async () => {
+    const configPath = "/tmp/jazz-unlimited-load-test.json";
+    const fileContent = JSON.stringify({ unlimited: true });
+
+    const loadFS = {
+      ...mockFS,
+      exists: mock((path: string) => Effect.succeed(path === configPath)),
+      readFileString: mock((path: string) =>
+        path === configPath ? Effect.succeed(fileContent) : Effect.succeed(""),
+      ),
+    } as unknown as FileSystem.FileSystem;
+
+    const fsLayer = Layer.succeed(FileSystem.FileSystem, loadFS);
+    const configLayer = createConfigLayer(false, configPath);
+
+    const unlimitedValue = await Effect.runPromise(
+      Effect.gen(function* () {
+        const config = yield* AgentConfigServiceTag;
+        return yield* config.get<boolean>("unlimited");
+      }).pipe(Effect.provide(configLayer), Effect.provide(fsLayer)),
+    );
+
+    expect(unlimitedValue).toBe(true);
   });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -326,6 +326,7 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.autoApprovedCommands && {
       autoApprovedCommands: override.autoApprovedCommands,
     }),
+    ...(override.unlimited !== undefined && { unlimited: override.unlimited }),
   };
 }
 


### PR DESCRIPTION
## What and why

Adds `jazz run` — a non-interactive, one-shot way to ask an agent a single question and get a clean answer back, built for driving Jazz from scripts and webhook handlers (Slack, Google Chat). The two existing entry points don't fit that use case: `jazz agent chat` is an interactive REPL (clears the screen, prints headers, loops on input), and `jazz workflow run` only executes a prompt baked into a workflow file. Neither can take a dynamic incoming message and return just the answer. `jazz run` fills that gap.

## Before this PR

- No headless way to run an agent against a dynamic prompt — you had to use the interactive chat REPL or a fixed-prompt workflow.
- In non-interactive (piped) mode, the batch output was wrapped in UI chrome: a `◉ Agent:` header, a `✔ Agent completed successfully` footer, blank lines, and any retry/status notices — all on **stdout**, mixed into the payload.
- Run failures in non-interactive mode could be swallowed silently (no clear error, exit code 0).
- The periodic "update available" box could print to stdout and corrupt scripted output.

## After this PR

`jazz run --agent <id> [prompt]` runs a single turn and prints a clean payload:

- **Prompt** comes from the positional argument or, when omitted, piped **stdin** — webhook text is untrusted, and stdin avoids shell-escaping it.
- **stdout** carries only the payload: the plain answer by default, or exactly one JSON envelope with `--json`:
  - success: `{ "ok": true, "answer": "...", "costUSD": 0.01, "tokenUsage": {...}, "toolCalls": [...] }`
  - failure: `{ "ok": false, "error": "...", "costUSD": 0 }`
- **stderr** carries all status/warning/tool chatter; **exit code** is 0 on success, non-zero on failure.
- `--approval-policy read-only|low-risk|high-risk` gates tool execution headlessly (`high-risk` approves everything). A tool above the policy is **declined and reported back to the agent** — not crashed — with a message steering it to use an allowed tool or explain the limitation (no "ask the user", since there's no human).
- `--timeout <ms>` and `--max-iterations <n>` add per-run guardrails; `--unlimited`/`--no-unlimited` are honored as elsewhere.

## Changes made

**New `jazz run` feature (the focus of this PR):**
- `src/cli/commands/run-agent.ts` — the command effect: prompt resolution (arg/stdin), agent lookup, `AgentRunner.run` with policy/timeout/max-iterations, and the pure `formatOneShotResult` / `formatOneShotError` / `isApprovalPolicyFlag` helpers.
- `src/cli/commands/run-agent.test.ts` — unit tests for the output formatters and policy-flag validation.
- `src/core/presentation/oneshot-presentation-service.ts` — a headless presentation service: nothing to stdout, chatter to stderr, approvals declined with a headless-appropriate steering message, interactive prompts return empty.
- `src/cli/cli-app.ts` — registers the `run` command and its flags; forces plain-terminal so Ink never mounts; validates `--approval-policy`.
- `src/app-layer.ts` — adds `skipUpdateCheck` to `runCliEffect` so the update notice can't corrupt the payload (`jazz run` sets it).
- `src/core/utils/error-handler.ts` — adds `getErrorMessage` to extract a concise single-line message from tagged errors (they often carry an empty `.message`).

**Stacked unlimited-mode commits (from PR #243, included because they are not yet on `main`):** all other files in the diff — `agent-loop.ts`, `tool-executor.ts`, `streaming-executor.ts`, `batch-executor.ts`, `llm-error.ts`, `subagent-tools.ts`, `workflow.ts`, `catch-up.ts`, config/chat-command plumbing, and the `[unlimited]` status chip. See **Notes for reviewers**.

## Impact

- New, additive CLI surface (`jazz run`); no existing command's behaviour changes.
- Makes Jazz usable as a backend for chat/webhook integrations: invoke per incoming message, capture stdout, post it back.
- `getErrorMessage` and the `skipUpdateCheck` option are small reusable additions used only by this feature today.
- Out of scope: per-platform formatting (Slack mrkdwn / Google Chat) is left to the caller; `jazz run` emits raw markdown / JSON.

## How to test

1. Build/run from source: `bun src/main.ts run --help` — confirm the command and its flags render.
2. Happy path (plain): `echo "Reply with exactly the word PONG." | bun src/main.ts run --agent <agent>` → stdout is just `PONG`, stderr empty, exit 0.
3. Happy path (JSON): add `--json` → stdout is a single line `{"ok":true,"answer":"PONG",...}`, parseable, exit 0.
4. Stream separation: redirect `1>out 2>err` and confirm `out` holds only the payload and `err` holds any chatter.
5. Error case (unknown agent): `echo hi | bun src/main.ts run --agent nope --json` → stdout `{"ok":false,"error":"No agent found with ID: nope","costUSD":0}`, exit non-zero.
6. Error case (bad flag): `--approval-policy all` → clear validation error, exit non-zero.
7. Edge case (no prompt, plain): `bun src/main.ts run --agent nope < /dev/null` → stdout empty, error on stderr, exit non-zero.
8. Policy edge case: with `--approval-policy read-only`, an agent that attempts a write/shell tool gets the tool declined and answers around it (no hang, no crash).

## Notes for reviewers

This branch is **stacked on `feat/unlimited-mode` (PR #243)**, which is not yet merged to `main`. Because the run command depends on that branch's additions (`AppConfig.unlimited`, `AgentRunnerOptions.unlimited`, the `--unlimited` plumbing), branching off `main` wouldn't compile. As a result this PR's diff against `main` includes all of #243's commits. **Please review the unlimited-mode changes in #243**; the new work in this PR is limited to the six files listed under "New `jazz run` feature" above. Once #243 merges, this PR's diff will collapse to just those files.
