### PR TITLE
feat(config): centralize agents and config in ~/.jazz

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -296,7 +296,7 @@ MCP (Model Context Protocol) provides a standardized way for AI agents to:
 
 Jazz loads MCP servers from multiple locations (later sources override earlier ones):
 
-1. **Main config** — `jazz.config.json` or `.jazz/config.json` (see [Configuration Reference](../reference/configuration.md))
+1. **Main config** — `~/.jazz/config.json` with optional `./.jazz/config.json` overrides (see [Configuration Reference](../reference/configuration.md))
 2. **`.agents/mcp.json`** — Project-level and user-level, following the [.agents convention](https://agentskills.io)
 
 Add MCP servers to any of these files under the `mcpServers` key:
@@ -551,7 +551,7 @@ For MCP servers running over HTTP (Streamable HTTP transport):
 
 **"Tool not found" Error**:
 
-- Ensure the MCP server is configured in `jazz.config.json`
+- Ensure the MCP server is configured in `~/.jazz/config.json` or `./.jazz/config.json`
 - Verify the server name matches the agent's tool configuration
 - Check that the server starts successfully (check logs)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,23 +4,29 @@ Jazz is configured via configuration files and environment variables.
 
 ## Configuration File Locations
 
-Jazz searches for config files in this order (first found wins):
+Jazz loads configuration from two layers:
 
-1. `$JAZZ_CONFIG_PATH` — Path from environment variable
-2. `./jazz.config.json` — Project-level
-3. `~/.jazz/config.json` — User-level (global)
+1. **`~/.jazz/config.json`** — Global config (agents, API keys, defaults). All writes go here.
+2. **`./.jazz/config.json`** — Optional project-local overrides (like `.claude/`). Read-only merge on top of global.
+
+Merge order: defaults → `~/.jazz/config.json` → `./.jazz/config.json`.
+
+Agents and storage always live in the Jazz home directory (`~/.jazz` or `JAZZ_HOME`), even when project overrides exist.
+
+You can replace the global config path with `$JAZZ_CONFIG_PATH` or `--config`. Project-local `./.jazz/config.json` still merges on top.
+
+Legacy `./jazz.config.json` in the project root is no longer discovered automatically. Move settings to `~/.jazz/config.json`.
 
 ## MCP Servers: `.agents/mcp.json`
 
 Jazz also loads MCP servers from the `.agents` convention paths. These are merged with the main config (project overrides user):
 
 - `~/.agents/mcp.json` — User-level MCP config
+- `./.agents/mcp.json` — Project-level MCP config
 
 See [MCP Servers](../integrations/index.md#mcp-servers) for format details.
 
-## Main Config: `jazz.config.json`
-
-Located at `~/.jazz/config.json` (or project paths above).
+## Main Config: `~/.jazz/config.json`
 
 ```json
 {
@@ -32,11 +38,16 @@ Located at `~/.jazz/config.json` (or project paths above).
 }
 ```
 
+## Project Overrides: `./.jazz/config.json`
+
+Use for project-specific settings such as MCP enable/disable flags or logging level. Do not put agent storage paths here — agents always load from `~/.jazz`.
+
 ## Environment Variables
 
 You can override settings or provide API keys via `.env` or system environment variables.
 
 - `OPENAI_API_KEY`: Key for OpenAI models.
 - `ANTHROPIC_API_KEY`: Key for Anthropic models.
-- `JAZZ_HOME`: Override the default home directory (default: `~/.jazz`).
+- `JAZZ_HOME`: Override the Jazz home directory (default: `~/.jazz`). Use when developing Jazz to isolate test data.
+- `JAZZ_CONFIG_PATH`: Override the global config file path.
 - `DEBUG`: Set to `true` for verbose logging.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,7 +3,7 @@
 Detailed technical documentation for Jazz.
 
 - **[CLI Reference](./cli.md)**: Complete guide to the Jazz Command Line Interface.
-- **[Configuration](./configuration.md)**: Configure Jazz with `jazz.config.json` and environmental variables.
+- **[Configuration](./configuration.md)**: Configure Jazz with `~/.jazz/config.json` and environment variables.
 - **[Tools Reference](./tools.md)**: List of all available tools and their capabilities.
 - **[Architecture](./architecture.md)**: Deep dive into Jazz's internal architecture and design.
 - **[TUI Architecture](./tui-architecture.md)**: Terminal UI (Ink) layout, append-only streaming behavior, workarounds, and flags.

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -31,7 +31,7 @@ const McpServersInputSchema = z.record(z.string(), McpServerConfigSchema);
 
 /**
  * Parse and validate MCP server JSON, then save to ~/.agents/mcp.json
- * and set enabled: true in jazz.config.json.
+ * and set enabled: true in ~/.jazz/config.json.
  */
 function parseAndSaveMcpServers(
   input: string,
@@ -65,13 +65,13 @@ function parseAndSaveMcpServers(
     }
 
     for (const [name, config] of entries) {
-      // Strip enabled — metadata lives in jazz.config.json, not mcp.json
+      // Strip enabled — metadata lives in ~/.jazz/config.json, not mcp.json
       const { enabled: _, ...serverConfig } = config;
 
       // Write full server config to ~/.agents/mcp.json
       yield* writeAgentsMcpServer(fs, name, serverConfig);
 
-      // Set enabled in jazz.config.json (enabled by default on add)
+      // Set enabled in ~/.jazz/config.json (enabled by default on add)
       yield* configService.set(`mcpServers.${name}`, { enabled: true });
 
       yield* terminal.success(`Added MCP server: ${name}`);
@@ -95,7 +95,7 @@ function readStdin(): Promise<string> {
  * Add an MCP server from JSON (inline argument, --file, stdin pipe, or interactive prompt)
  *
  * Writes the full server config to ~/.agents/mcp.json and sets enabled: true
- * in jazz.config.json.
+ * in ~/.jazz/config.json.
  *
  * Usage:
  *   jazz mcp add '{"name": {"command": "..."}}'
@@ -187,7 +187,7 @@ export function addMcpServerCommand(
  * List all configured MCP servers.
  *
  * Shows the merged view: full configs from .agents/mcp.json with
- * enable/disable status from jazz.config.json.
+ * enable/disable status from ~/.jazz/config.json.
  */
 export function listMcpServersCommand(): Effect.Effect<
   void,
@@ -223,7 +223,7 @@ export function listMcpServersCommand(): Effect.Effect<
  * Remove an MCP server interactively.
  *
  * Removes the server from ~/.agents/mcp.json and cleans up
- * any enable/disable metadata from jazz.config.json.
+ * any enable/disable metadata from ~/.jazz/config.json.
  */
 export function removeMcpServerCommand(): Effect.Effect<
   void,
@@ -283,7 +283,7 @@ export function removeMcpServerCommand(): Effect.Effect<
 /**
  * Enable a disabled MCP server interactively.
  *
- * Sets enabled: true (or removes the override) in jazz.config.json.
+ * Sets enabled: true (or removes the override) in ~/.jazz/config.json.
  */
 export function enableMcpServerCommand(): Effect.Effect<
   void,
@@ -321,7 +321,7 @@ export function enableMcpServerCommand(): Effect.Effect<
 /**
  * Disable an enabled MCP server interactively.
  *
- * Sets enabled: false in jazz.config.json.
+ * Sets enabled: false in ~/.jazz/config.json.
  */
 export function disableMcpServerCommand(): Effect.Effect<
   void,

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -28,6 +28,9 @@ export const FILE_LOCK_RETRY_DELAY_MS = 100;
 /** Default maximum number of LLM API retries on transient failures */
 export const DEFAULT_MAX_LLM_RETRIES = 10;
 
+/** AI SDK internal retries are disabled — Jazz retries via Effect.retry instead. */
+export const AI_SDK_MAX_RETRIES = 0;
+
 /** Maximum delay between LLM retry attempts in seconds (caps exponential backoff) */
 export const MAX_RETRY_DELAY_SECONDS = 30;
 

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -40,7 +40,7 @@ export interface TelemetryConfig {
 }
 
 /**
- * MCP server override stored in jazz.config.json.
+ * MCP server override stored in ~/.jazz/config.json or ./.jazz/config.json.
  * Only contains Jazz-specific metadata — full server definitions
  * live in ~/.agents/mcp.json (global) or .agents/mcp.json (project-local).
  */

--- a/src/core/utils/llm-error.test.ts
+++ b/src/core/utils/llm-error.test.ts
@@ -1,0 +1,22 @@
+import { APICallError, RetryError } from "ai";
+import { describe, expect, it } from "bun:test";
+import { extractCleanErrorMessage } from "./llm-error";
+
+describe("extractCleanErrorMessage", () => {
+  it("unwraps AI SDK RetryError to the last nested error message", () => {
+    const apiError = new APICallError({
+      message: "Cannot connect to API: Connect Timeout Error",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      isRetryable: true,
+    });
+    const retryError = new RetryError({
+      message: `Failed after 3 attempts. Last error: ${apiError.message}`,
+      reason: "maxRetriesExceeded",
+      errors: [apiError, apiError, apiError],
+    });
+
+    expect(extractCleanErrorMessage(retryError)).toBe(
+      "Cannot connect to API: Connect Timeout Error",
+    );
+  });
+});

--- a/src/core/utils/llm-error.ts
+++ b/src/core/utils/llm-error.ts
@@ -1,4 +1,4 @@
-import { APICallError } from "ai";
+import { APICallError, RetryError } from "ai";
 import { Duration, Schedule } from "effect";
 import { MAX_RETRY_DELAY_SECONDS } from "@/core/constants/agent";
 import type { ProviderName } from "@/core/constants/models";
@@ -93,6 +93,14 @@ export function truncateRequestBodyValues(
  * Returns just the core message without verbose details.
  */
 export function extractCleanErrorMessage(error: unknown): string {
+  if (RetryError.isInstance(error)) {
+    const lastError = error.lastError;
+    if (lastError !== undefined) {
+      return extractCleanErrorMessage(lastError);
+    }
+    return error.message;
+  }
+
   if (error instanceof Error) {
     // For API errors, try to extract just the message without all the extra properties
     if (APICallError.isInstance(error)) {

--- a/src/core/utils/runtime-detection.test.ts
+++ b/src/core/utils/runtime-detection.test.ts
@@ -6,6 +6,8 @@ import {
   getBuiltinSkillsDirectory,
   getBuiltinWorkflowsDirectory,
   getGlobalUserDataDirectory,
+  getJazzHomeDirectory,
+  getLocalJazzDirectory,
   getPackageRootDirectory,
   getUserDataDirectory,
   isRunningFromGlobalInstall,
@@ -200,41 +202,46 @@ describe("Runtime Detection", () => {
       expect(result).toBe(expected);
     });
 
-    it("should return {cwd}/.jazz when in development mode", () => {
+    it("should return ~/.jazz when in development mode", () => {
       process.argv[1] = path.join(jazzProjectDir, "src", "main.ts");
 
       const result = getUserDataDirectory();
-      const expected = path.resolve(process.cwd(), ".jazz");
+      const expected = path.join(os.homedir(), ".jazz");
 
       expect(result).toBe(expected);
     });
 
-    it("should fallback to {cwd}/.jazz when home directory cannot be determined", () => {
-      // Mock a global installation path
-      process.argv[1] = "/usr/local/bin/jazz";
+    it("should respect JAZZ_HOME override", () => {
+      const previous = process.env["JAZZ_HOME"];
+      process.env["JAZZ_HOME"] = "/tmp/jazz-test-home";
 
-      // We can't easily mock os.homedir() to return empty, but we can test the fallback
-      // by ensuring the function handles the case where homeDir might be empty
-      const result = getUserDataDirectory();
+      try {
+        expect(getUserDataDirectory()).toBe(path.resolve("/tmp/jazz-test-home"));
+        expect(getGlobalUserDataDirectory()).toBe(path.resolve("/tmp/jazz-test-home"));
+        expect(getJazzHomeDirectory()).toBe(path.resolve("/tmp/jazz-test-home"));
+      } finally {
+        if (previous === undefined) {
+          delete process.env["JAZZ_HOME"];
+        } else {
+          process.env["JAZZ_HOME"] = previous;
+        }
+      }
+    });
+  });
 
-      // If homeDir is available, it should use it; otherwise fallback
-      // Since we can't easily mock os.homedir(), we just verify it doesn't throw
-      expect(result).toBeTruthy();
-      expect(typeof result).toBe("string");
-      // Should either be ~/.jazz (if homeDir available) or {cwd}/.jazz (fallback)
-      expect(result).toMatch(/\.jazz$/);
+  describe("getLocalJazzDirectory", () => {
+    it("should return {cwd}/.jazz", () => {
+      expect(getLocalJazzDirectory()).toBe(path.resolve(process.cwd(), ".jazz"));
     });
   });
 
   describe("getGlobalUserDataDirectory", () => {
-    it("should always return ~/.jazz regardless of dev/prod mode (for schedulers)", () => {
+    it("should always return ~/.jazz regardless of dev/prod mode", () => {
       const homeDir = os.homedir();
       const expected = path.join(homeDir, ".jazz");
 
-      // Even when in development mode (process.argv points to jazz source), getGlobalUserDataDirectory
-      // must return ~/.jazz so scheduled workflows (launchd/cron) always use the same paths.
       process.argv[1] = path.join(jazzProjectDir, "src", "main.ts");
-      expect(getUserDataDirectory()).not.toBe(expected); // dev mode uses cwd
+      expect(getUserDataDirectory()).toBe(expected);
       expect(getGlobalUserDataDirectory()).toBe(expected);
     });
 
@@ -371,7 +378,7 @@ describe("Runtime Detection", () => {
 
       expect(isRunningFromGlobalInstall()).toBe(false);
       expect(isRunningInDevelopmentMode()).toBe(true);
-      expect(getUserDataDirectory()).toBe(path.resolve(process.cwd(), ".jazz"));
+      expect(getUserDataDirectory()).toBe(path.join(os.homedir(), ".jazz"));
     });
 
     it("should correctly identify global install when running 'jazz' command", () => {

--- a/src/core/utils/runtime-detection.ts
+++ b/src/core/utils/runtime-detection.ts
@@ -11,15 +11,16 @@ import { Effect } from "effect";
  * This module detects whether Jazz is running from a global installation or
  * from source code (development mode). This distinction is critical because:
  *
- *   - **Production** (npm i -g jazz-ai): User data stored in `~/.jazz`
- *   - **Development** (bun run cli):     User data stored in `./.jazz`
+ *   - **Global data** (`~/.jazz`): agents, config, history, skills, schedules
+ *   - **Project data** (`./.jazz`): optional local overrides (like `.claude/`)
  *
- * This separation prevents development from accidentally overwriting production
- * data (agents, configs, conversation history, skills, etc.).
+ * Set `JAZZ_HOME` to isolate data when developing Jazz itself.
  *
  * ## Directory Resolution (most commonly used)
- *   - `getUserDataDirectory()` - Returns ~/.jazz (prod) or ./.jazz (dev)
- *   - `getGlobalUserDataDirectory()` - Always returns ~/.jazz (for schedulers, etc.)
+ *   - `getJazzHomeDirectory()` - Returns `JAZZ_HOME` or `~/.jazz`
+ *   - `getLocalJazzDirectory()` - Returns `{cwd}/.jazz` for project overrides
+ *   - `getUserDataDirectory()` - Alias for `getJazzHomeDirectory()`
+ *   - `getGlobalUserDataDirectory()` - Alias for `getJazzHomeDirectory()`
  *   - `getPackageRootDirectory()` - The jazz-ai package installation directory
  *   - `getBuiltinSkillsDirectory()` - Where built-in skills are stored
  *   - `getBuiltinPersonasDirectory()` - Where built-in personas are stored
@@ -42,49 +43,64 @@ import { Effect } from "effect";
 // They use synchronous fs operations since they're called during startup.
 // ============================================================================
 
-/**
- * Get the directory where Jazz stores user data (agents, configs, skills, etc.)
- *
- * - Global install (npm i -g jazz-ai): Returns ~/.jazz
- * - Development mode (running from source): Returns {cwd}/.jazz
- *
- * This separation prevents development from overwriting production data.
- *
- */
-export function getUserDataDirectory(): string {
-  if (isRunningFromGlobalInstall()) {
+function expandHomePath(inputPath: string): string {
+  if (inputPath.startsWith("~")) {
     const homeDir = os.homedir();
     if (homeDir && homeDir.trim().length > 0) {
-      return path.join(homeDir, ".jazz");
+      return inputPath.replace(/^~(?=$|[\\/])/, homeDir);
     }
   }
-
-  return path.resolve(process.cwd(), ".jazz");
+  return inputPath;
 }
 
 /**
- * Get the global user data directory (~/.jazz), regardless of dev/prod mode.
+ * Get the Jazz home directory where agents, config, and user data are stored.
  *
- * Use this when the path will be used by processes that always run in
- * production context (e.g. launchd jobs, cron). Scheduled workflows, logs,
- * and schedule metadata should always live in ~/.jazz.
+ * Uses `JAZZ_HOME` when set, otherwise `~/.jazz`.
  */
-export function getGlobalUserDataDirectory(): string {
+export function getJazzHomeDirectory(): string {
+  const jazzHome = process.env["JAZZ_HOME"];
+  if (jazzHome && jazzHome.trim().length > 0) {
+    return path.resolve(expandHomePath(jazzHome.trim()));
+  }
+
   const homeDir = os.homedir();
   if (homeDir && homeDir.trim().length > 0) {
     return path.join(homeDir, ".jazz");
   }
+
   return path.resolve(process.cwd(), ".jazz");
 }
 
 /**
- * Get the directory where Jazz stores per-agent conversation history.
+ * Get the project-local Jazz directory for optional per-project overrides.
  *
- * - Global install: ~/.jazz/history
- * - Development:    ./.jazz/history
+ * Files here (e.g. `config.json`) merge on top of `~/.jazz/config.json`.
+ * Agents and storage always live in the Jazz home directory.
+ */
+export function getLocalJazzDirectory(): string {
+  return path.resolve(process.cwd(), ".jazz");
+}
+
+/**
+ * Get the directory where Jazz stores user data (agents, configs, skills, etc.)
+ */
+export function getUserDataDirectory(): string {
+  return getJazzHomeDirectory();
+}
+
+/**
+ * Get the global user data directory (~/.jazz or JAZZ_HOME).
+ */
+export function getGlobalUserDataDirectory(): string {
+  return getJazzHomeDirectory();
+}
+
+/**
+ * Get the directory where Jazz stores per-agent conversation history.
  */
 export function getHistoryDirectory(): string {
-  return path.join(getUserDataDirectory(), "history");
+  return path.join(getJazzHomeDirectory(), "history");
 }
 
 /**

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -1,7 +1,8 @@
-import { type FileSystem } from "@effect/platform/FileSystem";
+import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
-import { Effect } from "effect";
-import { AgentConfigServiceImpl } from "./config";
+import { Effect, Layer } from "effect";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
+import { AgentConfigServiceImpl, createConfigLayer } from "./config";
 import { type AppConfig } from "../core/types/index";
 
 // Mock FileSystem
@@ -101,5 +102,63 @@ describe("AgentConfigService", () => {
     expect(parsed.mcpServers).toBeDefined();
     expect(parsed.mcpServers.testServer).toEqual({ enabled: false });
     expect(parsed.mcpServers.testServer.command).toBeUndefined();
+  });
+});
+
+describe("createConfigLayer", () => {
+  function createTestFileSystem(fileContents: Map<string, string>): FileSystem {
+    return {
+      exists: (filePath: string) => Effect.succeed(fileContents.has(filePath)),
+      readFileString: (filePath: string) => Effect.succeed(fileContents.get(filePath) ?? ""),
+      writeFileString: mock(() => Effect.void),
+      makeDirectory: mock(() => Effect.void),
+    } as unknown as FileSystem;
+  }
+
+  it("merges global and local config with local overrides winning", async () => {
+    const homeDir = process.env["HOME"] ?? "/tmp";
+    const globalPath = `${homeDir}/.jazz/config.json`;
+    const localPath = `${process.cwd()}/.jazz/config.json`;
+
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ logging: { level: "info" } })],
+      [localPath, JSON.stringify({ logging: { level: "debug" } })],
+    ]);
+
+    const layer = createConfigLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      const level = yield* config.get<string>("logging.level");
+      const storagePath = yield* config.get<string>("storage.path");
+      return { level, storagePath };
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.level).toBe("debug");
+    expect(result.storagePath).toBe(`${homeDir}/.jazz`);
+  });
+
+  it("ignores local storage.path overrides", async () => {
+    const homeDir = process.env["HOME"] ?? "/tmp";
+    const globalPath = `${homeDir}/.jazz/config.json`;
+    const localPath = `${process.cwd()}/.jazz/config.json`;
+
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ storage: { type: "file", path: `${homeDir}/.jazz` } })],
+      [localPath, JSON.stringify({ storage: { type: "file", path: `${process.cwd()}/.jazz` } })],
+    ]);
+
+    const layer = createConfigLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      return yield* config.get<string>("storage.path");
+    }).pipe(Effect.provide(layer));
+
+    const storagePath = await Effect.runPromise(program);
+    expect(storagePath).toBe(`${homeDir}/.jazz`);
   });
 });

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
@@ -116,9 +118,9 @@ describe("createConfigLayer", () => {
   }
 
   it("merges global and local config with local overrides winning", async () => {
-    const homeDir = process.env["HOME"] ?? "/tmp";
-    const globalPath = `${homeDir}/.jazz/config.json`;
-    const localPath = `${process.cwd()}/.jazz/config.json`;
+    const homeDir = os.homedir();
+    const globalPath = path.join(homeDir, ".jazz", "config.json");
+    const localPath = path.join(process.cwd(), ".jazz", "config.json");
 
     const fileContents = new Map<string, string>([
       [globalPath, JSON.stringify({ logging: { level: "info" } })],
@@ -137,17 +139,23 @@ describe("createConfigLayer", () => {
 
     const result = await Effect.runPromise(program);
     expect(result.level).toBe("debug");
-    expect(result.storagePath).toBe(`${homeDir}/.jazz`);
+    expect(result.storagePath).toBe(path.join(homeDir, ".jazz"));
   });
 
   it("ignores local storage.path overrides", async () => {
-    const homeDir = process.env["HOME"] ?? "/tmp";
-    const globalPath = `${homeDir}/.jazz/config.json`;
-    const localPath = `${process.cwd()}/.jazz/config.json`;
+    const homeDir = os.homedir();
+    const globalPath = path.join(homeDir, ".jazz", "config.json");
+    const localPath = path.join(process.cwd(), ".jazz", "config.json");
 
     const fileContents = new Map<string, string>([
-      [globalPath, JSON.stringify({ storage: { type: "file", path: `${homeDir}/.jazz` } })],
-      [localPath, JSON.stringify({ storage: { type: "file", path: `${process.cwd()}/.jazz` } })],
+      [
+        globalPath,
+        JSON.stringify({ storage: { type: "file", path: path.join(homeDir, ".jazz") } }),
+      ],
+      [
+        localPath,
+        JSON.stringify({ storage: { type: "file", path: path.join(process.cwd(), ".jazz") } }),
+      ],
     ]);
 
     const layer = createConfigLayer().pipe(
@@ -159,6 +167,48 @@ describe("createConfigLayer", () => {
     }).pipe(Effect.provide(layer));
 
     const storagePath = await Effect.runPromise(program);
-    expect(storagePath).toBe(`${homeDir}/.jazz`);
+    expect(storagePath).toBe(path.join(homeDir, ".jazz"));
+  });
+
+  it("preserves custom global storage.path settings", async () => {
+    const homeDir = os.homedir();
+    const globalPath = path.join(homeDir, ".jazz", "config.json");
+    const customStoragePath = path.join(homeDir, ".jazz-custom-storage");
+
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ storage: { type: "file", path: customStoragePath } })],
+    ]);
+
+    const layer = createConfigLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      return yield* config.get<string>("storage.path");
+    }).pipe(Effect.provide(layer));
+
+    const storagePath = await Effect.runPromise(program);
+    expect(storagePath).toBe(customStoragePath);
+  });
+
+  it("merges local overrides when using a custom config path", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-custom-config.json");
+    const localPath = path.join(process.cwd(), ".jazz", "config.json");
+
+    const fileContents = new Map<string, string>([
+      [customConfigPath, JSON.stringify({ logging: { level: "info" } })],
+      [localPath, JSON.stringify({ logging: { level: "debug" } })],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      return yield* config.get<string>("logging.level");
+    }).pipe(Effect.provide(layer));
+
+    const level = await Effect.runPromise(program);
+    expect(level).toBe("debug");
   });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -234,11 +234,6 @@ export function createConfigLayer(
           })
         : mergeConfig(baseConfig, fileConfigWithoutMcp);
 
-      const mainConfigWithStorage: AppConfig = {
-        ...mainConfig,
-        storage: { type: "file", path: getJazzHomeDirectory() },
-      };
-
       // Load MCP definitions from .agents/mcp.json
       const agentsServers = yield* loadAgentsMcpServers(fs);
 
@@ -248,11 +243,7 @@ export function createConfigLayer(
         ...extractMcpOverridesFromFile(loaded.localConfig?.mcpServers),
       };
 
-      const finalConfig = mergeAgentsMcpIntoConfig(
-        mainConfigWithStorage,
-        agentsServers,
-        mcpOverrides,
-      );
+      const finalConfig = mergeAgentsMcpIntoConfig(mainConfig, agentsServers, mcpOverrides);
 
       return new AgentConfigServiceImpl(finalConfig, mcpOverrides, loaded.configPath, fs);
     }),
@@ -457,7 +448,30 @@ function loadConfigFile(
         );
       }
 
-      return { configPath: expandedPath, fileConfig: config, globalConfig: config };
+      const localConfigPath = `${getLocalJazzDirectory()}/config.json`;
+      const localConfigRaw = yield* readOptionalConfigFile(fs, localConfigPath);
+      const localConfig = localConfigRaw ? stripStorageOverride(localConfigRaw) : undefined;
+
+      const emptyBase = defaultConfig();
+      const mergedFromGlobal = mergeConfig(emptyBase, config);
+      const merged = localConfig ? mergeConfig(mergedFromGlobal, localConfig) : mergedFromGlobal;
+
+      const result: {
+        configPath: string;
+        fileConfig: Partial<AppConfig>;
+        globalConfig?: Partial<AppConfig>;
+        localConfig?: Partial<AppConfig>;
+      } = {
+        configPath: expandedPath,
+        fileConfig: merged,
+        globalConfig: config,
+      };
+
+      if (localConfigRaw) {
+        result.localConfig = localConfigRaw;
+      }
+
+      return result;
     }
 
     const envConfigPath = process.env["JAZZ_CONFIG_PATH"];

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -13,11 +13,15 @@ import type {
   WebSearchConfig,
 } from "@/core/types/index";
 import { safeParseJson } from "@/core/utils/json";
-import { getGlobalUserDataDirectory } from "@/core/utils/runtime-detection";
+import {
+  getGlobalUserDataDirectory,
+  getJazzHomeDirectory,
+  getLocalJazzDirectory,
+} from "@/core/utils/runtime-detection";
 
 /**
  * Extract only override fields (enabled) from a server config.
- * Used when persisting to jazz.config.json — full definitions live in mcp.json.
+ * Used when persisting to ~/.jazz/config.json — full definitions live in mcp.json.
  */
 function extractMcpOverride(entry: unknown): MCPServerOverride | undefined {
   if (!entry || typeof entry !== "object") return undefined;
@@ -154,7 +158,7 @@ export class AgentConfigServiceImpl implements AgentConfigService {
         }
 
         // Persist to file
-        const path = this.configPath ?? `${expandHome("~/.jazz")}/config.json`;
+        const path = this.configPath ?? `${getJazzHomeDirectory()}/config.json`;
         if (!this.configPath) {
           this.configPath = path;
           const dir = path.substring(0, path.lastIndexOf("/"));
@@ -230,13 +234,25 @@ export function createConfigLayer(
           })
         : mergeConfig(baseConfig, fileConfigWithoutMcp);
 
+      const mainConfigWithStorage: AppConfig = {
+        ...mainConfig,
+        storage: { type: "file", path: getJazzHomeDirectory() },
+      };
+
       // Load MCP definitions from .agents/mcp.json
       const agentsServers = yield* loadAgentsMcpServers(fs);
 
-      // Extract overrides from jazz (enabled only)
-      const mcpOverrides = extractMcpOverridesFromFile(fileConfig?.mcpServers);
+      // Extract overrides from global + local jazz config (local wins)
+      const mcpOverrides = {
+        ...extractMcpOverridesFromFile(loaded.globalConfig?.mcpServers),
+        ...extractMcpOverridesFromFile(loaded.localConfig?.mcpServers),
+      };
 
-      const finalConfig = mergeAgentsMcpIntoConfig(mainConfig, agentsServers, mcpOverrides);
+      const finalConfig = mergeAgentsMcpIntoConfig(
+        mainConfigWithStorage,
+        agentsServers,
+        mcpOverrides,
+      );
 
       return new AgentConfigServiceImpl(finalConfig, mcpOverrides, loaded.configPath, fs);
     }),
@@ -337,6 +353,34 @@ function expandHome(p: string): string {
   return p;
 }
 
+function stripStorageOverride(config: Partial<AppConfig>): Partial<AppConfig> {
+  const { storage: _storage, ...rest } = config;
+  return rest;
+}
+
+function readOptionalConfigFile(
+  fs: FileSystem.FileSystem,
+  filePath: string,
+): Effect.Effect<Partial<AppConfig> | undefined, never> {
+  return Effect.gen(function* () {
+    const exists = yield* fs.exists(filePath).pipe(Effect.catchAll(() => Effect.succeed(false)));
+    if (!exists) return undefined;
+
+    const content = yield* fs
+      .readFileString(filePath)
+      .pipe(Effect.catchAll(() => Effect.succeed("")));
+    if (!content.trim()) return undefined;
+
+    const parsed = safeParseJson<Partial<AppConfig>>(content);
+    if (Option.isNone(parsed)) return undefined;
+
+    const config = parsed.value;
+    if (typeof config !== "object" || config === null) return undefined;
+
+    return config;
+  });
+}
+
 function loadConfigFile(
   fs: FileSystem.FileSystem,
   customConfigPath?: string,
@@ -344,6 +388,8 @@ function loadConfigFile(
   {
     configPath?: string;
     fileConfig?: Partial<AppConfig>;
+    globalConfig?: Partial<AppConfig>;
+    localConfig?: Partial<AppConfig>;
   },
   ConfigurationError | ConfigurationNotFoundError
 > {
@@ -399,7 +445,6 @@ function loadConfigFile(
         );
       }
 
-      // Validate that the parsed config matches AppConfig structure
       const config = parsed.value;
       if (typeof config !== "object" || config === null) {
         return yield* Effect.fail(
@@ -412,33 +457,45 @@ function loadConfigFile(
         );
       }
 
-      return { configPath: expandedPath, fileConfig: config };
+      return { configPath: expandedPath, fileConfig: config, globalConfig: config };
     }
 
-    // Otherwise, use the default search order
     const envConfigPath = process.env["JAZZ_CONFIG_PATH"];
-    const candidates: readonly string[] = [
-      envConfigPath ? expandHome(envConfigPath) : "",
-      `${process.cwd()}/.jazz/config.json`,
-      `${process.cwd()}/jazz.config.json`,
-      `${expandHome("~/.jazz")}/config.json`,
-    ].filter(Boolean);
+    const globalConfigPath = envConfigPath
+      ? expandHome(envConfigPath)
+      : `${getJazzHomeDirectory()}/config.json`;
+    const localConfigPath = `${getLocalJazzDirectory()}/config.json`;
 
-    for (const path of candidates) {
-      const exists = yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
-      if (!exists) continue;
-      const content = yield* fs
-        .readFileString(path)
-        .pipe(Effect.catchAll(() => Effect.succeed("")));
-      if (!content) return { configPath: path };
-      const parsed = safeParseJson<Partial<AppConfig>>(content);
-      if (Option.isSome(parsed)) {
-        return { configPath: path, fileConfig: parsed.value };
-      }
-      // If parse failed, ignore and continue to next
+    const globalConfig = yield* readOptionalConfigFile(fs, globalConfigPath);
+    const localConfigRaw = yield* readOptionalConfigFile(fs, localConfigPath);
+    const localConfig = localConfigRaw ? stripStorageOverride(localConfigRaw) : undefined;
+
+    if (!globalConfig && !localConfig) {
+      return { configPath: globalConfigPath };
     }
 
-    return {};
+    const emptyBase = defaultConfig();
+    const mergedFromGlobal = globalConfig ? mergeConfig(emptyBase, globalConfig) : emptyBase;
+    const merged = localConfig ? mergeConfig(mergedFromGlobal, localConfig) : mergedFromGlobal;
+
+    const result: {
+      configPath: string;
+      fileConfig: Partial<AppConfig>;
+      globalConfig?: Partial<AppConfig>;
+      localConfig?: Partial<AppConfig>;
+    } = {
+      configPath: globalConfigPath,
+      fileConfig: merged,
+    };
+
+    if (globalConfig) {
+      result.globalConfig = globalConfig;
+    }
+    if (localConfigRaw) {
+      result.localConfig = localConfigRaw;
+    }
+
+    return result;
   });
 }
 
@@ -510,7 +567,7 @@ function extractMcpOverridesFromFile(
 
 /**
  * Merge full MCP server definitions from .agents/mcp.json with
- * enable/disable overrides from jazz.config.json, returning an updated AppConfig.
+ * enable/disable overrides from ~/.jazz/config.json, returning an updated AppConfig.
  */
 function mergeAgentsMcpIntoConfig(
   config: AppConfig,

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -45,7 +45,7 @@ import { createOllama, type OllamaCompletionProviderOptions } from "ollama-ai-pr
 import shortUUID from "short-uuid";
 import { minimax } from "vercel-minimax-ai-provider";
 import { z } from "zod";
-import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
+import { DEFAULT_MAX_ITERATIONS, AI_SDK_MAX_RETRIES } from "@/core/constants/agent";
 import { DEFAULT_CONTEXT_WINDOW, type ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -76,6 +76,45 @@ import { createModelFetcher, type ModelFetcherService } from "./model-fetcher";
 import { PROVIDER_MODELS, resolveLocalProviderBaseUrl } from "./models";
 import { selectParser } from "./reasoning";
 import { StreamProcessor } from "./stream-processor";
+
+/** DelayedPromise fields on streamText results reject when the stream fails. */
+const STREAM_TEXT_PROMISE_FIELDS = [
+  "content",
+  "text",
+  "reasoning",
+  "reasoningText",
+  "files",
+  "sources",
+  "toolCalls",
+  "staticToolCalls",
+  "dynamicToolCalls",
+  "staticToolResults",
+  "dynamicToolResults",
+  "toolResults",
+  "finishReason",
+  "rawFinishReason",
+  "usage",
+  "totalUsage",
+  "warnings",
+  "steps",
+  "request",
+  "response",
+  "providerMetadata",
+  "experimental_output",
+  "output",
+] as const;
+
+function suppressStreamTextUnhandledRejections(
+  result: Awaited<ReturnType<typeof streamText>>,
+): void {
+  const record = result as unknown as Record<string, unknown>;
+  for (const field of STREAM_TEXT_PROMISE_FIELDS) {
+    const value = record[field];
+    if (value != null && typeof (value as { then?: unknown }).then === "function") {
+      void Promise.resolve(value).catch(() => {});
+    }
+  }
+}
 
 interface AISDKConfig {
   llmConfig?: LLMConfig;
@@ -1170,6 +1209,7 @@ class AISDKService implements LLMService {
           model,
           messages: coreMessages,
           allowSystemInMessages: true,
+          maxRetries: AI_SDK_MAX_RETRIES,
           ...(typeof options.temperature === "number" ? { temperature: options.temperature } : {}),
           ...(tools ? { tools } : {}),
           ...(requestedToolChoice ? { toolChoice: requestedToolChoice } : {}),
@@ -1409,6 +1449,7 @@ class AISDKService implements LLMService {
                   model,
                   messages: coreMessages,
                   allowSystemInMessages: true,
+                  maxRetries: AI_SDK_MAX_RETRIES,
                   ...(typeof options.temperature === "number"
                     ? { temperature: options.temperature }
                     : {}),
@@ -1458,15 +1499,11 @@ class AISDKService implements LLMService {
                 // Close the stream
                 processor.close();
               } catch (error) {
-                // Suppress unhandled rejections on the AI SDK's internal
-                // DelayedPromise properties (usage, finishReason, steps).
-                // When the stream fails these all reject, but we only await
-                // them in the success path, so they'd otherwise surface as
-                // Bun unhandled-rejection dumps.
+                // Suppress unhandled rejections on streamText DelayedPromise fields.
+                // When the stream fails these all reject; we only consume fullStream,
+                // so they'd otherwise surface as Bun/Node unhandled-rejection dumps.
                 if (streamTextResult) {
-                  void Promise.resolve(streamTextResult.usage).catch(() => {});
-                  void Promise.resolve(streamTextResult.finishReason).catch(() => {});
-                  void Promise.resolve(streamTextResult.steps).catch(() => {});
+                  suppressStreamTextUnhandledRejections(streamTextResult);
                 }
 
                 const llmError = convertToLLMError(error, providerName);

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,11 +1,10 @@
 import { appendFile, mkdir } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { encode as encodeToon } from "@toon-format/toon";
 import { Effect, Layer, Option, Ref } from "effect";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { jsonBigIntReplacer } from "@/core/utils/logging-helpers";
-import { isRunningFromGlobalInstall } from "@/core/utils/runtime-detection";
+import { getJazzHomeDirectory } from "@/core/utils/runtime-detection";
 
 let globalLogFormat: "json" | "plain" | "toon" = "plain";
 let globalLogLevel: "debug" | "info" | "warn" | "error" = "info";
@@ -410,25 +409,13 @@ function writeToolCallToSessionFile(
 /**
  * Resolve the logs directory path
  * 1. Check JAZZ_LOG_DIR environment variable
- * 2. Check if installed globally (~/.jazz/logs)
- * 3. Default to cwd/logs
+ * 2. Default to ~/.jazz/logs (or JAZZ_HOME/logs)
  */
 function resolveLogsDirectory(): string {
-  // 1. Allow manual override via environment variable
   const override = process.env["JAZZ_LOG_DIR"];
   if (override && override.trim().length > 0) {
     return path.resolve(override);
   }
 
-  // 2. Check if we're in a globally installed package
-  if (isRunningFromGlobalInstall()) {
-    // Global install: use ~/.jazz/logs
-    const homeDir = os.homedir();
-    if (homeDir && homeDir.trim().length > 0) {
-      return path.join(homeDir, ".jazz", "logs");
-    }
-  }
-
-  // 3. Local development or local install: use cwd/logs
-  return path.resolve(process.cwd(), "logs");
+  return path.join(getJazzHomeDirectory(), "logs");
 }


### PR DESCRIPTION
## What this PR delivers

Jazz now treats `~/.jazz` as the single home for agents, storage, logs, and config writes — regardless of whether you run from a cloned repo, a global install, or a random project directory.

Configuration loads in two layers:
1. **`~/.jazz/config.json`** — global defaults (API keys, agents, storage)
2. **`./.jazz/config.json`** — optional project-local overrides merged on top

Project-root `./jazz.config.json` is **no longer auto-discovered**. Finding a config file in a repo no longer makes Jazz treat that repo as the data root.

## Why this matters

**For operators:** Agents, history, and logs stay in one predictable place (`~/.jazz`). Running Jazz inside someone else's repo (or a repo that happens to contain a stray `jazz.config.json`) won't silently redirect agent storage to that project.

**For maintainers:** Config loading, runtime path resolution, and logging all converge on `getJazzHomeDirectory()` instead of branching on "global vs dev" install detection.

## How Jazz behaviour changes

| Scenario | Before | After |
|---|---|---|
| Dev mode in jazz repo | User data could resolve to `{cwd}/.jazz` | Always `~/.jazz` (or `JAZZ_HOME`) |
| Project has `./jazz.config.json` | Used as primary config | Ignored — move to `~/.jazz/config.json` |
| Project has `./.jazz/config.json` | Could win over global (first-found) | Merged on top of global; local `storage.path` ignored |
| Config writes (`jazz config set`) | Could target discovered project config | Always persist to `~/.jazz/config.json` |
| Logs | `{cwd}/logs` in dev, `~/.jazz/logs` when global | Always `~/.jazz/logs` (or `JAZZ_LOG_DIR`) |
| LLM retries | AI SDK + Jazz both retried | AI SDK retries disabled (`maxRetries: 0`); Jazz owns retry UX |

## UX changes operators will notice

- Agents and config survive across projects — everything lives under `~/.jazz`
- Stray `jazz.config.json` in a repo no longer hijacks Jazz's home directory
- LLM error messages unwrap nested `RetryError` instead of showing "Failed after N attempts" wrappers

## Migration — config changes required

| Old | New |
|---|---|
| `./jazz.config.json` in project root | Move settings to `~/.jazz/config.json` |
| `./.jazz/config.json` with `storage.path` | Remove — storage is always `~/.jazz` |
| Dev workflow using `{cwd}/.jazz` for agents | Use `JAZZ_HOME=/tmp/jazz-dev` to isolate test data |

## Tests

- 49 tests passing across `config.test.ts`, `runtime-detection.test.ts`, `llm-error.test.ts`
- New: global + local config merge; local `storage.path` override ignored
- `bun run typecheck` passes

### Edge cases to verify manually

1. **Repo with legacy `./jazz.config.json`** — Jazz should ignore it; settings must come from `~/.jazz/config.json`
2. **Project override** — put `{ "logging": { "level": "debug" } }` in `./.jazz/config.json` → should override global logging only
3. **Cross-project agents** — create an agent in project A, run Jazz in project B → same agent list from `~/.jazz`
4. **JAZZ_HOME isolation** — `JAZZ_HOME=/tmp/jazz-test jazz agent list` → uses isolated directory

## Notes for reviewers

- `./.jazz/config.json` is intentionally read-only for storage — `stripStorageOverride()` prevents a project from redirecting agent data
- LLM retry changes are bundled because AI SDK's internal retries produced confusing double-retry error messages once deps were updated
- Docs updated in `docs/reference/configuration.md` and MCP integration docs