### PR TITLE
fix(llm): correct ollama /api/show URL so tool capabilities load at run time

### DIFF
--- a/src/services/llm/base-url-resolver.test.ts
+++ b/src/services/llm/base-url-resolver.test.ts
@@ -54,4 +54,24 @@ describe("resolveLocalProviderBaseUrl", () => {
     const config: LLMConfig = { llamacpp: { base_url: "" } };
     expect(resolveLocalProviderBaseUrl("llamacpp", config)).toBe("http://localhost:8080/v1");
   });
+
+  it("canonicalizes an ollama env base URL without /api to the /api root", () => {
+    process.env["OLLAMA_BASE_URL"] = "http://env-host:11434";
+    expect(resolveLocalProviderBaseUrl("ollama")).toBe("http://env-host:11434/api");
+  });
+
+  it("canonicalizes an ollama config base URL without /api to the /api root", () => {
+    const config: LLMConfig = { ollama: { base_url: "http://config-host:11434" } };
+    expect(resolveLocalProviderBaseUrl("ollama", config)).toBe("http://config-host:11434/api");
+  });
+
+  it("strips a trailing slash and keeps a single /api root for ollama", () => {
+    process.env["OLLAMA_BASE_URL"] = "http://env-host:11434/api/";
+    expect(resolveLocalProviderBaseUrl("ollama")).toBe("http://env-host:11434/api");
+  });
+
+  it("does NOT force /api onto llamacpp (its convention is /v1, not /api)", () => {
+    process.env["LLAMACPP_BASE_URL"] = "http://env-host:9000";
+    expect(resolveLocalProviderBaseUrl("llamacpp")).toBe("http://env-host:9000");
+  });
 });

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -9,6 +9,28 @@ mock.module("@/core/utils/models-dev-client", () => ({
   getMetadataFromMap: mock(() => null),
 }));
 
+/**
+ * Install a `global.fetch` mock for an ollama model fetch: `/api/tags` → `tags`,
+ * `/api/show` → `show` (200), anything else → 404. Returns the array of requested
+ * URLs (populated as fetch is invoked) so callers can assert which URLs were hit.
+ */
+function mockOllamaFetch(responses: { tags: unknown; show: unknown }): string[] {
+  const requestedUrls: string[] = [];
+  global.fetch = mock((url: string) => {
+    requestedUrls.push(url);
+    if (url.endsWith("/api/tags"))
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(responses.tags) });
+    if (url.endsWith("/api/show"))
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(responses.show),
+      });
+    return Promise.resolve({ ok: false, status: 404, statusText: "Not Found" });
+  }) as unknown as typeof fetch;
+  return requestedUrls;
+}
+
 describe("ModelFetcher", () => {
   const fetcher = createModelFetcher();
 
@@ -56,7 +78,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result.length).toBe(1);
@@ -180,7 +202,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result.length).toBe(1);
@@ -207,11 +229,35 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result.length).toBe(1);
     expect(result[0]!.isReasoningModel).toBe(true);
+    expect(result[0]!.supportsTools).toBe(true);
+  });
+
+  // Base-URL canonicalization (bare host → /api root) lives in resolveLocalProviderBaseUrl and is
+  // covered in base-url-resolver.test.ts. Here the base is already the canonical /api root, so this
+  // asserts the endpoints append correctly: /show (not /api/api/show) and /tags.
+  it("reaches /api/show (not /api/api/show) from the canonical /api-root base URL", async () => {
+    const requestedUrls = mockOllamaFetch({
+      tags: { models: [{ name: "qwen3.6:27b", details: { metadata: {} } }] },
+      show: {
+        model_info: { "qwen3.context_length": 262144 },
+        template: "{{ if .Thinking }}<think>{{ end }}",
+        capabilities: ["completion", "vision", "tools", "thinking"],
+      },
+    });
+
+    const result = await Effect.runPromise(
+      fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags"),
+    );
+
+    expect(requestedUrls).toContain("http://localhost:11434/api/show");
+    expect(requestedUrls.some((url) => url.includes("/api/api/"))).toBe(false);
+    expect(result.length).toBe(1);
+    expect(result[0]!.capabilities).toEqual(["completion", "vision", "tools", "thinking"]);
     expect(result[0]!.supportsTools).toBe(true);
   });
 
@@ -232,7 +278,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result[0]!.supportsTools).toBe(false);
@@ -255,7 +301,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result[0]!.supportsTools).toBe(false);
@@ -279,7 +325,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result[0]!.isReasoningModel).toBe(false);
@@ -348,7 +394,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result.length).toBe(1);
@@ -372,7 +418,7 @@ describe("ModelFetcher", () => {
       return Promise.reject("Unknown URL");
     }) as unknown as typeof fetch;
 
-    const program = fetcher.fetchModels("ollama", "http://localhost:11434", "/api/tags");
+    const program = fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags");
     const result = await Effect.runPromise(program);
 
     expect(result[0]!.supportsTools).toBe(false);

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -148,14 +148,15 @@ function extractOllamaContextLength(
 
 /**
  * Fetch detailed model info from Ollama /api/show endpoint
- * Returns context window, template, and capabilities when available
+ * Returns context window, template, and capabilities when available.
+ * `baseUrl` is the canonical `/api` root (see resolveLocalProviderBaseUrl), so `/show` appends directly.
  */
 async function fetchOllamaModelDetails(
   baseUrl: string,
   modelName: string,
 ): Promise<OllamaShowExtras> {
   try {
-    const response = await fetch(`${baseUrl}/api/show`, {
+    const response = await fetch(`${baseUrl}/show`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ model: modelName }),

--- a/src/services/llm/models.ts
+++ b/src/services/llm/models.ts
@@ -62,23 +62,45 @@ export const PROVIDER_MODELS: Record<ProviderName, ModelSource> = {
 } as const;
 
 /**
+ * Canonicalize an Ollama base URL to its REST API root (ending in `/api`).
+ *
+ * Ollama's REST endpoints (`/tags`, `/show`) and the ai-sdk provider all treat the base URL as the
+ * `/api` root. A config/env value may be written with or without `/api` (or a trailing slash), so
+ * normalize it here — the single place every consumer resolves the URL — to guarantee consistency
+ * and avoid mistakes like a doubled `/api/api`.
+ */
+function toOllamaApiRoot(url: string): string {
+  const trimmed = url.replace(/\/+$/, "");
+  if (trimmed.length === 0) return trimmed;
+  return /\/api$/.test(trimmed) ? trimmed : `${trimmed}/api`;
+}
+
+/**
  * Resolve the base URL for a local-server provider. Precedence:
  *   1. llmConfig.<provider>.base_url
  *   2. <PROVIDER>_BASE_URL env var
  *   3. PROVIDER_MODELS[<provider>].defaultBaseUrl
+ *
+ * For Ollama the result is canonicalized to the `/api` root so every consumer agrees on the base.
  */
 export function resolveLocalProviderBaseUrl(
   provider: "llamacpp" | "ollama",
   llmConfig?: LLMConfig,
 ): string {
   const fromConfig = llmConfig?.[provider]?.base_url;
-  if (fromConfig && fromConfig.length > 0) return fromConfig;
-
   const envVar = provider === "llamacpp" ? "LLAMACPP_BASE_URL" : "OLLAMA_BASE_URL";
   const fromEnv = process.env[envVar];
-  if (fromEnv && fromEnv.length > 0) return fromEnv;
-
   const source = PROVIDER_MODELS[provider];
   const fallback = source.type === "dynamic" ? source.defaultBaseUrl : undefined;
-  return fallback ?? "";
+
+  let resolved: string;
+  if (fromConfig && fromConfig.length > 0) {
+    resolved = fromConfig;
+  } else if (fromEnv && fromEnv.length > 0) {
+    resolved = fromEnv;
+  } else {
+    resolved = fallback ?? "";
+  }
+
+  return provider === "ollama" ? toOllamaApiRoot(resolved) : resolved;
 }


### PR DESCRIPTION
## What and why

Some tool-capable ollama models (e.g. `qwen3.6:27b`) silently lost their entire tools array at run time: the model received a tiny prompt with no tools and never emitted a tool call, while other models (e.g. `qwen3-coder:30b`) worked. The model itself was fine — the raw ollama `/api/chat` with tools produced a clean tool call. jazz was dropping the tools.

Prior fixes (#249, #251) made `/api/show` capabilities authoritative for ollama tool support, but were code-reading guesses and `qwen3.6` still got no tools. This PR is the result of instrumenting and observing a real run against a live ollama host.

## Root cause (observed on a live ollama host)

The ollama base URL convention is that it already ends in `/api` — `DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/api"` and the `OLLAMA_BASE_URL` env var follow this. The model-list call therefore appends `/tags` (`endpointPath: "/tags"`) to reach `.../api/tags`, which is correct.

But `fetchOllamaModelDetails` hardcoded `` `${baseUrl}/api/show` ``, producing **`http://localhost:11434/api/api/show`** — a doubled `/api` that returns **HTTP 404**. With no capabilities returned, run-time tool support fell back to models.dev:

- `qwen3-coder:30b` → present in models.dev (`supportsTools=true`) → tools included (~26k-token prompt, real tool call). **Masked the bug.**
- `qwen3.6:27b` → absent from models.dev → `supportsTools=false` → `buildToolConfig` dropped all 46 tools (~4k-token prompt, no tool call). **FAILED.**

The capabilities-based resolution from #251 was never actually exercised at run time because the `/api/show` request always 404'd.

### Before / after (live host, `OLLAMA_BASE_URL=http://localhost:11434/api`)

Before:
```
fetchOllamaModelDetails url=http://localhost:11434/api/api/show status=404 ok=false
transformOllamaModels name=qwen3.6:27b devMatched=false caps=undefined finalSupportsTools=false
buildToolConfig supportsTools=false tools.length=46
-> toolCalls: []   promptTokens: 3983
```

After:
```
fetchOllamaModelDetails url=http://localhost:11434/api/show status=200 ok=true
transformOllamaModels name=qwen3.6:27b caps=["completion","vision","tools","thinking"] finalSupportsTools=true
buildToolConfig supportsTools=true tools.length=46
-> toolCalls: [{ name: "ls", arguments: {"path":"/opt/ultron"} }]   promptTokens: 24400
```
`qwen3-coder:30b` continues to work (tools included, real tool call), now sourced from its real `/api/show` capabilities rather than models.dev.

## Changes

- Add `ollamaApiRoot(baseUrl)` to canonicalize the base URL to a single `/api` root, handling both the conventional `.../api` form and a bare host root (`http://host:11434`), then build `/show` from it.
- Why the existing tests missed this: they passed a **bare host** plus `endpointPath "/api/tags"` — the inverse of the production convention — so `` `${baseUrl}/api/show` `` happened to resolve correctly and hid the doubled-`/api`.
- Add regression tests using the real production convention (base ending in `/api`, `endpointPath "/tags"`) that assert `/api/show` is reached and `/api/api/` never is, plus a bare-host normalization test.

## How to test

```
bun install
bun run typecheck && bun run lint && bun test && bun run build
```
All green locally (1264 tests pass). Confirmed end-to-end against a live ollama host: `qwen3.6:27b` now resolves tool capabilities and emits a real tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)