### PR TITLE
fix(yolo): inherit auto-approve policy in sub-agents and on mid-turn toggle

### DIFF
--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { Effect, Layer } from "effect";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import type { LoggerService } from "@/core/interfaces/logger";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { PresentationService } from "@/core/interfaces/presentation";
+import type { Agent } from "@/core/types";
+import { AgentRunner } from "../agent-runner";
+import type { AgentRunnerOptions } from "../types";
+import { createSubagentTools } from "./subagent-tools";
+
+const mockLogger = {
+  debug: () => Effect.void,
+  info: () => Effect.void,
+  warn: () => Effect.void,
+  error: () => Effect.void,
+  setSessionId: () => Effect.void,
+  clearSessionId: () => Effect.void,
+  writeToFile: () => Effect.void,
+  logToolCall: () => Effect.void,
+} as unknown as LoggerService;
+
+const mockPresentationService = {
+  writeOutput: () => Effect.void,
+} as unknown as PresentationService;
+
+const testLayer = Layer.mergeAll(
+  Layer.succeed(LoggerServiceTag, mockLogger),
+  Layer.succeed(PresentationServiceTag, mockPresentationService),
+);
+
+const parentAgent: Agent = {
+  id: "parent-agent",
+  name: "Parent",
+  description: "",
+  model: "test-model",
+  config: { persona: "default" } as Agent["config"],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function getSpawnTool() {
+  const tool = createSubagentTools().find((t) => t.name === "spawn_subagent");
+  if (!tool) throw new Error("spawn_subagent tool not found");
+  return tool;
+}
+
+describe("spawn_subagent auto-approve inheritance", () => {
+  it("forwards the parent's auto-approve policy and allowlists to the sub-agent", async () => {
+    let captured: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      captured = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+
+    try {
+      const tool = getSpawnTool();
+      const context = {
+        agentId: parentAgent.id,
+        parentAgent,
+        getAutoApprovePolicy: () => true as const,
+        autoApprovedCommands: ["git status"],
+        autoApprovedTools: ["read_file"],
+        onAutoApproveCommand: () => Effect.void,
+        onAutoApproveTool: () => {},
+      };
+
+      await Effect.runPromise(
+        (
+          tool.execute({ task: "do a thing", persona: "default" }, context) as Effect.Effect<
+            unknown,
+            unknown,
+            LoggerService | PresentationService
+          >
+        ).pipe(Effect.provide(testLayer)),
+      );
+
+      expect(captured).toBeDefined();
+      const forwardedPolicy = captured?.autoApprovePolicy;
+      const resolved = typeof forwardedPolicy === "function" ? forwardedPolicy() : forwardedPolicy;
+      expect(resolved).toBe(true);
+      expect(captured?.autoApprovedCommands).toEqual(["git status"]);
+      expect(captured?.autoApprovedTools).toEqual(["read_file"]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -139,6 +139,17 @@ ${args.task}`;
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
             maxIterations: context.parentMaxIterations ?? DEFAULT_MAX_ITERATIONS,
             ephemeralRegionId: regionId,
+            ...(context.getAutoApprovePolicy
+              ? { autoApprovePolicy: context.getAutoApprovePolicy }
+              : {}),
+            ...(context.autoApprovedCommands
+              ? { autoApprovedCommands: context.autoApprovedCommands }
+              : {}),
+            ...(context.autoApprovedTools ? { autoApprovedTools: context.autoApprovedTools } : {}),
+            ...(context.onAutoApproveCommand
+              ? { onAutoApproveCommand: context.onAutoApproveCommand }
+              : {}),
+            ...(context.onAutoApproveTool ? { onAutoApproveTool: context.onAutoApproveTool } : {}),
           }).pipe(
             Effect.tapError(() =>
               Effect.sync(() =>

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -375,9 +375,7 @@ export class ChatServiceImpl implements ChatService {
             ...(options?.maxIterations !== undefined
               ? { maxIterations: options.maxIterations }
               : {}),
-            ...(autoApprovePolicy !== undefined
-              ? { autoApprovePolicy: getCurrentAutoApprovePolicy }
-              : {}),
+            autoApprovePolicy: getCurrentAutoApprovePolicy,
             autoApprovedCommands,
             autoApprovedTools,
             onAutoApproveCommand: (command: string) =>


### PR DESCRIPTION
## What changes for you

Yolo mode now actually suppresses **all** permission prompts during an agent turn. Previously it would *sometimes* still ask — this fixes the two paths where the auto-approve policy was being dropped.

## The bug

Yolo mode was only consulted in the top-level tool loop. Two paths lost the policy:

**1. Sub-agents didn't inherit yolo (main culprit).**
When the agent delegated work via `spawn_subagent`, the sub-agent's `AgentRunner.runRecursive(...)` call did **not** forward the parent's `autoApprovePolicy` or session allowlists. So any approval-requiring tool the sub-agent ran (git push, file edit, `execute_command`, …) prompted you — even in yolo. Because it only happens when the model delegates, it felt intermittent.

**2. Mid-turn toggle was ignored on a fresh session.**
`chat-service` only attached the live policy getter to a run when the policy was already defined *at turn start*. On a fresh session (policy still `undefined`), hitting Shift+Tab to enable yolo *during* a turn had no effect for that turn.

## The fix

| Area | Before | After |
|------|--------|-------|
| `subagent-tools.ts` | sub-agent run got no approval config | forwards `getAutoApprovePolicy`, `autoApprovedCommands`, `autoApprovedTools`, and both always-approve callbacks from the parent context |
| `chat-service.ts` | policy getter attached only when policy already defined | getter always passed; returns `undefined` when unset, which `shouldAutoApprove` already treats as "always prompt" — safe default unchanged |

The chat-service change is behaviour-preserving for the safe-mode default; it only adds the ability for a mid-turn switch to take effect.

## Out of scope

Interactive CLI confirmations (`catch-up-prompt.ts`, `mcp.ts` remove-server, `workflow.ts`, `config-wizard.ts`) are config/destructive prompts outside the agent run loop and are intentionally left as-is.

## Verification

- New regression test (`subagent-tools.test.ts`) — written failing first, asserts sub-agents inherit the parent policy; now passes.
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun test` → **1268 pass, 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)