### PR TITLE
fix(ci): switch ci-reviewer to qwen/qwen3-coder:free

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,12 +2,12 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "openrouter/owl-alpha",
+  "model": "qwen/qwen3-coder:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "openrouter/owl-alpha",
-    "reasoningEffort": "high",
+    "llmModel": "qwen/qwen3-coder:free",
+    "reasoningEffort": "disable",
     "tools": [
       "context_info",
       "find",


### PR DESCRIPTION
## What this PR does

Switches the CI code review agent from `openrouter/owl-alpha` to `qwen/qwen3-coder:free` so automated PR reviews can run again.

## Why

`openrouter/owl-alpha` has a catalog page on OpenRouter but no live provider endpoints in the API, so `ci-reviewer` fails immediately with:

```
LLMRequestError: No endpoints found for openrouter/owl-alpha
```

`qwen/qwen3-coder:free` is available on OpenRouter, supports native tool calling (required for grep, git_diff, read_file, etc.), and is free — a good fit for CI code review.

`reasoningEffort` is set to `"disable"` because this model does not support reasoning parameters; leaving it at `"high"` would cause OpenRouter to filter for reasoning-capable endpoints and could trigger another 404.

## How to test

- [ ] Open a PR against this repo and confirm the **AI Code Review** check completes without `LLMRequestError`
- [ ] Verify the review header shows model `qwen/qwen3-coder:free`
- [ ] Confirm inline review comments are posted (tool calling works end-to-end)
- [ ] Edge case: re-run the review job on a PR with a large diff — agent should still complete without endpoint errors