### PR TITLE
feat(agents): custom tools in agent config (record + command handlers) and envAllowlist

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
         "@types/ink-big-text": "^1.2.4",
         "@types/ink-gradient": "^2.0.4",
@@ -150,6 +151,8 @@
     "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
 
     "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -91,7 +91,12 @@ pattern behind confirmation-card / propose-then-confirm flows:
 tool arguments serialized as JSON on the child's stdin. Exit code `0` returns stdout (capped at
 16 KB) as the tool result; a non-zero exit, spawn error, or timeout produces a failure result the
 model sees the same way it sees a failing builtin tool. The command's environment is sanitized
-the same way `execute_command` sanitizes its shell environment (see `envAllowlist` below).
+the same way `execute_command` sanitizes its shell environment (see `envAllowlist` below), using
+the `envAllowlist` of the agent that DECLARED the tool, not whichever agent happens to be calling
+it. **Security note:** command tools execute with no interactive approval step — they are always
+registered `high-risk` and run whatever the deployment configured the moment the model calls
+them, so treat `handler.command` entries as deployment-authored, trusted commands, not
+user-supplied ones.
 
 ```json
 {
@@ -117,18 +122,26 @@ the same way `execute_command` sanitizes its shell environment (see `envAllowlis
   start with the `mcp_` prefix (reserved for MCP-sourced tools).
 - At most 16 entries per agent.
 - `description`: 1-1024 characters — this is what the model reads to decide when to call the tool.
-- `parameters`: a JSON Schema object; must have `"type": "object"`.
+- `parameters`: a JSON Schema object; must have `"type": "object"`. Only a subset of JSON Schema
+  is honored by the converter that turns this into the runtime validator: unsupported keywords
+  are silently dropped, and a property with a missing or unrecognized `type` degrades to an
+  empty object schema — which then rejects a scalar argument (string/number/boolean) passed for
+  that property. Stick to `string`, `number`, `integer`, `boolean`, `null`, `enum`, and plain
+  nested objects/arrays of those.
 - `handler.response` (record): optional string, at most 1024 characters, defaults to `"Recorded."`.
 - `handler.command` (command): a non-empty array of non-empty strings.
 
 ### Collisions and re-registration
 
-A custom tool name that collides with an already-registered builtin or MCP tool name fails
-agent startup with a configuration error rather than silently overriding the existing tool —
-rename the custom tool or remove the conflicting one. Because tool registration runs on every
-agent run (not just once per process), re-registering the *exact same* custom tool definition
-under a name that's already registered is a no-op, not a collision; only a genuinely different
-definition sharing that name is rejected.
+A custom tool name that collides with an already-registered builtin or MCP tool name — or one of
+its aliases (e.g. `glob`) — fails the run with a configuration error rather than silently
+overriding the existing tool; rename the custom tool or remove the conflicting one. Because tool
+registration runs on every agent run (not just once per process), re-registering the *exact
+same* custom tool definition under a name that's already registered is a no-op, not a collision;
+only a genuinely different definition sharing that name is rejected — and since the registry has
+no way to update an existing registration in place, that rejection fails the run MID-SESSION
+(not at process startup): restart the session, or revert the custom tool definition to match
+what was registered earlier.
 
 ## Agent Config: `envAllowlist`
 
@@ -139,7 +152,9 @@ path; it does not affect `grep`/`find`/`git` tool spawns). By default, any varia
 matches `API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH` (case-insensitive) is stripped before a
 child process is spawned. Listing a name in `envAllowlist` copies that variable from the
 process environment into the child's environment even though it matches the scrub regex — it
-never invents a value that isn't already set.
+never invents a value that isn't already set. `SSH_*`-prefixed names and the small set of base
+env vars Jazz always sets itself (`PATH`, `HOME`, `USER`, `SHELL`, etc.) can never be
+allowlisted — that block applies unconditionally, regardless of `envAllowlist` membership.
 
 ```json
 {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,3 +51,104 @@ You can override settings or provide API keys via `.env` or system environment v
 - `JAZZ_HOME`: Override the Jazz home directory (default: `~/.jazz`). Use when developing Jazz to isolate test data.
 - `JAZZ_CONFIG_PATH`: Override the global config file path.
 - `DEBUG`: Set to `true` for verbose logging.
+
+## Agent Config: `customTools`
+
+`customTools` is an optional field on an agent's `config`, letting a deployment declare new
+tools directly in the agent's JSON config instead of shipping code — the closest analog is the
+Claude Agent SDK's custom tools (name, description, input schema, handler, registered alongside
+builtins). Declaring a custom tool is not enough to expose it: its `name` must also appear in
+the agent's `tools` array, exactly like a builtin or MCP tool. A declared-but-unlisted custom
+tool is simply skipped at registration.
+
+Each entry has a `handler.type` of either `record` or `command`.
+
+**`record`** — no side effect. The call is validated and appended to the run's `toolCalls` (the
+same field every other tool call surfaces in), so the *caller* embedding Jazz can read the
+arguments and act on them; the model itself only ever sees the fixed `response`. This is the
+pattern behind confirmation-card / propose-then-confirm flows:
+
+```json
+{
+  "name": "propose_action",
+  "description": "Propose an action for the user to confirm before it is carried out.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "action": { "type": "string", "description": "Short description of the proposed action" },
+      "payload": { "type": "object", "description": "Structured data needed to carry out the action" }
+    },
+    "required": ["action"]
+  },
+  "handler": {
+    "type": "record",
+    "response": "Proposal recorded — the user will see a confirmation card."
+  }
+}
+```
+
+**`command`** — spawns `handler.command` directly (an argv array, no shell) with the validated
+tool arguments serialized as JSON on the child's stdin. Exit code `0` returns stdout (capped at
+16 KB) as the tool result; a non-zero exit, spawn error, or timeout produces a failure result the
+model sees the same way it sees a failing builtin tool. The command's environment is sanitized
+the same way `execute_command` sanitizes its shell environment (see `envAllowlist` below).
+
+```json
+{
+  "name": "lint_project",
+  "description": "Run the project linter",
+  "parameters": {
+    "type": "object",
+    "properties": {}
+  },
+  "handler": {
+    "type": "command",
+    "command": ["./lint.sh"],
+    "timeoutMs": 30000
+  }
+}
+```
+
+`timeoutMs` defaults to 30 000 ms and is capped at 300 000 ms (5 minutes) when set.
+
+### Validation rules
+
+- `name`: must match `^[a-z][a-z0-9_]{1,63}$`, must be unique within `customTools`, and must not
+  start with the `mcp_` prefix (reserved for MCP-sourced tools).
+- At most 16 entries per agent.
+- `description`: 1-1024 characters — this is what the model reads to decide when to call the tool.
+- `parameters`: a JSON Schema object; must have `"type": "object"`.
+- `handler.response` (record): optional string, at most 1024 characters, defaults to `"Recorded."`.
+- `handler.command` (command): a non-empty array of non-empty strings.
+
+### Collisions and re-registration
+
+A custom tool name that collides with an already-registered builtin or MCP tool name fails
+agent startup with a configuration error rather than silently overriding the existing tool —
+rename the custom tool or remove the conflicting one. Because tool registration runs on every
+agent run (not just once per process), re-registering the *exact same* custom tool definition
+under a name that's already registered is a no-op, not a collision; only a genuinely different
+definition sharing that name is rejected.
+
+## Agent Config: `envAllowlist`
+
+`envAllowlist` is an optional `string[]` field on an agent's `config` that exempts specific
+environment variable names from the sensitive-name scrub applied to shell commands the agent
+runs (`execute_command` and custom `command`-handler tools share this same env-sanitization
+path; it does not affect `grep`/`find`/`git` tool spawns). By default, any variable whose name
+matches `API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH` (case-insensitive) is stripped before a
+child process is spawned. Listing a name in `envAllowlist` copies that variable from the
+process environment into the child's environment even though it matches the scrub regex — it
+never invents a value that isn't already set.
+
+```json
+{
+  "envAllowlist": ["MY_SERVICE_TOKEN"]
+}
+```
+
+Validation: at most 32 names, each matching `^[A-Z][A-Z0-9_]{0,63}$` (uppercase letters,
+digits, and underscores, starting with a letter, up to 64 characters).
+
+**Security note:** allowlisting a secret-bearing variable hands it to every shell command the
+agent runs — the deployment owns that trade-off.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,7 +65,9 @@ Each entry has a `handler.type` of either `record` or `command`.
 
 **`record`** — no side effect. The call is validated and appended to the run's `toolCalls` (the
 same field every other tool call surfaces in), so the *caller* embedding Jazz can read the
-arguments and act on them; the model itself only ever sees the fixed `response`. This is the
+arguments and act on them; the model itself only ever sees the fixed `response`. Note that
+`toolCalls` reports calls as the model sent them — including calls whose arguments failed schema
+validation — so callers must re-validate arguments before acting on them. This is the
 pattern behind confirmation-card / propose-then-confirm flows:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/bun": "^1.3.14",
     "@types/ink-big-text": "^1.2.4",
     "@types/ink-gradient": "^2.0.4",

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -30,6 +30,7 @@ import { agentPromptBuilder } from "./agent-prompt";
 import { Summarizer } from "./context/summarizer";
 import { executeWithStreaming, executeWithoutStreaming } from "./execution";
 import { createAgentRunMetrics } from "./metrics/agent-run-metrics";
+import { registerCustomToolsForAgent } from "./tools/custom-tools";
 import {
   BUILTIN_TOOL_CATEGORIES,
   registerMCPToolsForAgent,
@@ -118,6 +119,13 @@ function initializeAgentRun(
         }),
       ),
     );
+
+    // Register the agent's declared custom tools (record handler only for now).
+    // Unlike MCP registration above, failures here are NOT swallowed: a name
+    // collision with an already-registered tool is a configuration error that
+    // should fail agent startup rather than silently override the existing
+    // tool.
+    yield* registerCustomToolsForAgent(agent, agentToolNames);
 
     // Resolve which built-in categories the persona wants. Default = all of
     // BUILTIN_TOOL_CATEGORIES (current behavior). If toolProfile.categories is

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -472,8 +472,11 @@ export function executeAgentLoop(
 
               response = {
                 ...response,
-                toolCalls: completion.toolCalls,
-                toolResults: Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
+                toolCalls: [...(response.toolCalls ?? []), ...completion.toolCalls],
+                toolResults: {
+                  ...response.toolResults,
+                  ...Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
+                },
               };
 
               const queuedMessage = options.checkQueuedMessage?.();

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -131,6 +131,7 @@ export class ToolExecutor {
         } catch (parseError) {
           throw new Error(
             `Invalid JSON in tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+            { cause: parseError },
           );
         }
 

--- a/src/core/agent/tools/custom-tool-validation.ts
+++ b/src/core/agent/tools/custom-tool-validation.ts
@@ -1,0 +1,120 @@
+import type { CustomToolDefinition } from "@/core/types/agent";
+
+/**
+ * Pure, framework-agnostic shape validation for a single `CustomToolDefinition`.
+ *
+ * This is the single source of truth for the per-definition checks (name,
+ * description, parameters shape, handler shape) shared between:
+ * - `AgentServiceImpl.validateAgentConfig` (`src/services/agent-service.ts`),
+ *   which validates the full `customTools` array (including array-level
+ *   checks like max length and duplicate names) when an agent config is
+ *   created or updated.
+ * - `registerCustomToolsForAgent` (`custom-tools.ts`), which re-validates
+ *   each selected definition at registration time (every `AgentRunner.run`),
+ *   since an agent config can be loaded from a file or other source that
+ *   never went through `validateAgentConfig`.
+ *
+ * Lives in `core/` (not `services/`) so both call sites can use it without
+ * `core/` importing from `services/` — the service delegates to this
+ * function instead of duplicating the checks.
+ */
+export interface CustomToolShapeIssue {
+  readonly message: string;
+  readonly suggestion: string;
+}
+
+/**
+ * Returns a `CustomToolShapeIssue` describing the first validation problem
+ * found, or `null` if `customTool` has a well-formed name, description,
+ * parameters schema, and handler.
+ */
+export function validateCustomToolDefinitionShape(
+  customTool: CustomToolDefinition,
+): CustomToolShapeIssue | null {
+  const { name, description, parameters, handler } = customTool;
+
+  if (typeof name !== "string" || !/^[a-z][a-z0-9_]{1,63}$/.test(name)) {
+    return {
+      message: `Invalid custom tool name "${String(name)}"`,
+      suggestion:
+        "Use lowercase letters, digits, and underscores only, starting with a letter, 2-64 characters (e.g. list_files).",
+    };
+  }
+
+  if (name.startsWith("mcp_")) {
+    return {
+      message: `Custom tool name "${name}" cannot start with the reserved "mcp_" prefix`,
+      suggestion: "Choose a name that does not start with mcp_.",
+    };
+  }
+
+  if (typeof description !== "string" || description.length < 1 || description.length > 1024) {
+    return {
+      message: `Custom tool "${name}" description must be a string between 1 and 1024 characters`,
+      suggestion: "Provide a short, non-empty description of what the tool does.",
+    };
+  }
+
+  if (
+    typeof parameters !== "object" ||
+    parameters === null ||
+    Array.isArray(parameters) ||
+    parameters["type"] !== "object"
+  ) {
+    return {
+      message: `Custom tool "${name}" parameters must be a JSON Schema object with "type": "object"`,
+      suggestion: 'Set parameters to an object schema, e.g. { type: "object", properties: {} }.',
+    };
+  }
+
+  if (
+    typeof handler !== "object" ||
+    handler === null ||
+    (handler.type !== "record" && handler.type !== "command")
+  ) {
+    const handlerType =
+      typeof handler === "object" && handler !== null && "type" in handler
+        ? String((handler as { type: unknown }).type)
+        : typeof handler;
+    return {
+      message: `Custom tool "${name}" handler.type must be "record" or "command" (got "${handlerType}")`,
+      suggestion: 'Set handler.type to "record" or "command".',
+    };
+  }
+
+  if (handler.type === "record") {
+    if (
+      handler.response !== undefined &&
+      (typeof handler.response !== "string" || handler.response.length > 1024)
+    ) {
+      return {
+        message: `Custom tool "${name}" handler.response must be a string of at most 1024 characters`,
+        suggestion: "Shorten the fixed response or remove it.",
+      };
+    }
+    return null;
+  }
+
+  if (
+    !Array.isArray(handler.command) ||
+    handler.command.length === 0 ||
+    handler.command.some((part) => typeof part !== "string" || part.length === 0)
+  ) {
+    return {
+      message: `Custom tool "${name}" handler.command must be a non-empty array of non-empty strings`,
+      suggestion: 'Provide a command like ["ls", "-la"].',
+    };
+  }
+
+  if (
+    handler.timeoutMs !== undefined &&
+    (!Number.isInteger(handler.timeoutMs) || handler.timeoutMs <= 0 || handler.timeoutMs > 300_000)
+  ) {
+    return {
+      message: `Custom tool "${name}" handler.timeoutMs must be a positive integer of at most 300000`,
+      suggestion: "Set timeoutMs between 1 and 300000 milliseconds, or omit it.",
+    };
+  }
+
+  return null;
+}

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -21,7 +21,12 @@ import { SkillServiceTag, type SkillService } from "@/core/skills/skill-service"
 import type { Agent, CustomToolDefinition } from "@/core/types/agent";
 import { AgentConfigurationError } from "@/core/types/errors";
 import type { ToolExecutionResult } from "@/core/types/tools";
-import { registerCustomToolsForAgent } from "./custom-tools";
+import {
+  appendCapped,
+  decodeCapped,
+  EMPTY_CAPPED_OUTPUT,
+  registerCustomToolsForAgent,
+} from "./custom-tools";
 import { createToolRegistryLayer } from "./tool-registry";
 
 // ---------------------------------------------------------------------------
@@ -1191,5 +1196,27 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     expect(typeof result.result).toBe("string");
     expect(Buffer.byteLength(result.result as string, "utf8")).toBeLessThanOrEqual(16 * 1024);
     expect(Buffer.byteLength(result.result as string, "utf8")).toBeGreaterThan(16 * 1024 - 4);
+  });
+
+  it("decodes a multi-byte UTF-8 character intact when it is split across two appended chunks", () => {
+    // "é" (U+00E9) encodes to the 2-byte UTF-8 sequence 0xC3 0xA9. Feeding
+    // each byte as a separate chunk reproduces a character split across a
+    // stream `data` event boundary — decoding per-chunk (the old behavior)
+    // would turn each half into a lone replacement character (U+FFFD).
+    const multiByteCharacter = Buffer.from("é", "utf8");
+    expect(multiByteCharacter.byteLength).toBe(2);
+    const firstHalf = multiByteCharacter.subarray(0, 1);
+    const secondHalf = multiByteCharacter.subarray(1, 2);
+
+    let accumulated = EMPTY_CAPPED_OUTPUT;
+    accumulated = appendCapped(accumulated, Buffer.from("prefix-", "utf8"), 16 * 1024);
+    accumulated = appendCapped(accumulated, firstHalf, 16 * 1024);
+    accumulated = appendCapped(accumulated, secondHalf, 16 * 1024);
+    accumulated = appendCapped(accumulated, Buffer.from("-suffix", "utf8"), 16 * 1024);
+
+    const decoded = decodeCapped(accumulated);
+
+    expect(decoded).toBe("prefix-é-suffix");
+    expect(decoded).not.toContain("�");
   });
 });

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -39,7 +39,11 @@ const mockLogger: LoggerService = {
   logToolCall: mock(() => Effect.void),
 } as unknown as LoggerService;
 
-function makeAgent(customTools: readonly CustomToolDefinition[], tools: readonly string[]): Agent {
+function makeAgent(
+  customTools: readonly CustomToolDefinition[],
+  tools: readonly string[],
+  envAllowlist?: readonly string[],
+): Agent {
   return {
     id: "agent-1",
     name: "Test Agent",
@@ -50,6 +54,7 @@ function makeAgent(customTools: readonly CustomToolDefinition[], tools: readonly
       llmModel: "gpt-4",
       tools,
       customTools,
+      ...(envAllowlist !== undefined ? { envAllowlist } : {}),
     },
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -150,6 +155,86 @@ describe("registerCustomToolsForAgent", () => {
       expect(result.left).toBeInstanceOf(AgentConfigurationError);
       expect(String((result.left as AgentConfigurationError).message)).toContain("propose_action");
     }
+  });
+
+  it("fails CLOSED (does not silently register as a record handler) on an unrecognized handler.type", async () => {
+    const { registry, registered } = makeMockRegistry([]);
+    const badHandlerDefinition = {
+      ...recordToolDefinition,
+      name: "bad_handler_tool",
+      handler: { type: "shell_exec" },
+    } as unknown as CustomToolDefinition;
+    const agent = makeAgent([badHandlerDefinition], ["bad_handler_tool"]);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        registerCustomToolsForAgent(agent, agent.config.tools ?? []).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(ToolRegistryTag, registry),
+              Layer.succeed(LoggerServiceTag, mockLogger),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(AgentConfigurationError);
+      const message = String((result.left as AgentConfigurationError).message);
+      expect(message).toContain("bad_handler_tool");
+      expect(message).toContain("shell_exec");
+    }
+    expect(registered).toEqual([]);
+  });
+
+  it("fails at registration on a bad tool name from a raw (unvalidated) config, without going through validateAgentConfig", async () => {
+    const { registry, registered } = makeMockRegistry([]);
+    const rawUnvalidatedDefinition = {
+      ...recordToolDefinition,
+      name: "Not A Valid Name!",
+    } as unknown as CustomToolDefinition;
+    // Constructed directly (not via AgentServiceImpl.createAgent/updateAgent),
+    // simulating an agent config loaded from a file that never ran
+    // `validateAgentConfig`.
+    const agent = makeAgent([rawUnvalidatedDefinition], ["Not A Valid Name!"]);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        registerCustomToolsForAgent(agent, agent.config.tools ?? []).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(ToolRegistryTag, registry),
+              Layer.succeed(LoggerServiceTag, mockLogger),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(AgentConfigurationError);
+      expect(String((result.left as AgentConfigurationError).message)).toContain(
+        "Invalid custom tool name",
+      );
+    }
+    expect(registered).toEqual([]);
+  });
+
+  it("registers record-handler custom tools as read-only", async () => {
+    const { registry } = makeMockRegistry([]);
+    let capturedTool: any;
+    (registry.registerTool as unknown as ReturnType<typeof mock>) = mock((tool: any) => {
+      capturedTool = tool;
+      return Effect.succeed(undefined);
+    });
+    const agent = makeAgent([recordToolDefinition], ["propose_action"]);
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    expect(capturedTool.riskLevel).toBe("read-only");
   });
 
   it("registers command-handler entries (execution behavior covered in the command-handler suite below)", async () => {
@@ -796,7 +881,10 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     } as unknown as FileSystemContextService;
   }
 
-  async function registerAndCapture(definition: CustomToolDefinition): Promise<{
+  async function registerAndCapture(
+    definition: CustomToolDefinition,
+    declaringAgentEnvAllowlist?: readonly string[],
+  ): Promise<{
     execute: (
       args: Record<string, unknown>,
       context: Record<string, unknown>,
@@ -808,7 +896,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
       capturedTool = tool;
       return Effect.succeed(undefined);
     });
-    const agent = makeAgent([definition], [definition.name]);
+    const agent = makeAgent([definition], [definition.name], declaringAgentEnvAllowlist);
 
     await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
 
@@ -925,7 +1013,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     expect((result.result as string).length).toBe(16 * 1024);
   });
 
-  it("scrubs a sensitive-name env var by default, but passes it through when allowlisted", async () => {
+  it("scrubs a sensitive-name env var when the declaring agent has no envAllowlist, but passes it through when the declaring agent allowlists it", async () => {
     const originalValue = process.env["FAKE_TOKEN"];
     process.env["FAKE_TOKEN"] = "supersecret";
 
@@ -940,27 +1028,15 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
         },
       };
 
-      const tool = await registerAndCapture(definition);
-
-      const withoutAllowlist = await runTool(tool.execute({}, { agentId: "agent-1" }));
+      const withoutAllowlistTool = await registerAndCapture(definition);
+      const withoutAllowlist = await runTool(
+        withoutAllowlistTool.execute({}, { agentId: "agent-1" }),
+      );
       expect(withoutAllowlist.success).toBe(true);
       expect(withoutAllowlist.result).toBe("");
 
-      const parentAgent: Agent = {
-        id: "agent-1",
-        name: "Test Agent",
-        model: "openai/gpt-4",
-        config: {
-          persona: "default",
-          llmProvider: "openai",
-          llmModel: "gpt-4",
-          envAllowlist: ["FAKE_TOKEN"],
-        },
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      const withAllowlist = await runTool(tool.execute({}, { agentId: "agent-1", parentAgent }));
+      const withAllowlistTool = await registerAndCapture(definition, ["FAKE_TOKEN"]);
+      const withAllowlist = await runTool(withAllowlistTool.execute({}, { agentId: "agent-1" }));
       expect(withAllowlist.success).toBe(true);
       expect(withAllowlist.result).toBe("supersecret");
     } finally {
@@ -970,5 +1046,83 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
         process.env["FAKE_TOKEN"] = originalValue;
       }
     }
+  });
+
+  it("uses the DECLARING agent's envAllowlist, not context.parentAgent's, at call time", async () => {
+    const originalValue = process.env["FAKE_TOKEN"];
+    process.env["FAKE_TOKEN"] = "supersecret";
+
+    try {
+      const definition: CustomToolDefinition = {
+        name: "print_env_declarer_scoped",
+        description: "Prints FAKE_TOKEN from its environment",
+        parameters: { type: "object", properties: {} },
+        handler: {
+          type: "command",
+          command: ["node", "-e", "process.stdout.write(process.env.FAKE_TOKEN || '')"],
+        },
+      };
+
+      // Agent A (the declaring agent) allowlists FAKE_TOKEN at registration time.
+      const tool = await registerAndCapture(definition, ["FAKE_TOKEN"]);
+
+      // Agent B, an unrelated agent with an empty allowlist, is the
+      // `parentAgent` in the execution context — e.g. a subagent calling a
+      // tool registered by its parent. The declaring agent's allowlist must
+      // still apply.
+      const agentBWithEmptyAllowlist: Agent = {
+        id: "agent-b",
+        name: "Agent B",
+        model: "openai/gpt-4",
+        config: {
+          persona: "default",
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          envAllowlist: [],
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = await runTool(
+        tool.execute({}, { agentId: "agent-b", parentAgent: agentBWithEmptyAllowlist }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.result).toBe("supersecret");
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["FAKE_TOKEN"];
+      } else {
+        process.env["FAKE_TOKEN"] = originalValue;
+      }
+    }
+  });
+
+  it("carries Tool.timeoutMs = handler.timeoutMs + 5000ms margin so the executor's default 3-minute timeout can't undercut it", async () => {
+    const definition: CustomToolDefinition = {
+      name: "long_running_command",
+      description: "A command tool with a configured 240s timeout",
+      parameters: { type: "object", properties: {} },
+      handler: {
+        type: "command",
+        command: ["node", "-e", "process.exit(0);"],
+        timeoutMs: 240_000,
+      },
+    };
+
+    const tool = (await registerAndCapture(definition)) as unknown as { timeoutMs?: number };
+    expect(tool.timeoutMs).toBe(245_000);
+  });
+
+  it("registers command-handler custom tools as high-risk", async () => {
+    const definition: CustomToolDefinition = {
+      name: "high_risk_command",
+      description: "Spawns a process",
+      parameters: { type: "object", properties: {} },
+      handler: { type: "command", command: ["node", "-e", "process.exit(0);"] },
+    };
+
+    const tool = (await registerAndCapture(definition)) as unknown as { riskLevel?: string };
+    expect(tool.riskLevel).toBe("high-risk");
   });
 });

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -412,6 +412,138 @@ describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
     expect(runResult.toolResults?.["propose_action"]).toBe("Custom response!");
   });
 
+  it("accumulates toolCalls across MULTIPLE tool-calling iterations within one run, in order", async () => {
+    const secondToolDefinition: CustomToolDefinition = {
+      ...recordToolDefinition,
+      name: "second_action",
+      parameters: { type: "object", properties: {} },
+      handler: { type: "record", response: "Second response!" },
+    };
+
+    let callCount = 0;
+    const mockLlmService: LLMService = {
+      getProvider: mock(() =>
+        Effect.succeed({
+          name: "openai",
+          supportedModels: [{ id: "gpt-4", supportsTools: true }],
+          defaultModel: "gpt-4",
+          authenticate: () => Effect.void,
+        }),
+      ),
+      listProviders: mock(() => Effect.succeed([])),
+      createChatCompletion: mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Effect.succeed({
+            id: "completion-1",
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_1",
+                type: "function" as const,
+                function: {
+                  name: "propose_action",
+                  arguments: JSON.stringify({ action: "first_step" }),
+                },
+              },
+            ],
+          });
+        }
+        if (callCount === 2) {
+          return Effect.succeed({
+            id: "completion-2",
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_2",
+                type: "function" as const,
+                function: {
+                  name: "second_action",
+                  arguments: JSON.stringify({}),
+                },
+              },
+            ],
+          });
+        }
+        return Effect.succeed({
+          id: "completion-3",
+          model: "gpt-4",
+          content: "Done.",
+        });
+      }),
+      createStreamingChatCompletion: mock(() =>
+        Effect.succeed({
+          stream: Stream.empty,
+          response: Effect.succeed({ id: "unused", model: "gpt-4", content: "unused" }),
+          cancel: Effect.void,
+        }),
+      ),
+      supportsNativeWebSearch: mock(() => Effect.succeed(false)),
+    } as unknown as LLMService;
+
+    const agent: Agent = {
+      id: "agent-with-two-tool-iterations",
+      name: "Custom Tool Agent",
+      model: "openai/gpt-4",
+      config: {
+        persona: "default",
+        llmProvider: "openai",
+        llmModel: "gpt-4",
+        tools: ["propose_action", "second_action"],
+        customTools: [recordToolDefinition, secondToolDefinition],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(MCPServerManagerTag, mockMcpServerManager),
+      Layer.succeed(LLMServiceTag, mockLlmService),
+      Layer.succeed(TerminalServiceTag, mockTerminalService),
+      Layer.succeed(FileSystem.FileSystem, mockFileSystem),
+      Layer.succeed(FileSystemContextServiceTag, mockFileSystemContext),
+    );
+
+    const realToolRegistryLayer = createToolRegistryLayer();
+
+    const runResult = await Effect.runPromise(
+      AgentRunner.run({
+        agent,
+        userInput: "please do a two-step action",
+        sessionId: "test-session-two-tool-iterations",
+        stream: false,
+        maxIterations: 4,
+      }).pipe(Effect.provide(Layer.mergeAll(testLayer, realToolRegistryLayer))) as Effect.Effect<
+        import("../types").AgentResponse,
+        never,
+        never
+      >,
+    );
+
+    expect(runResult.content).toBe("Done.");
+
+    const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
+      name: toolCall.function?.name ?? "",
+      arguments: toolCall.function?.arguments ?? "",
+    }));
+    // Both iterations' tool calls must be present, in call order — the bug
+    // being fixed overwrote `response.toolCalls` on each iteration, so only
+    // the LAST tool-bearing iteration ever survived to the final result.
+    expect(toolCalls).toEqual([
+      { name: "propose_action", arguments: JSON.stringify({ action: "first_step" }) },
+      { name: "second_action", arguments: JSON.stringify({}) },
+    ]);
+
+    expect(runResult.toolResults?.["propose_action"]).toBe("Custom response!");
+    expect(runResult.toolResults?.["second_action"]).toBe("Second response!");
+  });
+
   it("re-registers the same custom tool across two AgentRunner.run calls sharing one registry", async () => {
     let callCount = 0;
     const mockLlmService: LLMService = {

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -20,6 +20,7 @@ import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-regis
 import { SkillServiceTag, type SkillService } from "@/core/skills/skill-service";
 import type { Agent, CustomToolDefinition } from "@/core/types/agent";
 import { AgentConfigurationError } from "@/core/types/errors";
+import type { ToolExecutionResult } from "@/core/types/tools";
 import { registerCustomToolsForAgent } from "./custom-tools";
 import { createToolRegistryLayer } from "./tool-registry";
 
@@ -151,7 +152,7 @@ describe("registerCustomToolsForAgent", () => {
     }
   });
 
-  it("skips command-handler entries with a debug log, without registering them", async () => {
+  it("registers command-handler entries (execution behavior covered in the command-handler suite below)", async () => {
     const commandToolDefinition: CustomToolDefinition = {
       name: "run_command",
       description: "Runs a shell command",
@@ -163,7 +164,7 @@ describe("registerCustomToolsForAgent", () => {
 
     await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
 
-    expect(registered).toEqual([]);
+    expect(registered).toEqual([{ name: "run_command" }]);
   });
 
   it("record handler execute returns the configured canned response", async () => {
@@ -641,6 +642,201 @@ describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
       expect(String((secondRunResult.left as AgentConfigurationError).message)).toContain(
         "propose_action",
       );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// command-handler custom tools: real-process tests. Each definition spawns
+// `node -e <script>` directly (no shell), exercising the actual child_process
+// wiring in `buildCommandTool` rather than mocking it away.
+// ---------------------------------------------------------------------------
+
+describe("registerCustomToolsForAgent: command-handler execution", () => {
+  function makeFsContext(cwd: string): FileSystemContextService {
+    return {
+      getCwd: () => Effect.succeed(cwd),
+      setCwd: () => Effect.void,
+      resolvePath: (_key: unknown, path: string) => Effect.succeed(path),
+      findDirectory: () => Effect.succeed({ results: [] as readonly string[] }),
+      resolvePathForMkdir: (_key: unknown, path: string) => Effect.succeed(path),
+      escapePath: (path: string) => path,
+    } as unknown as FileSystemContextService;
+  }
+
+  async function registerAndCapture(definition: CustomToolDefinition): Promise<{
+    execute: (
+      args: Record<string, unknown>,
+      context: Record<string, unknown>,
+    ) => Effect.Effect<ToolExecutionResult, unknown, FileSystemContextService | LoggerService>;
+  }> {
+    const { registry } = makeMockRegistry([]);
+    let capturedTool: unknown;
+    (registry.registerTool as unknown as ReturnType<typeof mock>) = mock((tool: unknown) => {
+      capturedTool = tool;
+      return Effect.succeed(undefined);
+    });
+    const agent = makeAgent([definition], [definition.name]);
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    return capturedTool as {
+      execute: (
+        args: Record<string, unknown>,
+        context: Record<string, unknown>,
+      ) => Effect.Effect<ToolExecutionResult, unknown, FileSystemContextService | LoggerService>;
+    };
+  }
+
+  function runTool(
+    effect: Effect.Effect<ToolExecutionResult, unknown, FileSystemContextService | LoggerService>,
+    cwd: string = process.cwd(),
+  ): Promise<ToolExecutionResult> {
+    return Effect.runPromise(
+      effect.pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(FileSystemContextServiceTag, makeFsContext(cwd)),
+            Layer.succeed(LoggerServiceTag, mockLogger),
+          ),
+        ),
+      ) as Effect.Effect<ToolExecutionResult, never, never>,
+    );
+  }
+
+  it("delivers the validated tool arguments as JSON on the command's stdin", async () => {
+    const definition: CustomToolDefinition = {
+      name: "echo_stdin",
+      description: "Echoes stdin back to stdout",
+      parameters: {
+        type: "object",
+        properties: { value: { type: "string" } },
+        required: ["value"],
+      },
+      handler: {
+        type: "command",
+        command: [
+          "node",
+          "-e",
+          "let data='';process.stdin.on('data',(c)=>{data+=c;});process.stdin.on('end',()=>{process.stdout.write(data);});",
+        ],
+      },
+    };
+
+    const tool = await registerAndCapture(definition);
+    const result = await runTool(tool.execute({ value: "hello" }, { agentId: "agent-1" }));
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(JSON.stringify({ value: "hello" }));
+  });
+
+  it("returns an error result carrying stderr when the command exits non-zero", async () => {
+    const definition: CustomToolDefinition = {
+      name: "fail_command",
+      description: "Always fails with stderr output",
+      parameters: { type: "object", properties: {} },
+      handler: {
+        type: "command",
+        command: ["node", "-e", "process.stderr.write('boom'); process.exit(1);"],
+      },
+    };
+
+    const tool = await registerAndCapture(definition);
+    const result = await runTool(tool.execute({}, { agentId: "agent-1" }));
+
+    expect(result.success).toBe(false);
+    expect(result.result).toBeNull();
+    expect(String(result.error ?? "")).toContain("boom");
+    expect(String(result.error ?? "")).toContain("1");
+  });
+
+  it("kills the command and returns a timeout error when it runs past timeoutMs", async () => {
+    const definition: CustomToolDefinition = {
+      name: "slow_command",
+      description: "Sleeps well past the configured timeout",
+      parameters: { type: "object", properties: {} },
+      handler: {
+        type: "command",
+        command: ["node", "-e", "setTimeout(() => {}, 5000);"],
+        timeoutMs: 150,
+      },
+    };
+
+    const tool = await registerAndCapture(definition);
+    const start = Date.now();
+    const result = await runTool(tool.execute({}, { agentId: "agent-1" }));
+    const elapsedMs = Date.now() - start;
+
+    expect(result.success).toBe(false);
+    expect(result.result).toBeNull();
+    expect(String(result.error ?? "").toLowerCase()).toContain("timed out");
+    // Should be killed close to timeoutMs, nowhere near the 5s sleep.
+    expect(elapsedMs).toBeLessThan(4000);
+  });
+
+  it("caps stdout at 16 KB even when the command writes far more", async () => {
+    const definition: CustomToolDefinition = {
+      name: "huge_stdout",
+      description: "Writes 200 KB of output",
+      parameters: { type: "object", properties: {} },
+      handler: {
+        type: "command",
+        command: ["node", "-e", "process.stdout.write('a'.repeat(200 * 1024));"],
+      },
+    };
+
+    const tool = await registerAndCapture(definition);
+    const result = await runTool(tool.execute({}, { agentId: "agent-1" }));
+
+    expect(result.success).toBe(true);
+    expect(typeof result.result).toBe("string");
+    expect((result.result as string).length).toBe(16 * 1024);
+  });
+
+  it("scrubs a sensitive-name env var by default, but passes it through when allowlisted", async () => {
+    const originalValue = process.env["FAKE_TOKEN"];
+    process.env["FAKE_TOKEN"] = "supersecret";
+
+    try {
+      const definition: CustomToolDefinition = {
+        name: "print_env",
+        description: "Prints FAKE_TOKEN from its environment",
+        parameters: { type: "object", properties: {} },
+        handler: {
+          type: "command",
+          command: ["node", "-e", "process.stdout.write(process.env.FAKE_TOKEN || '')"],
+        },
+      };
+
+      const tool = await registerAndCapture(definition);
+
+      const withoutAllowlist = await runTool(tool.execute({}, { agentId: "agent-1" }));
+      expect(withoutAllowlist.success).toBe(true);
+      expect(withoutAllowlist.result).toBe("");
+
+      const parentAgent: Agent = {
+        id: "agent-1",
+        name: "Test Agent",
+        model: "openai/gpt-4",
+        config: {
+          persona: "default",
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          envAllowlist: ["FAKE_TOKEN"],
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const withAllowlist = await runTool(tool.execute({}, { agentId: "agent-1", parentAgent }));
+      expect(withAllowlist.success).toBe(true);
+      expect(withAllowlist.result).toBe("supersecret");
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["FAKE_TOKEN"];
+      } else {
+        process.env["FAKE_TOKEN"] = originalValue;
+      }
     }
   });
 });

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -1,0 +1,413 @@
+import { FileSystem } from "@effect/platform";
+import { describe, expect, it, mock } from "bun:test";
+import { Effect, Layer, Stream } from "effect";
+import { AgentRunner } from "@/core/agent/agent-runner";
+import type { AgentConfigService } from "@/core/interfaces/agent-config";
+import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
+import type { FileSystemContextService } from "@/core/interfaces/fs";
+import { FileSystemContextServiceTag } from "@/core/interfaces/fs";
+import type { LLMService } from "@/core/interfaces/llm";
+import { LLMServiceTag } from "@/core/interfaces/llm";
+import type { LoggerService } from "@/core/interfaces/logger";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import type { MCPServerManager } from "@/core/interfaces/mcp-server";
+import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
+import type { PresentationService } from "@/core/interfaces/presentation";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { TerminalService } from "@/core/interfaces/terminal";
+import { TerminalServiceTag } from "@/core/interfaces/terminal";
+import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import { SkillServiceTag, type SkillService } from "@/core/skills/skill-service";
+import type { Agent, CustomToolDefinition } from "@/core/types/agent";
+import { AgentConfigurationError } from "@/core/types/errors";
+import { registerCustomToolsForAgent } from "./custom-tools";
+import { createToolRegistryLayer } from "./tool-registry";
+
+// ---------------------------------------------------------------------------
+// Unit tests: registerCustomToolsForAgent against a lightweight mock registry
+// ---------------------------------------------------------------------------
+
+const mockLogger: LoggerService = {
+  debug: mock(() => Effect.void),
+  info: mock(() => Effect.void),
+  warn: mock(() => Effect.void),
+  error: mock(() => Effect.void),
+  setSessionId: mock(() => Effect.void),
+  clearSessionId: mock(() => Effect.void),
+  writeToFile: mock(() => Effect.void),
+  logToolCall: mock(() => Effect.void),
+} as unknown as LoggerService;
+
+function makeAgent(customTools: readonly CustomToolDefinition[], tools: readonly string[]): Agent {
+  return {
+    id: "agent-1",
+    name: "Test Agent",
+    model: "openai/gpt-4",
+    config: {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+      tools,
+      customTools,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function makeMockRegistry(existingToolNames: readonly string[]) {
+  const registered: Array<{ name: string }> = [];
+  const registry = {
+    registerTool: mock((tool: { name: string }) => {
+      registered.push({ name: tool.name });
+      return Effect.succeed(undefined);
+    }),
+    registerForCategory: mock(() => mock(() => Effect.succeed(undefined))),
+    listAllTools: mock(() => Effect.succeed(existingToolNames)),
+    listTools: mock(() => Effect.succeed(existingToolNames)),
+    getTool: mock(() => Effect.fail(new Error("not found"))),
+    getToolDefinitions: mock(() => Effect.succeed([])),
+    listToolsByCategory: mock(() => Effect.succeed({})),
+    getToolsInCategory: mock(() => Effect.succeed([])),
+    listCategories: mock(() => Effect.succeed([])),
+    executeTool: mock(() => Effect.succeed({ success: true, result: null })),
+  } as unknown as ToolRegistry;
+  return { registry, registered };
+}
+
+function runWithRegistry<A>(
+  program: Effect.Effect<A, Error, ToolRegistry | LoggerService>,
+  registry: ToolRegistry,
+): Promise<A> {
+  return Effect.runPromise(
+    program.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(ToolRegistryTag, registry),
+          Layer.succeed(LoggerServiceTag, mockLogger),
+        ),
+      ),
+    ),
+  );
+}
+
+const recordToolDefinition: CustomToolDefinition = {
+  name: "propose_action",
+  description: "Propose an action for a human to review.",
+  parameters: {
+    type: "object",
+    properties: {
+      action: { type: "string", description: "The action being proposed" },
+    },
+    required: ["action"],
+  },
+  handler: { type: "record", response: "Custom response!" },
+};
+
+describe("registerCustomToolsForAgent", () => {
+  it("only registers custom tools whose name is in the agent's tool list", async () => {
+    const otherTool: CustomToolDefinition = {
+      ...recordToolDefinition,
+      name: "not_selected",
+    };
+    const { registry, registered } = makeMockRegistry([]);
+    const agent = makeAgent([recordToolDefinition, otherTool], ["propose_action"]);
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    expect(registered).toEqual([{ name: "propose_action" }]);
+  });
+
+  it("does nothing when the agent declares no custom tools", async () => {
+    const { registry, registered } = makeMockRegistry([]);
+    const agent = makeAgent([], ["propose_action"]);
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    expect(registered).toEqual([]);
+  });
+
+  it("fails startup with AgentConfigurationError on a name collision", async () => {
+    const { registry } = makeMockRegistry(["propose_action"]);
+    const agent = makeAgent([recordToolDefinition], ["propose_action"]);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        registerCustomToolsForAgent(agent, agent.config.tools ?? []).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(ToolRegistryTag, registry),
+              Layer.succeed(LoggerServiceTag, mockLogger),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(AgentConfigurationError);
+      expect(String((result.left as AgentConfigurationError).message)).toContain("propose_action");
+    }
+  });
+
+  it("skips command-handler entries with a debug log, without registering them", async () => {
+    const commandToolDefinition: CustomToolDefinition = {
+      name: "run_command",
+      description: "Runs a shell command",
+      parameters: { type: "object", properties: {} },
+      handler: { type: "command", command: ["echo", "hi"] },
+    };
+    const { registry, registered } = makeMockRegistry([]);
+    const agent = makeAgent([commandToolDefinition], ["run_command"]);
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    expect(registered).toEqual([]);
+  });
+
+  it("record handler execute returns the configured canned response", async () => {
+    const { registry, registered: _registered } = makeMockRegistry([]);
+    const agent = makeAgent([recordToolDefinition], ["propose_action"]);
+
+    let capturedTool:
+      | {
+          execute: (
+            args: Record<string, unknown>,
+            context: unknown,
+          ) => Effect.Effect<unknown, unknown, unknown>;
+        }
+      | undefined;
+    (registry.registerTool as unknown as ReturnType<typeof mock>) = mock((tool: any) => {
+      capturedTool = tool;
+      return Effect.succeed(undefined);
+    });
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    expect(capturedTool).toBeDefined();
+    const result = await Effect.runPromise(
+      capturedTool!.execute({ action: "do_something" }, { agentId: "agent-1" }) as Effect.Effect<
+        { success: boolean; result: unknown },
+        never,
+        never
+      >,
+    );
+    expect(result).toEqual({ success: true, result: "Custom response!" });
+  });
+
+  it("record handler defaults to 'Recorded.' when no response is configured", async () => {
+    const definitionWithoutResponse: CustomToolDefinition = {
+      ...recordToolDefinition,
+      handler: { type: "record" },
+    };
+    const { registry } = makeMockRegistry([]);
+    const agent = makeAgent([definitionWithoutResponse], ["propose_action"]);
+
+    let capturedTool: any;
+    (registry.registerTool as unknown as ReturnType<typeof mock>) = mock((tool: any) => {
+      capturedTool = tool;
+      return Effect.succeed(undefined);
+    });
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    const result = await Effect.runPromise(
+      capturedTool.execute({ action: "do_something" }, { agentId: "agent-1" }),
+    );
+    expect(result).toEqual({ success: true, result: "Recorded." });
+  });
+
+  it("rejects args that fail the converted zod schema, same as MCP tool args", async () => {
+    const { registry } = makeMockRegistry([]);
+    const agent = makeAgent([recordToolDefinition], ["propose_action"]);
+
+    let capturedTool: any;
+    (registry.registerTool as unknown as ReturnType<typeof mock>) = mock((tool: any) => {
+      capturedTool = tool;
+      return Effect.succeed(undefined);
+    });
+
+    await runWithRegistry(registerCustomToolsForAgent(agent, agent.config.tools ?? []), registry);
+
+    // "action" is required by the schema but omitted here.
+    const result = await Effect.runPromise(capturedTool.execute({}, { agentId: "agent-1" }));
+    expect(result.success).toBe(false);
+    expect(String(result.error ?? "")).toContain("action");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test: drive a full AgentRunner.run() with a scripted LLM that
+// calls the custom tool, and assert it surfaces in the run's `toolCalls`
+// (the same field run-agent.ts's JSON envelope reads from `runResult.toolCalls`).
+// ---------------------------------------------------------------------------
+
+describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
+  const mockPresentationService: PresentationService = {
+    presentThinking: mock(() => Effect.void),
+    presentThinkingEnd: mock(() => Effect.void),
+    createStreamingRenderer: mock(() =>
+      Effect.succeed({
+        renderEvent: mock(() => Effect.void),
+        stop: mock(() => Effect.void),
+        handleEvent: mock(() => Effect.void),
+        setInterruptHandler: mock(() => Effect.void),
+        reset: mock(() => Effect.void),
+        flush: mock(() => Effect.void),
+      }),
+    ),
+    renderMarkdown: mock((content: string) => Effect.succeed(content)),
+    presentAgentResponse: mock(() => Effect.void),
+    presentCompletion: mock(() => Effect.void),
+    presentWarning: mock(() => Effect.void),
+    presentStatus: mock(() => Effect.void),
+    writeOutput: mock(() => Effect.void),
+    writeBlankLine: mock(() => Effect.void),
+    formatToolExecutionStart: mock(() => Effect.succeed("Tool starting")),
+    formatToolExecutionComplete: mock(() => Effect.succeed("Tool completed")),
+    formatToolResult: mock(() => "Tool result"),
+    formatToolExecutionError: mock(() => Effect.succeed("Tool failed")),
+    formatToolsDetected: mock(() => Effect.succeed("Tools detected")),
+    requestApproval: mock(() => Effect.succeed({ approved: true as const })),
+  } as unknown as PresentationService;
+
+  const mockTerminalService = {} as unknown as TerminalService;
+  const mockFileSystem = {} as unknown as FileSystem.FileSystem;
+  const mockFileSystemContext = {} as unknown as FileSystemContextService;
+
+  const mockSkillService = {
+    listSkills: mock(() => Effect.succeed([])),
+  } as unknown as SkillService;
+
+  const mockAppConfig = {
+    output: {
+      showMetrics: true,
+      streaming: { enabled: false, textBufferMs: 100 },
+      mode: "markdown" as const,
+    },
+    llm: { openai: { api_key: "test-key" } },
+  };
+
+  const mockAgentConfigService = {
+    appConfig: Effect.succeed(mockAppConfig),
+    get: mock(() => Effect.succeed(undefined)),
+    getOrElse: mock((_key: string, fallback: unknown) => Effect.succeed(fallback)),
+    getOrFail: mock(() => Effect.succeed(undefined)),
+    has: mock(() => Effect.succeed(false)),
+    set: mock(() => Effect.void),
+  } as unknown as AgentConfigService;
+
+  const mockMcpServerManager = {
+    connectServer: mock(() => Effect.fail(new Error("Not implemented"))),
+    disconnectServer: mock(() => Effect.void),
+    getServerTools: mock(() => Effect.succeed([])),
+    discoverTools: mock(() => Effect.succeed([])),
+    listServers: mock(() => Effect.succeed([])),
+    isConnected: mock(() => Effect.succeed(false)),
+    disconnectAllServers: mock(() => Effect.void),
+  } as unknown as MCPServerManager;
+
+  it("propagates a custom-tool call into runResult.toolCalls with the canned response as the model-visible result", async () => {
+    let callCount = 0;
+    const mockLlmService: LLMService = {
+      getProvider: mock(() =>
+        Effect.succeed({
+          name: "openai",
+          supportedModels: [{ id: "gpt-4", supportsTools: true }],
+          defaultModel: "gpt-4",
+          authenticate: () => Effect.void,
+        }),
+      ),
+      listProviders: mock(() => Effect.succeed([])),
+      createChatCompletion: mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Effect.succeed({
+            id: "completion-1",
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_1",
+                type: "function" as const,
+                function: {
+                  name: "propose_action",
+                  arguments: JSON.stringify({ action: "do_something" }),
+                },
+              },
+            ],
+          });
+        }
+        return Effect.succeed({
+          id: "completion-2",
+          model: "gpt-4",
+          content: "Done.",
+        });
+      }),
+      createStreamingChatCompletion: mock(() =>
+        Effect.succeed({
+          stream: Stream.empty,
+          response: Effect.succeed({ id: "unused", model: "gpt-4", content: "unused" }),
+          cancel: Effect.void,
+        }),
+      ),
+      supportsNativeWebSearch: mock(() => Effect.succeed(false)),
+    } as unknown as LLMService;
+
+    const agent: Agent = {
+      id: "agent-with-custom-tool",
+      name: "Custom Tool Agent",
+      model: "openai/gpt-4",
+      config: {
+        persona: "default",
+        llmProvider: "openai",
+        llmModel: "gpt-4",
+        tools: ["propose_action"],
+        customTools: [recordToolDefinition],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(MCPServerManagerTag, mockMcpServerManager),
+      Layer.succeed(LLMServiceTag, mockLlmService),
+      Layer.succeed(TerminalServiceTag, mockTerminalService),
+      Layer.succeed(FileSystem.FileSystem, mockFileSystem),
+      Layer.succeed(FileSystemContextServiceTag, mockFileSystemContext),
+    );
+
+    const realToolRegistryLayer = createToolRegistryLayer();
+
+    const runResult = await Effect.runPromise(
+      AgentRunner.run({
+        agent,
+        userInput: "please propose an action",
+        sessionId: "test-session-custom-tool",
+        stream: false,
+        maxIterations: 3,
+      }).pipe(Effect.provide(Layer.mergeAll(testLayer, realToolRegistryLayer))) as Effect.Effect<
+        import("../types").AgentResponse,
+        never,
+        never
+      >,
+    );
+
+    expect(runResult.content).toBe("Done.");
+
+    const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
+      name: toolCall.function?.name ?? "",
+      arguments: toolCall.function?.arguments ?? "",
+    }));
+    expect(toolCalls).toEqual([
+      { name: "propose_action", arguments: JSON.stringify({ action: "do_something" }) },
+    ]);
+
+    expect(runResult.toolResults?.["propose_action"]).toBe("Custom response!");
+  });
+});

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -410,4 +410,237 @@ describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
 
     expect(runResult.toolResults?.["propose_action"]).toBe("Custom response!");
   });
+
+  it("re-registers the same custom tool across two AgentRunner.run calls sharing one registry", async () => {
+    let callCount = 0;
+    const mockLlmService: LLMService = {
+      getProvider: mock(() =>
+        Effect.succeed({
+          name: "openai",
+          supportedModels: [{ id: "gpt-4", supportsTools: true }],
+          defaultModel: "gpt-4",
+          authenticate: () => Effect.void,
+        }),
+      ),
+      listProviders: mock(() => Effect.succeed([])),
+      createChatCompletion: mock(() => {
+        callCount++;
+        // Every run calls the tool on its first LLM turn, then wraps up.
+        if (callCount % 2 === 1) {
+          return Effect.succeed({
+            id: `completion-${callCount}`,
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: `call_${callCount}`,
+                type: "function" as const,
+                function: {
+                  name: "propose_action",
+                  arguments: JSON.stringify({ action: "do_something" }),
+                },
+              },
+            ],
+          });
+        }
+        return Effect.succeed({
+          id: `completion-${callCount}`,
+          model: "gpt-4",
+          content: "Done.",
+        });
+      }),
+      createStreamingChatCompletion: mock(() =>
+        Effect.succeed({
+          stream: Stream.empty,
+          response: Effect.succeed({ id: "unused", model: "gpt-4", content: "unused" }),
+          cancel: Effect.void,
+        }),
+      ),
+      supportsNativeWebSearch: mock(() => Effect.succeed(false)),
+    } as unknown as LLMService;
+
+    const agent: Agent = {
+      id: "agent-with-custom-tool-two-turns",
+      name: "Custom Tool Agent",
+      model: "openai/gpt-4",
+      config: {
+        persona: "default",
+        llmProvider: "openai",
+        llmModel: "gpt-4",
+        tools: ["propose_action"],
+        customTools: [recordToolDefinition],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(MCPServerManagerTag, mockMcpServerManager),
+      Layer.succeed(LLMServiceTag, mockLlmService),
+      Layer.succeed(TerminalServiceTag, mockTerminalService),
+      Layer.succeed(FileSystem.FileSystem, mockFileSystem),
+      Layer.succeed(FileSystemContextServiceTag, mockFileSystemContext),
+    );
+
+    // A single ToolRegistry layer, shared across both `run` calls below,
+    // mirrors the session-lifetime singleton in app-layer.ts: registration
+    // runs on every AgentRunner.run against the SAME registry instance.
+    const sharedToolRegistryLayer = createToolRegistryLayer();
+    const runLayer = Layer.mergeAll(testLayer, sharedToolRegistryLayer);
+
+    const runOptions = {
+      agent,
+      userInput: "please propose an action",
+      sessionId: "test-session-custom-tool-two-turns",
+      stream: false,
+      maxIterations: 3,
+    };
+
+    const firstRun = await Effect.runPromise(
+      AgentRunner.run(runOptions).pipe(Effect.provide(runLayer)) as Effect.Effect<
+        import("../types").AgentResponse,
+        never,
+        never
+      >,
+    );
+    expect(firstRun.content).toBe("Done.");
+    expect(firstRun.toolResults?.["propose_action"]).toBe("Custom response!");
+
+    // Second run reuses the same registry, exactly like a second chat turn in
+    // the same session: registration must be idempotent instead of throwing.
+    const secondRun = await Effect.runPromise(
+      AgentRunner.run(runOptions).pipe(Effect.provide(runLayer)) as Effect.Effect<
+        import("../types").AgentResponse,
+        never,
+        never
+      >,
+    );
+    expect(secondRun.content).toBe("Done.");
+    expect(secondRun.toolResults?.["propose_action"]).toBe("Custom response!");
+  });
+
+  it("fails with AgentConfigurationError when a second run declares a CHANGED definition for the same name", async () => {
+    const mockLlmService: LLMService = {
+      getProvider: mock(() =>
+        Effect.succeed({
+          name: "openai",
+          supportedModels: [{ id: "gpt-4", supportsTools: true }],
+          defaultModel: "gpt-4",
+          authenticate: () => Effect.void,
+        }),
+      ),
+      listProviders: mock(() => Effect.succeed([])),
+      createChatCompletion: mock(() =>
+        Effect.succeed({
+          id: "completion-1",
+          model: "gpt-4",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_1",
+              type: "function" as const,
+              function: {
+                name: "propose_action",
+                arguments: JSON.stringify({ action: "do_something" }),
+              },
+            },
+          ],
+        }),
+      ),
+      createStreamingChatCompletion: mock(() =>
+        Effect.succeed({
+          stream: Stream.empty,
+          response: Effect.succeed({ id: "unused", model: "gpt-4", content: "unused" }),
+          cancel: Effect.void,
+        }),
+      ),
+      supportsNativeWebSearch: mock(() => Effect.succeed(false)),
+    } as unknown as LLMService;
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(MCPServerManagerTag, mockMcpServerManager),
+      Layer.succeed(LLMServiceTag, mockLlmService),
+      Layer.succeed(TerminalServiceTag, mockTerminalService),
+      Layer.succeed(FileSystem.FileSystem, mockFileSystem),
+      Layer.succeed(FileSystemContextServiceTag, mockFileSystemContext),
+    );
+
+    const sharedToolRegistryLayer = createToolRegistryLayer();
+    const runLayer = Layer.mergeAll(testLayer, sharedToolRegistryLayer);
+
+    const firstAgent: Agent = {
+      id: "agent-original-definition",
+      name: "Custom Tool Agent",
+      model: "openai/gpt-4",
+      config: {
+        persona: "default",
+        llmProvider: "openai",
+        llmModel: "gpt-4",
+        tools: ["propose_action"],
+        customTools: [recordToolDefinition],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const firstRun = await Effect.runPromise(
+      AgentRunner.run({
+        agent: firstAgent,
+        userInput: "please propose an action",
+        sessionId: "test-session-changed-definition",
+        stream: false,
+        maxIterations: 3,
+      }).pipe(Effect.provide(runLayer)) as Effect.Effect<
+        import("../types").AgentResponse,
+        never,
+        never
+      >,
+    );
+    expect(firstRun.toolResults?.["propose_action"]).toBe("Custom response!");
+
+    const changedDefinition: CustomToolDefinition = {
+      ...recordToolDefinition,
+      handler: { type: "record", response: "A completely different response!" },
+    };
+    const secondAgent: Agent = {
+      ...firstAgent,
+      id: "agent-changed-definition",
+      config: {
+        ...firstAgent.config,
+        customTools: [changedDefinition],
+      },
+    };
+
+    const secondRunResult = await Effect.runPromise(
+      Effect.either(
+        AgentRunner.run({
+          agent: secondAgent,
+          userInput: "please propose an action",
+          sessionId: "test-session-changed-definition-2",
+          stream: false,
+          maxIterations: 3,
+        }).pipe(Effect.provide(runLayer)) as Effect.Effect<
+          import("../types").AgentResponse,
+          Error,
+          never
+        >,
+      ),
+    );
+
+    expect(secondRunResult._tag).toBe("Left");
+    if (secondRunResult._tag === "Left") {
+      expect(secondRunResult.left).toBeInstanceOf(AgentConfigurationError);
+      expect(String((secondRunResult.left as AgentConfigurationError).message)).toContain(
+        "propose_action",
+      );
+    }
+  });
 });

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -61,7 +61,10 @@ function makeAgent(
   };
 }
 
-function makeMockRegistry(existingToolNames: readonly string[]) {
+function makeMockRegistry(
+  existingToolNames: readonly string[],
+  aliases: Record<string, string> = {},
+) {
   const registered: Array<{ name: string }> = [];
   const registry = {
     registerTool: mock((tool: { name: string }) => {
@@ -71,7 +74,16 @@ function makeMockRegistry(existingToolNames: readonly string[]) {
     registerForCategory: mock(() => mock(() => Effect.succeed(undefined))),
     listAllTools: mock(() => Effect.succeed(existingToolNames)),
     listTools: mock(() => Effect.succeed(existingToolNames)),
-    getTool: mock(() => Effect.fail(new Error("not found"))),
+    // Mirrors DefaultToolRegistry.getTool: resolves `name` through the
+    // alias map first, then looks it up among the pre-seeded builtin/MCP
+    // tool names — so tests can simulate a custom tool colliding with an
+    // existing tool's ALIAS (e.g. "glob"), not just its primary name.
+    getTool: mock((name: string) => {
+      const resolvedName = aliases[name] ?? name;
+      return existingToolNames.includes(resolvedName)
+        ? Effect.succeed({ name: resolvedName, sourceCustomToolDefinition: undefined })
+        : Effect.fail(new Error("not found"));
+    }),
     getToolDefinitions: mock(() => Effect.succeed([])),
     listToolsByCategory: mock(() => Effect.succeed({})),
     getToolsInCategory: mock(() => Effect.succeed([])),
@@ -133,7 +145,7 @@ describe("registerCustomToolsForAgent", () => {
     expect(registered).toEqual([]);
   });
 
-  it("fails startup with AgentConfigurationError on a name collision", async () => {
+  it("fails with AgentConfigurationError naming a builtin/MCP collision distinctly from a changed-definition collision", async () => {
     const { registry } = makeMockRegistry(["propose_action"]);
     const agent = makeAgent([recordToolDefinition], ["propose_action"]);
 
@@ -153,7 +165,38 @@ describe("registerCustomToolsForAgent", () => {
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(result.left).toBeInstanceOf(AgentConfigurationError);
-      expect(String((result.left as AgentConfigurationError).message)).toContain("propose_action");
+      const message = String((result.left as AgentConfigurationError).message);
+      expect(message).toContain("propose_action");
+      expect(message).toContain("builtin or MCP");
+      expect(message).not.toContain("definition changed");
+    }
+  });
+
+  it("fails at registration when a custom tool shadows an existing tool's ALIAS (e.g. 'glob')", async () => {
+    const { registry } = makeMockRegistry(["find_files"], { glob: "find_files" });
+    const aliasShadowingDefinition: CustomToolDefinition = {
+      ...recordToolDefinition,
+      name: "glob",
+    };
+    const agent = makeAgent([aliasShadowingDefinition], ["glob"]);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        registerCustomToolsForAgent(agent, agent.config.tools ?? []).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(ToolRegistryTag, registry),
+              Layer.succeed(LoggerServiceTag, mockLogger),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(AgentConfigurationError);
+      expect(String((result.left as AgentConfigurationError).message)).toContain("glob");
     }
   });
 
@@ -856,9 +899,9 @@ describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
     expect(secondRunResult._tag).toBe("Left");
     if (secondRunResult._tag === "Left") {
       expect(secondRunResult.left).toBeInstanceOf(AgentConfigurationError);
-      expect(String((secondRunResult.left as AgentConfigurationError).message)).toContain(
-        "propose_action",
-      );
+      const message = String((secondRunResult.left as AgentConfigurationError).message);
+      expect(message).toContain("propose_action");
+      expect(message).toContain("definition changed");
     }
   });
 });
@@ -1124,5 +1167,29 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
 
     const tool = (await registerAndCapture(definition)) as unknown as { riskLevel?: string };
     expect(tool.riskLevel).toBe("high-risk");
+  });
+
+  it("caps stdout at exactly 16 KB in BYTES, not JS string length, for multi-byte UTF-8 output", async () => {
+    // Each "é" is 2 bytes in UTF-8 but counts as 1 UTF-16 code unit in
+    // `String.prototype.length` — writing well past the cap in multi-byte
+    // characters exercises the Buffer.byteLength-based cap rather than a
+    // naive string-length cap.
+    const definition: CustomToolDefinition = {
+      name: "huge_multibyte_stdout",
+      description: "Writes 20000 multi-byte characters",
+      parameters: { type: "object", properties: {} },
+      handler: {
+        type: "command",
+        command: ["node", "-e", "process.stdout.write('\\u00e9'.repeat(20000));"],
+      },
+    };
+
+    const tool = await registerAndCapture(definition);
+    const result = await runTool(tool.execute({}, { agentId: "agent-1" }));
+
+    expect(result.success).toBe(true);
+    expect(typeof result.result).toBe("string");
+    expect(Buffer.byteLength(result.result as string, "utf8")).toBeLessThanOrEqual(16 * 1024);
+    expect(Buffer.byteLength(result.result as string, "utf8")).toBeGreaterThan(16 * 1024 - 4);
   });
 });

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -1,12 +1,21 @@
+import { type ChildProcess, spawn } from "child_process";
 import { Effect, Option } from "effect";
 import type { z } from "zod";
+import { type FileSystemContextService, FileSystemContextServiceTag } from "@/core/interfaces/fs";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { ToolRegistryTag, type Tool, type ToolRegistry } from "@/core/interfaces/tool-registry";
-import type { Agent, CustomToolDefinition, CustomToolRecordHandler } from "@/core/types/agent";
+import type {
+  Agent,
+  CustomToolCommandHandler,
+  CustomToolDefinition,
+  CustomToolRecordHandler,
+} from "@/core/types/agent";
 import { AgentConfigurationError } from "@/core/types/errors";
 import type { ToolCategory, ToolExecutionResult } from "@/core/types/tools";
+import { createSanitizedEnv, type ProcessEnvRecord } from "@/core/utils/env-utils";
 import { convertMCPSchemaToZod } from "@/core/utils/mcp-schema-converter";
 import { defineTool, makeZodValidator } from "./base-tool";
+import { buildKeyFromContext } from "./context-utils";
 
 /**
  * Custom-tool registration module
@@ -15,11 +24,119 @@ import { defineTool, makeZodValidator } from "./base-tool";
  * `@/core/types/agent`) into the shared `ToolRegistry`, mirroring the shape
  * of `registerMCPToolsForAgent` in `register-tools.ts`.
  *
- * Only the `record` handler is implemented here: it always returns a fixed
- * response with no side effects. `command` handler entries are recognized
- * but intentionally skipped (with a debug log) — that handler ships in a
- * follow-up task.
+ * Two handlers are implemented:
+ * - `record`: always returns a fixed response with no side effects.
+ * - `command`: spawns `handler.command` directly (no shell), matching
+ *   `execute_command`'s env-sanitization, cwd resolution, and timeout/kill
+ *   semantics (see `shell-tools.ts`).
  */
+
+/** Hard cap on captured stdout/stderr per command execution, in bytes. */
+const COMMAND_OUTPUT_CAP_BYTES = 16 * 1024;
+
+/** Default kill timeout for `command`-handler custom tools when unset. */
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+type CommandExecutionOutcome =
+  | {
+      readonly ok: true;
+      readonly exitCode: number;
+      readonly stdout: string;
+      readonly stderr: string;
+    }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Append `chunk` to `current`, truncating so the combined string never
+ * exceeds `capBytes`. Caps per chunk (not post-hoc) so an unbounded stream
+ * never balloons memory before being sliced down.
+ */
+function appendCapped(current: string, chunk: string, capBytes: number): string {
+  if (current.length >= capBytes) {
+    return current;
+  }
+  return current + chunk.slice(0, capBytes - current.length);
+}
+
+/**
+ * Spawn `argv` directly (no shell), write `stdin` to the child's stdin, and
+ * collect stdout/stderr up to `COMMAND_OUTPUT_CAP_BYTES` each. Resolves
+ * (never rejects) with either the process outcome or a bounded error message
+ * covering spawn failures and timeout kills — mirrors how `execute_command`
+ * in `shell-tools.ts` reports failures to the model.
+ */
+function runCustomToolCommand(
+  argv: readonly string[],
+  stdin: string,
+  cwd: string,
+  env: ProcessEnvRecord,
+  timeoutMs: number,
+): Promise<CommandExecutionOutcome> {
+  return new Promise((resolve) => {
+    const [command, ...args] = argv;
+    if (!command) {
+      resolve({ ok: false, error: "Custom tool command is empty" });
+      return;
+    }
+
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let child: ChildProcess;
+
+    try {
+      child = spawn(command, args, {
+        cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        env,
+        detached: false,
+      });
+    } catch (spawnError) {
+      resolve({
+        ok: false,
+        error: spawnError instanceof Error ? spawnError.message : String(spawnError),
+      });
+      return;
+    }
+
+    const finish = (outcome: CommandExecutionOutcome): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutHandle);
+      resolve(outcome);
+    };
+
+    const timeoutHandle = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({ ok: false, error: `Command timed out after ${timeoutMs}ms` });
+    }, timeoutMs);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      stdout = appendCapped(stdout, data.toString(), COMMAND_OUTPUT_CAP_BYTES);
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      stderr = appendCapped(stderr, data.toString(), COMMAND_OUTPUT_CAP_BYTES);
+    });
+
+    child.on("error", (error) => {
+      finish({ ok: false, error: error instanceof Error ? error.message : String(error) });
+    });
+
+    child.on("close", (code) => {
+      finish({ ok: true, exitCode: code ?? 0, stdout, stderr });
+    });
+
+    // If the child exits before consuming stdin (or never reads it), writing
+    // can raise EPIPE. The close/error handlers above still settle the
+    // promise, so just prevent an unhandled 'error' event on the stream.
+    child.stdin?.on("error", () => {});
+    child.stdin?.write(stdin);
+    child.stdin?.end();
+  });
+}
 
 export const CUSTOM_TOOLS_CATEGORY: ToolCategory = {
   id: "custom_tools",
@@ -47,6 +164,71 @@ function buildRecordTool(
       validate,
       handler: (): Effect.Effect<ToolExecutionResult, Error, never> =>
         Effect.succeed({ success: true, result: response }),
+    }),
+    sourceCustomToolDefinition: definition,
+  };
+}
+
+/**
+ * Build a `Tool` for a `command`-handler custom tool definition.
+ *
+ * Execution spawns `handler.command` argv directly (no shell), with the
+ * validated tool arguments serialized as JSON on the child's stdin. Env and
+ * cwd resolution match `execute_command`: `createSanitizedEnv({},
+ * agent.config.envAllowlist ?? [])` for env, and the run's current working
+ * directory (via `FileSystemContextService.getCwd`) for cwd — this handler
+ * has no `workingDirectory` argument to override it, since the tool's
+ * parameters are entirely user-declared. Exit code 0 succeeds with the
+ * captured (bounded) stdout; a non-zero exit, timeout, or spawn error
+ * produces the same error-result shape `execute_command` uses.
+ */
+function buildCommandTool(
+  definition: CustomToolDefinition & { readonly handler: CustomToolCommandHandler },
+): Tool<FileSystemContextService | LoggerService> {
+  const parameters = convertMCPSchemaToZod(definition.parameters, definition.name);
+  const validate = makeZodValidator(parameters as z.ZodType<Record<string, unknown>>);
+  const commandArgv = definition.handler.command;
+  const timeoutMs = definition.handler.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+
+  return {
+    ...defineTool<FileSystemContextService | LoggerService, Record<string, unknown>>({
+      name: definition.name,
+      description: definition.description,
+      parameters,
+      validate,
+      handler: (
+        args,
+        context,
+      ): Effect.Effect<ToolExecutionResult, Error, FileSystemContextService | LoggerService> =>
+        Effect.gen(function* () {
+          const shell = yield* FileSystemContextServiceTag;
+          const logger = yield* LoggerServiceTag;
+
+          const cwd = yield* shell.getCwd(buildKeyFromContext(context));
+          const envAllowlist = context.parentAgent?.config.envAllowlist ?? [];
+          const sanitizedEnv = createSanitizedEnv({}, envAllowlist);
+          const stdinPayload = JSON.stringify(args);
+
+          const outcome = yield* Effect.promise(() =>
+            runCustomToolCommand(commandArgv, stdinPayload, cwd, sanitizedEnv, timeoutMs),
+          );
+
+          if (!outcome.ok) {
+            yield* logger.debug(
+              `Custom tool "${definition.name}" command execution failed: ${outcome.error}`,
+            );
+            return { success: false, result: null, error: outcome.error };
+          }
+
+          if (outcome.exitCode !== 0) {
+            const message = `Command exited with code ${outcome.exitCode}${
+              outcome.stderr ? `: ${outcome.stderr}` : ""
+            }`;
+            return { success: false, result: null, error: message };
+          }
+
+          return { success: true, result: outcome.stdout };
+        }),
     }),
     sourceCustomToolDefinition: definition,
   };
@@ -91,8 +273,8 @@ function isDeepEqual(left: unknown, right: unknown): boolean {
  * (builtin or MCP) fails startup with `AgentConfigurationError` rather than
  * silently overriding the existing registration.
  *
- * `command`-handler entries are recognized but skipped (debug log only) —
- * implementing that handler is a follow-up task.
+ * `command`-handler entries spawn the declared command directly (no shell)
+ * on each invocation; see `buildCommandTool` for execution semantics.
  */
 export function registerCustomToolsForAgent(
   agent: Agent,
@@ -152,9 +334,13 @@ export function registerCustomToolsForAgent(
       }
 
       if (definition.handler.type === "command") {
-        yield* logger.debug(
-          `Skipping custom tool "${definition.name}": command handler is not yet implemented`,
+        const commandTool = buildCommandTool(
+          definition as CustomToolDefinition & { readonly handler: CustomToolCommandHandler },
         );
+        yield* registry.registerTool(commandTool, CUSTOM_TOOLS_CATEGORY);
+        registeredToolNames.add(definition.name);
+
+        yield* logger.debug(`Registered custom tool "${definition.name}" (command handler)`);
         continue;
       }
 

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -1,0 +1,117 @@
+import { Effect } from "effect";
+import type { z } from "zod";
+import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
+import { ToolRegistryTag, type Tool, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import type { Agent, CustomToolDefinition, CustomToolRecordHandler } from "@/core/types/agent";
+import { AgentConfigurationError } from "@/core/types/errors";
+import type { ToolCategory, ToolExecutionResult } from "@/core/types/tools";
+import { convertMCPSchemaToZod } from "@/core/utils/mcp-schema-converter";
+import { defineTool, makeZodValidator } from "./base-tool";
+
+/**
+ * Custom-tool registration module
+ *
+ * Registers agent-declared `customTools` (see `CustomToolDefinition` in
+ * `@/core/types/agent`) into the shared `ToolRegistry`, mirroring the shape
+ * of `registerMCPToolsForAgent` in `register-tools.ts`.
+ *
+ * Only the `record` handler is implemented here: it always returns a fixed
+ * response with no side effects. `command` handler entries are recognized
+ * but intentionally skipped (with a debug log) — that handler ships in a
+ * follow-up task.
+ */
+
+export const CUSTOM_TOOLS_CATEGORY: ToolCategory = {
+  id: "custom_tools",
+  displayName: "Custom Tools",
+};
+
+/**
+ * Build a `Tool` for a `record`-handler custom tool definition.
+ *
+ * Execution has no side effects: it always succeeds with the handler's fixed
+ * `response`, defaulting to `"Recorded."` when omitted.
+ */
+function buildRecordTool(
+  definition: CustomToolDefinition & { readonly handler: CustomToolRecordHandler },
+): Tool<never> {
+  const parameters = convertMCPSchemaToZod(definition.parameters, definition.name);
+  const validate = makeZodValidator(parameters as z.ZodType<Record<string, unknown>>);
+  const response = definition.handler.response ?? "Recorded.";
+
+  return defineTool<never, Record<string, unknown>>({
+    name: definition.name,
+    description: definition.description,
+    parameters,
+    validate,
+    handler: (): Effect.Effect<ToolExecutionResult, Error, never> =>
+      Effect.succeed({ success: true, result: response }),
+  });
+}
+
+/**
+ * Register an agent's declared custom tools into the shared `ToolRegistry`.
+ *
+ * Only entries whose `name` appears in `agentToolNames` are registered — an
+ * agent may declare custom tools it doesn't actually expose to itself (e.g.
+ * shared config templates). Colliding with an already-registered tool name
+ * (builtin or MCP) fails startup with `AgentConfigurationError` rather than
+ * silently overriding the existing registration.
+ *
+ * `command`-handler entries are recognized but skipped (debug log only) —
+ * implementing that handler is a follow-up task.
+ */
+export function registerCustomToolsForAgent(
+  agent: Agent,
+  agentToolNames: readonly string[],
+): Effect.Effect<void, Error, ToolRegistry | LoggerService> {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const logger = yield* LoggerServiceTag;
+
+    const customTools = agent.config.customTools ?? [];
+    if (customTools.length === 0) {
+      return;
+    }
+
+    const requestedNames = new Set(agentToolNames);
+    const selected = customTools.filter((definition) => requestedNames.has(definition.name));
+
+    if (selected.length === 0) {
+      yield* logger.debug(
+        "Agent declares custom tools but none are referenced in its tool list, skipping registration",
+      );
+      return;
+    }
+
+    const registeredToolNames = new Set(yield* registry.listAllTools());
+
+    for (const definition of selected) {
+      if (registeredToolNames.has(definition.name)) {
+        return yield* Effect.fail(
+          new AgentConfigurationError({
+            agentId: agent.id,
+            field: "config.customTools",
+            message: `Custom tool "${definition.name}" collides with an already-registered tool (builtin or MCP). Rename the custom tool or remove the conflicting one.`,
+            suggestion: `Choose a unique name for the "${definition.name}" custom tool.`,
+          }),
+        );
+      }
+
+      if (definition.handler.type === "command") {
+        yield* logger.debug(
+          `Skipping custom tool "${definition.name}": command handler is not yet implemented`,
+        );
+        continue;
+      }
+
+      const tool = buildRecordTool(
+        definition as CustomToolDefinition & { readonly handler: CustomToolRecordHandler },
+      );
+      yield* registry.registerTool(tool, CUSTOM_TOOLS_CATEGORY);
+      registeredToolNames.add(definition.name);
+
+      yield* logger.debug(`Registered custom tool "${definition.name}" (record handler)`);
+    }
+  });
+}

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -16,6 +16,7 @@ import { createSanitizedEnv, type ProcessEnvRecord } from "@/core/utils/env-util
 import { convertMCPSchemaToZod } from "@/core/utils/mcp-schema-converter";
 import { defineTool, makeZodValidator } from "./base-tool";
 import { buildKeyFromContext } from "./context-utils";
+import { validateCustomToolDefinitionShape } from "./custom-tool-validation";
 
 /**
  * Custom-tool registration module
@@ -36,6 +37,12 @@ const COMMAND_OUTPUT_CAP_BYTES = 16 * 1024;
 
 /** Default kill timeout for `command`-handler custom tools when unset. */
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+/** Extra margin added on top of a command tool's configured `timeoutMs` when
+ * registering it with the tool executor (see `buildCommandTool`), so the
+ * executor's own timeout can never fire before the command's internal kill
+ * timeout has a chance to. */
+const EXECUTOR_TIMEOUT_MARGIN_MS = 5_000;
 
 type CommandExecutionOutcome =
   | {
@@ -162,6 +169,9 @@ function buildRecordTool(
       description: definition.description,
       parameters,
       validate,
+      // Read-only: fixed response, no side effects — matches defineTool's
+      // own default for non-approval tools, set explicitly here for clarity.
+      riskLevel: "read-only",
       handler: (): Effect.Effect<ToolExecutionResult, Error, never> =>
         Effect.succeed({ success: true, result: response }),
     }),
@@ -175,15 +185,29 @@ function buildRecordTool(
  * Execution spawns `handler.command` argv directly (no shell), with the
  * validated tool arguments serialized as JSON on the child's stdin. Env and
  * cwd resolution match `execute_command`: `createSanitizedEnv({},
- * agent.config.envAllowlist ?? [])` for env, and the run's current working
- * directory (via `FileSystemContextService.getCwd`) for cwd — this handler
- * has no `workingDirectory` argument to override it, since the tool's
- * parameters are entirely user-declared. Exit code 0 succeeds with the
- * captured (bounded) stdout; a non-zero exit, timeout, or spawn error
- * produces the same error-result shape `execute_command` uses.
+ * declaringEnvAllowlist)` for env, and the run's current working directory
+ * (via `FileSystemContextService.getCwd`) for cwd — this handler has no
+ * `workingDirectory` argument to override it, since the tool's parameters
+ * are entirely user-declared. Exit code 0 succeeds with the captured
+ * (bounded) stdout; a non-zero exit, timeout, or spawn error produces the
+ * same error-result shape `execute_command` uses.
+ *
+ * `declaringEnvAllowlist` is the `envAllowlist` of the AGENT THAT DECLARED
+ * this custom tool (captured once, at registration time), not whichever
+ * agent happens to be `context.parentAgent` when the tool is invoked. This
+ * matters because subagents can call tools registered by a parent agent
+ * (or vice versa) under a `ToolExecutionContext` whose `parentAgent` differs
+ * from the declaring agent — using the call-time `context.parentAgent`
+ * would silently apply the WRONG agent's allowlist (e.g. leaking a token the
+ * declaring agent was never granted, or scrubbing one it was).
+ *
+ * Command tools spawn arbitrary processes on every invocation with no
+ * interactive approval step, so they are always registered `high-risk`
+ * regardless of what the command itself does.
  */
 function buildCommandTool(
   definition: CustomToolDefinition & { readonly handler: CustomToolCommandHandler },
+  declaringEnvAllowlist: readonly string[],
 ): Tool<FileSystemContextService | LoggerService> {
   const parameters = convertMCPSchemaToZod(definition.parameters, definition.name);
   const validate = makeZodValidator(parameters as z.ZodType<Record<string, unknown>>);
@@ -196,6 +220,14 @@ function buildCommandTool(
       description: definition.description,
       parameters,
       validate,
+      riskLevel: "high-risk",
+      // Give the tool executor's own timeout (TOOL_TIMEOUT_MS, 3 minutes by
+      // default) a margin above this tool's configured kill timeout, so a
+      // command tool configured close to (or past) the 3-minute default
+      // executor timeout isn't cut off by the executor before its own
+      // internal timeout/kill logic in `runCustomToolCommand` gets a chance
+      // to run.
+      timeoutMs: timeoutMs + EXECUTOR_TIMEOUT_MARGIN_MS,
       handler: (
         args,
         context,
@@ -205,8 +237,7 @@ function buildCommandTool(
           const logger = yield* LoggerServiceTag;
 
           const cwd = yield* shell.getCwd(buildKeyFromContext(context));
-          const envAllowlist = context.parentAgent?.config.envAllowlist ?? [];
-          const sanitizedEnv = createSanitizedEnv({}, envAllowlist);
+          const sanitizedEnv = createSanitizedEnv({}, declaringEnvAllowlist);
           const stdinPayload = JSON.stringify(args);
 
           const outcome = yield* Effect.promise(() =>
@@ -269,12 +300,22 @@ function isDeepEqual(left: unknown, right: unknown): boolean {
  *
  * Only entries whose `name` appears in `agentToolNames` are registered — an
  * agent may declare custom tools it doesn't actually expose to itself (e.g.
- * shared config templates). Colliding with an already-registered tool name
- * (builtin or MCP) fails startup with `AgentConfigurationError` rather than
- * silently overriding the existing registration.
+ * shared config templates). Every selected definition is re-validated here
+ * (via `validateCustomToolDefinitionShape`) even though `AgentServiceImpl.
+ * validateAgentConfig` runs the same checks on create/update — an agent
+ * config can be loaded from a file or another untrusted source that never
+ * went through that path, so registration fails CLOSED on any malformed
+ * definition (including an unrecognized `handler.type`) instead of silently
+ * treating it as a `record` handler.
+ *
+ * Colliding with an already-registered tool name (builtin or MCP) fails the
+ * run with `AgentConfigurationError` rather than silently overriding the
+ * existing registration.
  *
  * `command`-handler entries spawn the declared command directly (no shell)
- * on each invocation; see `buildCommandTool` for execution semantics.
+ * on each invocation, using THIS agent's `envAllowlist` (captured at
+ * registration time — see `buildCommandTool`'s doc comment for why call-time
+ * `context.parentAgent` would be the wrong source).
  */
 export function registerCustomToolsForAgent(
   agent: Agent,
@@ -299,9 +340,22 @@ export function registerCustomToolsForAgent(
       return;
     }
 
+    const declaringEnvAllowlist = agent.config.envAllowlist ?? [];
     const registeredToolNames = new Set(yield* registry.listAllTools());
 
     for (const definition of selected) {
+      const shapeIssue = validateCustomToolDefinitionShape(definition);
+      if (shapeIssue) {
+        yield* Effect.fail(
+          new AgentConfigurationError({
+            agentId: agent.id,
+            field: "config.customTools",
+            message: shapeIssue.message,
+            suggestion: shapeIssue.suggestion,
+          }),
+        );
+      }
+
       if (registeredToolNames.has(definition.name)) {
         // The ToolRegistry is a session-lifetime singleton and this function
         // runs on every AgentRunner.run (i.e. every chat turn), so seeing the
@@ -336,6 +390,7 @@ export function registerCustomToolsForAgent(
       if (definition.handler.type === "command") {
         const commandTool = buildCommandTool(
           definition as CustomToolDefinition & { readonly handler: CustomToolCommandHandler },
+          declaringEnvAllowlist,
         );
         yield* registry.registerTool(commandTool, CUSTOM_TOOLS_CATEGORY);
         registeredToolNames.add(definition.name);

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import type { z } from "zod";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { ToolRegistryTag, type Tool, type ToolRegistry } from "@/core/interfaces/tool-registry";
@@ -39,14 +39,47 @@ function buildRecordTool(
   const validate = makeZodValidator(parameters as z.ZodType<Record<string, unknown>>);
   const response = definition.handler.response ?? "Recorded.";
 
-  return defineTool<never, Record<string, unknown>>({
-    name: definition.name,
-    description: definition.description,
-    parameters,
-    validate,
-    handler: (): Effect.Effect<ToolExecutionResult, Error, never> =>
-      Effect.succeed({ success: true, result: response }),
-  });
+  return {
+    ...defineTool<never, Record<string, unknown>>({
+      name: definition.name,
+      description: definition.description,
+      parameters,
+      validate,
+      handler: (): Effect.Effect<ToolExecutionResult, Error, never> =>
+        Effect.succeed({ success: true, result: response }),
+    }),
+    sourceCustomToolDefinition: definition,
+  };
+}
+
+/**
+ * Structural equality for JSON-like values (the shape `CustomToolDefinition`
+ * is restricted to: strings, numbers, booleans, null, arrays, and plain
+ * objects). Used to tell whether a re-registration is the exact same custom
+ * tool definition, or a genuinely different one that happens to share a name.
+ */
+function isDeepEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) {
+    return false;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    return left.every((item, index) => isDeepEqual(item, right[index]));
+  }
+
+  const leftEntries = Object.entries(left as Record<string, unknown>);
+  const rightRecord = right as Record<string, unknown>;
+  if (leftEntries.length !== Object.keys(rightRecord).length) {
+    return false;
+  }
+  return leftEntries.every(([key, value]) => isDeepEqual(value, rightRecord[key]));
 }
 
 /**
@@ -88,7 +121,27 @@ export function registerCustomToolsForAgent(
 
     for (const definition of selected) {
       if (registeredToolNames.has(definition.name)) {
-        return yield* Effect.fail(
+        // The ToolRegistry is a session-lifetime singleton and this function
+        // runs on every AgentRunner.run (i.e. every chat turn), so seeing the
+        // name again is expected — it's not necessarily a collision. Only
+        // fail if the existing registration is NOT this same custom-tool
+        // definition (a different custom tool, or a builtin/MCP tool).
+        const existingTool = yield* registry.getTool(definition.name).pipe(Effect.option);
+        const existingDefinition = existingTool.pipe(
+          Option.flatMap((tool) => Option.fromNullable(tool.sourceCustomToolDefinition)),
+        );
+
+        if (
+          Option.isSome(existingDefinition) &&
+          isDeepEqual(existingDefinition.value, definition)
+        ) {
+          yield* logger.debug(
+            `Custom tool "${definition.name}" is already registered with an identical definition, skipping re-registration`,
+          );
+          continue;
+        }
+
+        yield* Effect.fail(
           new AgentConfigurationError({
             agentId: agent.id,
             field: "config.customTools",

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -32,8 +32,8 @@ import { validateCustomToolDefinitionShape } from "./custom-tool-validation";
  *   semantics (see `shell-tools.ts`).
  */
 
-/** Hard cap on captured stdout/stderr per command execution, in bytes. */
-const COMMAND_OUTPUT_CAP_BYTES = 16 * 1024;
+/** Hard cap on captured stdout/stderr per command execution, in BYTES (not UTF-16 code units). */
+const MAX_COMMAND_OUTPUT_BYTES = 16 * 1024;
 
 /** Default kill timeout for `command`-handler custom tools when unset. */
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
@@ -53,21 +53,38 @@ type CommandExecutionOutcome =
     }
   | { readonly ok: false; readonly error: string };
 
+/** Accumulated command output, tracked in both decoded text and true byte count. */
+interface CappedOutput {
+  readonly text: string;
+  readonly bytes: number;
+}
+
+const EMPTY_CAPPED_OUTPUT: CappedOutput = { text: "", bytes: 0 };
+
 /**
- * Append `chunk` to `current`, truncating so the combined string never
- * exceeds `capBytes`. Caps per chunk (not post-hoc) so an unbounded stream
- * never balloons memory before being sliced down.
+ * Append a raw stdout/stderr `chunk` (as delivered by Node's child_process
+ * stream, before any string decoding) to `current`, truncating so the
+ * combined output never exceeds `capBytes` BYTES — measured via
+ * `Buffer.byteLength`/`Buffer.subarray`, not `String.prototype.length` (which
+ * counts UTF-16 code units and undercounts multi-byte UTF-8 output). Caps per
+ * chunk (not post-hoc) so an unbounded stream never balloons memory before
+ * being sliced down.
  */
-function appendCapped(current: string, chunk: string, capBytes: number): string {
-  if (current.length >= capBytes) {
+function appendCapped(current: CappedOutput, chunk: Buffer, capBytes: number): CappedOutput {
+  if (current.bytes >= capBytes) {
     return current;
   }
-  return current + chunk.slice(0, capBytes - current.length);
+  const remainingBytes = capBytes - current.bytes;
+  const truncatedChunk = chunk.subarray(0, remainingBytes);
+  return {
+    text: current.text + truncatedChunk.toString(),
+    bytes: current.bytes + truncatedChunk.byteLength,
+  };
 }
 
 /**
  * Spawn `argv` directly (no shell), write `stdin` to the child's stdin, and
- * collect stdout/stderr up to `COMMAND_OUTPUT_CAP_BYTES` each. Resolves
+ * collect stdout/stderr up to `MAX_COMMAND_OUTPUT_BYTES` each. Resolves
  * (never rejects) with either the process outcome or a bounded error message
  * covering spawn failures and timeout kills — mirrors how `execute_command`
  * in `shell-tools.ts` reports failures to the model.
@@ -87,8 +104,8 @@ function runCustomToolCommand(
     }
 
     let settled = false;
-    let stdout = "";
-    let stderr = "";
+    let stdout: CappedOutput = EMPTY_CAPPED_OUTPUT;
+    let stderr: CappedOutput = EMPTY_CAPPED_OUTPUT;
     let child: ChildProcess;
 
     try {
@@ -121,11 +138,11 @@ function runCustomToolCommand(
     }, timeoutMs);
 
     child.stdout?.on("data", (data: Buffer) => {
-      stdout = appendCapped(stdout, data.toString(), COMMAND_OUTPUT_CAP_BYTES);
+      stdout = appendCapped(stdout, data, MAX_COMMAND_OUTPUT_BYTES);
     });
 
     child.stderr?.on("data", (data: Buffer) => {
-      stderr = appendCapped(stderr, data.toString(), COMMAND_OUTPUT_CAP_BYTES);
+      stderr = appendCapped(stderr, data, MAX_COMMAND_OUTPUT_BYTES);
     });
 
     child.on("error", (error) => {
@@ -133,7 +150,7 @@ function runCustomToolCommand(
     });
 
     child.on("close", (code) => {
-      finish({ ok: true, exitCode: code ?? 0, stdout, stderr });
+      finish({ ok: true, exitCode: code ?? 0, stdout: stdout.text, stderr: stderr.text });
     });
 
     // If the child exits before consuming stdin (or never reads it), writing
@@ -308,9 +325,9 @@ function isDeepEqual(left: unknown, right: unknown): boolean {
  * definition (including an unrecognized `handler.type`) instead of silently
  * treating it as a `record` handler.
  *
- * Colliding with an already-registered tool name (builtin or MCP) fails the
- * run with `AgentConfigurationError` rather than silently overriding the
- * existing registration.
+ * Colliding with an already-registered tool name OR ALIAS (builtin, MCP, or
+ * another custom tool) fails the run with `AgentConfigurationError` rather
+ * than silently overriding the existing registration.
  *
  * `command`-handler entries spawn the declared command directly (no shell)
  * on each invocation, using THIS agent's `envAllowlist` (captured at
@@ -341,7 +358,6 @@ export function registerCustomToolsForAgent(
     }
 
     const declaringEnvAllowlist = agent.config.envAllowlist ?? [];
-    const registeredToolNames = new Set(yield* registry.listAllTools());
 
     for (const definition of selected) {
       const shapeIssue = validateCustomToolDefinitionShape(definition);
@@ -356,15 +372,21 @@ export function registerCustomToolsForAgent(
         );
       }
 
-      if (registeredToolNames.has(definition.name)) {
+      // Resolving through `getTool` (rather than `listAllTools`, which only
+      // returns primary names) also catches a custom tool shadowing an ALIAS
+      // of an existing tool (e.g. "glob", an alias for "find_files") — the
+      // registry resolves aliases transparently, so this lookup finds the
+      // collision either way.
+      const existingTool = yield* registry.getTool(definition.name).pipe(Effect.option);
+
+      if (Option.isSome(existingTool)) {
         // The ToolRegistry is a session-lifetime singleton and this function
         // runs on every AgentRunner.run (i.e. every chat turn), so seeing the
         // name again is expected — it's not necessarily a collision. Only
         // fail if the existing registration is NOT this same custom-tool
         // definition (a different custom tool, or a builtin/MCP tool).
-        const existingTool = yield* registry.getTool(definition.name).pipe(Effect.option);
-        const existingDefinition = existingTool.pipe(
-          Option.flatMap((tool) => Option.fromNullable(tool.sourceCustomToolDefinition)),
+        const existingDefinition = Option.fromNullable(
+          existingTool.value.sourceCustomToolDefinition,
         );
 
         if (
@@ -377,14 +399,29 @@ export function registerCustomToolsForAgent(
           continue;
         }
 
-        yield* Effect.fail(
-          new AgentConfigurationError({
-            agentId: agent.id,
-            field: "config.customTools",
-            message: `Custom tool "${definition.name}" collides with an already-registered tool (builtin or MCP). Rename the custom tool or remove the conflicting one.`,
-            suggestion: `Choose a unique name for the "${definition.name}" custom tool.`,
-          }),
-        );
+        if (Option.isSome(existingDefinition)) {
+          // Same name, but the previously-registered custom tool's
+          // definition differs from this run's — the ToolRegistry has no way
+          // to update an existing registration in place, so this fails the
+          // RUN mid-session rather than at process startup.
+          yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: agent.id,
+              field: "config.customTools",
+              message: `Custom tool "${definition.name}" is already registered with a different definition than before (definition changed — restart the session or revert the config).`,
+              suggestion: `Restart the session, or revert the "${definition.name}" custom tool definition to match what was registered earlier.`,
+            }),
+          );
+        } else {
+          yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: agent.id,
+              field: "config.customTools",
+              message: `Custom tool "${definition.name}" collides with an existing builtin or MCP tool (or one of its aliases). Rename yours.`,
+              suggestion: `Choose a unique name for the "${definition.name}" custom tool.`,
+            }),
+          );
+        }
       }
 
       if (definition.handler.type === "command") {
@@ -393,7 +430,6 @@ export function registerCustomToolsForAgent(
           declaringEnvAllowlist,
         );
         yield* registry.registerTool(commandTool, CUSTOM_TOOLS_CATEGORY);
-        registeredToolNames.add(definition.name);
 
         yield* logger.debug(`Registered custom tool "${definition.name}" (command handler)`);
         continue;
@@ -403,7 +439,6 @@ export function registerCustomToolsForAgent(
         definition as CustomToolDefinition & { readonly handler: CustomToolRecordHandler },
       );
       yield* registry.registerTool(tool, CUSTOM_TOOLS_CATEGORY);
-      registeredToolNames.add(definition.name);
 
       yield* logger.debug(`Registered custom tool "${definition.name}" (record handler)`);
     }

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -53,13 +53,13 @@ type CommandExecutionOutcome =
     }
   | { readonly ok: false; readonly error: string };
 
-/** Accumulated command output, tracked in both decoded text and true byte count. */
-interface CappedOutput {
-  readonly text: string;
+/** Accumulated command output, tracked as raw (capped) byte chunks plus a running byte count. */
+export interface CappedOutput {
+  readonly chunks: readonly Buffer[];
   readonly bytes: number;
 }
 
-const EMPTY_CAPPED_OUTPUT: CappedOutput = { text: "", bytes: 0 };
+export const EMPTY_CAPPED_OUTPUT: CappedOutput = { chunks: [], bytes: 0 };
 
 /**
  * Append a raw stdout/stderr `chunk` (as delivered by Node's child_process
@@ -69,17 +69,31 @@ const EMPTY_CAPPED_OUTPUT: CappedOutput = { text: "", bytes: 0 };
  * counts UTF-16 code units and undercounts multi-byte UTF-8 output). Caps per
  * chunk (not post-hoc) so an unbounded stream never balloons memory before
  * being sliced down.
+ *
+ * Deliberately keeps the raw `Buffer` chunks rather than decoding here: a
+ * multi-byte UTF-8 character can straddle two separate `data` events (or,
+ * post-cap, straddle the truncation cut itself), and decoding chunk-by-chunk
+ * would turn each half into a replacement character (U+FFFD). Decoding is
+ * deferred to `decodeCapped`, which runs once over the fully concatenated
+ * buffer so only in-stream chunk seams are healed — a character split by the
+ * cap cut itself can still yield one trailing replacement character, which is
+ * an acceptable, inherent cost of truncating raw bytes.
  */
-function appendCapped(current: CappedOutput, chunk: Buffer, capBytes: number): CappedOutput {
+export function appendCapped(current: CappedOutput, chunk: Buffer, capBytes: number): CappedOutput {
   if (current.bytes >= capBytes) {
     return current;
   }
   const remainingBytes = capBytes - current.bytes;
   const truncatedChunk = chunk.subarray(0, remainingBytes);
   return {
-    text: current.text + truncatedChunk.toString(),
+    chunks: [...current.chunks, truncatedChunk],
     bytes: current.bytes + truncatedChunk.byteLength,
   };
+}
+
+/** Decode a `CappedOutput`'s accumulated raw chunks to a UTF-8 string, once, over the full concatenated buffer. */
+export function decodeCapped(current: CappedOutput): string {
+  return Buffer.concat(current.chunks).toString("utf8");
 }
 
 /**
@@ -150,7 +164,12 @@ function runCustomToolCommand(
     });
 
     child.on("close", (code) => {
-      finish({ ok: true, exitCode: code ?? 0, stdout: stdout.text, stderr: stderr.text });
+      finish({
+        ok: true,
+        exitCode: code ?? 0,
+        stdout: decodeCapped(stdout),
+        stderr: decodeCapped(stderr),
+      });
     });
 
     // If the child exits before consuming stdin (or never reads it), writing

--- a/src/core/agent/tools/shell-tools.test.ts
+++ b/src/core/agent/tools/shell-tools.test.ts
@@ -7,7 +7,7 @@ import { createToolRegistryLayer } from "./tool-registry";
 import { FileSystemContextServiceTag, type FileSystemContextService } from "../../interfaces/fs";
 import { LoggerServiceTag, type LoggerService } from "../../interfaces/logger";
 import { TerminalServiceTag, type TerminalService } from "../../interfaces/terminal";
-import type { ToolExecutionResult } from "../../types";
+import type { Agent, ToolExecutionResult } from "../../types";
 
 describe("Shell Tools", () => {
   const createTestLayer = () => {
@@ -225,6 +225,58 @@ describe("Shell Tools", () => {
     expect(result.result).toHaveProperty("stdout");
     expect(result.result).toHaveProperty("stderr");
     expect(result.result).toHaveProperty("success", true);
+  });
+
+  it("passes the agent's envAllowlist through to the sanitized child env", async () => {
+    const originalValue = process.env["MY_ALLOWED_TOKEN"];
+    process.env["MY_ALLOWED_TOKEN"] = "letmethrough";
+
+    try {
+      const tool = shellTools.execute;
+      const parentAgent: Agent = {
+        id: "test-agent",
+        name: "test-agent",
+        model: "openai/gpt-4o",
+        config: {
+          persona: "default",
+          llmProvider: "openai",
+          llmModel: "gpt-4o",
+          envAllowlist: ["MY_ALLOWED_TOKEN"],
+        } as Agent["config"],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const context = {
+        agentId: "test-agent",
+        conversationId: "test-conversation",
+        parentAgent,
+      };
+
+      const result: ToolExecutionResult = await Effect.runPromise(
+        Effect.provide(
+          tool.execute(
+            {
+              command: "echo $MY_ALLOWED_TOKEN",
+              description: "Print the allowlisted env var to prove it passed through.",
+            },
+            context,
+          ),
+          createTestLayer(),
+        ),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.result).toHaveProperty("stdout");
+      if (result.result && typeof result.result === "object" && "stdout" in result.result) {
+        expect((result.result as { stdout: string }).stdout.trim()).toBe("letmethrough");
+      }
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["MY_ALLOWED_TOKEN"];
+      } else {
+        process.env["MY_ALLOWED_TOKEN"] = originalValue;
+      }
+    }
   });
 
   it("should handle invalid commands gracefully", async () => {

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -249,8 +249,10 @@ This command will be executed on your system. Only approve commands you trust.`;
         }
 
         try {
-          // Sanitize environment variables for security
-          const sanitizedEnv = createSanitizedEnv();
+          // Sanitize environment variables for security, exempting any
+          // agent-configured allowlist from the sensitive-name scrub.
+          const envAllowlist = context.parentAgent?.config.envAllowlist ?? [];
+          const sanitizedEnv = createSanitizedEnv({}, envAllowlist);
 
           const result = yield* Effect.promise<{
             stdout: string;

--- a/src/core/interfaces/tool-registry.ts
+++ b/src/core/interfaces/tool-registry.ts
@@ -2,6 +2,7 @@ import { FileSystem } from "@effect/platform";
 import { Context, Effect } from "effect";
 import type z from "zod";
 import type { SkillService } from "@/core/skills/skill-service";
+import type { CustomToolDefinition } from "@/core/types/agent";
 import type { ToolNotFoundError } from "@/core/types/errors";
 import type {
   ToolCategory,
@@ -76,6 +77,15 @@ export interface Tool<R = never> {
    * Overrides the default TOOL_TIMEOUT_MS (3 minutes).
    */
   readonly timeoutMs?: number;
+  /**
+   * Present only on tools built from an agent's declared `customTools` config
+   * (see `CustomToolDefinition` in `@/core/types/agent`). The `ToolRegistry` is
+   * a session-lifetime singleton and custom-tool registration re-runs on every
+   * `AgentRunner.run`, so this lets the registration path tell whether a name
+   * collision is a harmless re-registration of the same custom tool (safe to
+   * skip) versus a genuine conflict with a different tool.
+   */
+  readonly sourceCustomToolDefinition?: CustomToolDefinition;
   /**
    * Executes the tool with the provided arguments and context.
    *

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -65,4 +65,49 @@ export interface AgentConfig {
    * 32 names. Does not affect `grep`/`find`/`git` tool spawns.
    */
   readonly envAllowlist?: readonly string[];
+  /**
+   * User-declared tools this agent can call, in addition to built-in tools.
+   * At most 16 entries; names must be unique within the array and must not
+   * start with `mcp_` (reserved for MCP-sourced tools). Collisions with
+   * registered builtin tool names are rejected at registration time, not here.
+   */
+  readonly customTools?: readonly CustomToolDefinition[];
+}
+
+/**
+ * A custom tool handler that always returns a fixed response without
+ * executing anything, useful for stubbing or documentation-style tools.
+ */
+export interface CustomToolRecordHandler {
+  readonly type: "record";
+  /** Fixed response returned when the tool is invoked. Defaults to an empty response when omitted. */
+  readonly response?: string;
+}
+
+/**
+ * A custom tool handler that shells out to an external command when invoked.
+ */
+export interface CustomToolCommandHandler {
+  readonly type: "command";
+  /** Command and arguments to execute, e.g. `["echo", "hello"]`. Must be non-empty. */
+  readonly command: readonly string[];
+  /** Maximum execution time in milliseconds before the command is killed. Must be a positive integer, at most 300_000 (5 minutes). */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * User-declared custom tool exposed to an agent's LLM in addition to built-in tools.
+ *
+ * The `parameters` field is a JSON Schema object describing the tool's input,
+ * following the same shape LLM providers expect for function/tool calling.
+ */
+export interface CustomToolDefinition {
+  /** Unique tool name. Must match `^[a-z][a-z0-9_]{1,63}$` and must not start with `mcp_`. */
+  readonly name: string;
+  /** Human-readable description of what the tool does, shown to the LLM. 1-1024 characters. */
+  readonly description: string;
+  /** JSON Schema object describing the tool's parameters. Must have `type: "object"`. */
+  readonly parameters: Record<string, unknown>;
+  /** How the tool behaves when invoked: return a fixed response, or run a command. */
+  readonly handler: CustomToolRecordHandler | CustomToolCommandHandler;
 }

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -80,7 +80,7 @@ export interface AgentConfig {
  */
 export interface CustomToolRecordHandler {
   readonly type: "record";
-  /** Fixed response returned when the tool is invoked. Defaults to an empty response when omitted. */
+  /** Fixed response returned when the tool is invoked. Defaults to `"Recorded."` when omitted. */
   readonly response?: string;
 }
 

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -58,4 +58,11 @@ export interface AgentConfig {
   readonly temperature?: number;
   readonly tools?: readonly string[];
   readonly webSearchProvider?: WebSearchProviderName;
+  /**
+   * Env var names exempted from the `execute_command` shell env scrub, even
+   * when they match the sensitive-name regex (API|KEY|SECRET|TOKEN|PASSWORD|
+   * CREDENTIAL|AUTH). Each name must match `^[A-Z][A-Z0-9_]{0,63}$`; at most
+   * 32 names. Does not affect `grep`/`find`/`git` tool spawns.
+   */
+  readonly envAllowlist?: readonly string[];
 }

--- a/src/core/utils/env-utils.test.ts
+++ b/src/core/utils/env-utils.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { createSanitizedEnv } from "./env-utils";
+
+describe("createSanitizedEnv", () => {
+  it("scrubs sensitive-looking env vars by default", () => {
+    const originalValue = process.env["MY_SECRET_TOKEN"];
+    process.env["MY_SECRET_TOKEN"] = "super-secret-value";
+
+    try {
+      const sanitized = createSanitizedEnv();
+      expect(sanitized["MY_SECRET_TOKEN"]).toBeUndefined();
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["MY_SECRET_TOKEN"];
+      } else {
+        process.env["MY_SECRET_TOKEN"] = originalValue;
+      }
+    }
+  });
+
+  it("copies an allowlisted var through even though it matches the scrub regex", () => {
+    const originalValue = process.env["MY_SECRET_TOKEN"];
+    process.env["MY_SECRET_TOKEN"] = "super-secret-value";
+
+    try {
+      const sanitized = createSanitizedEnv({}, ["MY_SECRET_TOKEN"]);
+      expect(sanitized["MY_SECRET_TOKEN"]).toBe("super-secret-value");
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["MY_SECRET_TOKEN"];
+      } else {
+        process.env["MY_SECRET_TOKEN"] = originalValue;
+      }
+    }
+  });
+
+  it("does not invent an allowlisted var that is absent from process.env", () => {
+    const originalValue = process.env["MY_ABSENT_TOKEN"];
+    delete process.env["MY_ABSENT_TOKEN"];
+
+    try {
+      const sanitized = createSanitizedEnv({}, ["MY_ABSENT_TOKEN"]);
+      expect(sanitized["MY_ABSENT_TOKEN"]).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(sanitized, "MY_ABSENT_TOKEN")).toBe(false);
+    } finally {
+      if (originalValue !== undefined) {
+        process.env["MY_ABSENT_TOKEN"] = originalValue;
+      }
+    }
+  });
+
+  it("still scrubs non-allowlisted sensitive vars when an allowlist is provided", () => {
+    const originalSecret = process.env["OTHER_SECRET_KEY"];
+    const originalAllowed = process.env["MY_SECRET_TOKEN"];
+    process.env["OTHER_SECRET_KEY"] = "should-be-scrubbed";
+    process.env["MY_SECRET_TOKEN"] = "should-pass";
+
+    try {
+      const sanitized = createSanitizedEnv({}, ["MY_SECRET_TOKEN"]);
+      expect(sanitized["OTHER_SECRET_KEY"]).toBeUndefined();
+      expect(sanitized["MY_SECRET_TOKEN"]).toBe("should-pass");
+    } finally {
+      if (originalSecret === undefined) {
+        delete process.env["OTHER_SECRET_KEY"];
+      } else {
+        process.env["OTHER_SECRET_KEY"] = originalSecret;
+      }
+      if (originalAllowed === undefined) {
+        delete process.env["MY_SECRET_TOKEN"];
+      } else {
+        process.env["MY_SECRET_TOKEN"] = originalAllowed;
+      }
+    }
+  });
+
+  it("still blocks SSH_* vars even when allowlisted", () => {
+    const originalValue = process.env["SSH_AUTH_SOCK"];
+    process.env["SSH_AUTH_SOCK"] = "/tmp/ssh-agent.sock";
+
+    try {
+      const sanitized = createSanitizedEnv({}, ["SSH_AUTH_SOCK"]);
+      expect(sanitized["SSH_AUTH_SOCK"]).toBeUndefined();
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["SSH_AUTH_SOCK"];
+      } else {
+        process.env["SSH_AUTH_SOCK"] = originalValue;
+      }
+    }
+  });
+});

--- a/src/core/utils/env-utils.ts
+++ b/src/core/utils/env-utils.ts
@@ -3,8 +3,18 @@ export type ProcessEnvRecord = Record<string, string | undefined>;
 /**
  * Build a sanitized environment for child process execution.
  * Strips sensitive vars while preserving essentials like PATH.
+ *
+ * @param overrides - Values merged into the base environment before scrubbing.
+ * @param allowlist - Env var names exempted from the sensitive-name scrub
+ * regex. A name only appears in the result if it is present in
+ * `process.env` — the allowlist never invents a value. The `SSH_*` prefix
+ * block and the `key in baseEnv` guard still apply regardless of allowlist
+ * membership.
  */
-export function createSanitizedEnv(overrides: ProcessEnvRecord = {}): ProcessEnvRecord {
+export function createSanitizedEnv(
+  overrides: ProcessEnvRecord = {},
+  allowlist: readonly string[] = [],
+): ProcessEnvRecord {
   const baseEnv: ProcessEnvRecord = {
     PATH: process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin",
     HOME: process.env["HOME"],
@@ -28,8 +38,10 @@ export function createSanitizedEnv(overrides: ProcessEnvRecord = {}): ProcessEnv
       continue;
     }
 
+    const isAllowlisted = allowlist.includes(key);
+
     if (
-      /API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH/i.test(key) ||
+      (!isAllowlisted && /API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH/i.test(key)) ||
       key in baseEnv ||
       key.startsWith("SSH_")
     ) {

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -4,10 +4,11 @@ import { AgentServiceImpl } from "./agent-service";
 import { type StorageService } from "../core/interfaces/storage";
 import {
   AgentAlreadyExistsError,
+  AgentConfigurationError,
   StorageNotFoundError,
   ValidationError,
 } from "../core/types/errors";
-import { type Agent } from "../core/types/index";
+import { type Agent, type AgentConfig } from "../core/types/index";
 
 // Mock Storage Service
 const mockStorage = {
@@ -109,6 +110,79 @@ describe("AgentService", () => {
       if (result._tag === "Failure") {
         // @ts-expect-error - accessing error
         expect(result.cause.error).toBeInstanceOf(AgentAlreadyExistsError);
+      }
+    });
+  });
+
+  describe("validateAgentConfig envAllowlist", () => {
+    const baseConfig: AgentConfig = {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+    };
+
+    it("accepts well-formed allowlist names", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        envAllowlist: ["MY_TOKEN", "A", "SOME_LONG_NAME_2"],
+      });
+
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("rejects a name that does not start with an uppercase letter", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        envAllowlist: ["1BAD_NAME"],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a lowercase name", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        envAllowlist: ["my_token"],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a name longer than 64 characters", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        envAllowlist: [`A${"B".repeat(64)}`],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects more than 32 allowlist names", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        envAllowlist: Array.from({ length: 33 }, (_unused, index) => `VAR_${index}`),
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
       }
     });
   });

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -187,6 +187,361 @@ describe("AgentService", () => {
     });
   });
 
+  describe("validateAgentConfig customTools", () => {
+    const baseConfig: AgentConfig = {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+    };
+
+    it("accepts a valid record-handler tool", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "Responds with a fixed pong message.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("accepts a valid command-handler tool", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "list_files",
+            description: "Lists files in the current directory.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "command", command: ["ls", "-la"], timeoutMs: 5000 },
+          },
+        ],
+      });
+
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("rejects more than 16 custom tools", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: Array.from({ length: 17 }, (_unused, index) => ({
+          name: `tool_${index}`,
+          description: "A tool.",
+          parameters: { type: "object", properties: {} },
+          handler: { type: "record" as const, response: "ok" },
+        })),
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a non-array customTools value", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        // @ts-expect-error - testing invalid input shape
+        customTools: { name: "not-an-array" },
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a name that does not match the required pattern", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "Ping",
+            description: "Bad name casing.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a name starting with mcp_", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "mcp_something",
+            description: "Reserved prefix.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects duplicate names within the array", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "First.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+          {
+            name: "ping",
+            description: "Second.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong2" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a description that is empty", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a description longer than 1024 characters", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "A".repeat(1025),
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects parameters that are not a plain object", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "Bad parameters.",
+            // @ts-expect-error - testing invalid input shape
+            parameters: null,
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it('rejects parameters whose type is not "object"', async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "Bad parameters type.",
+            parameters: { type: "string" },
+            handler: { type: "record", response: "pong" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects an unknown handler type", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "Bad handler type.",
+            parameters: { type: "object", properties: {} },
+            // @ts-expect-error - testing invalid input shape
+            handler: { type: "bogus" },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a record response longer than 1024 characters", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "ping",
+            description: "Oversized response.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "record", response: "A".repeat(1025) },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a command handler with an empty command array", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "list_files",
+            description: "Empty command.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "command", command: [] },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a command handler with an empty string entry", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "list_files",
+            description: "Empty entry in command.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "command", command: ["ls", ""] },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a timeoutMs that is not a positive integer", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "list_files",
+            description: "Bad timeout.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "command", command: ["ls"], timeoutMs: 0 },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a timeoutMs greater than 300_000", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        customTools: [
+          {
+            name: "list_files",
+            description: "Timeout too large.",
+            parameters: { type: "object", properties: {} },
+            handler: { type: "command", command: ["ls"], timeoutMs: 300_001 },
+          },
+        ],
+      });
+
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+  });
+
   describe("deleteAgent", () => {
     it("should delete an agent", async () => {
       // @ts-expect-error - mocking

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect";
 import shortuuid from "short-uuid";
+import { validateCustomToolDefinitionShape } from "@/core/agent/tools/custom-tool-validation";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { StorageServiceTag, type StorageService } from "@/core/interfaces/storage";
@@ -256,27 +257,16 @@ export class AgentServiceImpl implements AgentService {
         const seenNames = new Set<string>();
 
         for (const customTool of customTools) {
-          const { name, description, parameters, handler } = customTool;
+          const { name } = customTool;
 
-          if (!/^[a-z][a-z0-9_]{1,63}$/.test(name)) {
+          const shapeIssue = validateCustomToolDefinitionShape(customTool);
+          if (shapeIssue) {
             return yield* Effect.fail(
               new AgentConfigurationError({
                 agentId: "unknown",
                 field: "config.customTools",
-                message: `Invalid custom tool name "${name}"`,
-                suggestion:
-                  "Use lowercase letters, digits, and underscores only, starting with a letter, 2-64 characters (e.g. list_files).",
-              }),
-            );
-          }
-
-          if (name.startsWith("mcp_")) {
-            return yield* Effect.fail(
-              new AgentConfigurationError({
-                agentId: "unknown",
-                field: "config.customTools",
-                message: `Custom tool name "${name}" cannot start with the reserved "mcp_" prefix`,
-                suggestion: "Choose a name that does not start with mcp_.",
+                message: shapeIssue.message,
+                suggestion: shapeIssue.suggestion,
               }),
             );
           }
@@ -292,100 +282,6 @@ export class AgentServiceImpl implements AgentService {
             );
           }
           seenNames.add(name);
-
-          if (
-            typeof description !== "string" ||
-            description.length < 1 ||
-            description.length > 1024
-          ) {
-            return yield* Effect.fail(
-              new AgentConfigurationError({
-                agentId: "unknown",
-                field: "config.customTools",
-                message: `Custom tool "${name}" description must be a string between 1 and 1024 characters`,
-                suggestion: "Provide a short, non-empty description of what the tool does.",
-              }),
-            );
-          }
-
-          if (
-            typeof parameters !== "object" ||
-            parameters === null ||
-            Array.isArray(parameters) ||
-            parameters["type"] !== "object"
-          ) {
-            return yield* Effect.fail(
-              new AgentConfigurationError({
-                agentId: "unknown",
-                field: "config.customTools",
-                message: `Custom tool "${name}" parameters must be a JSON Schema object with "type": "object"`,
-                suggestion:
-                  'Set parameters to an object schema, e.g. { type: "object", properties: {} }.',
-              }),
-            );
-          }
-
-          if (
-            typeof handler !== "object" ||
-            handler === null ||
-            (handler.type !== "record" && handler.type !== "command")
-          ) {
-            return yield* Effect.fail(
-              new AgentConfigurationError({
-                agentId: "unknown",
-                field: "config.customTools",
-                message: `Custom tool "${name}" handler.type must be "record" or "command"`,
-                suggestion: 'Set handler.type to "record" or "command".',
-              }),
-            );
-          }
-
-          if (handler.type === "record") {
-            if (
-              handler.response !== undefined &&
-              (typeof handler.response !== "string" || handler.response.length > 1024)
-            ) {
-              return yield* Effect.fail(
-                new AgentConfigurationError({
-                  agentId: "unknown",
-                  field: "config.customTools",
-                  message: `Custom tool "${name}" handler.response must be a string of at most 1024 characters`,
-                  suggestion: "Shorten the fixed response or remove it.",
-                }),
-              );
-            }
-          } else {
-            if (
-              !Array.isArray(handler.command) ||
-              handler.command.length === 0 ||
-              handler.command.some((part) => typeof part !== "string" || part.length === 0)
-            ) {
-              return yield* Effect.fail(
-                new AgentConfigurationError({
-                  agentId: "unknown",
-                  field: "config.customTools",
-                  message: `Custom tool "${name}" handler.command must be a non-empty array of non-empty strings`,
-                  suggestion: 'Provide a command like ["ls", "-la"].',
-                }),
-              );
-            }
-
-            if (
-              handler.timeoutMs !== undefined &&
-              (!Number.isInteger(handler.timeoutMs) ||
-                handler.timeoutMs <= 0 ||
-                handler.timeoutMs > 300_000)
-            ) {
-              return yield* Effect.fail(
-                new AgentConfigurationError({
-                  agentId: "unknown",
-                  field: "config.customTools",
-                  message: `Custom tool "${name}" handler.timeoutMs must be a positive integer of at most 300000`,
-                  suggestion: "Set timeoutMs between 1 and 300000 milliseconds, or omit it.",
-                }),
-              );
-            }
-          }
         }
       }
 

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -10,7 +10,7 @@ import {
   StorageNotFoundError,
   ValidationError,
 } from "@/core/types/errors";
-import { type Agent, type AgentConfig } from "@/core/types/index";
+import { type Agent, type AgentConfig, type CustomToolDefinition } from "@/core/types/index";
 import { CommonSuggestions } from "@/core/utils/error-handler";
 
 export class AgentServiceImpl implements AgentService {
@@ -184,18 +184,33 @@ export class AgentServiceImpl implements AgentService {
 
       // Validate envAllowlist
       if (config.envAllowlist) {
-        if (config.envAllowlist.length > 32) {
+        if (!Array.isArray(config.envAllowlist)) {
           return yield* Effect.fail(
             new AgentConfigurationError({
               agentId: "unknown",
               field: "config.envAllowlist",
-              message: `envAllowlist cannot contain more than 32 names (${config.envAllowlist.length} provided)`,
+              message: "envAllowlist must be provided as an array of env var names",
+              suggestion: 'Supply an array of uppercase env var names, e.g. ["MY_TOKEN"].',
+            }),
+          );
+        }
+
+        // `Array.isArray` narrows to `any[]`, discarding the `readonly string[]`
+        // element type, so re-assert it explicitly before using the value.
+        const envAllowlist = config.envAllowlist as readonly string[];
+
+        if (envAllowlist.length > 32) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.envAllowlist",
+              message: `envAllowlist cannot contain more than 32 names (${envAllowlist.length} provided)`,
               suggestion: "Remove unused entries so at most 32 names remain.",
             }),
           );
         }
 
-        for (const name of config.envAllowlist) {
+        for (const name of envAllowlist) {
           if (!/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
             return yield* Effect.fail(
               new AgentConfigurationError({
@@ -206,6 +221,170 @@ export class AgentServiceImpl implements AgentService {
                   "Use uppercase letters, digits, and underscores only, starting with a letter, up to 64 characters (e.g. MY_TOKEN).",
               }),
             );
+          }
+        }
+      }
+
+      // Validate customTools
+      if (config.customTools) {
+        if (!Array.isArray(config.customTools)) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.customTools",
+              message: "customTools must be provided as an array of tool definitions",
+              suggestion: "Supply an array of custom tool definitions.",
+            }),
+          );
+        }
+
+        // `Array.isArray` narrows to `any[]`, discarding the `readonly
+        // CustomToolDefinition[]` element type, so re-assert it explicitly.
+        const customTools = config.customTools as readonly CustomToolDefinition[];
+
+        if (customTools.length > 16) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.customTools",
+              message: `customTools cannot contain more than 16 entries (${customTools.length} provided)`,
+              suggestion: "Remove unused entries so at most 16 custom tools remain.",
+            }),
+          );
+        }
+
+        const seenNames = new Set<string>();
+
+        for (const customTool of customTools) {
+          const { name, description, parameters, handler } = customTool;
+
+          if (!/^[a-z][a-z0-9_]{1,63}$/.test(name)) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Invalid custom tool name "${name}"`,
+                suggestion:
+                  "Use lowercase letters, digits, and underscores only, starting with a letter, 2-64 characters (e.g. list_files).",
+              }),
+            );
+          }
+
+          if (name.startsWith("mcp_")) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Custom tool name "${name}" cannot start with the reserved "mcp_" prefix`,
+                suggestion: "Choose a name that does not start with mcp_.",
+              }),
+            );
+          }
+
+          if (seenNames.has(name)) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Duplicate custom tool name "${name}"`,
+                suggestion: "Ensure every custom tool has a unique name.",
+              }),
+            );
+          }
+          seenNames.add(name);
+
+          if (
+            typeof description !== "string" ||
+            description.length < 1 ||
+            description.length > 1024
+          ) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Custom tool "${name}" description must be a string between 1 and 1024 characters`,
+                suggestion: "Provide a short, non-empty description of what the tool does.",
+              }),
+            );
+          }
+
+          if (
+            typeof parameters !== "object" ||
+            parameters === null ||
+            Array.isArray(parameters) ||
+            parameters["type"] !== "object"
+          ) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Custom tool "${name}" parameters must be a JSON Schema object with "type": "object"`,
+                suggestion:
+                  'Set parameters to an object schema, e.g. { type: "object", properties: {} }.',
+              }),
+            );
+          }
+
+          if (
+            typeof handler !== "object" ||
+            handler === null ||
+            (handler.type !== "record" && handler.type !== "command")
+          ) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.customTools",
+                message: `Custom tool "${name}" handler.type must be "record" or "command"`,
+                suggestion: 'Set handler.type to "record" or "command".',
+              }),
+            );
+          }
+
+          if (handler.type === "record") {
+            if (
+              handler.response !== undefined &&
+              (typeof handler.response !== "string" || handler.response.length > 1024)
+            ) {
+              return yield* Effect.fail(
+                new AgentConfigurationError({
+                  agentId: "unknown",
+                  field: "config.customTools",
+                  message: `Custom tool "${name}" handler.response must be a string of at most 1024 characters`,
+                  suggestion: "Shorten the fixed response or remove it.",
+                }),
+              );
+            }
+          } else {
+            if (
+              !Array.isArray(handler.command) ||
+              handler.command.length === 0 ||
+              handler.command.some((part) => typeof part !== "string" || part.length === 0)
+            ) {
+              return yield* Effect.fail(
+                new AgentConfigurationError({
+                  agentId: "unknown",
+                  field: "config.customTools",
+                  message: `Custom tool "${name}" handler.command must be a non-empty array of non-empty strings`,
+                  suggestion: 'Provide a command like ["ls", "-la"].',
+                }),
+              );
+            }
+
+            if (
+              handler.timeoutMs !== undefined &&
+              (!Number.isInteger(handler.timeoutMs) ||
+                handler.timeoutMs <= 0 ||
+                handler.timeoutMs > 300_000)
+            ) {
+              return yield* Effect.fail(
+                new AgentConfigurationError({
+                  agentId: "unknown",
+                  field: "config.customTools",
+                  message: `Custom tool "${name}" handler.timeoutMs must be a positive integer of at most 300000`,
+                  suggestion: "Set timeoutMs between 1 and 300000 milliseconds, or omit it.",
+                }),
+              );
+            }
           }
         }
       }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -182,6 +182,34 @@ export class AgentServiceImpl implements AgentService {
         }
       }
 
+      // Validate envAllowlist
+      if (config.envAllowlist) {
+        if (config.envAllowlist.length > 32) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.envAllowlist",
+              message: `envAllowlist cannot contain more than 32 names (${config.envAllowlist.length} provided)`,
+              suggestion: "Remove unused entries so at most 32 names remain.",
+            }),
+          );
+        }
+
+        for (const name of config.envAllowlist) {
+          if (!/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.envAllowlist",
+                message: `Invalid env var name "${name}" in envAllowlist`,
+                suggestion:
+                  "Use uppercase letters, digits, and underscores only, starting with a letter, up to 64 characters (e.g. MY_TOKEN).",
+              }),
+            );
+          }
+        }
+      }
+
       // Validate tools
       if (config.tools) {
         if (!Array.isArray(config.tools)) {

--- a/src/services/storage/file.ts
+++ b/src/services/storage/file.ts
@@ -124,7 +124,7 @@ export class FileStorageService implements StorageService {
           ),
         );
 
-        let normalizedTools: readonly string[] = [];
+        let normalizedTools: readonly string[];
         try {
           normalizedTools = normalizeToolConfig(rawData.config?.tools, {
             agentId: rawData.id,


### PR DESCRIPTION
## What this PR delivers

Agent configs can now declare **custom tools** — the Claude Agent SDK's custom-tools concept (name / description / JSON-Schema parameters / handler) translated to Jazz's config-driven model — plus an **`envAllowlist`** escape hatch for the shell env scrub.

Two handler kinds:

- **`record`** — no side effect: the call is appended to the run's `toolCalls` and the model receives a canned `response`. This is the "caller acts on it" pattern (confirmation cards, propose-then-confirm, structured asks) — the embedding application reads `jazz run --json`'s `toolCalls` and does the rest. Small models call tools far more reliably than they emit fenced JSON in prose.
- **`command`** — the tool is backed by a deployment-authored argv (no shell): validated arguments arrive as JSON on stdin, env goes through the existing sanitizer (honoring the declaring agent's `envAllowlist`), output is byte-capped, timeouts kill.

## Why

The first consumer is the ksyl Chat gateway, which today parses fenced ```ksyl-proposal``` blocks out of the model's prose to drive one-click confirmation cards — a brittle structured-output contract with a 27b model. With this PR it declares `propose_action`/`ask_user`/`create_poll` as record tools and reads structured calls instead. The `command` handler and `envAllowlist` generalize two more integration workarounds (wrapper scripts around credentials, scrub-dodging env names).

## Key design points

- Registration mirrors MCP tools: same registry, same JSON-Schema→Zod converter, same arg-validation path; tools activate only when listed in the agent's `tools` array.
- Provenance-marked, deep-equal **idempotent re-registration** — the registry is a session-lifetime singleton and registration runs per turn, so identical re-registration no-ops while a changed definition or a name held by a builtin/MCP tool (including aliases) fails with a targeted error.
- **Fail-closed everywhere:** unknown `handler.type` errors at registration (covers raw file-loaded configs that bypass `validateAgentConfig`); shared pure validator lives in `core/` (service delegates), respecting layering.
- **`toolCalls` now accumulates across loop iterations** (previously each tool-bearing iteration overwrote the field — the envelope only reported the last one). This is load-bearing for any consumer reading calls out of `--json`, and is regression-tested with a two-iteration integration test.
- Command tools are registered `riskLevel: "high-risk"` and execute without interactive approval (they're deployment-authored); documented next to the `envAllowlist` security note.
- `envAllowlist` is **declarer-scoped** (captured at registration), never invents values, and can never override the `SSH_*`/base-env guards.

## Tests

1358 passing (baseline 1306): env-utils contract, config validation matrix, registration/collision/idempotency (real shared-registry two-run tests), record + toolCalls accumulation integration tests, real-process command-handler tests (stdin JSON, timeout kill, byte cap, env allowlist). The 3 pre-existing `tsc --project tsconfig.test.json` errors in `persona-service.test.ts` / `storage/file.test.ts` / `terminal.test.ts` reproduce at the branch base and are untouched by this branch.

## Known follow-ups (deliberately deferred, none load-bearing for the first consumer)

- Fold the captured `envAllowlist` into the idempotency comparison (today an allowlist-only change no-ops until session restart; single-run processes unaffected).
- Optional per-call validation marker in the envelope (`toolCalls` reports calls as the model sent them — docs tell callers to re-validate; a marker needs a non-lossy `toolResults` shape first).
- Process-group kill on command timeout (grandchildren can outlive SIGKILL — same behavior as `execute_command`).
- `execute_command` remains caller-scoped for `envAllowlist` while command tools are declarer-scoped (documented asymmetry).
- Full config validation on the file-load path (pre-existing, repo-wide).

Docs: `docs/reference/configuration.md` gains full `customTools` + `envAllowlist` sections (examples, validation rules, collision semantics, JSON-Schema subset caveats, security notes).
