### PR TITLE
feat(cli): add --events NDJSON stream flag to jazz run

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -25,7 +25,11 @@ import {
   editPersonaCommand,
   deletePersonaCommand,
 } from "./commands/persona";
-import { isApprovalPolicyFlag, runAgentOnceCommand } from "./commands/run-agent";
+import {
+  isApprovalPolicyFlag,
+  parseEventCategories,
+  runAgentOnceCommand,
+} from "./commands/run-agent";
 import { updateCommand } from "./commands/update";
 import { wizardCommand } from "./commands/wizard";
 import {
@@ -81,6 +85,10 @@ function registerRunCommand(program: Command): void {
       "Maximum agent reasoning iterations for this run",
       parsePositiveInt("--max-iterations"),
     )
+    .option(
+      "--events <categories>",
+      "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,all). stdout stays the clean payload.",
+    )
     .action(
       (
         prompt: string | undefined,
@@ -90,6 +98,7 @@ function registerRunCommand(program: Command): void {
           approvalPolicy?: string;
           timeout?: number;
           maxIterations?: number;
+          events?: string;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -101,6 +110,20 @@ function registerRunCommand(program: Command): void {
             process.stdout.write(`${JSON.stringify({ ok: false, error: message, costUSD: 0 })}\n`);
           } else {
             process.stderr.write(`${message}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const eventCategories =
+          options.events !== undefined ? parseEventCategories(options.events) : undefined;
+        if (eventCategories !== undefined && !eventCategories.ok) {
+          if (json) {
+            process.stdout.write(
+              `${JSON.stringify({ ok: false, error: eventCategories.error, costUSD: 0 })}\n`,
+            );
+          } else {
+            process.stderr.write(`${eventCategories.error}\n`);
           }
           process.exitCode = 1;
           return;
@@ -120,6 +143,7 @@ function registerRunCommand(program: Command): void {
             ...(options.maxIterations !== undefined
               ? { maxIterations: options.maxIterations }
               : {}),
+            ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
           }),
           {
             verbose: opts.verbose,

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -4,6 +4,7 @@ import {
   formatOneShotResult,
   isApprovalPolicyFlag,
   type OneShotSuccess,
+  parseEventCategories,
 } from "./run-agent";
 
 const baseResult: OneShotSuccess = {
@@ -68,5 +69,71 @@ describe("isApprovalPolicyFlag", () => {
   it("rejects anything else", () => {
     expect(isApprovalPolicyFlag("all")).toBe(false);
     expect(isApprovalPolicyFlag("")).toBe(false);
+  });
+});
+
+describe("parseEventCategories", () => {
+  it("maps 'tools' to the four tool event types plus error", () => {
+    const result = parseEventCategories("tools");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.types].sort()).toEqual(
+      [
+        "error",
+        "tool_call",
+        "tool_execution_complete",
+        "tool_execution_start",
+        "tools_detected",
+      ].sort(),
+    );
+  });
+
+  it("maps 'all' to every category type plus error", () => {
+    const result = parseEventCategories("all");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const expected = [
+      "error",
+      "tools_detected",
+      "tool_call",
+      "tool_execution_start",
+      "tool_execution_complete",
+      "thinking_start",
+      "thinking_chunk",
+      "thinking_complete",
+      "text_start",
+      "text_chunk",
+      "stream_start",
+      "usage_update",
+      "complete",
+    ];
+    expect([...result.types].sort()).toEqual(expected.sort());
+  });
+
+  it("unions multiple categories", () => {
+    const result = parseEventCategories("tools,reasoning");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.types.has("tool_execution_start")).toBe(true);
+    expect(result.types.has("thinking_chunk")).toBe(true);
+    expect(result.types.has("text_chunk")).toBe(false);
+    expect(result.types.has("error")).toBe(true);
+  });
+
+  it("tolerates whitespace and case", () => {
+    const result = parseEventCategories(" Tools , TEXT ");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.types.has("tool_execution_start")).toBe(true);
+    expect(result.types.has("text_chunk")).toBe(true);
+  });
+
+  it("rejects an unknown category with a helpful message", () => {
+    const result = parseEventCategories("bogus");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe(
+      'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, all.',
+    );
   });
 });

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -136,4 +136,14 @@ describe("parseEventCategories", () => {
       'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, all.',
     );
   });
+
+  it.each(["toString", "constructor", "hasOwnProperty", "__proto__", "valueOf"])(
+    "rejects inherited Object.prototype key %p instead of treating it as a category",
+    (inheritedKey) => {
+      const result = parseEventCategories(inheritedKey);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain("Invalid --events category");
+    },
+  );
 });

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -1,8 +1,9 @@
 import { Duration, Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
-import { OneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
+import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
 import { AgentNotFoundError } from "@/core/types/errors";
+import type { StreamEvent } from "@/core/types/streaming";
 import type { AutoApprovePolicy } from "@/core/types/tools";
 import { CommonSuggestions, getErrorMessage } from "@/core/utils/error-handler";
 
@@ -85,6 +86,57 @@ export interface RunAgentOnceOptions {
   readonly approvalPolicy?: ApprovalPolicyFlag | undefined;
   readonly timeoutMs?: number | undefined;
   readonly maxIterations?: number | undefined;
+  readonly eventTypes?: ReadonlySet<StreamEvent["type"]> | undefined;
+}
+
+const EVENT_CATEGORY_TYPES = {
+  tools: ["tools_detected", "tool_call", "tool_execution_start", "tool_execution_complete"],
+  reasoning: ["thinking_start", "thinking_chunk", "thinking_complete"],
+  text: ["text_start", "text_chunk"],
+  usage: ["stream_start", "usage_update", "complete"],
+} as const satisfies Record<string, readonly StreamEvent["type"][]>;
+
+type EventCategory = keyof typeof EVENT_CATEGORY_TYPES;
+
+function isEventCategory(value: string): value is EventCategory {
+  return value in EVENT_CATEGORY_TYPES;
+}
+
+/**
+ * Parse the comma-separated `--events` flag into the set of `StreamEvent` types
+ * to emit. The `error` type is always included so failures surface on the live
+ * stream regardless of the selected categories.
+ */
+export function parseEventCategories(
+  raw: string,
+): { ok: true; types: ReadonlySet<StreamEvent["type"]> } | { ok: false; error: string } {
+  const types = new Set<StreamEvent["type"]>(["error"]);
+  const categories = raw
+    .split(",")
+    .map((category) => category.trim().toLowerCase())
+    .filter((category) => category.length > 0);
+
+  for (const category of categories) {
+    if (category === "all") {
+      for (const eventTypes of Object.values(EVENT_CATEGORY_TYPES)) {
+        for (const eventType of eventTypes) {
+          types.add(eventType);
+        }
+      }
+      continue;
+    }
+    if (!isEventCategory(category)) {
+      return {
+        ok: false,
+        error: `Invalid --events category "${category}". Expected: tools, reasoning, text, usage, all.`,
+      };
+    }
+    for (const eventType of EVENT_CATEGORY_TYPES[category]) {
+      types.add(eventType);
+    }
+  }
+
+  return { ok: true, types };
 }
 
 function readStdin(): Promise<string> {
@@ -212,6 +264,6 @@ export function runAgentOnceCommand(
     );
   }).pipe(
     Effect.catchAll((error) => failOneShot(getErrorMessage(error), outputOptions)),
-    Effect.provide(OneShotPresentationServiceLayer),
+    Effect.provide(makeOneShotPresentationServiceLayer(options.eventTypes ?? new Set())),
   );
 }

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -99,7 +99,7 @@ const EVENT_CATEGORY_TYPES = {
 type EventCategory = keyof typeof EVENT_CATEGORY_TYPES;
 
 function isEventCategory(value: string): value is EventCategory {
-  return value in EVENT_CATEGORY_TYPES;
+  return Object.prototype.hasOwnProperty.call(EVENT_CATEGORY_TYPES, value);
 }
 
 /**

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { DEFAULT_DISPLAY_CONFIG } from "@/core/agent/types";
+import type { StreamingRendererConfig } from "@/core/interfaces/presentation";
+import type { StreamEvent } from "@/core/types/streaming";
+import { OneShotPresentationService } from "./oneshot-presentation-service";
+
+const rendererConfig: StreamingRendererConfig = {
+  displayConfig: DEFAULT_DISPLAY_CONFIG,
+  streamingConfig: {},
+  showMetrics: false,
+  agentName: "test-agent",
+};
+
+const toolExecutionStartEvent: StreamEvent = {
+  type: "tool_execution_start",
+  toolName: "web_search",
+  toolCallId: "call_1",
+};
+
+const textChunkEvent: StreamEvent = {
+  type: "text_chunk",
+  delta: "hello",
+  accumulated: "hello",
+  sequence: 0,
+};
+
+describe("OneShotPresentationService streaming renderer", () => {
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+  });
+
+  function captureStderr(): { lines: string[] } {
+    const captured = { lines: [] as string[] };
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    return captured;
+  }
+
+  it("emits only events whose type is in the selected set", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+    );
+    const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));
+
+    const captured = captureStderr();
+    Effect.runSync(renderer.handleEvent(toolExecutionStartEvent));
+    Effect.runSync(renderer.handleEvent(textChunkEvent));
+
+    expect(captured.lines).toHaveLength(1);
+    expect(captured.lines[0]?.endsWith("\n")).toBe(true);
+    const parsed = JSON.parse(captured.lines[0] as string) as { type: string };
+    expect(parsed.type).toBe("tool_execution_start");
+  });
+
+  it("returns a noop renderer that writes nothing when no types are selected", () => {
+    const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
+    const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));
+
+    const captured = captureStderr();
+    Effect.runSync(renderer.handleEvent(toolExecutionStartEvent));
+
+    expect(captured.lines).toHaveLength(0);
+  });
+
+  it("truncates string values longer than 200 characters with an ellipsis", () => {
+    const longResult = "x".repeat(500);
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_complete"]),
+    );
+    const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));
+
+    const captured = captureStderr();
+    Effect.runSync(
+      renderer.handleEvent({
+        type: "tool_execution_complete",
+        toolCallId: "call_1",
+        result: longResult,
+        durationMs: 12,
+      }),
+    );
+
+    expect(captured.lines).toHaveLength(1);
+    const parsed = JSON.parse(captured.lines[0] as string) as { result: string };
+    expect(parsed.result.length).toBe(201);
+    expect(parsed.result.endsWith("…")).toBe(true);
+    expect(parsed.result.startsWith("x".repeat(200))).toBe(true);
+  });
+});

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -92,4 +92,88 @@ describe("OneShotPresentationService streaming renderer", () => {
     expect(parsed.result.endsWith("…")).toBe(true);
     expect(parsed.result.startsWith("x".repeat(200))).toBe(true);
   });
+
+  it("serializes Error-valued event fields to a plain object with a non-empty message", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["error"]),
+    );
+    const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));
+
+    const captured = captureStderr();
+    const errorEvent = {
+      type: "error",
+      error: new Error("model request failed"),
+      recoverable: false,
+    } as unknown as StreamEvent;
+    Effect.runSync(renderer.handleEvent(errorEvent));
+
+    expect(captured.lines).toHaveLength(1);
+    const parsed = JSON.parse(captured.lines[0] as string) as {
+      error: { name: string; message: string };
+    };
+    expect(parsed.error.message).toBe("model request failed");
+    expect(parsed.error.name).toBe("Error");
+  });
+});
+
+describe("OneShotPresentationService NDJSON stderr purity", () => {
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+  });
+
+  function captureStderr(): { lines: string[] } {
+    const captured = { lines: [] as string[] };
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    return captured;
+  }
+
+  it("emits presentWarning as a parseable JSON line when events are active", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["error"]),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(service.presentWarning("test-agent", "heads up"));
+
+    expect(captured.lines).toHaveLength(1);
+    const line = captured.lines[0] as string;
+    expect(line).not.toContain("⚠");
+    const parsed = JSON.parse(line) as { type: string; agentName: string; message: string };
+    expect(parsed).toEqual({ type: "warning", agentName: "test-agent", message: "heads up" });
+  });
+
+  it("emits presentStatus as a parseable JSON line when events are active", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["error"]),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(service.presentStatus("working", "progress"));
+
+    expect(captured.lines).toHaveLength(1);
+    const parsed = JSON.parse(captured.lines[0] as string) as {
+      type: string;
+      level: string;
+      message: string;
+    };
+    expect(parsed).toEqual({ type: "status", level: "progress", message: "working" });
+  });
+
+  it("keeps plain-text warnings when events are not active", () => {
+    const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
+
+    const captured = captureStderr();
+    Effect.runSync(service.presentWarning("test-agent", "heads up"));
+
+    expect(captured.lines).toHaveLength(1);
+    expect(captured.lines[0]).toBe("⚠ test-agent: heads up\n");
+  });
 });

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -11,6 +11,20 @@ import type { StreamEvent } from "@/core/types/streaming";
 import type { ApprovalRequest, ApprovalOutcome } from "@/core/types/tools";
 import { resolveDisplayConfig } from "@/core/utils/display-config";
 
+const MAX_EVENT_STRING_LENGTH = 200;
+
+/**
+ * JSON replacer that caps any long string value so a single tool result or file
+ * payload cannot gush megabytes onto stderr. Bounds NDJSON line size to keep the
+ * live-progress stream cheap to parse downstream.
+ */
+function truncateLongStrings(_key: string, value: unknown): unknown {
+  if (typeof value === "string" && value.length > MAX_EVENT_STRING_LENGTH) {
+    return `${value.slice(0, MAX_EVENT_STRING_LENGTH)}…`;
+  }
+  return value;
+}
+
 /**
  * Presentation service for headless, one-shot agent runs (`jazz run`).
  *
@@ -26,8 +40,11 @@ import { resolveDisplayConfig } from "@/core/utils/display-config";
  * This differs from QuietPresentationService, which blanket-approves every tool
  * and is meant for trusted background runs.
  */
-class OneShotPresentationService implements PresentationService {
-  constructor(_displayConfig = DEFAULT_DISPLAY_CONFIG) {}
+export class OneShotPresentationService implements PresentationService {
+  constructor(
+    _displayConfig = DEFAULT_DISPLAY_CONFIG,
+    private readonly emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
+  ) {}
 
   presentThinking(_agentName: string, _isFirstIteration: boolean): Effect.Effect<void, never> {
     return Effect.void;
@@ -93,13 +110,29 @@ class OneShotPresentationService implements PresentationService {
   createStreamingRenderer(
     _config: StreamingRendererConfig,
   ): Effect.Effect<StreamingRenderer, never> {
-    const noopRenderer: StreamingRenderer = {
-      handleEvent: (_event: StreamEvent) => Effect.void,
+    if (this.emitEventTypes.size === 0) {
+      const noopRenderer: StreamingRenderer = {
+        handleEvent: (_event: StreamEvent) => Effect.void,
+        setInterruptHandler: (_handler: (() => void) | null) => Effect.void,
+        reset: () => Effect.void,
+        flush: () => Effect.void,
+      };
+      return Effect.succeed(noopRenderer);
+    }
+
+    const emitEventTypes = this.emitEventTypes;
+    const emittingRenderer: StreamingRenderer = {
+      handleEvent: (event: StreamEvent) =>
+        Effect.sync(() => {
+          if (emitEventTypes.has(event.type)) {
+            process.stderr.write(`${JSON.stringify(event, truncateLongStrings)}\n`);
+          }
+        }),
       setInterruptHandler: (_handler: (() => void) | null) => Effect.void,
       reset: () => Effect.void,
       flush: () => Effect.void,
     };
-    return Effect.succeed(noopRenderer);
+    return Effect.succeed(emittingRenderer);
   }
 
   writeOutput(message: string): Effect.Effect<void, never> {
@@ -155,14 +188,24 @@ class OneShotPresentationService implements PresentationService {
 
 /**
  * Layer providing the one-shot presentation service for `jazz run`.
+ *
+ * When `emitEventTypes` is non-empty, the streaming renderer emits matching
+ * `StreamEvent`s as NDJSON to stderr for live-progress consumers; stdout stays
+ * reserved for the final payload.
  */
-export const OneShotPresentationServiceLayer = Layer.effect(
-  PresentationServiceTag,
-  Effect.gen(function* () {
-    const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
-    const displayConfig = Option.isSome(configServiceOption)
-      ? resolveDisplayConfig(yield* configServiceOption.value.appConfig)
-      : DEFAULT_DISPLAY_CONFIG;
-    return new OneShotPresentationService(displayConfig);
-  }),
-);
+export function makeOneShotPresentationServiceLayer(
+  emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
+) {
+  return Layer.effect(
+    PresentationServiceTag,
+    Effect.gen(function* () {
+      const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
+      const displayConfig = Option.isSome(configServiceOption)
+        ? resolveDisplayConfig(yield* configServiceOption.value.appConfig)
+        : DEFAULT_DISPLAY_CONFIG;
+      return new OneShotPresentationService(displayConfig, emitEventTypes);
+    }),
+  );
+}
+
+export const OneShotPresentationServiceLayer = makeOneShotPresentationServiceLayer();

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -13,14 +13,29 @@ import { resolveDisplayConfig } from "@/core/utils/display-config";
 
 const MAX_EVENT_STRING_LENGTH = 200;
 
+function truncateString(value: string): string {
+  return value.length > MAX_EVENT_STRING_LENGTH
+    ? `${value.slice(0, MAX_EVENT_STRING_LENGTH)}…`
+    : value;
+}
+
 /**
  * JSON replacer that caps any long string value so a single tool result or file
- * payload cannot gush megabytes onto stderr. Bounds NDJSON line size to keep the
- * live-progress stream cheap to parse downstream.
+ * payload cannot gush megabytes onto stderr, and serializes `Error` instances to
+ * a plain object (their `message`/`stack` are non-enumerable and would otherwise
+ * stringify to `{}`). Bounds NDJSON line size to keep the live-progress stream
+ * cheap to parse downstream.
  */
 function truncateLongStrings(_key: string, value: unknown): unknown {
-  if (typeof value === "string" && value.length > MAX_EVENT_STRING_LENGTH) {
-    return `${value.slice(0, MAX_EVENT_STRING_LENGTH)}…`;
+  if (typeof value === "string") {
+    return truncateString(value);
+  }
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: truncateString(value.message),
+      ...(value.stack !== undefined ? { stack: truncateString(value.stack) } : {}),
+    };
   }
   return value;
 }
@@ -54,8 +69,20 @@ export class OneShotPresentationService implements PresentationService {
     return Effect.void;
   }
 
+  private get eventsActive(): boolean {
+    return this.emitEventTypes.size > 0;
+  }
+
+  private emitNdjson(payload: Record<string, unknown>): void {
+    process.stderr.write(`${JSON.stringify(payload, truncateLongStrings)}\n`);
+  }
+
   presentWarning(agentName: string, message: string): Effect.Effect<void, never> {
     return Effect.sync(() => {
+      if (this.eventsActive) {
+        this.emitNdjson({ type: "warning", agentName, message });
+        return;
+      }
       process.stderr.write(`⚠ ${agentName}: ${message}\n`);
     });
   }
@@ -137,6 +164,10 @@ export class OneShotPresentationService implements PresentationService {
 
   writeOutput(message: string): Effect.Effect<void, never> {
     return Effect.sync(() => {
+      if (this.eventsActive) {
+        this.emitNdjson({ type: "output", message });
+        return;
+      }
       process.stderr.write(message);
     });
   }
@@ -150,6 +181,10 @@ export class OneShotPresentationService implements PresentationService {
     level: "info" | "success" | "warning" | "error" | "progress",
   ): Effect.Effect<void, never> {
     return Effect.sync(() => {
+      if (this.eventsActive) {
+        this.emitNdjson({ type: "status", level, message });
+        return;
+      }
       const prefixes: Record<typeof level, string> = {
         info: "ℹ",
         success: "✓",


### PR DESCRIPTION
## What

Adds an opt-in `--events <categories>` flag to `jazz run` that emits selected agent `StreamEvent`s as **NDJSON to stderr** while the run is in progress.

```
jazz run --agent ksyl --json --events tools --timeout 600000 "summarize the repo"
```

## Why

`jazz run` is the headless entrypoint for gateways (Slack, Google Chat, webhooks). Today it only prints a single final payload to stdout, so a gateway has no way to show *live* progress while a long agent run is happening. The motivating case is a **Google Chat gateway that streams live tool-progress** ("running web_search…", "reading file…") into a thread while the agent works, then posts the final answer.

## How it works

- **stdout is unchanged.** Nothing about the stdout contract moves: in `--json` mode it is still exactly one final JSON object; in plain mode it is still the trimmed answer. The event stream goes to **stderr only**, as newline-delimited JSON (one `StreamEvent` per line).
- **Off by default / opt-in.** Without `--events`, the one-shot streaming renderer stays a noop (events are dropped, as before). The flag is the only thing that turns emission on.
- **Categories** (comma-separated, case/whitespace tolerant):
  - `tools` → `tools_detected`, `tool_call`, `tool_execution_start`, `tool_execution_complete`
  - `reasoning` → `thinking_start`, `thinking_chunk`, `thinking_complete`
  - `text` → `text_start`, `text_chunk`
  - `usage` → `stream_start`, `usage_update`, `complete`
  - `all` → every type
  - `error` is **always** included when any category is enabled, so failures always surface on the live stream.
- **Size safety.** A JSON replacer truncates any string value longer than 200 chars (appending `…`) so a single large tool result or file payload cannot dump megabytes onto stderr and keeps each NDJSON line cheap to parse downstream.
- **Validation** mirrors the existing `--approval-policy` handling: an invalid category writes a JSON error to stdout in `--json` mode (or to stderr otherwise) and sets `process.exitCode = 1`.

## Changes

- `src/core/presentation/oneshot-presentation-service.ts` — `OneShotPresentationService` takes a second `emitEventTypes` constructor param; `createStreamingRenderer` returns an NDJSON-to-stderr renderer when the set is non-empty (noop otherwise). Adds the `truncateLongStrings` JSON replacer and a `makeOneShotPresentationServiceLayer(emitEventTypes)` factory; the existing `OneShotPresentationServiceLayer` is preserved as the empty-set default.
- `src/cli/commands/run-agent.ts` — adds `eventTypes` to `RunAgentOnceOptions`, exports `parseEventCategories`, and provides the layer built from the selected types.
- `src/cli/cli-app.ts` — registers the `--events <categories>` option and wires parsing/validation into the action.
- Tests: `parseEventCategories` (category mapping, `all`, unions, case/whitespace tolerance, invalid input) and the streaming renderer (only-selected-types emitted, noop when empty, 200-char truncation).

## Validation

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun test` — pass (1236 pass, 0 fail)
- `bun run build` — pass