### PR TITLE
fix(llm): derive ollama tool support from /api/show capabilities

### DIFF
--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -188,6 +188,55 @@ describe("ModelFetcher", () => {
     expect(result[0]!.isReasoningModel).toBe(true);
   });
 
+  it("sets supportsTools=true for a thinking ollama model whose /api/show capabilities include tools (gemma4 regression)", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "gemma4:26b-a4b-it-q4_K_M", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "gemma3.context_length": 131072 },
+      template: "{{ if .Thinking }}<think>{{ end }}",
+      capabilities: ["completion", "vision", "tools", "thinking"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result.length).toBe(1);
+    expect(result[0]!.isReasoningModel).toBe(true);
+    expect(result[0]!.supportsTools).toBe(true);
+  });
+
+  it("sets supportsTools=false for an ollama model whose /api/show capabilities omit tools", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "embeddinggemma:300m", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "gemma3.context_length": 2048 },
+      capabilities: ["completion"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.supportsTools).toBe(false);
+  });
+
   it("sets isReasoningModel=false for ollama models without thinking capability or tag template", async () => {
     const mockTagsResponse = {
       models: [{ name: "llama3.1:8b", details: { metadata: {} } }],

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -237,6 +237,29 @@ describe("ModelFetcher", () => {
     expect(result[0]!.supportsTools).toBe(false);
   });
 
+  it("trusts capabilities over legacy metadata: capabilities without tools wins even if metadata claims supports_tools", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "embeddinggemma:300m", details: { metadata: { supports_tools: true } } }],
+    };
+    const mockShowResponse = {
+      model_info: { "gemma3.context_length": 2048 },
+      capabilities: ["completion"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.supportsTools).toBe(false);
+  });
+
   it("sets isReasoningModel=false for ollama models without thinking capability or tag template", async () => {
     const mockTagsResponse = {
       models: [{ name: "llama3.1:8b", details: { metadata: {} } }],

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -182,8 +182,24 @@ const TOOL_PARAMS = new Set([
 ]);
 
 /**
- * Fallback when model is not in models.dev: read tool support from Ollama manifest metadata.
+ * Fallback when model is not in models.dev: derive tool support from Ollama's own
+ * capability reporting.
+ *
+ * Ollama exposes tool support in two places that don't always agree:
+ *  - `/api/show` returns a `capabilities` array (e.g. ["completion","tools","thinking"]).
+ *    This is the authoritative signal and is present for every modern tool-capable model,
+ *    including thinking/vision models like gemma4. Tool capability is independent of the
+ *    thinking capability — a model can have both.
+ *  - `/api/tags` may include legacy `details.metadata` flags for some models.
+ *
+ * We trust `capabilities` first, then fall back to manifest metadata. Never gate on the
+ * thinking/reasoning capability: thinking-capable models can also call tools.
  */
+function ollamaToolSupportFromCapabilities(capabilities: readonly string[] | undefined): boolean {
+  if (!capabilities) return false;
+  return capabilities.includes("tools");
+}
+
 function ollamaToolSupportFromMetadata(model: OllamaModel): boolean {
   const metadata = model.details?.metadata;
   if (!metadata || typeof metadata !== "object") return false;
@@ -317,7 +333,9 @@ async function transformOllamaModels(
         } else {
           entry.fallback = {
             contextWindow: extras.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-            supportsTools: ollamaToolSupportFromMetadata(model),
+            supportsTools:
+              ollamaToolSupportFromCapabilities(extras.capabilities) ||
+              ollamaToolSupportFromMetadata(model),
             isReasoningModel: hasReasoningParser({
               provider: "ollama",
               modelId: model.name,

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -333,9 +333,12 @@ async function transformOllamaModels(
         } else {
           entry.fallback = {
             contextWindow: extras.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+            // Trust /api/show capabilities authoritatively when present (it's the source of truth for
+            // tool support); only fall back to the legacy manifest metadata when capabilities is absent.
             supportsTools:
-              ollamaToolSupportFromCapabilities(extras.capabilities) ||
-              ollamaToolSupportFromMetadata(model),
+              extras.capabilities !== undefined
+                ? ollamaToolSupportFromCapabilities(extras.capabilities)
+                : ollamaToolSupportFromMetadata(model),
             isReasoningModel: hasReasoningParser({
               provider: "ollama",
               modelId: model.name,


### PR DESCRIPTION
## What and why

Same jazz agent (35 tools, persona \`default\`, high-risk approval), two ollama models on one server behaved differently:

- \`ollama/qwen3-coder:30b\` → jazz sent ~26,480 prompt tokens (full tool schema), model made real tool calls. **Worked.**
- \`ollama/gemma4:26b-a4b-it-q4_K_M\` → jazz sent only ~4,069 prompt tokens (**no tools**), model hallucinated instead of calling tools (\`toolCalls: []\`).

At the raw ollama API, gemma4 accepts tools and emits clean \`tool_calls\` (verified, streaming + non-streaming). So ollama and the model are fine — jazz was omitting the tools for gemma4.

## Root cause

The only thing that drops the tools array is \`supportsTools === false\` in \`buildToolConfig\` (\`src/services/llm/ai-sdk-service.ts:140\`). There is **no** gate on \`isReasoningModel\`/\`thinking\` — the earlier "reasoning model strips tools" hypothesis was wrong.

The real bug is in how \`supportsTools\` is derived for ollama models in \`src/services/llm/model-fetcher.ts\` (\`transformOllamaModels\`):

1. If the model is in models.dev → \`supportsTools\` comes from models.dev.
2. Otherwise → it came **only** from \`ollamaToolSupportFromMetadata\`, which reads \`details.metadata.supports_tools\` from \`/api/tags\`.

\`qwen3-coder:30b\` resolves via models.dev (bare key \`qwen3-coder\` → \`tool_call: true\`), so it works.

\`gemma4:26b-a4b-it-q4_K_M\` **misses models.dev** (no bare \`gemma4\` key; only \`ollama-cloud/gemma4:31b\` and \`nano-gpt/TEE/gemma4-31b\` exist). It then falls back to \`details.metadata\`, which ollama does **not** populate with a \`supports_tools\` flag → \`supportsTools: false\`. Meanwhile the authoritative \`/api/show\` \`capabilities\` array (\`["completion","vision","tools","thinking"]\`) was fetched and attached as metadata but never consulted for tool support.

## Before / after

- **Before:** ollama models missing from models.dev had \`supportsTools\` derived only from \`/api/tags\` metadata flags → tool-capable models like gemma4 silently lost their tools.
- **After:** the ollama fallback trusts the \`/api/show\` \`capabilities\` array (\`"tools"\`) first, then the legacy metadata flag. Model-agnostic; never gates on the thinking/reasoning capability (thinking-capable models can also call tools).

## Changes made

- \`src/services/llm/model-fetcher.ts\`: added \`ollamaToolSupportFromCapabilities\` and used it (OR'd with the legacy metadata check) when building the ollama fallback \`supportsTools\`.
- \`src/services/llm/model-fetcher.test.ts\`: regression test — a thinking ollama model (gemma4-shaped, \`capabilities: [completion, vision, tools, thinking]\`, not in models.dev) now resolves \`supportsTools=true\`; plus a negative test for a model whose capabilities omit \`tools\`.

## Impact

Tool-capable ollama models that aren't catalogued in models.dev (gemma4 and others) now receive their tool definitions and can call tools. \`qwen3-coder\` and any model resolved via models.dev are unaffected (they never hit this fallback).

## How to test

- \`bun test src/services/llm/model-fetcher.test.ts\` — 13 pass (incl. 2 new).
- \`bun run typecheck\`, \`bun run lint\`, \`bun test\` (1253 pass), \`bun run build\` — all green.