### PR TITLE
fix(llm): ollama reasoning 'disable' now sends think:false; add --reasoning flag to run

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -28,6 +28,7 @@ import {
 import {
   isApprovalPolicyFlag,
   parseEventCategories,
+  isReasoningEffortFlag,
   runAgentOnceCommand,
 } from "./commands/run-agent";
 import { updateCommand } from "./commands/update";
@@ -89,6 +90,10 @@ function registerRunCommand(program: Command): void {
       "--events <categories>",
       "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,all). stdout stays the clean payload.",
     )
+    .option(
+      "--reasoning <effort>",
+      "Reasoning effort for this run: low | medium | high | disable (overrides the agent's config)",
+    )
     .action(
       (
         prompt: string | undefined,
@@ -99,6 +104,7 @@ function registerRunCommand(program: Command): void {
           timeout?: number;
           maxIterations?: number;
           events?: string;
+          reasoning?: string;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -129,6 +135,17 @@ function registerRunCommand(program: Command): void {
           return;
         }
 
+        if (options.reasoning !== undefined && !isReasoningEffortFlag(options.reasoning)) {
+          const message = `Invalid --reasoning "${options.reasoning}". Expected low, medium, high, or disable.`;
+          if (json) {
+            process.stdout.write(`${JSON.stringify({ ok: false, error: message, costUSD: 0 })}\n`);
+          } else {
+            process.stderr.write(`${message}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
         // Force plain terminal so Ink never mounts and writes to stdout; the
         // one-shot presentation layer keeps stdout clean for the payload.
         process.env["JAZZ_NO_TUI"] = "1";
@@ -138,6 +155,9 @@ function registerRunCommand(program: Command): void {
             json,
             ...(options.approvalPolicy !== undefined && isApprovalPolicyFlag(options.approvalPolicy)
               ? { approvalPolicy: options.approvalPolicy }
+              : {}),
+            ...(options.reasoning !== undefined && isReasoningEffortFlag(options.reasoning)
+              ? { reasoningEffort: options.reasoning }
               : {}),
             ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
             ...(options.maxIterations !== undefined

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -3,6 +3,7 @@ import {
   formatOneShotError,
   formatOneShotResult,
   isApprovalPolicyFlag,
+  isReasoningEffortFlag,
   type OneShotSuccess,
   parseEventCategories,
 } from "./run-agent";
@@ -146,4 +147,20 @@ describe("parseEventCategories", () => {
       expect(result.error).toContain("Invalid --events category");
     },
   );
+});
+
+describe("isReasoningEffortFlag", () => {
+  it("accepts the four reasoning levels", () => {
+    expect(isReasoningEffortFlag("disable")).toBe(true);
+    expect(isReasoningEffortFlag("low")).toBe(true);
+    expect(isReasoningEffortFlag("medium")).toBe(true);
+    expect(isReasoningEffortFlag("high")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isReasoningEffortFlag("off")).toBe(false);
+    expect(isReasoningEffortFlag("none")).toBe(false);
+    expect(isReasoningEffortFlag("")).toBe(false);
+    expect(isReasoningEffortFlag("HIGH")).toBe(false);
+  });
 });

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -81,9 +81,17 @@ export function isApprovalPolicyFlag(value: string): value is ApprovalPolicyFlag
   return (VALID_APPROVAL_POLICIES as readonly string[]).includes(value);
 }
 
+const VALID_REASONING_EFFORTS = ["disable", "low", "medium", "high"] as const;
+export type ReasoningEffort = (typeof VALID_REASONING_EFFORTS)[number];
+
+export function isReasoningEffortFlag(value: string): value is ReasoningEffort {
+  return (VALID_REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
 export interface RunAgentOnceOptions {
   readonly json: boolean;
   readonly approvalPolicy?: ApprovalPolicyFlag | undefined;
+  readonly reasoningEffort?: ReasoningEffort | undefined;
   readonly timeoutMs?: number | undefined;
   readonly maxIterations?: number | undefined;
   readonly eventTypes?: ReadonlySet<StreamEvent["type"]> | undefined;
@@ -219,10 +227,15 @@ export function runAgentOnceCommand(
       ),
     );
 
+    const agentForRun =
+      options.reasoningEffort !== undefined
+        ? { ...agent, config: { ...agent.config, reasoningEffort: options.reasoningEffort } }
+        : agent;
+
     const autoApprovePolicy: AutoApprovePolicy | undefined = options.approvalPolicy;
     const runId = `run-${agent.id}-${Date.now()}`;
     const runEffect = AgentRunner.run({
-      agent,
+      agent: agentForRun,
       userInput: prompt,
       sessionId: runId,
       conversationId: runId,

--- a/src/services/llm/ai-sdk-service.test.ts
+++ b/src/services/llm/ai-sdk-service.test.ts
@@ -10,6 +10,7 @@ import { AVAILABLE_PROVIDERS } from "../../core/constants/models";
 import type { AgentConfigService } from "../../core/interfaces/agent-config";
 import { AgentConfigServiceTag } from "../../core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "../../core/interfaces/llm";
+import type { ChatCompletionOptions } from "../../core/types/chat";
 import {
   LLMAuthenticationError,
   LLMConfigurationError,
@@ -19,7 +20,7 @@ import {
 import type { AppConfig, LLMConfig, StreamEvent } from "../../core/types/index";
 import { AgentConfigServiceImpl } from "../config";
 import { createLoggerLayer } from "../logger";
-import { createAISDKServiceLayer } from "./ai-sdk-service";
+import { buildProviderOptions, createAISDKServiceLayer } from "./ai-sdk-service";
 import { PROVIDER_MODELS } from "./models";
 
 mock.module("@/core/utils/models-dev-client", () => ({
@@ -917,5 +918,37 @@ describe("AI SDK Service - Unit Tests", () => {
         expect(Cause.defects(exit.cause).length).toBe(0);
       }
     });
+  });
+});
+
+describe("buildProviderOptions - ollama reasoning", () => {
+  function ollamaOptions(
+    reasoningEffort: ChatCompletionOptions["reasoning_effort"],
+  ): ChatCompletionOptions {
+    return {
+      model: "gemma4:26b-a4b-it",
+      messages: [{ role: "user", content: "hi" }],
+      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    };
+  }
+
+  it("sends think:false when reasoning is disabled", () => {
+    const result = buildProviderOptions("ollama", ollamaOptions("disable"));
+    expect(result).toEqual({ ollama: { think: false } });
+  });
+
+  it("sends think:false when no reasoning effort is provided", () => {
+    const result = buildProviderOptions("ollama", ollamaOptions(undefined));
+    expect(result).toEqual({ ollama: { think: false } });
+  });
+
+  it("sends think:true when reasoning effort is high", () => {
+    const result = buildProviderOptions("ollama", ollamaOptions("high"));
+    expect(result).toEqual({ ollama: { think: true } });
+  });
+
+  it("sends think:true when reasoning effort is low", () => {
+    const result = buildProviderOptions("ollama", ollamaOptions("low"));
+    expect(result).toEqual({ ollama: { think: true } });
   });
 });

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -658,7 +658,7 @@ function buildProviderCacheFingerprint(providerName: ProviderName, llmConfig?: L
   }
 }
 
-function buildProviderOptions(
+export function buildProviderOptions(
   providerName: ProviderName,
   options: ChatCompletionOptions,
   webSearchConfig?: WebSearchConfig,
@@ -744,7 +744,15 @@ function buildProviderOptions(
           } satisfies OllamaCompletionProviderOptions,
         };
       }
-      break;
+      // Thinking-capable ollama models default thinking ON when no flag is sent,
+      // which makes the ai-sdk ollama provider emit reasoning into a separate
+      // field and return empty content/no tool calls. Disabling reasoning must
+      // therefore explicitly turn thinking off.
+      return {
+        ollama: {
+          think: false,
+        } satisfies OllamaCompletionProviderOptions,
+      };
     }
     case "openrouter": {
       const reasoningEffort = options.reasoning_effort;


### PR DESCRIPTION
## What and why

Thinking-capable Ollama models (e.g. `gemma4:26b-a4b-it`) default thinking **ON** when no `think` flag is sent. The jazz ai-sdk Ollama provider then mishandles that output — the model puts its reasoning in a separate `thinking` field and returns empty `content` with no tool calls — so a run fails with **"model returned an empty response"**.

The Ollama branch of `buildProviderOptions` only sent `think: true` when reasoning was enabled; on `"disable"` (the default) it `break`'d and sent **no** flag at all, making `reasoningEffort: "disable"` a silent no-op. This blocked running local thinking-capable models through jazz.

Verified at the raw Ollama API: gemma4 with `think: false` emits clean `tool_calls`; with thinking on it returns reasoning + empty content. Non-thinking models (e.g. `qwen3-coder`) are unaffected.

## Before / after

- **Before:** ollama + `reasoning_effort: "disable"` → no provider options → thinking defaults ON → empty response / no tool calls on thinking-capable models.
- **After:** ollama + `reasoning_effort: "disable"` (or unset) → `{ ollama: { think: false } }` → thinking off → clean content and tool calls. `"low" | "medium" | "high"` still map to `{ ollama: { think: true } }`.

## Changes made

1. **Bug fix** (`src/services/llm/ai-sdk-service.ts`): the Ollama case of `buildProviderOptions` now returns `{ ollama: { think: false } }` when reasoning is disabled instead of falling through with no flag. Exported `buildProviderOptions` for unit testing.
2. **New `--reasoning <effort>` flag on `jazz run`** (`src/cli/cli-app.ts`, `src/cli/commands/run-agent.ts`): lets a one-shot caller override the agent's configured reasoning effort per run (`low | medium | high | disable`). Validated like `--approval-policy` (JSON error to stdout in `--json` mode, else stderr; `exitCode = 1`). When set, the run uses a cloned agent config so the override propagates to the LLM call.
3. Added `ReasoningEffort` type + `isReasoningEffortFlag` validator alongside the existing `isApprovalPolicyFlag`.

## Impact

Unblocks running local thinking-capable models like `gemma4:26b-a4b-it` through jazz against a host Ollama — previously they returned empty responses. Also gives scripts/webhooks a per-run reasoning override without editing the agent.

## How to test

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun test` — 1234 pass, 0 fail
- `bun run build` — pass
- New unit tests: ollama + `"disable"` (and unset) → `{ ollama: { think: false } }`, ollama + `"high"`/`"low"` → `{ ollama: { think: true } }`; `isReasoningEffortFlag` accepts the four levels and rejects junk.

## Reviewer notes

The e2e run against the host Ollama was skipped: the `bun build` output externalizes `ink` and other deps, so the standalone `dist/main.js` cannot run on the server without `node_modules`. The fix is API-verified (raw Ollama `think:false` yields clean tool_calls) and covered by unit tests.
