### PR TITLE
fix(config): merge maxRetries and telemetry from loaded config file

### DIFF
--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -211,4 +211,32 @@ describe("createConfigLayer", () => {
     const level = await Effect.runPromise(program);
     expect(level).toBe("debug");
   });
+
+  it("preserves maxRetries and telemetry from a custom config file", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-retries-config.json");
+
+    const fileContents = new Map<string, string>([
+      [
+        customConfigPath,
+        JSON.stringify({
+          maxRetries: 8,
+          telemetry: { enabled: false },
+        }),
+      ],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      const maxRetries = yield* config.get<number>("maxRetries");
+      const telemetryEnabled = yield* config.get<boolean>("telemetry.enabled");
+      return { maxRetries, telemetryEnabled };
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.maxRetries).toBe(8);
+    expect(result.telemetryEnabled).toBe(false);
+  });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -334,7 +334,7 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
       autoApprovedCommands: override.autoApprovedCommands,
     }),
     ...(override.maxRetries !== undefined && { maxRetries: override.maxRetries }),
-    ...(override.telemetry && { telemetry: { ...base.telemetry, ...override.telemetry } }),
+    ...(override.telemetry && { telemetry: { ...(base.telemetry ?? {}), ...override.telemetry } }),
   };
 }
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -333,6 +333,8 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.autoApprovedCommands && {
       autoApprovedCommands: override.autoApprovedCommands,
     }),
+    ...(override.maxRetries !== undefined && { maxRetries: override.maxRetries }),
+    ...(override.telemetry && { telemetry: { ...base.telemetry, ...override.telemetry } }),
   };
 }
 


### PR DESCRIPTION
## What this PR does
Fixes `mergeConfig()` in `src/services/config.ts` to include `maxRetries` and `telemetry` when merging a loaded config file into the in-memory `AppConfig`.

## Why
`mergeConfig()` reconstructs the merged config field-by-field, but only copies over `storage`, `logging`, `output`, `google`, `llm`, `web_search`, `mcpServers`, `notifications`, and `autoApprovedCommands` from the override. `maxRetries` and `telemetry` are declared on `AppConfig` but were never copied from the loaded file, so a user-configured `"maxRetries": 8` in `jazz.config.json` (or `~/.jazz/config.json`) was silently ignored — the runtime always fell back to the default. Found this while debugging why a downstream project's `jazz.config.json` settings weren't taking effect in CI.

## How to test
- `bun test src/services/config.test.ts` — added a regression test (`preserves maxRetries and telemetry from a custom config file`) that loads a config file containing only `maxRetries`/`telemetry` and asserts both values are readable afterward; it fails on `main` and passes with this change.
- Edge case: existing tests still confirm defaults are used when the file omits these fields (untouched behavior).
