### PR TITLE
feat(workflows): --json, --timeout and --events for headless workflow runs

### DIFF
--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -127,7 +127,20 @@ jazz workflow run email-cleanup --auto-approve
 
 # Run with a specific agent
 jazz workflow run email-cleanup --agent research-bot
+
+# Headless / scripted use (webhook gateways, systemd timers, CI):
+# --json prints exactly one JSON envelope { ok, answer, costUSD, tokenUsage, toolCalls }
+# on stdout (ok:false + non-zero exit on failure), suppressing all terminal chatter.
+# --timeout aborts the run cleanly after the given milliseconds.
+# --events streams event categories as NDJSON to stderr while stdout stays clean.
+jazz workflow run email-cleanup --auto-approve --json --timeout 1200000 --events tools
 ```
+
+**Note for headless runs**: `--json` implies non-interactive — if the agent is missing
+the command fails fast with an `ok:false` envelope instead of opening the agent picker.
+Combine it with `--auto-approve` (and an `autoApprove` policy in the workflow frontmatter
+that covers the tools the workflow needs), otherwise the run may stall waiting for an
+approval nobody can give.
 
 ### Schedule Workflows
 

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -480,6 +480,19 @@ function registerWorkflowCommands(program: Command): void {
       "--scheduled",
       "Indicates this run was triggered by the system scheduler (launchd/cron)",
     )
+    .option(
+      "--json",
+      "Emit a single JSON envelope { ok, answer, costUSD, tokenUsage, toolCalls } on stdout (for scripts/gateways); all chatter is suppressed",
+    )
+    .option(
+      "--timeout <ms>",
+      "Abort the run after this many milliseconds",
+      parsePositiveInt("--timeout"),
+    )
+    .option(
+      "--events <categories>",
+      "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,all). stdout stays the clean payload.",
+    )
     .action(
       (
         name: string,
@@ -488,20 +501,49 @@ function registerWorkflowCommands(program: Command): void {
           agent?: string;
           maxIterations?: number;
           scheduled?: boolean;
+          json?: boolean;
+          timeout?: number;
+          events?: string;
         },
         command: Command,
       ) => {
         const opts = program.opts<CliOptions>();
+        const json = options.json === true;
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
+
+        const eventCategories =
+          options.events !== undefined ? parseEventCategories(options.events) : undefined;
+        if (eventCategories !== undefined && !eventCategories.ok) {
+          if (json) {
+            process.stdout.write(
+              `${JSON.stringify({ ok: false, error: eventCategories.error, costUSD: 0 })}\n`,
+            );
+          } else {
+            process.stderr.write(`${eventCategories.error}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (json) {
+          // Force plain terminal so Ink never mounts and writes to stdout; the
+          // one-shot presentation layer keeps stdout clean for the payload.
+          process.env["JAZZ_NO_TUI"] = "1";
+        }
+
         runCliEffect(
-          runWorkflowCommand(name, options),
+          runWorkflowCommand(name, {
+            ...options,
+            ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+            ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
+          }),
           {
             verbose: opts.verbose,
             debug: opts.debug,
             configPath: opts.config,
           },
-          { skipCatchUp: isWorkflowRunCommand },
+          { skipCatchUp: isWorkflowRunCommand, skipUpdateCheck: json },
         );
       },
     );

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -512,16 +512,20 @@ function registerWorkflowCommands(program: Command): void {
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
 
+        // Only the one-shot presentation layer (json mode) can emit NDJSON
+        // events; in interactive mode --events would be silently ignored.
+        if (options.events !== undefined && !json) {
+          process.stderr.write("--events requires --json.\n");
+          process.exitCode = 1;
+          return;
+        }
+
         const eventCategories =
           options.events !== undefined ? parseEventCategories(options.events) : undefined;
         if (eventCategories !== undefined && !eventCategories.ok) {
-          if (json) {
-            process.stdout.write(
-              `${JSON.stringify({ ok: false, error: eventCategories.error, costUSD: 0 })}\n`,
-            );
-          } else {
-            process.stderr.write(`${eventCategories.error}\n`);
-          }
+          process.stdout.write(
+            `${JSON.stringify({ ok: false, error: eventCategories.error, costUSD: 0 })}\n`,
+          );
           process.exitCode = 1;
           return;
         }

--- a/src/cli/commands/workflow.test.ts
+++ b/src/cli/commands/workflow.test.ts
@@ -101,6 +101,138 @@ describe("runWorkflowCommand", () => {
     rmSync(jazzHomeDir, { recursive: true, force: true });
   });
 
+  describe("json mode", () => {
+    let stdoutWrites: string[];
+    let originalStdoutWrite: typeof process.stdout.write;
+
+    beforeEach(() => {
+      stdoutWrites = [];
+      originalStdoutWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = ((chunk: string | Uint8Array) => {
+        stdoutWrites.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write;
+      (mockTerminal.heading as ReturnType<typeof mock>).mockClear();
+      (mockTerminal.log as ReturnType<typeof mock>).mockClear();
+    });
+
+    afterEach(() => {
+      process.stdout.write = originalStdoutWrite;
+    });
+
+    it("emits exactly one ok:true envelope with the answer on stdout and no terminal chatter", async () => {
+      AgentRunner.run = mock(() =>
+        Effect.succeed({
+          content: "the daily review",
+          costUSD: 0.12,
+          usage: { promptTokens: 100, completionTokens: 50 },
+          toolCalls: [],
+        }),
+      ) as unknown as typeof AgentRunner.run;
+
+      const program = runWorkflowCommand("code-review", {
+        autoApprove: true,
+        agent: "ci-reviewer",
+        json: true,
+      });
+      const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<
+        void,
+        unknown,
+        never
+      >;
+
+      await Effect.runPromiseExit(runnable);
+
+      expect(stdoutWrites).toHaveLength(1);
+      const envelope = JSON.parse(stdoutWrites[0] as string) as Record<string, unknown>;
+      expect(envelope["ok"]).toBe(true);
+      expect(envelope["answer"]).toBe("the daily review");
+      expect(envelope["costUSD"]).toBe(0.12);
+      expect(envelope["tokenUsage"]).toEqual({
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      });
+      expect(process.exitCode).toBe(0);
+      expect(mockTerminal.heading).not.toHaveBeenCalled();
+      expect(mockTerminal.log).not.toHaveBeenCalled();
+    });
+
+    it("emits an ok:false envelope on stdout and exits non-zero when the run fails", async () => {
+      AgentRunner.run = mock(() =>
+        Effect.fail(new Error("LLMRateLimitError: rate limited")),
+      ) as unknown as typeof AgentRunner.run;
+
+      const program = runWorkflowCommand("code-review", {
+        autoApprove: true,
+        agent: "ci-reviewer",
+        json: true,
+      });
+      const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<
+        void,
+        unknown,
+        never
+      >;
+
+      await Effect.runPromiseExit(runnable);
+
+      expect(stdoutWrites).toHaveLength(1);
+      const envelope = JSON.parse(stdoutWrites[0] as string) as Record<string, unknown>;
+      expect(envelope["ok"]).toBe(false);
+      expect(String(envelope["error"])).toContain("rate limited");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("aborts a hung run at --timeout and reports it in the envelope", async () => {
+      AgentRunner.run = mock(() => Effect.never) as unknown as typeof AgentRunner.run;
+
+      const program = runWorkflowCommand("code-review", {
+        autoApprove: true,
+        agent: "ci-reviewer",
+        json: true,
+        timeoutMs: 20,
+      });
+      const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<
+        void,
+        unknown,
+        never
+      >;
+
+      await Effect.runPromiseExit(runnable);
+
+      expect(stdoutWrites).toHaveLength(1);
+      const envelope = JSON.parse(stdoutWrites[0] as string) as Record<string, unknown>;
+      expect(envelope["ok"]).toBe(false);
+      expect(String(envelope["error"])).toContain("timeout");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("fails fast with an envelope when the agent does not exist, without opening the picker", async () => {
+      const failingAgentService = {
+        getAgent: mock(() => Effect.fail(new Error("not found"))),
+        listAgents: mock(() => Effect.succeed([mockAgent])),
+      } as unknown as AgentService;
+      const layer = Layer.mergeAll(
+        Layer.succeed(TerminalServiceTag, mockTerminal),
+        Layer.succeed(WorkflowServiceTag, mockWorkflowService),
+        Layer.succeed(LoggerServiceTag, mockLogger),
+        Layer.succeed(SchedulerServiceTag, mockScheduler),
+        Layer.succeed(AgentServiceTag, failingAgentService),
+        NodeFileSystem.layer,
+      );
+
+      const program = runWorkflowCommand("code-review", { agent: "ghost", json: true });
+      const runnable = program.pipe(Effect.provide(layer)) as Effect.Effect<void, unknown, never>;
+
+      await Effect.runPromiseExit(runnable);
+
+      expect(stdoutWrites).toHaveLength(1);
+      const envelope = JSON.parse(stdoutWrites[0] as string) as Record<string, unknown>;
+      expect(envelope["ok"]).toBe(false);
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
   it("sets a non-zero exit code when the agent run fails (e.g. a rate limit error)", async () => {
     const rateLimitError = new Error("LLMRateLimitError: rate limited after 11 retries");
     AgentRunner.run = mock(() => Effect.fail(rateLimitError)) as unknown as typeof AgentRunner.run;

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Duration, Effect } from "effect";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import React from "react";
@@ -8,8 +8,11 @@ import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { TerminalServiceTag } from "@/core/interfaces/terminal";
+import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
 import type { Agent } from "@/core/types/agent";
+import type { StreamEvent } from "@/core/types/streaming";
 import { describeCronSchedule } from "@/core/utils/cron-utils";
+import { getErrorMessage } from "@/core/utils/error-handler";
 import {
   type CatchUpCandidate,
   getCatchUpCandidates,
@@ -25,6 +28,7 @@ import {
 import { SchedulerServiceTag } from "@/core/workflows/scheduler-service";
 import { WorkflowServiceTag, type WorkflowMetadata } from "@/core/workflows/workflow-service";
 import { groupWorkflows, formatWorkflow } from "@/core/workflows/workflow-utils";
+import { formatOneShotError, formatOneShotResult } from "./run-agent";
 
 /**
  * CLI commands for managing and running workflows.
@@ -194,14 +198,30 @@ export function runWorkflowCommand(
     agent?: string;
     maxIterations?: number;
     scheduled?: boolean;
+    /** Emit a single JSON envelope on stdout (same shape as `jazz run --json`) and suppress terminal chatter. */
+    json?: boolean;
+    /** Abort the run after this many milliseconds. */
+    timeoutMs?: number;
+    /** Stream these event types as NDJSON to stderr during the run (json mode only). */
+    eventTypes?: ReadonlySet<StreamEvent["type"]>;
   },
 ) {
-  return Effect.gen(function* () {
+  const jsonMode = options?.json === true;
+
+  // In json mode every terminal write is suppressed: stdout must carry exactly
+  // one JSON envelope, and error detail travels inside that envelope instead.
+  // Takes a thunk so the terminal call isn't even constructed when suppressed.
+  const say = <E, R>(make: () => Effect.Effect<void, E, R>): Effect.Effect<void, E, R> =>
+    jsonMode ? Effect.void : Effect.suspend(make);
+
+  const command = Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const workflowService = yield* WorkflowServiceTag;
     const logger = yield* LoggerServiceTag;
 
-    const isNonInteractive = options?.autoApprove === true;
+    // json mode implies non-interactive: a headless caller can never answer
+    // the agent picker, so missing agents must fail fast.
+    const isNonInteractive = options?.autoApprove === true || jsonMode;
     const isSchedulerTriggered = options?.scheduled === true;
 
     // When triggered by the system scheduler (--scheduled), guard against RunAtLoad
@@ -240,8 +260,8 @@ export function runWorkflowCommand(
       }
     }
 
-    yield* terminal.heading(`🚀 Running workflow: ${workflowName}`);
-    yield* terminal.log("");
+    yield* say(() => terminal.heading(`🚀 Running workflow: ${workflowName}`));
+    yield* say(() => terminal.log(""));
 
     // Record the run start as early as possible. Until this lands every
     // failed scheduled run (e.g. agent not found) exited before reaching
@@ -271,8 +291,8 @@ export function runWorkflowCommand(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
           yield* markFailed(`Workflow not found: ${workflowName}`);
-          yield* terminal.error(`Workflow not found: ${workflowName}`);
-          yield* terminal.info("Run 'jazz workflow list' to see available workflows.");
+          yield* say(() => terminal.error(`Workflow not found: ${workflowName}`));
+          yield* say(() => terminal.info("Run 'jazz workflow list' to see available workflows."));
           return yield* Effect.fail(error);
         }),
       ),
@@ -287,15 +307,17 @@ export function runWorkflowCommand(
 
     if (agentResult._tag === "Right") {
       agent = agentResult.right;
-      yield* terminal.info(`Using agent: ${agent.name}`);
+      yield* say(() => terminal.info(`Using agent: ${agent.name}`));
     } else {
-      // In non-interactive mode (--auto-approve), fail immediately if agent not found
+      // In non-interactive mode (--auto-approve or --json), fail immediately if agent not found
       if (isNonInteractive) {
         const errorMessage = `Agent '${agentIdentifier}' not found. Scheduled workflows require a valid agent — update the workflow or re-schedule with an existing agent.`;
         yield* markFailed(errorMessage);
-        yield* terminal.error(`Agent '${agentIdentifier}' not found.`);
-        yield* terminal.info(
-          "Scheduled workflows require a valid agent. Update the workflow or create the agent.",
+        yield* say(() => terminal.error(`Agent '${agentIdentifier}' not found.`));
+        yield* say(() =>
+          terminal.info(
+            "Scheduled workflows require a valid agent. Update the workflow or create the agent.",
+          ),
         );
         return yield* Effect.fail(new Error(errorMessage));
       }
@@ -345,10 +367,10 @@ export function runWorkflowCommand(
         : workflow.metadata.autoApprove;
 
     if (autoApprovePolicy) {
-      yield* terminal.info(`Auto-approve policy: ${autoApprovePolicy}`);
+      yield* say(() => terminal.info(`Auto-approve policy: ${autoApprovePolicy}`));
     }
 
-    yield* terminal.log("");
+    yield* say(() => terminal.log(""));
     yield* logger.info("Starting workflow execution", {
       workflow: workflowName,
       agent: agent.name,
@@ -358,14 +380,24 @@ export function runWorkflowCommand(
     // Run the agent with the workflow prompt. Iteration cap precedence:
     // CLI --max-iterations flag > workflow metadata > default (omitted here).
     const resolvedMaxIterations = options?.maxIterations ?? workflow.metadata.maxIterations;
-    const runResult = yield* AgentRunner.run({
+    const runEffect = AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       sessionId: `workflow-${workflowName}-${Date.now()}`,
       conversationId: `workflow-${workflowName}-${Date.now()}`,
       ...(resolvedMaxIterations != null ? { maxIterations: resolvedMaxIterations } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
-    }).pipe(
+    });
+    const runResult = yield* (
+      options?.timeoutMs != null
+        ? runEffect.pipe(
+            Effect.timeoutFail({
+              duration: Duration.millis(options.timeoutMs),
+              onTimeout: () => new Error(`Run exceeded the ${options.timeoutMs}ms timeout.`),
+            }),
+          )
+        : runEffect
+    ).pipe(
       Effect.tap((result) =>
         updateLatestRunRecord(workflowName, {
           completedAt: new Date().toISOString(),
@@ -392,6 +424,34 @@ export function runWorkflowCommand(
       ),
     );
 
+    if (jsonMode) {
+      const promptTokens = runResult.usage?.promptTokens ?? 0;
+      const completionTokens = runResult.usage?.completionTokens ?? 0;
+      const toolCalls = (runResult.toolCalls ?? []).map((toolCall) => ({
+        id: toolCall.id,
+        name: toolCall.function?.name ?? "",
+        arguments: toolCall.function?.arguments ?? "",
+      }));
+      yield* Effect.sync(() => {
+        process.stdout.write(
+          formatOneShotResult(
+            {
+              answer: runResult.content,
+              costUSD: runResult.costUSD ?? 0,
+              tokenUsage: {
+                promptTokens,
+                completionTokens,
+                totalTokens: promptTokens + completionTokens,
+              },
+              toolCalls,
+            },
+            { json: true },
+          ),
+        );
+      });
+      return;
+    }
+
     yield* terminal.log("");
     yield* terminal.success(`Workflow completed: ${workflowName}`);
 
@@ -400,6 +460,24 @@ export function runWorkflowCommand(
       yield* terminal.log(`[JAZZ_SUMMARY] ${JSON.stringify(summary)}`);
     }
   });
+
+  if (!jsonMode) {
+    return command;
+  }
+
+  // json mode: stdout carries exactly one envelope — on failure an ok:false
+  // envelope (with a non-zero exit code) instead of a rendered error, and the
+  // one-shot presentation layer keeps agent streaming off stdout (optionally
+  // emitting NDJSON events on stderr, as `jazz run --events` does).
+  return command.pipe(
+    Effect.catchAll((error) =>
+      Effect.sync(() => {
+        process.stdout.write(formatOneShotError(getErrorMessage(error), { json: true }));
+        process.exitCode = 1;
+      }),
+    ),
+    Effect.provide(makeOneShotPresentationServiceLayer(options?.eventTypes ?? new Set())),
+  );
 }
 
 /**

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -307,7 +307,7 @@ export function runWorkflowCommand(
 
     if (agentResult._tag === "Right") {
       agent = agentResult.right;
-      yield* say(() => terminal.info(`Using agent: ${agent.name}`));
+      yield* say(() => terminal.info(`Using agent: ${agent.name} (${agent.model})`));
     } else {
       // In non-interactive mode (--auto-approve or --json), fail immediately if agent not found
       if (isNonInteractive) {
@@ -357,7 +357,7 @@ export function runWorkflowCommand(
       }
 
       agent = selectedAgent;
-      yield* terminal.info(`Using agent: ${agent.name}`);
+      yield* terminal.info(`Using agent: ${agent.name} (${agent.model})`);
     }
 
     // Determine auto-approve policy


### PR DESCRIPTION
## What changes

`jazz workflow run` gains the same scripted-use contract that `jazz run` already has, so gateways, systemd timers, and CI can run workflows headlessly and parse the result:

- **`--json`** — stdout carries exactly one envelope `{ ok, answer, costUSD, tokenUsage, toolCalls }` (same shape as `jazz run --json`). On any failure it prints `{ ok: false, error }` and exits non-zero. All terminal chatter (heading, agent line, `[JAZZ_SUMMARY]`) is suppressed, Ink never mounts (`JAZZ_NO_TUI=1`), and the one-shot presentation layer keeps agent streaming off stdout.
- **`--timeout <ms>`** — aborts the run cleanly with a timeout error (previously callers had to SIGKILL from outside and lost all output).
- **`--events <categories>`** — streams NDJSON tool/reasoning/text/usage events to stderr during the run, stdout stays the clean payload.
- `--json` implies non-interactive: a missing agent fails fast with an `ok:false` envelope instead of opening the interactive agent picker (which would hang a headless caller forever).

## Before / after

Before: a scheduled/scripted caller of `jazz workflow run` got human-formatted terminal output with no way to extract the agent's answer, no timeout, and an interactive picker hang if the agent was missing.

After: `jazz workflow run daily-news --auto-approve --json --timeout 1200000 --events tools` behaves exactly like `jazz run --json`, while keeping workflow semantics (WORKFLOW.md prompt, frontmatter autoApprove/maxIterations, run history).

Run-history recording (#267's exit-code fix included) is unchanged in both modes.

## Verification

- `bun test` — 1367 tests pass, including 4 new tests covering the ok:true envelope + chatter suppression, ok:false envelope + exit code, `--timeout` abort, and missing-agent fail-fast.
- `bun run typecheck` and `bun run lint` clean.
- Manual smoke: `bun src/main.ts workflow run nonexistent --json` → `{"ok":false,"error":"Workflow not found: nonexistent","costUSD":0}`, exit 1, zero bytes on stderr; invalid `--events` category rejected with a json envelope.

## Motivation

ksyl-bot's gateway needs to trigger a scheduled `daily-news` workflow inside its Docker sandbox and post the answer to Google Chat; without `--json` the answer was unrecoverable from the CLI output.