### PR TITLE
fix(run): emit tool events on headless one-shot non-streaming path

### DIFF
--- a/src/core/agent/execution/batch-executor.test.ts
+++ b/src/core/agent/execution/batch-executor.test.ts
@@ -1,0 +1,245 @@
+import { FileSystem } from "@effect/platform";
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { OneShotPresentationService } from "@/core/presentation/oneshot-presentation-service";
+import { SkillServiceTag } from "@/core/skills/skill-service";
+import { executeWithoutStreaming } from "./batch-executor";
+import { AgentConfigServiceTag } from "../../interfaces/agent-config";
+import { FileSystemContextServiceTag } from "../../interfaces/fs";
+import type { LLMService } from "../../interfaces/llm";
+import { LLMServiceTag } from "../../interfaces/llm";
+import { LoggerServiceTag } from "../../interfaces/logger";
+import { MCPServerManagerTag } from "../../interfaces/mcp-server";
+import { PresentationServiceTag } from "../../interfaces/presentation";
+import { TerminalServiceTag } from "../../interfaces/terminal";
+import { ToolRegistryTag } from "../../interfaces/tool-registry";
+import type { ChatCompletionResponse } from "../../types/chat";
+import type { StreamEvent } from "../../types/streaming";
+import type { RecursiveRunner } from "../context/summarizer";
+import { createAgentRunMetrics } from "../metrics/agent-run-metrics";
+import { DEFAULT_DISPLAY_CONFIG } from "../types";
+import type { AgentRunContext, AgentRunnerOptions, AgentResponse } from "../types";
+
+const mockLogger = {
+  debug: () => Effect.void,
+  info: () => Effect.void,
+  warn: () => Effect.void,
+  error: () => Effect.void,
+  setSessionId: () => Effect.void,
+  clearSessionId: () => Effect.void,
+  writeToFile: () => Effect.void,
+  logToolCall: () => Effect.void,
+} as any;
+
+const mockToolRegistry = {
+  getTool: () => Effect.succeed({ approvalExecuteToolName: undefined, timeoutMs: 1000 }),
+  listTools: () => Effect.succeed([]),
+  listAllTools: () => Effect.succeed(["ls"]),
+  getToolDefinitions: () => Effect.succeed([]),
+  getToolsInCategory: () => Effect.succeed([]),
+  executeTool: () => Effect.succeed({ success: true, result: { entries: ["a", "b"] } }),
+} as any;
+
+const mockAgentConfigService = {
+  appConfig: Effect.succeed({}),
+} as any;
+
+const mockSkillService = {
+  listSkills: () => Effect.succeed([]),
+} as any;
+
+const toolCallCompletion: ChatCompletionResponse = {
+  id: "c1",
+  model: "qwen3-coder",
+  content: "",
+  toolCalls: [
+    {
+      id: "call_1",
+      type: "function" as const,
+      function: { name: "ls", arguments: JSON.stringify({ path: "/opt/ultron" }) },
+    },
+  ],
+};
+
+const finalCompletion: ChatCompletionResponse = {
+  id: "c2",
+  model: "qwen3-coder",
+  content: "There are 2 entries.",
+};
+
+function makeLLMService(): LLMService {
+  let call = 0;
+  return {
+    createStreamingChatCompletion: () => Effect.fail(new Error("streaming must not be used")),
+    createChatCompletion: () =>
+      Effect.sync(() => {
+        call += 1;
+        return call === 1 ? toolCallCompletion : finalCompletion;
+      }),
+    listProviders: () => Effect.succeed([]),
+    getProvider: () => Effect.fail(new Error("not implemented")),
+    supportsNativeWebSearch: () => Effect.succeed(false),
+  } as unknown as LLMService;
+}
+
+function makeOptions(): AgentRunnerOptions {
+  return {
+    sessionId: "test-session",
+    agent: {
+      id: "agent-1",
+      name: "test-agent",
+      config: {
+        persona: "default",
+        llmModel: "qwen3-coder",
+        llmProvider: "ollama",
+        reasoningEffort: "disable",
+      },
+    } as any,
+    userInput: "list /opt/ultron",
+  };
+}
+
+function makeRunContext(): AgentRunContext {
+  const agent = {
+    id: "agent-1",
+    name: "test-agent",
+    config: {
+      persona: "default",
+      llmModel: "qwen3-coder",
+      llmProvider: "ollama",
+      reasoningEffort: "disable",
+    },
+  } as any;
+
+  return {
+    actualConversationId: "conv-123",
+    context: { agentId: "agent-1", conversationId: "conv-123" },
+    tools: [],
+    messages: [{ role: "user", content: "list /opt/ultron" }],
+    runMetrics: createAgentRunMetrics({
+      agent,
+      conversationId: "conv-123",
+      provider: "ollama",
+      model: "qwen3-coder",
+      reasoningEffort: "disable",
+    }),
+    provider: "ollama",
+    model: "qwen3-coder",
+    agent,
+    expandedToolNames: ["ls"],
+    connectedMCPServers: [],
+    knownSkills: [],
+    maxRetries: 0,
+  };
+}
+
+const runRecursive: RecursiveRunner = () =>
+  Effect.succeed({ content: "recursive", conversationId: "id" } as AgentResponse);
+
+function buildLayer(presentationService: OneShotPresentationService) {
+  return Layer.mergeAll(
+    Layer.succeed(LoggerServiceTag, mockLogger),
+    Layer.succeed(PresentationServiceTag, presentationService as any),
+    Layer.succeed(LLMServiceTag, makeLLMService()),
+    Layer.succeed(ToolRegistryTag, mockToolRegistry),
+    Layer.succeed(MCPServerManagerTag, {} as any),
+    Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+    Layer.succeed(FileSystem.FileSystem, {} as any),
+    Layer.succeed(TerminalServiceTag, {} as any),
+    Layer.succeed(FileSystemContextServiceTag, {} as any),
+    Layer.succeed(SkillServiceTag, mockSkillService),
+  );
+}
+
+describe("executeWithoutStreaming tool event emission", () => {
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+  });
+
+  function captureStderr(): { lines: string[] } {
+    const captured = { lines: [] as string[] };
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    return captured;
+  }
+
+  function parseEventLines(lines: string[]): StreamEvent[] {
+    const events: StreamEvent[] = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      try {
+        events.push(JSON.parse(trimmed) as StreamEvent);
+      } catch {
+        // Non-JSON stray writes are not part of the contract under test.
+      }
+    }
+    return events;
+  }
+
+  it("emits tool lifecycle NDJSON on the non-streaming path when --events tools is active", async () => {
+    const presentationService = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>([
+        "error",
+        "tools_detected",
+        "tool_call",
+        "tool_execution_start",
+        "tool_execution_complete",
+      ]),
+    );
+
+    const captured = captureStderr();
+
+    await Effect.runPromise(
+      executeWithoutStreaming(
+        makeOptions(),
+        makeRunContext(),
+        DEFAULT_DISPLAY_CONFIG,
+        false,
+        runRecursive,
+      ).pipe(Effect.provide(buildLayer(presentationService))),
+    );
+
+    const events = parseEventLines(captured.lines);
+    const eventTypes = events.map((event) => event.type);
+
+    expect(eventTypes).toContain("tools_detected");
+    expect(eventTypes).toContain("tool_execution_start");
+    expect(eventTypes).toContain("tool_execution_complete");
+
+    const startEvent = events.find((event) => event.type === "tool_execution_start") as
+      | Extract<StreamEvent, { type: "tool_execution_start" }>
+      | undefined;
+    expect(startEvent?.toolName).toBe("ls");
+  });
+
+  it("does not emit tool NDJSON when no event categories are requested", async () => {
+    const presentationService = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
+
+    const captured = captureStderr();
+
+    await Effect.runPromise(
+      executeWithoutStreaming(
+        makeOptions(),
+        makeRunContext(),
+        DEFAULT_DISPLAY_CONFIG,
+        false,
+        runRecursive,
+      ).pipe(Effect.provide(buildLayer(presentationService))),
+    );
+
+    const events = parseEventLines(captured.lines);
+    const toolEventTypes = events
+      .map((event) => event.type)
+      .filter((type) =>
+        ["tools_detected", "tool_execution_start", "tool_execution_complete"].includes(type),
+      );
+
+    expect(toolEventTypes).toHaveLength(0);
+  });
+});

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -7,7 +7,7 @@ import { DEFAULT_MAX_LLM_RETRIES, LLM_TIMEOUT_SECONDS } from "@/core/constants/a
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
-import type { PresentationService } from "@/core/interfaces/presentation";
+import type { PresentationService, StreamingRenderer } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { ConversationMessages } from "@/core/types";
@@ -47,6 +47,23 @@ export function executeWithoutStreaming(
 
     const reasoningEffort = agent.config.reasoningEffort ?? "disable";
     const shouldShowThinking = displayConfig.showThinking && reasoningEffort !== "disable";
+
+    // Some presentation services (the headless one-shot `--events` emitter) only
+    // surface tool lifecycle events through a streaming renderer. On this batch
+    // path the tool executor would otherwise fall back to the plain `format*`
+    // methods and never emit those events, so route tool events through a
+    // renderer when the service asks for it. Visual services return false here
+    // and keep their batch `format*` rendering unchanged.
+    const toolEventRenderer: StreamingRenderer | null =
+      presentationService.emitsToolEventsViaRenderer?.() === true
+        ? yield* presentationService.createStreamingRenderer({
+            displayConfig,
+            streamingConfig: { enabled: true },
+            showMetrics,
+            agentName: agent.name,
+            reasoningEffort,
+          })
+        : null;
 
     const strategy: CompletionStrategy = {
       shouldShowThinking,
@@ -141,7 +158,7 @@ export function executeWithoutStreaming(
       },
 
       getRenderer() {
-        return null;
+        return toolEventRenderer;
       },
     };
 

--- a/src/core/interfaces/presentation.ts
+++ b/src/core/interfaces/presentation.ts
@@ -133,6 +133,17 @@ export interface PresentationService {
   ) => Effect.Effect<StreamingRenderer, never>;
 
   /**
+   * Whether tool lifecycle events must be routed through a streaming renderer
+   * even on the non-streaming (batch) execution path.
+   *
+   * The headless one-shot service uses the renderer as its only `--events`
+   * NDJSON emit seam, so it returns true when events are requested. Visual
+   * services (CLI, Ink) render tool activity through their own `format*`
+   * fallbacks in batch mode and return false to keep that behavior unchanged.
+   */
+  readonly emitsToolEventsViaRenderer?: () => boolean;
+
+  /**
    * Write output directly (for non-streaming mode)
    */
   readonly writeOutput: (message: string) => Effect.Effect<void, never>;

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -73,6 +73,10 @@ export class OneShotPresentationService implements PresentationService {
     return this.emitEventTypes.size > 0;
   }
 
+  emitsToolEventsViaRenderer(): boolean {
+    return this.eventsActive;
+  }
+
   private emitNdjson(payload: Record<string, unknown>): void {
     process.stderr.write(`${JSON.stringify(payload, truncateLongStrings)}\n`);
   }


### PR DESCRIPTION
## What and why

The `--events <categories>` NDJSON stream (added in PR #247, shipped in 0.12.0) **does not emit tool events in the headless one-shot `jazz run` path**.

Running, against a model that uses tools:

```
jazz run --agent <a> --json --events tools --approval-policy high-risk
```

surfaced only empty `{"type":"output","message":""}` lines on stderr and **never** `tools_detected`, `tool_execution_start`, or `tool_execution_complete` — even though tools clearly executed (the answer was tool-derived).

### Root cause

The `--events` emit seam lives only in `OneShotPresentationService.createStreamingRenderer().handleEvent` (`src/core/presentation/oneshot-presentation-service.ts`). Tool lifecycle events are pushed to `renderer.handleEvent` from `ToolExecutor` — but only when a renderer is present.

A headless run (no TTY, `JAZZ_NO_TUI=1`) auto-detects streaming **off** (`shouldEnableStreaming` returns false for a non-TTY stdout) and takes `executeWithoutStreaming`. Its `CompletionStrategy.getRenderer()` returned `null` (`src/core/agent/execution/batch-executor.ts:143-145`). With a null renderer, `ToolExecutor` falls back to `presentationService.formatTool*` + `writeOutput` (`src/core/agent/execution/tool-executor.ts`). In the one-shot service those `format*` methods return `""`, and `writeOutput("")` emits the empty `{"type":"output"}` lines — exactly the observed stderr. Tool events were never routed through the only seam that emits `--events` NDJSON.

## Before / after

- **Before:** `jazz run --events tools` (headless) → only empty `{"type":"output"}` lines; no tool events.
- **After:** `jazz run --events tools` (headless) → `tools_detected`, `tool_execution_start`, `tool_execution_complete` NDJSON on stderr, regardless of the streaming/non-streaming execution path. stdout (the final JSON envelope) is unchanged.

## Changes made

- Added an optional `emitsToolEventsViaRenderer()` capability to `PresentationService` (`src/core/interfaces/presentation.ts`).
- `OneShotPresentationService` returns `true` when `--events` is active (`src/core/presentation/oneshot-presentation-service.ts`).
- `executeWithoutStreaming` (`src/core/agent/execution/batch-executor.ts`) now creates the emitting renderer and returns it from `getRenderer()` when the service asks for it, so tool events flow through the same NDJSON seam on the non-streaming path.
- Visual services (CLI, Ink) and Quiet default to `false` (the method is optional), so their batch `format*` rendering is unchanged — neither the streaming path nor the interactive TUI regress.
- Added a regression test (`src/core/agent/execution/batch-executor.test.ts`) driving the real `executeWithoutStreaming` + real `ToolExecutor` + real `OneShotPresentationService`, asserting `tools_detected` / `tool_execution_start` / `tool_execution_complete` land on stderr when `--events tools` is set, and that nothing tool-related is emitted when no categories are requested. The positive test fails on `main` (renderer `null`) and passes with the fix.

## Impact

`jazz run --events tools` now reports live tool progress to NDJSON consumers in the headless/scripted path it was designed for — not only when streaming happens to be enabled.

## How to test

```
bun run typecheck   # pass
bun run lint        # pass
bun test            # 1253 pass, 0 fail
bun run build       # dist/main.js built
```

### End-to-end note

I verified the fix at the integration level via the new regression test (real executor + real tool executor + real one-shot service, asserting the exact NDJSON on stderr). A full live e2e against the host ollama could not complete here: the local ollama exposes only **cloud-proxied** models, and the one accessible model (`gpt-oss:120b-cloud`) did not receive the tool definitions through jazz's ollama provider in this environment (a raw `POST /api/chat` with `tools` made the same model emit a tool call, so the model is capable — the tools were not reaching the wire for that provider/model). That is a separate, pre-existing provider concern unrelated to this `--events` routing fix. With a tool-capable model on the batch path, the regression test demonstrates the events are emitted.
