### PR TITLE
feat(cli): add jazz run one-shot command and --max-iterations flag

### DIFF
--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -221,6 +221,13 @@ export function runCliEffect<R, E extends JazzError | Error>(
      * doesn't also trigger catch-up execution for scheduled workflows.
      */
     readonly skipCatchUp?: boolean | undefined;
+    /**
+     * Skip the periodic "update available" notice on startup.
+     *
+     * Intended for machine-readable commands like `jazz run`, where the notice
+     * box would otherwise corrupt the clean stdout payload.
+     */
+    readonly skipUpdateCheck?: boolean | undefined;
   } = {},
 ): void {
   const cliOptionsLayer = Layer.succeed(CLIOptionsTag, {
@@ -244,7 +251,10 @@ export function runCliEffect<R, E extends JazzError | Error>(
       yield* promptFailedRunsWarning();
     }
 
-    const fiber = yield* Effect.fork(autoCheckForUpdate().pipe(Effect.zipRight(effect)));
+    const shouldSkipUpdateCheck =
+      process.env["JAZZ_DISABLE_UPDATE_CHECK"] === "1" || options.skipUpdateCheck === true;
+    const startupCheck = shouldSkipUpdateCheck ? Effect.void : autoCheckForUpdate();
+    const fiber = yield* Effect.fork(startupCheck.pipe(Effect.zipRight(effect)));
     let signalCount = 0;
     type SignalName = "SIGINT" | "SIGTERM";
 

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -25,6 +25,7 @@ import {
   editPersonaCommand,
   deletePersonaCommand,
 } from "./commands/persona";
+import { isApprovalPolicyFlag, runAgentOnceCommand } from "./commands/run-agent";
 import { updateCommand } from "./commands/update";
 import { wizardCommand } from "./commands/wizard";
 import {
@@ -37,6 +38,7 @@ import {
   catchupWorkflowCommand,
   workflowHistoryCommand,
 } from "./commands/workflow";
+import { parsePositiveInt } from "./utils/option-parsers";
 
 /**
  * CLI Application setup and command registration
@@ -51,6 +53,83 @@ interface CliOptions {
   config?: string;
   output?: string;
   tui?: boolean;
+}
+
+/**
+ * Register the one-shot `run` command — non-interactive agent invocation for
+ * scripts and webhook handlers.
+ */
+function registerRunCommand(program: Command): void {
+  program
+    .command("run [prompt]")
+    .description(
+      "Run an agent once non-interactively (for scripts/webhooks). Prompt comes from the argument or piped stdin; the answer goes to stdout, all chatter to stderr.",
+    )
+    .requiredOption("--agent <agentId>", "Agent ID or name to run")
+    .option("--json", "Emit a single JSON envelope { ok, answer, costUSD, tokenUsage, toolCalls }")
+    .option(
+      "--approval-policy <policy>",
+      "Auto-approve tools up to a risk level: read-only | low-risk | high-risk (high-risk approves everything). Tools above the level are declined.",
+    )
+    .option(
+      "--timeout <ms>",
+      "Abort the run after this many milliseconds",
+      parsePositiveInt("--timeout"),
+    )
+    .option(
+      "--max-iterations <n>",
+      "Maximum agent reasoning iterations for this run",
+      parsePositiveInt("--max-iterations"),
+    )
+    .action(
+      (
+        prompt: string | undefined,
+        options: {
+          agent: string;
+          json?: boolean;
+          approvalPolicy?: string;
+          timeout?: number;
+          maxIterations?: number;
+        },
+      ) => {
+        const opts = program.opts<CliOptions>();
+        const json = options.json === true;
+
+        if (options.approvalPolicy !== undefined && !isApprovalPolicyFlag(options.approvalPolicy)) {
+          const message = `Invalid --approval-policy "${options.approvalPolicy}". Expected read-only, low-risk, or high-risk.`;
+          if (json) {
+            process.stdout.write(`${JSON.stringify({ ok: false, error: message, costUSD: 0 })}\n`);
+          } else {
+            process.stderr.write(`${message}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Force plain terminal so Ink never mounts and writes to stdout; the
+        // one-shot presentation layer keeps stdout clean for the payload.
+        process.env["JAZZ_NO_TUI"] = "1";
+
+        runCliEffect(
+          runAgentOnceCommand(options.agent, prompt, {
+            json,
+            ...(options.approvalPolicy !== undefined && isApprovalPolicyFlag(options.approvalPolicy)
+              ? { approvalPolicy: options.approvalPolicy }
+              : {}),
+            ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+            ...(options.maxIterations !== undefined
+              ? { maxIterations: options.maxIterations }
+              : {}),
+          }),
+          {
+            verbose: opts.verbose,
+            debug: opts.debug,
+            configPath: opts.config,
+          },
+          { skipCatchUp: true, skipUpdateCheck: true },
+        );
+      },
+    );
 }
 
 /**
@@ -127,22 +206,30 @@ function registerAgentCommands(program: Command): void {
     .description("Start a chat with an AI agent by ID or name")
     .option("--stream", "Force streaming mode (real-time output)")
     .option("--no-stream", "Disable streaming mode")
+    .option(
+      "--max-iterations <n>",
+      "Maximum agent reasoning iterations per turn (default 80)",
+      parsePositiveInt("--max-iterations"),
+    )
     .action(
       (
         agentIdentifier: string,
         options: {
           stream?: boolean;
           noStream?: boolean;
+          maxIterations?: number;
         },
       ) => {
         const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
         runCliEffect(
-          chatWithAIAgentCommand(
-            agentIdentifier,
-            streamOption !== undefined ? { stream: streamOption } : {},
-          ),
+          chatWithAIAgentCommand(agentIdentifier, {
+            ...(streamOption !== undefined ? { stream: streamOption } : {}),
+            ...(options.maxIterations !== undefined
+              ? { maxIterations: options.maxIterations }
+              : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
@@ -341,13 +428,23 @@ function registerWorkflowCommands(program: Command): void {
     .option("--auto-approve", "Auto-approve tool executions based on workflow policy")
     .option("--agent <agentId>", "Agent ID or name to use for this workflow run")
     .option(
+      "--max-iterations <n>",
+      "Maximum agent reasoning iterations (overrides the workflow's own setting)",
+      parsePositiveInt("--max-iterations"),
+    )
+    .option(
       "--scheduled",
       "Indicates this run was triggered by the system scheduler (launchd/cron)",
     )
     .action(
       (
         name: string,
-        options: { autoApprove?: boolean; agent?: string; scheduled?: boolean },
+        options: {
+          autoApprove?: boolean;
+          agent?: string;
+          maxIterations?: number;
+          scheduled?: boolean;
+        },
         command: Command,
       ) => {
         const opts = program.opts<CliOptions>();
@@ -474,6 +571,7 @@ export function createCLIApp(): Effect.Effect<Command, never> {
     });
 
     // Register all commands
+    registerRunCommand(program);
     registerAgentCommands(program);
     registerPersonaCommands(program);
     registerConfigCommands(program);

--- a/src/cli/commands/chat-agent.ts
+++ b/src/cli/commands/chat-agent.ts
@@ -22,6 +22,7 @@ export function chatWithAIAgentCommand(
   agentIdentifier: string,
   options?: {
     stream?: boolean;
+    maxIterations?: number;
   },
 ) {
   return Effect.gen(function* () {

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatOneShotError,
+  formatOneShotResult,
+  isApprovalPolicyFlag,
+  type OneShotSuccess,
+} from "./run-agent";
+
+const baseResult: OneShotSuccess = {
+  answer: "Hello from the agent",
+  costUSD: 0.0012,
+  tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+  toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
+};
+
+describe("formatOneShotResult", () => {
+  it("plain mode emits only the trimmed answer with a trailing newline", () => {
+    const output = formatOneShotResult({ ...baseResult, answer: "  Hello  \n\n" }, { json: false });
+    expect(output).toBe("Hello\n");
+  });
+
+  it("plain mode does not include header, footer, or JSON envelope keys", () => {
+    const output = formatOneShotResult(baseResult, { json: false });
+    expect(output).not.toContain("◉");
+    expect(output).not.toContain("completed");
+    expect(output).not.toContain('"ok"');
+  });
+
+  it("json mode emits exactly one single-line envelope", () => {
+    const output = formatOneShotResult(baseResult, { json: true });
+    expect(output.endsWith("\n")).toBe(true);
+    expect(output.trimEnd().includes("\n")).toBe(false);
+    expect(JSON.parse(output)).toEqual({
+      ok: true,
+      answer: "Hello from the agent",
+      costUSD: 0.0012,
+      tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
+    });
+  });
+});
+
+describe("formatOneShotError", () => {
+  it("plain mode emits the message with a trailing newline", () => {
+    expect(formatOneShotError("Agent not found", { json: false })).toBe("Agent not found\n");
+  });
+
+  it("json mode emits an ok:false envelope including costUSD", () => {
+    expect(JSON.parse(formatOneShotError("boom", { json: true }, 0.5))).toEqual({
+      ok: false,
+      error: "boom",
+      costUSD: 0.5,
+    });
+  });
+
+  it("json mode defaults costUSD to 0", () => {
+    expect(JSON.parse(formatOneShotError("boom", { json: true })).costUSD).toBe(0);
+  });
+});
+
+describe("isApprovalPolicyFlag", () => {
+  it("accepts the three risk levels", () => {
+    expect(isApprovalPolicyFlag("read-only")).toBe(true);
+    expect(isApprovalPolicyFlag("low-risk")).toBe(true);
+    expect(isApprovalPolicyFlag("high-risk")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isApprovalPolicyFlag("all")).toBe(false);
+    expect(isApprovalPolicyFlag("")).toBe(false);
+  });
+});

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -88,6 +88,11 @@ export interface RunAgentOnceOptions {
 }
 
 function readStdin(): Promise<string> {
+  // If stdin already ended, the "end" event has fired and won't fire again —
+  // registering a new listener would hang forever.
+  if (process.stdin.readableEnded) {
+    return Promise.resolve("");
+  }
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     process.stdin.on("data", (chunk) => chunks.push(chunk));
@@ -186,8 +191,8 @@ export function runAgentOnceCommand(
     const completionTokens = runResult.usage?.completionTokens ?? 0;
     const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
       id: toolCall.id,
-      name: toolCall.function.name,
-      arguments: toolCall.function.arguments,
+      name: toolCall.function?.name ?? "",
+      arguments: toolCall.function?.arguments ?? "",
     }));
 
     yield* writeStdout(

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -1,0 +1,212 @@
+import { Duration, Effect } from "effect";
+import { AgentRunner } from "@/core/agent/agent-runner";
+import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { OneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
+import { AgentNotFoundError } from "@/core/types/errors";
+import type { AutoApprovePolicy } from "@/core/types/tools";
+import { CommonSuggestions, getErrorMessage } from "@/core/utils/error-handler";
+
+/**
+ * One-shot, non-interactive agent invocation — designed to be driven from
+ * scripts and webhook handlers (Slack, Google Chat, etc.).
+ *
+ * Unlike `jazz agent chat` (an interactive REPL) and `jazz workflow run` (a
+ * fixed, file-defined prompt), this command takes a dynamic prompt, runs a
+ * single turn, and prints a clean payload to stdout. All operational noise
+ * (status notices, tool chatter, the `◉ Agent:` header, the `✔ completed`
+ * footer) is routed to stderr so stdout carries only the answer (plain mode)
+ * or exactly one JSON object (`--json`).
+ */
+
+export interface OneShotTokenUsage {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+  readonly totalTokens: number;
+}
+
+export interface OneShotToolCall {
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: string;
+}
+
+export interface OneShotSuccess {
+  readonly answer: string;
+  readonly costUSD: number;
+  readonly tokenUsage: OneShotTokenUsage;
+  readonly toolCalls: readonly OneShotToolCall[];
+}
+
+export interface OneShotOutputOptions {
+  readonly json: boolean;
+}
+
+/**
+ * Format a successful run for stdout.
+ *
+ * Plain mode returns just the trimmed answer (raw markdown, ready to be
+ * translated to Slack mrkdwn / Google Chat formatting downstream). JSON mode
+ * returns exactly one single-line envelope.
+ */
+export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutputOptions): string {
+  if (!options.json) {
+    return `${result.answer.trim()}\n`;
+  }
+
+  return `${JSON.stringify({
+    ok: true,
+    answer: result.answer,
+    costUSD: result.costUSD,
+    tokenUsage: result.tokenUsage,
+    toolCalls: result.toolCalls,
+  })}\n`;
+}
+
+/** Format a failure (plain message to stderr, or JSON envelope to stdout in --json mode). */
+export function formatOneShotError(
+  message: string,
+  options: OneShotOutputOptions,
+  costUSD = 0,
+): string {
+  return options.json
+    ? `${JSON.stringify({ ok: false, error: message, costUSD })}\n`
+    : `${message}\n`;
+}
+
+const VALID_APPROVAL_POLICIES = ["read-only", "low-risk", "high-risk"] as const;
+export type ApprovalPolicyFlag = (typeof VALID_APPROVAL_POLICIES)[number];
+
+export function isApprovalPolicyFlag(value: string): value is ApprovalPolicyFlag {
+  return (VALID_APPROVAL_POLICIES as readonly string[]).includes(value);
+}
+
+export interface RunAgentOnceOptions {
+  readonly json: boolean;
+  readonly approvalPolicy?: ApprovalPolicyFlag | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly maxIterations?: number | undefined;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    process.stdin.on("error", reject);
+  });
+}
+
+const writeStdout = (message: string): Effect.Effect<void, never> =>
+  Effect.sync(() => {
+    process.stdout.write(message);
+  });
+
+const failOneShot = (
+  message: string,
+  options: OneShotOutputOptions,
+  costUSD = 0,
+): Effect.Effect<void, never> =>
+  Effect.sync(() => {
+    const formatted = formatOneShotError(message, options, costUSD);
+    // JSON mode keeps the single-object stdout contract; plain mode sends the
+    // human-readable error to stderr so stdout stays empty on failure.
+    if (options.json) {
+      process.stdout.write(formatted);
+    } else {
+      process.stderr.write(formatted);
+    }
+    process.exitCode = 1;
+  });
+
+/**
+ * Run an agent once against a dynamic prompt and print a clean payload.
+ *
+ * The prompt comes from the positional argument or, when absent, piped stdin —
+ * webhook text is untrusted and stdin avoids shell-escaping it.
+ */
+export function runAgentOnceCommand(
+  agentIdentifier: string,
+  promptArg: string | undefined,
+  options: RunAgentOnceOptions,
+) {
+  const outputOptions: OneShotOutputOptions = { json: options.json };
+
+  return Effect.gen(function* () {
+    const normalizedIdentifier = agentIdentifier.trim();
+    if (normalizedIdentifier.length === 0) {
+      return yield* failOneShot("No agent specified. Use --agent <agentId>.", outputOptions);
+    }
+
+    let prompt = promptArg ?? "";
+    if (prompt.trim().length === 0 && !process.stdin.isTTY) {
+      prompt = yield* Effect.tryPromise({
+        try: () => readStdin(),
+        catch: () => new Error("Failed to read prompt from stdin."),
+      }).pipe(Effect.catchAll(() => Effect.succeed("")));
+    }
+    if (prompt.trim().length === 0) {
+      return yield* failOneShot(
+        "No prompt provided. Pass it as an argument or pipe it via stdin.",
+        outputOptions,
+      );
+    }
+
+    const agent = yield* getAgentByIdentifier(normalizedIdentifier).pipe(
+      Effect.catchTag("StorageNotFoundError", () =>
+        Effect.fail(
+          new AgentNotFoundError({
+            agentId: normalizedIdentifier,
+            suggestion: CommonSuggestions.checkAgentExists(normalizedIdentifier),
+          }),
+        ),
+      ),
+    );
+
+    const autoApprovePolicy: AutoApprovePolicy | undefined = options.approvalPolicy;
+    const runId = `run-${agent.id}-${Date.now()}`;
+    const runEffect = AgentRunner.run({
+      agent,
+      userInput: prompt,
+      sessionId: runId,
+      conversationId: runId,
+      ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
+      ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
+    });
+
+    const runResult = yield* options.timeoutMs != null
+      ? runEffect.pipe(
+          Effect.timeoutFail({
+            duration: Duration.millis(options.timeoutMs),
+            onTimeout: () => new Error(`Run exceeded the ${options.timeoutMs}ms timeout.`),
+          }),
+        )
+      : runEffect;
+
+    const promptTokens = runResult.usage?.promptTokens ?? 0;
+    const completionTokens = runResult.usage?.completionTokens ?? 0;
+    const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
+      id: toolCall.id,
+      name: toolCall.function.name,
+      arguments: toolCall.function.arguments,
+    }));
+
+    yield* writeStdout(
+      formatOneShotResult(
+        {
+          answer: runResult.content,
+          costUSD: runResult.costUSD ?? 0,
+          tokenUsage: {
+            promptTokens,
+            completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          toolCalls,
+        },
+        outputOptions,
+      ),
+    );
+  }).pipe(
+    Effect.catchAll((error) => failOneShot(getErrorMessage(error), outputOptions)),
+    Effect.provide(OneShotPresentationServiceLayer),
+  );
+}

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -192,6 +192,7 @@ export function runWorkflowCommand(
   options?: {
     autoApprove?: boolean;
     agent?: string;
+    maxIterations?: number;
     scheduled?: boolean;
   },
 ) {
@@ -354,16 +355,15 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // Run the agent with the workflow prompt
-    // maxIterations from workflow metadata is optional — omit for no limit
+    // Run the agent with the workflow prompt. Iteration cap precedence:
+    // CLI --max-iterations flag > workflow metadata > default (omitted here).
+    const resolvedMaxIterations = options?.maxIterations ?? workflow.metadata.maxIterations;
     const runResult = yield* AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       sessionId: `workflow-${workflowName}-${Date.now()}`,
       conversationId: `workflow-${workflowName}-${Date.now()}`,
-      ...(workflow.metadata.maxIterations != null
-        ? { maxIterations: workflow.metadata.maxIterations }
-        : {}),
+      ...(resolvedMaxIterations != null ? { maxIterations: resolvedMaxIterations } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
     }).pipe(
       Effect.tap((result) =>

--- a/src/cli/utils/option-parsers.test.ts
+++ b/src/cli/utils/option-parsers.test.ts
@@ -9,8 +9,9 @@ describe("parsePositiveInt", () => {
     expect(parse("1")).toBe(1);
   });
 
-  it("ignores trailing non-numeric characters like parseInt", () => {
-    expect(parse("30s")).toBe(30);
+  it("rejects trailing non-numeric characters instead of silently truncating", () => {
+    expect(() => parse("30s")).toThrow('--timeout must be a positive integer (got "30s").');
+    expect(() => parse("10.5")).toThrow("--timeout must be a positive integer");
   });
 
   it("throws on zero, negatives, and non-numeric input", () => {

--- a/src/cli/utils/option-parsers.test.ts
+++ b/src/cli/utils/option-parsers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { parsePositiveInt } from "./option-parsers";
+
+describe("parsePositiveInt", () => {
+  const parse = parsePositiveInt("--timeout");
+
+  it("parses a positive integer string", () => {
+    expect(parse("5000")).toBe(5000);
+    expect(parse("1")).toBe(1);
+  });
+
+  it("ignores trailing non-numeric characters like parseInt", () => {
+    expect(parse("30s")).toBe(30);
+  });
+
+  it("throws on zero, negatives, and non-numeric input", () => {
+    expect(() => parse("0")).toThrow('--timeout must be a positive integer (got "0").');
+    expect(() => parse("-3")).toThrow("--timeout must be a positive integer");
+    expect(() => parse("abc")).toThrow("--timeout must be a positive integer");
+  });
+
+  it("uses the provided label in the error message", () => {
+    expect(() => parsePositiveInt("--max-iterations")("x")).toThrow(
+      "--max-iterations must be a positive integer",
+    );
+  });
+});

--- a/src/cli/utils/option-parsers.ts
+++ b/src/cli/utils/option-parsers.ts
@@ -13,8 +13,13 @@
  */
 export function parsePositiveInt(label: string) {
   return (raw: string): number => {
+    // Reject trailing non-digits — Number.parseInt would silently accept "30s"
+    // as 30, which is a dangerous footgun for flags like --timeout.
+    if (!/^\d+$/.test(raw)) {
+      throw new Error(`${label} must be a positive integer (got "${raw}").`);
+    }
     const value = Number.parseInt(raw, 10);
-    if (!Number.isFinite(value) || value <= 0) {
+    if (value <= 0) {
       throw new Error(`${label} must be a positive integer (got "${raw}").`);
     }
     return value;

--- a/src/cli/utils/option-parsers.ts
+++ b/src/cli/utils/option-parsers.ts
@@ -1,0 +1,22 @@
+/**
+ * Commander.js option parsers shared across CLI command definitions.
+ */
+
+/**
+ * Build a Commander option parser that accepts only positive integers.
+ *
+ * Commander passes option values as raw strings; this validates and coerces
+ * them, throwing a clear error (which Commander surfaces to the user) when the
+ * value is not a positive integer.
+ *
+ * @param label - The flag name used in the error message (e.g. "--timeout").
+ */
+export function parsePositiveInt(label: string) {
+  return (raw: string): number => {
+    const value = Number.parseInt(raw, 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`${label} must be a positive integer (got "${raw}").`);
+    }
+    return value;
+  };
+}

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -36,6 +36,7 @@ export interface ChatService {
       stream?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
+      maxIterations?: number;
     },
   ) => Effect.Effect<
     void,

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -1,0 +1,168 @@
+import { Effect, Layer, Option } from "effect";
+import { DEFAULT_DISPLAY_CONFIG } from "@/core/agent/types";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
+import type {
+  PresentationService,
+  StreamingRenderer,
+  StreamingRendererConfig,
+} from "@/core/interfaces/presentation";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { StreamEvent } from "@/core/types/streaming";
+import type { ApprovalRequest, ApprovalOutcome } from "@/core/types/tools";
+import { resolveDisplayConfig } from "@/core/utils/display-config";
+
+/**
+ * Presentation service for headless, one-shot agent runs (`jazz run`).
+ *
+ * Keeps stdout clean for a machine-readable payload: nothing the agent loop
+ * emits reaches stdout. Operational chatter (status, warnings, stray writes)
+ * is routed to stderr instead. Interactive prompts cannot be answered without
+ * a human, so:
+ *  - approvals are DECLINED (the run's `autoApprovePolicy` already auto-approved
+ *    everything it was allowed to; anything still asking is above the policy
+ *    threshold and is refused rather than blanket-approved),
+ *  - user-input / file-picker requests return empty.
+ *
+ * This differs from QuietPresentationService, which blanket-approves every tool
+ * and is meant for trusted background runs.
+ */
+class OneShotPresentationService implements PresentationService {
+  constructor(_displayConfig = DEFAULT_DISPLAY_CONFIG) {}
+
+  presentThinking(_agentName: string, _isFirstIteration: boolean): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentCompletion(_agentName: string): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentWarning(agentName: string, message: string): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      process.stderr.write(`⚠ ${agentName}: ${message}\n`);
+    });
+  }
+
+  presentAgentResponse(_agentName: string, _content: string): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  renderMarkdown(markdown: string): Effect.Effect<string, never> {
+    return Effect.succeed(markdown);
+  }
+
+  formatToolArguments(_toolName: string, args?: Record<string, unknown>): string {
+    if (!args || Object.keys(args).length === 0) return "";
+    return ` ${JSON.stringify(args)}`;
+  }
+
+  formatToolResult(_toolName: string, result: string): string {
+    return result;
+  }
+
+  formatToolExecutionStart(
+    _toolName: string,
+    _args?: Record<string, unknown>,
+    _options?: { readonly metadata?: Record<string, unknown> },
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolExecutionComplete(
+    _summary: string | null,
+    _durationMs: number,
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolExecutionError(
+    _errorMessage: string,
+    _durationMs: number,
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  formatToolsDetected(
+    _agentName: string,
+    _toolNames: readonly string[],
+    _toolsRequiringApproval: readonly string[],
+  ): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  createStreamingRenderer(
+    _config: StreamingRendererConfig,
+  ): Effect.Effect<StreamingRenderer, never> {
+    const noopRenderer: StreamingRenderer = {
+      handleEvent: (_event: StreamEvent) => Effect.void,
+      setInterruptHandler: (_handler: (() => void) | null) => Effect.void,
+      reset: () => Effect.void,
+      flush: () => Effect.void,
+    };
+    return Effect.succeed(noopRenderer);
+  }
+
+  writeOutput(message: string): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      process.stderr.write(message);
+    });
+  }
+
+  writeBlankLine(): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  presentStatus(
+    message: string,
+    level: "info" | "success" | "warning" | "error" | "progress",
+  ): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      const prefixes: Record<typeof level, string> = {
+        info: "ℹ",
+        success: "✓",
+        warning: "⚠",
+        error: "✗",
+        progress: "⏳",
+      };
+      process.stderr.write(`${prefixes[level]} ${message}\n`);
+    });
+  }
+
+  requestApproval(request: ApprovalRequest): Effect.Effect<ApprovalOutcome, never> {
+    // Headless: no human to approve. Decline, but steer the model away from the
+    // default "ask the user to try again" recovery (there is no user) and toward
+    // either an allowed tool or a clear explanation of what it could not do.
+    const userMessage =
+      `The "${request.toolName}" tool requires approval and was automatically declined ` +
+      `because this is a non-interactive run. Do not ask the user to approve or retry — ` +
+      `there is no one to respond. Either accomplish the task using tools that do not ` +
+      `require approval, or clearly explain what could not be done and why.`;
+    return Effect.succeed({ approved: false, userMessage });
+  }
+
+  signalToolExecutionStarted(): Effect.Effect<void, never> {
+    return Effect.void;
+  }
+
+  requestUserInput(): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+
+  requestFilePicker(): Effect.Effect<string, never> {
+    return Effect.succeed("");
+  }
+}
+
+/**
+ * Layer providing the one-shot presentation service for `jazz run`.
+ */
+export const OneShotPresentationServiceLayer = Layer.effect(
+  PresentationServiceTag,
+  Effect.gen(function* () {
+    const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
+    const displayConfig = Option.isSome(configServiceOption)
+      ? resolveDisplayConfig(yield* configServiceOption.value.appConfig)
+      : DEFAULT_DISPLAY_CONFIG;
+    return new OneShotPresentationService(displayConfig);
+  }),
+);

--- a/src/core/utils/error-handler.ts
+++ b/src/core/utils/error-handler.ts
@@ -494,6 +494,21 @@ export function formatError(error: JazzError): string {
 }
 
 /**
+ * Extract a concise, single-line human message from any error.
+ *
+ * JazzError types carry their detail in structured fields (often with an empty
+ * `.message`), so fall back to the suggestion engine's message for those.
+ * Useful for machine-readable surfaces (e.g. `jazz run --json`) that need a
+ * meaningful string without the full decorated multi-line output.
+ */
+export function getErrorMessage(error: JazzError | Error): string {
+  if ("_tag" in error && typeof (error as { _tag: unknown })._tag === "string") {
+    return generateSuggestions(error).message;
+  }
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+/**
  * Enhanced error handler that provides actionable suggestions
  *
  * Handles both JazzError types (with structured suggestions) and generic Error objects.

--- a/src/core/utils/error-handler.ts
+++ b/src/core/utils/error-handler.ts
@@ -502,7 +502,12 @@ export function formatError(error: JazzError): string {
  * meaningful string without the full decorated multi-line output.
  */
 export function getErrorMessage(error: JazzError | Error): string {
-  if ("_tag" in error && typeof (error as { _tag: unknown })._tag === "string") {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "_tag" in error &&
+    typeof (error as { _tag: unknown })._tag === "string"
+  ) {
     return generateSuggestions(error).message;
   }
   return error instanceof Error && error.message ? error.message : String(error);

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -52,6 +52,7 @@ export class ChatServiceImpl implements ChatService {
       stream?: boolean;
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
+      maxIterations?: number;
     },
   ): Effect.Effect<
     void,
@@ -371,6 +372,9 @@ export class ChatServiceImpl implements ChatService {
             sessionId, // Pass the sessionId for logging
             conversationHistory,
             ...(options?.stream !== undefined ? { stream: options.stream } : {}),
+            ...(options?.maxIterations !== undefined
+              ? { maxIterations: options.maxIterations }
+              : {}),
             ...(autoApprovePolicy !== undefined
               ? { autoApprovePolicy: getCurrentAutoApprovePolicy }
               : {}),


### PR DESCRIPTION
## What and why

Adds `jazz run` — a non-interactive, one-shot way to ask an agent a single question and get a clean answer back, built for driving Jazz from scripts and webhook handlers (Slack, Google Chat). It also exposes a bounded `--max-iterations <n>` flag on the commands that run agents.

This replaces the abandoned "unlimited mode" (PR #243, now closed) with a much simpler, safer model: instead of a binary switch that lifts *seven* guardrails at once, the only guardrail users legitimately want to raise — how many reasoning steps a run may take — becomes an explicit, bounded flag. Timeouts, retry cap, meltdown detection, and budget nudges stay fixed at their defaults. Want a longer run? `--max-iterations 10000`.

## Before this PR

- No headless way to run an agent against a dynamic prompt — only the interactive `agent chat` REPL or a fixed-prompt `workflow run`.
- The only way to raise the 80-step iteration cap was the all-or-nothing "unlimited mode," which also disabled timeouts, the retry cap, and meltdown detection — uselessly dangerous.
- In piped/non-interactive mode, batch output was wrapped in UI chrome (`◉ Agent:` header, `✔ completed` footer, blank lines, status notices) on stdout, mixed into the payload; failures could be swallowed with a 0 exit code.

## After this PR

`jazz run --agent <id> [prompt]` runs one turn and prints a clean payload:

- **Prompt** from the positional arg or piped **stdin** (stdin avoids shell-escaping untrusted webhook text).
- **stdout** carries only the payload: plain answer by default, or one JSON envelope with `--json`:
  - success: `{ "ok": true, "answer": "...", "costUSD": 0.01, "tokenUsage": {...}, "toolCalls": [...] }`
  - failure: `{ "ok": false, "error": "...", "costUSD": 0 }`
- **stderr** carries all status/tool chatter; **exit code** is 0 on success, non-zero on failure.
- `--approval-policy read-only|low-risk|high-risk` gates tool execution headlessly (`high-risk` approves all). A tool above the policy is **declined and reported back to the agent** — not crashed — steering it to use an allowed tool or explain the limitation.
- `--timeout <ms>` and `--max-iterations <n>` per-run guardrails.

`--max-iterations <n>` is also available on `agent chat` and `workflow run` (precedence on workflows: flag > workflow metadata > default). Default behaviour is unchanged when the flag is omitted (cap = 80).

## Changes made

**New `jazz run` command**
- `src/cli/commands/run-agent.ts` — command effect (prompt from arg/stdin, agent lookup, `AgentRunner.run` with policy/timeout/max-iterations) plus pure `formatOneShotResult` / `formatOneShotError` / `isApprovalPolicyFlag` helpers.
- `src/cli/commands/run-agent.test.ts` — unit tests for output formatters and policy-flag validation.
- `src/core/presentation/oneshot-presentation-service.ts` — headless presentation: nothing to stdout, chatter to stderr, approvals declined with a headless-appropriate steering message.
- `src/cli/utils/option-parsers.ts` (+ `option-parsers.test.ts`) — shared `parsePositiveInt` Commander parser.
- `src/app-layer.ts` — `skipUpdateCheck` option on `runCliEffect` so the update notice can't corrupt the payload.
- `src/core/utils/error-handler.ts` — `getErrorMessage` for concise machine-readable error strings from tagged errors.

**`--max-iterations` flag**
- `src/cli/cli-app.ts` — registers `run`; adds `--max-iterations` to `agent chat` and `workflow run`.
- `src/cli/commands/chat-agent.ts`, `src/core/interfaces/chat-service.ts`, `src/services/chat-service.ts` — thread `maxIterations` through `startChatSession` into `runnerOptions`.
- `src/cli/commands/workflow.ts` — apply `--max-iterations` with precedence flag > metadata > default.

## Impact

- New, additive CLI surface (`jazz run`) and one new flag; no existing command's default behaviour changes.
- Makes Jazz usable as a backend for chat/webhook integrations: invoke per incoming message, capture stdout, post it back.
- Supersedes PR #243 (unlimited mode), which is closed. None of unlimited mode's guardrail-lifting reaches `main`.
- Out of scope: per-platform output formatting (Slack mrkdwn / Google Chat) is the caller's responsibility; making other guardrails configurable.

## How to test

1. `bun src/main.ts run --help` — confirm `--agent`, `--json`, `--approval-policy`, `--timeout`, `--max-iterations` render; no `--unlimited` anywhere.
2. Happy path (plain): `echo "Reply with exactly the word PONG." | bun src/main.ts run --agent <agent>` → stdout is just `PONG`, stderr empty, exit 0.
3. Happy path (JSON): add `--json` → stdout is one line `{"ok":true,"answer":"PONG",...}`, parseable, exit 0.
4. Iteration cap: add `--max-iterations 5` → still answers; verify a large value (`10000`) is accepted and `0`/`-1`/`abc` are rejected with a clear error.
5. Stream separation: redirect `1>out 2>err`; `out` holds only the payload, `err` holds chatter.
6. Error case (unknown agent): `echo hi | bun src/main.ts run --agent nope --json` → `{"ok":false,"error":"No agent found with ID: nope","costUSD":0}`, exit non-zero.
7. Edge case (no prompt, plain): `bun src/main.ts run --agent nope < /dev/null` → stdout empty, error on stderr, exit non-zero.
8. `bun src/main.ts agent chat --help` and `workflow run --help` — confirm `--max-iterations` is present.

## Notes for reviewers

This branch is cut cleanly from `main`, so the diff is only the run command and the `--max-iterations` flag. PR #243 (unlimited mode) is being closed in favour of this approach; nothing from it is included here.
