### PR TITLE
feat(llm): surface rate-limit/server-error/network reason in retry notices

### DIFF
--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -1,6 +1,10 @@
 import { Duration, Effect, Fiber, Ref, Schedule } from "effect";
 import { LLM_SLOW_MODEL_HINT_SECONDS } from "@/core/constants/agent";
-import { isRetryableLLMError, makeLLMRetrySchedule } from "@/core/utils/llm-error";
+import {
+  describeRetryableLLMError,
+  isRetryableLLMError,
+  makeLLMRetrySchedule,
+} from "@/core/utils/llm-error";
 
 export type PresentStatusFn = (
   message: string,
@@ -39,8 +43,9 @@ export function makeUserVisibleLlmRetrySchedule(
       isRetryableLLMError(error)
         ? Effect.gen(function* () {
             const attempt = yield* Ref.updateAndGet(attemptRef, (count) => count + 1);
+            const reason = describeRetryableLLMError(error);
             yield* presentStatus(
-              `${agentName} hit a temporary network or model issue. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
+              `${agentName} hit a ${reason}. Trying again (attempt ${attempt} of up to ${maxRetries})…`,
               "progress",
             );
           })

--- a/src/core/utils/llm-error.test.ts
+++ b/src/core/utils/llm-error.test.ts
@@ -1,6 +1,7 @@
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "bun:test";
-import { extractCleanErrorMessage } from "./llm-error";
+import { LLMRateLimitError, LLMRequestError } from "@/core/types/errors";
+import { describeRetryableLLMError, extractCleanErrorMessage } from "./llm-error";
 
 describe("extractCleanErrorMessage", () => {
   it("unwraps AI SDK RetryError to the last nested error message", () => {
@@ -18,5 +19,33 @@ describe("extractCleanErrorMessage", () => {
     expect(extractCleanErrorMessage(retryError)).toBe(
       "Cannot connect to API: Connect Timeout Error",
     );
+  });
+});
+
+describe("describeRetryableLLMError", () => {
+  it("describes a rate limit error", () => {
+    const error = new LLMRateLimitError({ provider: "openrouter", message: "Too many requests" });
+    expect(describeRetryableLLMError(error)).toBe("rate limit");
+  });
+
+  it("describes a server error with its status code", () => {
+    const error = new LLMRequestError({
+      provider: "openrouter",
+      message: "Service unavailable",
+      statusCode: 503,
+    });
+    expect(describeRetryableLLMError(error)).toBe("server error (503)");
+  });
+
+  it("describes a connection failure with no status code as a network issue", () => {
+    const error = new LLMRequestError({
+      provider: "openrouter",
+      message: "fetch failed",
+    });
+    expect(describeRetryableLLMError(error)).toBe("network issue");
+  });
+
+  it("falls back to a generic description for unrecognized errors", () => {
+    expect(describeRetryableLLMError(new Error("boom"))).toBe("unknown issue");
   });
 });

--- a/src/core/utils/llm-error.ts
+++ b/src/core/utils/llm-error.ts
@@ -268,6 +268,19 @@ export function isRetryableLLMError(error: unknown): boolean {
 }
 
 /**
+ * Short, user-facing description of why a retryable LLM error occurred
+ * (rate limit / server error / network issue), for surfacing in retry notices.
+ */
+export function describeRetryableLLMError(error: unknown): string {
+  if (error instanceof LLMRateLimitError) return "rate limit";
+  if (error instanceof LLMRequestError) {
+    if (error.statusCode === undefined) return "network issue";
+    return `server error (${error.statusCode})`;
+  }
+  return "unknown issue";
+}
+
+/**
  * Exponential backoff schedule for LLM retries, delay capped at MAX_RETRY_DELAY_SECONDS.
  * Only retries on transient errors (rate limits, connection failures, 5xx).
  */


### PR DESCRIPTION
## What this PR does
Surfaces the actual reason for an LLM retry (rate limit / server error with status code / network issue) in the user-facing retry notice, instead of a generic "temporary network or model issue" message for all three cases.

## Why
While debugging a run that kept retrying, there was no way to tell from the output whether it was hitting a rate limit (429), a server error (5xx), or a plain connection failure — `makeUserVisibleLlmRetrySchedule` in `llm-retry-present.ts` printed the same generic message regardless of cause, even though `LLMRateLimitError`/`LLMRequestError` already carry a `statusCode` that distinguishes them. This info isn't available anywhere else either — debug-level logs (`logger.debug`) don't appear in `--output raw` mode, so there was genuinely no way to diagnose the cause from CI output.

Added `describeRetryableLLMError()` in `llm-error.ts`, which maps the error to a short description ("rate limit", "server error (503)", "network issue", or a generic fallback), and used it in the retry notice.

## How to test
- `bun test src/core/utils/llm-error.test.ts` — new tests cover all three retryable error shapes plus the generic fallback.
- Before: `default hit a temporary network or model issue. Trying again (attempt 1 of up to 8)…`
- After: `default hit a rate limit. Trying again (attempt 1 of up to 8)…` (or `a server error (503)` / `a network issue`, depending on cause).
