### PR TITLE
fix(streaming): cap pending buffer when no newline is found

### DIFF
--- a/src/cli/presentation/markdown-split.test.ts
+++ b/src/cli/presentation/markdown-split.test.ts
@@ -46,6 +46,17 @@ const cases: Case[] = [
     expected: MAX_PENDING_TAIL,
   },
   {
+    name: "no newline within cap falls back to nearest word boundary before the cap",
+    // A space sits 100 chars before the cap; no newline anywhere in the text.
+    input: "a".repeat(MAX_PENDING_TAIL - 100) + " " + "b".repeat(5000),
+    expected: MAX_PENDING_TAIL - 100 + 1,
+  },
+  {
+    name: "no newline and no whitespace within search window cuts at the hard cap",
+    input: "a".repeat(MAX_PENDING_TAIL + 5000),
+    expected: MAX_PENDING_TAIL,
+  },
+  {
     name: "inline code spanning split rejects offset inside backticks",
     input: "para 1.\n\n`open code without close " + "x".repeat(SOFT_TAIL),
     expected: (s) => s.indexOf("\n\n") + 2,

--- a/src/cli/presentation/markdown-split.ts
+++ b/src/cli/presentation/markdown-split.ts
@@ -263,11 +263,28 @@ function findLastSentenceEnd(text: string, upperBound: number): number | null {
   return lastEnd;
 }
 
+/** How far back from the cap to search for a whitespace boundary before giving up. */
+const HARD_CAP_WHITESPACE_SEARCH_WINDOW = 500;
+
 function tryHardCapFallback(text: string): number {
   if (text.length <= MAX_PENDING_TAIL) return 0;
-  // Find the last \n at or before MAX_PENDING_TAIL.
-  const idx = text.lastIndexOf("\n", MAX_PENDING_TAIL);
-  return idx === -1 ? 0 : idx + 1;
+
+  // Prefer a newline at or before the cap.
+  const newlineIndex = text.lastIndexOf("\n", MAX_PENDING_TAIL);
+  if (newlineIndex !== -1) return newlineIndex + 1;
+
+  // No newline within the cap. Walk back from the cap looking for a
+  // whitespace boundary so we don't split mid-word.
+  const searchFloor = Math.max(0, MAX_PENDING_TAIL - HARD_CAP_WHITESPACE_SEARCH_WINDOW);
+  for (let index = MAX_PENDING_TAIL; index > searchFloor; index--) {
+    const character = text[index];
+    if (character === " " || character === "\t") return index + 1;
+  }
+
+  // Pathological: no newline and no whitespace within the search window
+  // (e.g. a long URL or base64 blob). Cut at the cap anyway so the pending
+  // buffer stays bounded — a cosmetic mid-token break beats unbounded growth.
+  return MAX_PENDING_TAIL;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `tryHardCapFallback` returned `0` (no split) when the pending streaming buffer exceeded `MAX_PENDING_TAIL` but contained no newline within the cap — e.g. a long URL, base64 blob, or single-line JSON — so the buffer grew unbounded instead of being capped.
- Adds a word-boundary fallback (walks back up to 500 chars looking for whitespace), and falls back to a hard cut at the cap only in the pathological case of no newline *and* no whitespace nearby.

Fixes #214

## Test plan
- [x] Added unit tests in `markdown-split.test.ts` covering: word-boundary fallback, and hard-cut-at-cap when neither newline nor whitespace is found
- [x] `bun test` — 1295 pass, 0 fail
- [x] `bun run typecheck` / `bun run lint` clean