### PR TITLE
fix(ci): honest not-reviewed fallback and stronger free reviewer model

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "poolside/laguna-xs-2.1:free",
+  "model": "qwen/qwen3-coder:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "poolside/laguna-xs-2.1:free",
+    "llmModel": "qwen/qwen3-coder:free",
     "reasoningEffort": "disable",
     "tools": [
       "context_info",

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -326,11 +326,16 @@ jobs:
             }
 
             // Build the review body from the agent's markdown summary when available.
-            // Fall back to a generated summary so the comment is never empty.
+            // A run that produced NEITHER block did not finish the review — saying
+            // "No issues found" there would disguise a failed review as a clean pass.
+            const reviewCompleted = markdownSummary !== null || (Array.isArray(comments) && comments.length > 0);
             const summarySection = markdownSummary
               || (Array.isArray(comments) && comments.length > 0
                 ? `Found ${comments.length} issue(s). See inline comments below.`
-                : 'No issues found.');
+                : '⚠️ The review agent did not produce a parseable verdict (its output contained neither the summary block nor the comments block). Treat this PR as **not reviewed** — re-run the workflow or review manually.');
+            if (!reviewCompleted) {
+              core.warning('jazz code review produced no parseable output; posted a not-reviewed notice instead of a verdict.');
+            }
 
             if (!Array.isArray(comments) || comments.length === 0) {
               await github.rest.issues.createComment({


### PR DESCRIPTION
## What this PR does

Two fixes for the CI code review, prompted by PR #265's review run:

1. **Honest fallback.** When the reviewer agent's output contains neither the markdown-summary block nor the JSON-comments block, the workflow used to post "No issues found." — disguising an unfinished review as a clean pass (observed: the agent's final output on #265 was mid-analysis narration, "Let me now check…", with no verdict blocks). It now posts a ⚠️ "treat this PR as not reviewed" notice and emits a workflow warning annotation.

2. **Stronger free reviewer model.** `poolside/laguna-xs-2.1:free` (the *extra-small* of its family) is the likely cause of the narrate-instead-of-act behavior. Switched to `qwen/qwen3-coder:free`: code-specialized, explicitly agentic/tool-call-trained, 1M context for large diffs, still free. Alternative if it underperforms or throttles: `nvidia/nemotron-3-ultra-550b-a55b:free`.

## Follow-up

The structural fix lands with #265 (custom tools): convert the reviewer to a `record` tool like `submit_review(summary, comments[])` so the verdict arrives schema-validated through tool-calling instead of being regex-extracted from prose.

## How to test

Next PR (or a re-run of the review workflow on any open PR) exercises both: a completed review posts normally with the new model label; a non-verdict output now posts the not-reviewed notice.