### PR TITLE
fix(ci): publish on node 22 with pinned npm 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
   REGISTRY_URL: https://registry.npmjs.org
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Ensure npm 11.5.1 or later
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## What this PR does

The v0.12.7 publish run failed at "Ensure npm 11.5.1 or later": `npm install -g npm@latest` now resolves to npm 12, which requires node ≥22.22.2, but the workflow pins `NODE_VERSION: "20"` → `EBADENGINE`.

Fix: bump `NODE_VERSION` to 22 and pin the npm upgrade to `npm@^11.5.1` — satisfies the step's stated intent without breaking again when npm 13 drops node 22.

## Why

Unblocks the v0.12.7 npm publish (custom tools + envAllowlist + CLI exit codes). After merge, re-run the publish via workflow_dispatch from main against the existing v0.12.7 tag.