### PR TITLE
chore(ci): switch CI agents to openrouter/owl-alpha

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "minimax/minimax-m2.5:free",
+  "model": "openrouter/owl-alpha",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "minimax/minimax-m2.5:free",
+    "llmModel": "openrouter/owl-alpha",
     "reasoningEffort": "high",
     "tools": [
       "context_info",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -2,11 +2,11 @@
   "id": "pr-assistant",
   "name": "pr-assistant",
   "description": "Pull request assistant agent for /jazz PR comments",
-  "model": "minimax/minimax-m2.5:free",
+  "model": "openrouter/owl-alpha",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "minimax/minimax-m2.5:free",
+    "llmModel": "openrouter/owl-alpha",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",

--- a/.github/jazz/agents/release-notes.json
+++ b/.github/jazz/agents/release-notes.json
@@ -2,11 +2,11 @@
   "id": "release-notes",
   "name": "release-notes",
   "description": "Release notes generator agent",
-  "model": "minimax/minimax-m2.5:free",
+  "model": "openrouter/owl-alpha",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "minimax/minimax-m2.5:free",
+    "llmModel": "openrouter/owl-alpha",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",


### PR DESCRIPTION
## What and why

Switches the three CI agents to OpenRouter's `owl-alpha` model. They were pinned to `minimax/minimax-m2.5:free`; this points them at `openrouter/owl-alpha` instead.

## Before this PR

- `ci-reviewer`, `release-notes`, and `pr-assistant` (under `.github/jazz/agents/`) all ran on `minimax/minimax-m2.5:free`.

## After this PR

- All three run on `openrouter/owl-alpha`. The provider was already `openrouter`, so only the model id changes.

## Changes made

- `.github/jazz/agents/ci-reviewer.json` — `model` + `config.llmModel` → `openrouter/owl-alpha`
- `.github/jazz/agents/release-notes.json` — `model` + `config.llmModel` → `openrouter/owl-alpha`
- `.github/jazz/agents/pr-assistant.json` — `model` + `config.llmModel` → `openrouter/owl-alpha`

## Impact

- Future CI runs (PR code review, release-notes generation, `/jazz` PR-assistant comments) use `openrouter/owl-alpha`.
- No application or library code changes; provider unchanged (`openrouter`).
- Assumes `openrouter/owl-alpha` is available to the OpenRouter key configured in CI.

## How to test

1. `grep -rin minimax .github/` → no matches.
2. `grep -rn owl-alpha .github/jazz/agents/` → both `model` and `llmModel` are `openrouter/owl-alpha` in all three files.
3. Each file parses as valid JSON.
4. Edge case: confirm the CI OpenRouter key can serve `openrouter/owl-alpha` — if the model id is wrong or unavailable, CI agent runs will fail at the LLM call.
