### PR TITLE
feat(agent): support per-agent temperature, gated by model support

### DIFF
--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -76,6 +76,9 @@ export function executeWithoutStreaming(
             tools: runContext.tools,
             toolChoice: "auto" as const,
             reasoning_effort: reasoningEffort,
+            ...(typeof agent.config.temperature === "number"
+              ? { temperature: agent.config.temperature }
+              : {}),
             ...(agent.config.llmApiKeys ? { providerApiKeys: agent.config.llmApiKeys } : {}),
           };
 

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -106,6 +106,9 @@ export function executeWithStreaming(
             tools: runContext.tools,
             toolChoice: "auto" as const,
             reasoning_effort: reasoningEffort,
+            ...(typeof agent.config.temperature === "number"
+              ? { temperature: agent.config.temperature }
+              : {}),
             ...(agent.config.llmApiKeys ? { providerApiKeys: agent.config.llmApiKeys } : {}),
           };
 

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -55,6 +55,7 @@ export interface AgentConfig {
   /** Optional per-agent API key overrides by provider. Falls back to global config, then env vars. */
   readonly llmApiKeys?: Partial<Record<ProviderName, string>>;
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
+  readonly temperature?: number;
   readonly tools?: readonly string[];
   readonly webSearchProvider?: WebSearchProviderName;
 }

--- a/src/core/types/llm.ts
+++ b/src/core/types/llm.ts
@@ -26,6 +26,8 @@ export interface ModelInfo {
   readonly supportsVision?: boolean;
   /** Whether the model accepts PDF input natively. */
   readonly supportsPdf?: boolean;
+  /** Whether the model accepts a custom temperature. Defaults to true when unknown. */
+  readonly supportsTemperature?: boolean;
   /** Context window size in tokens. If not specified, defaults to 128000. */
   readonly contextWindow?: number;
   /** Raw chat template string (Jinja for llama.cpp, Go-template for ollama). Used for reasoning-parser selection. */

--- a/src/core/utils/models-dev-client.ts
+++ b/src/core/utils/models-dev-client.ts
@@ -26,6 +26,8 @@ export interface ModelsDevMetadata {
   readonly supportsVision: boolean;
   /** Whether the model accepts PDF input natively. Derived from modalities.input containing "pdf". */
   readonly supportsPdf: boolean;
+  /** Whether the model accepts a custom temperature (from models.dev `temperature`). Defaults to true when absent. */
+  readonly supportsTemperature: boolean;
   /** Input price in USD per 1M tokens (from models.dev cost.input). */
   readonly inputPricePerMillion?: number;
   /** Output price in USD per 1M tokens (from models.dev cost.output). */
@@ -39,6 +41,7 @@ type ModelsDevProvider = {
       limit?: { context?: number; output?: number };
       tool_call?: boolean;
       reasoning?: boolean;
+      temperature?: boolean;
       modalities?: { input?: string[]; output?: string[] };
       cost?: { input?: number; output?: number };
     }
@@ -112,6 +115,7 @@ function buildMap(api: ModelsDevApi): Map<string, ModelsDevMetadata> {
         isReasoningModel: Boolean(spec.reasoning),
         supportsVision: inputModalities.includes("image"),
         supportsPdf: inputModalities.includes("pdf"),
+        supportsTemperature: spec.temperature !== false,
         ...(inputPrice !== undefined && { inputPricePerMillion: inputPrice }),
         ...(outputPrice !== undefined && { outputPricePerMillion: outputPrice }),
       };

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -952,6 +952,7 @@ class AISDKService implements LLMService {
               isReasoningModel: dev?.isReasoningModel ?? false,
               supportsVision: dev?.supportsVision ?? false,
               supportsPdf: dev?.supportsPdf ?? false,
+              supportsTemperature: dev?.supportsTemperature ?? true,
             };
           });
           this.modelInfoCache.set(providerName, resolved);
@@ -1210,7 +1211,9 @@ class AISDKService implements LLMService {
           messages: coreMessages,
           allowSystemInMessages: true,
           maxRetries: AI_SDK_MAX_RETRIES,
-          ...(typeof options.temperature === "number" ? { temperature: options.temperature } : {}),
+          ...(typeof options.temperature === "number" && modelInfo?.supportsTemperature !== false
+            ? { temperature: options.temperature }
+            : {}),
           ...(tools ? { tools } : {}),
           ...(requestedToolChoice ? { toolChoice: requestedToolChoice } : {}),
           ...(providerOptions ? { providerOptions } : {}),
@@ -1450,7 +1453,8 @@ class AISDKService implements LLMService {
                   messages: coreMessages,
                   allowSystemInMessages: true,
                   maxRetries: AI_SDK_MAX_RETRIES,
-                  ...(typeof options.temperature === "number"
+                  ...(typeof options.temperature === "number" &&
+                  modelInfo?.supportsTemperature !== false
                     ? { temperature: options.temperature }
                     : {}),
                   ...(tools ? { tools } : {}),

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -62,6 +62,50 @@ describe("ModelFetcher", () => {
     expect(result[0]!.supportsTools).toBe(true);
   });
 
+  it("sets supportsTemperature=true for an OpenRouter model whose supported_parameters include temperature", async () => {
+    const mockResponse = {
+      data: [
+        {
+          id: "m2",
+          name: "Model 2",
+          context_length: 8192,
+          supported_parameters: ["tools", "temperature"],
+        },
+      ],
+    };
+
+    global.fetch = mock(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) }),
+    ) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("openrouter", "https://or.api", "/models", "key");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.supportsTemperature).toBe(true);
+  });
+
+  it("sets supportsTemperature=false for an OpenRouter model whose supported_parameters omit temperature (e.g. o-series reasoners)", async () => {
+    const mockResponse = {
+      data: [
+        {
+          id: "o3",
+          name: "o3",
+          context_length: 200000,
+          supported_parameters: ["tools", "reasoning"],
+        },
+      ],
+    };
+
+    global.fetch = mock(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) }),
+    ) as unknown as typeof fetch;
+
+    const program = fetcher.fetchModels("openrouter", "https://or.api", "/models", "key");
+    const result = await Effect.runPromise(program);
+
+    expect(result[0]!.supportsTemperature).toBe(false);
+  });
+
   it("should handle Ollama with special transformation", async () => {
     const mockTagsResponse = {
       models: [{ name: "llama3:latest", details: { metadata: { supports_tools: true } } }],
@@ -84,6 +128,7 @@ describe("ModelFetcher", () => {
     expect(result.length).toBe(1);
     expect(result[0]!.id).toBe("llama3:latest");
     expect(result[0]!.contextWindow).toBe(4096);
+    expect(result[0]!.supportsTemperature).toBe(true);
   });
 
   it("should fail gracefully on 404", async () => {

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -51,6 +51,7 @@ function resolveToModelInfo(
       isReasoningModel: dev.isReasoningModel,
       supportsVision: dev.supportsVision,
       supportsPdf: dev.supportsPdf,
+      supportsTemperature: dev.supportsTemperature,
     };
   }
   const fb = entry.fallback;
@@ -62,6 +63,7 @@ function resolveToModelInfo(
     isReasoningModel: fb?.isReasoningModel ?? false,
     supportsVision: fb?.supportsVision ?? false,
     supportsPdf: fb?.supportsPdf ?? false,
+    supportsTemperature: fb?.supportsTemperature ?? true,
   };
 }
 
@@ -248,6 +250,7 @@ const LIST_EXTRACTORS: Partial<Record<ProviderName, (data: unknown) => RawModelE
           contextWindow: model.context_length ?? DEFAULT_CONTEXT_WINDOW,
           supportsTools,
           isReasoningModel,
+          supportsTemperature: supportedParameters.includes("temperature"),
         },
       };
     });


### PR DESCRIPTION
## What this PR does
Adds `temperature` to `AgentConfig`, threads it into the LLM call for both the streaming and non-streaming execution paths, and gates it on a new `supportsTemperature` model capability sourced from models.dev.

## Why
There was no way to configure a per-agent sampling temperature. `ChatCompletionOptions.temperature` already existed and was already forwarded to `generateText`/`streamText` in `ai-sdk-service.ts`, but nothing in the agent execution path (`streaming-executor.ts`, `batch-executor.ts`) ever read a temperature value from the agent and passed it through — `AgentConfig` didn't even have the field.

Some models reject a custom temperature outright — e.g. OpenAI's `o1`/`o3` return a 400 error ("Unsupported value: 'temperature' does not support values other than 1 with this model"). models.dev's `api.json` already tracks this per-model as a `temperature: boolean` field (confirmed: `openai/o3` → `temperature: false`, `anthropic/claude-sonnet-4-5` → `temperature: true`, `deepseek/deepseek-reasoner` → `temperature: true` — notably this does **not** correlate with whether a model is a "reasoning" model, so gating on `isReasoningModel` would have been wrong). This PR adds `supportsTemperature` to `ModelsDevMetadata`/`ModelInfo`, sourced from that field (defaulting to `true` when models.dev has no entry), and for OpenRouter also derives it from the model's own `supported_parameters` list as a fallback when models.dev doesn't have the model. The LLM call site now only forwards `temperature` when `modelInfo?.supportsTemperature !== false`, so an agent-configured temperature is silently dropped only for models that are known to reject it.

## How to test
- `bun test src/services/llm/model-fetcher.test.ts` — new tests cover the OpenRouter `supported_parameters`-derived fallback (both with and without `"temperature"` present) and the local-provider default-true case.
- `bun test src/services/llm/ai-sdk-service.test.ts src/core/agent/execution` — unaffected existing tests still pass.
- `bun run typecheck && bun run lint` — clean.
- Edge case: set `temperature` on an agent whose model resolves to `supportsTemperature: false` (e.g. `openai/o3`) and confirm the outgoing request omits `temperature` entirely rather than erroring.
