### PR TITLE
chore(ci): switch jazz agents to poolside/laguna-xs-2.1:free

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "qwen/qwen3-coder:free",
+  "model": "poolside/laguna-xs-2.1:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "qwen/qwen3-coder:free",
+    "llmModel": "poolside/laguna-xs-2.1:free",
     "reasoningEffort": "disable",
     "tools": [
       "context_info",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -2,11 +2,11 @@
   "id": "pr-assistant",
   "name": "pr-assistant",
   "description": "Pull request assistant agent for /jazz PR comments",
-  "model": "openrouter/owl-alpha",
+  "model": "poolside/laguna-xs-2.1:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "openrouter/owl-alpha",
+    "llmModel": "poolside/laguna-xs-2.1:free",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",


### PR DESCRIPTION
## What this PR does
Switches the CI review and PR-assistant Jazz agents to use `poolside/laguna-xs-2.1:free` via OpenRouter instead of `qwen/qwen3-coder:free` and `openrouter/owl-alpha`.

## Why
Standardizes both GitHub Actions Jazz agents on the same free-tier model.

## How to test
- Trigger the `code-review` job (open a PR or comment `/jazz-review`) and confirm the posted review comment shows `*Model: poolside/laguna-xs-2.1:free*`.
- Trigger the `assistant` job (comment `/jazz <request>`) and confirm it runs successfully and responds.
- Edge case: verify the agent still produces the expected fenced markdown/JSON output blocks with the new model (weaker/different models can deviate from the output contract, which the existing fallback parsing in `jazz.yml` should still handle).
