### PR TITLE
fix(llm): resolve ollama tool support from /api/show capabilities at run time

### DIFF
--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, it, mock, beforeEach } from "bun:test";
 import { Effect } from "effect";
-import { createModelFetcher } from "./model-fetcher";
+import type { ModelsDevMetadata } from "@/core/utils/models-dev-client";
+import { createModelFetcher, resolveOllamaToolSupport, type OllamaModel } from "./model-fetcher";
 
 // Mock models-dev-client
 mock.module("@/core/utils/models-dev-client", () => ({
@@ -328,5 +329,88 @@ describe("ModelFetcher", () => {
     const result = await Effect.runPromise(program);
 
     expect(result[0]!.isReasoningModel).toBe(false);
+  });
+
+  it("run-path seam: ollama model not in models.dev with tools capability resolves supportsTools=true", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "qwen3.6:27b", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "qwen3.context_length": 32768 },
+      capabilities: ["completion", "tools", "thinking"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result.length).toBe(1);
+    expect(result[0]!.supportsTools).toBe(true);
+  });
+
+  it("run-path seam: ollama model whose capabilities omit tools resolves supportsTools=false", async () => {
+    const mockTagsResponse = {
+      models: [{ name: "embeddinggemma:300m", details: { metadata: {} } }],
+    };
+    const mockShowResponse = {
+      model_info: { "gemma3.context_length": 2048 },
+      capabilities: ["completion"],
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/api/tags"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTagsResponse) });
+      if (url.endsWith("/api/show"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockShowResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.supportsTools).toBe(false);
+  });
+
+  describe("resolveOllamaToolSupport", () => {
+    const noMetadataModel: OllamaModel = { name: "model:tag", details: { metadata: {} } };
+    const toolCapableDev: ModelsDevMetadata = {
+      contextWindow: 32768,
+      supportsTools: true,
+      isReasoningModel: false,
+      supportsVision: false,
+      supportsPdf: false,
+    };
+    const nonToolDev: ModelsDevMetadata = { ...toolCapableDev, supportsTools: false };
+
+    it("trusts /api/show capabilities over a stale models.dev tool_call=false (run-path gap)", () => {
+      expect(resolveOllamaToolSupport(["completion", "tools"], nonToolDev, noMetadataModel)).toBe(
+        true,
+      );
+    });
+
+    it("drops tools when capabilities omit tools even if models.dev claims tool_call=true", () => {
+      expect(resolveOllamaToolSupport(["completion"], toolCapableDev, noMetadataModel)).toBe(false);
+    });
+
+    it("falls back to models.dev tool_call when /api/show capabilities are absent", () => {
+      expect(resolveOllamaToolSupport(undefined, toolCapableDev, noMetadataModel)).toBe(true);
+      expect(resolveOllamaToolSupport(undefined, nonToolDev, noMetadataModel)).toBe(false);
+    });
+
+    it("falls back to legacy manifest metadata when neither capabilities nor models.dev are present", () => {
+      const metadataModel: OllamaModel = {
+        name: "legacy:tag",
+        details: { metadata: { supports_tools: true } },
+      };
+      expect(resolveOllamaToolSupport(undefined, undefined, metadataModel)).toBe(true);
+      expect(resolveOllamaToolSupport(undefined, undefined, noMetadataModel)).toBe(false);
+    });
   });
 });

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -72,7 +72,7 @@ type OpenRouterModel = {
   supported_parameters?: string[];
 };
 
-type OllamaModel = {
+export type OllamaModel = {
   name: string;
   model?: string;
   details?: {
@@ -182,18 +182,11 @@ const TOOL_PARAMS = new Set([
 ]);
 
 /**
- * Fallback when model is not in models.dev: derive tool support from Ollama's own
- * capability reporting.
- *
- * Ollama exposes tool support in two places that don't always agree:
- *  - `/api/show` returns a `capabilities` array (e.g. ["completion","tools","thinking"]).
- *    This is the authoritative signal and is present for every modern tool-capable model,
- *    including thinking/vision models like gemma4. Tool capability is independent of the
- *    thinking capability — a model can have both.
- *  - `/api/tags` may include legacy `details.metadata` flags for some models.
- *
- * We trust `capabilities` first, then fall back to manifest metadata. Never gate on the
- * thinking/reasoning capability: thinking-capable models can also call tools.
+ * Tool support from Ollama's `/api/show` `capabilities` array
+ * (e.g. ["completion","tools","thinking"]). Present for every modern tool-capable model,
+ * including thinking/vision models like gemma4; tool capability is independent of the
+ * thinking capability, so a model can have both. Never gate on the thinking/reasoning
+ * capability.
  */
 function ollamaToolSupportFromCapabilities(capabilities: readonly string[] | undefined): boolean {
   if (!capabilities) return false;
@@ -205,6 +198,36 @@ function ollamaToolSupportFromMetadata(model: OllamaModel): boolean {
   if (!metadata || typeof metadata !== "object") return false;
   const flag = metadata["supports_tools"] ?? metadata["tool_use"] ?? metadata["function_calling"];
   return typeof flag === "boolean" && flag;
+}
+
+/**
+ * Authoritative tool-support decision for a local Ollama model.
+ *
+ * Ollama's `/api/show` `capabilities` array describes the actual model loaded on the host,
+ * so it outranks models.dev. models.dev is matched by a normalized bare key
+ * ("last-provider-wins"), which can miss an Ollama tag entirely or collide with a different
+ * provider's same-named model and report a stale/wrong `tool_call` — either way it would
+ * gate tools incorrectly. Precedence:
+ *  1. `/api/show` capabilities, when present (authoritative for the real local model).
+ *  2. models.dev `tool_call`, when the model resolved against models.dev.
+ *  3. legacy `/api/tags` manifest metadata flags.
+ *
+ * This is shared by both the model-listing path and the agent run path, which resolve
+ * supportsTools through the same fetched ModelInfo, so a tool-capable local model is never
+ * silently stripped of its tools.
+ */
+export function resolveOllamaToolSupport(
+  capabilities: readonly string[] | undefined,
+  dev: ModelsDevMetadata | undefined,
+  model: OllamaModel,
+): boolean {
+  if (capabilities !== undefined) {
+    return ollamaToolSupportFromCapabilities(capabilities);
+  }
+  if (dev) {
+    return dev.supportsTools;
+  }
+  return ollamaToolSupportFromMetadata(model);
 }
 
 // List extractors: provider API response → RawModelEntry[] (metadata resolved via models.dev or fallback)
@@ -327,18 +350,14 @@ async function transformOllamaModels(
         const extras = await fetchOllamaModelDetails(baseUrl, model.name);
         const entry: RawModelEntry = { id: model.name, displayName: model.name };
         const dev = getMetadataFromMap(modelsDevMap, model.name);
+        const supportsTools = resolveOllamaToolSupport(extras.capabilities, dev, model);
         let base: ModelInfo;
         if (dev) {
           base = resolveToModelInfo(entry, modelsDevMap);
         } else {
           entry.fallback = {
             contextWindow: extras.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-            // Trust /api/show capabilities authoritatively when present (it's the source of truth for
-            // tool support); only fall back to the legacy manifest metadata when capabilities is absent.
-            supportsTools:
-              extras.capabilities !== undefined
-                ? ollamaToolSupportFromCapabilities(extras.capabilities)
-                : ollamaToolSupportFromMetadata(model),
+            supportsTools,
             isReasoningModel: hasReasoningParser({
               provider: "ollama",
               modelId: model.name,
@@ -350,6 +369,7 @@ async function transformOllamaModels(
         }
         return {
           ...base,
+          supportsTools,
           ...(extras.template ? { chatTemplate: extras.template } : {}),
           ...(extras.capabilities ? { capabilities: extras.capabilities } : {}),
         };


### PR DESCRIPTION
## The bug

At **agent-run time** jazz decided whether an ollama model supports tools using the **models.dev catalog**, discarding ollama's own `/api/show` `capabilities`. Any tool-capable ollama model whose name resolved against a models.dev entry inherited that entry's `tool_call` flag; a tool-capable local model that mapped to a stale/wrong catalog entry (models.dev keys are matched by a normalized **bare key, last-provider-wins**, which can miss an ollama tag entirely or collide with a different provider's same-named model) was gated to `supportsTools=false`. `buildToolConfig` then strips the entire tools array, so the model can never call tools.

PR #249 fixed only the **model-listing** path's no-models.dev branch (`ollamaToolSupportFromCapabilities`). It did **not** fix the run path: when a model *did* resolve against models.dev, `transformOllamaModels` took `supportsTools` straight from `dev.supportsTools` and ignored the authoritative `/api/show` capabilities. The run path (`resolveModelInfo` -> `getProviderModels` -> `fetchModels` -> `transformOllamaModels`) shares that function, so it inherited the gap.

## Evidence (reproduced through the gateway against a real ollama, 35 tools, headless `--json`)

- `qwen3-coder:30b` -> ~26,480-token prompt, tools INCLUDED, real tool calls. **WORKS** (bare key `qwen3-coder` hits models.dev with `tool_call:true`).
- `gemma4:26b-a4b-it-q4_K_M` -> ~4,071-token prompt, NO tools, `toolCalls:[]`. **FAILS**.
- `qwen3.6:27b` -> ~3,986-token prompt, NO tools, emitted a tool call as TEXT. **FAILS**.

All three report `"tools"` in `/api/show` `capabilities`. qwen3-coder works only because its catalog hit happens to be tool-capable; the others were gated on a models.dev result that doesn't reflect the real local model.

## The fix

A single shared `resolveOllamaToolSupport(capabilities, dev, model)` makes `/api/show` `capabilities` authoritative whenever present, then falls back to models.dev `tool_call`, then to legacy `/api/tags` manifest metadata. It is applied in **both** branches of `transformOllamaModels`, so `supportsTools` no longer depends on whether the model name maps cleanly to a models.dev key. The listing path and run path share this function, so both are fixed.

General and behavior-preserving:
- Any tool-capable local ollama model (capabilities include `tools`) keeps its tools at run time, regardless of catalog naming.
- models.dev-resolved models (qwen3-coder etc.) stay working.
- Non-ollama providers are untouched.
- Tool capability is never gated on the thinking/reasoning capability.

## Tests

`src/services/llm/model-fetcher.test.ts`:
- Run-path seam (`fetchModels`): ollama model not in models.dev with `tools` capability -> `supportsTools=true`; capabilities without `tools` -> `supportsTools=false`.
- Unit (`resolveOllamaToolSupport`): capabilities outrank a stale `tool_call:false` dev entry (the run-path gap); capabilities-without-tools drop tools even if dev says `tool_call:true`; models.dev fallback when capabilities absent; legacy manifest metadata fallback when neither present.

## Validation

`bun run typecheck`, `bun run lint`, `bun test` (1262 pass), `bun run build` all pass. No `any`.

## Left for post-release e2e

Full e2e against the live ollama is environment-constrained here (remote host). Correctness is proven via the integration test at the real resolution path (`fetchModels` -> `supportsTools=true` -> tools retained by `buildToolConfig`). The end-to-end agent tool-calling run against gemma4/qwen3.6 on the live host is the maintainer's post-release check.