### PR TITLE
feat(summarizer): predictable model selection, drop cheapest-model oracle

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "qwen/qwen3-coder:free",
+  "model": "cohere/north-mini-code:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "qwen/qwen3-coder:free",
+    "llmModel": "cohere/north-mini-code:free",
     "reasoningEffort": "disable",
     "tools": [
       "context_info",

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
-import { Summarizer, type RecursiveRunner } from "./summarizer";
+import { selectSummarizerModel, Summarizer, type RecursiveRunner } from "./summarizer";
 import { AgentConfigServiceTag, type AgentConfigService } from "../../interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "../../interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "../../interfaces/logger";
@@ -121,6 +121,104 @@ function createMockRecursiveRunner(mockContent: string): RecursiveRunner {
 }
 
 describe("Summarizer", () => {
+  describe("selectSummarizerModel", () => {
+    it("defaults to the parent model when summarizerModel is unset", () => {
+      const agent = createMockAgent();
+      const result = selectSummarizerModel(agent);
+      expect(result.config).toEqual({ provider: "openai", model: "gpt-4" });
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("uses a valid configured summarizerModel", () => {
+      const agent = createMockAgent({
+        config: {
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          persona: "default",
+          tools: [],
+          summarizerModel: "anthropic/claude-3-5-haiku-latest",
+        },
+      });
+      const result = selectSummarizerModel(agent);
+      expect(result.config).toEqual({
+        provider: "anthropic",
+        model: "claude-3-5-haiku-latest",
+      });
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("falls back to the parent model and warns on an invalid summarizerModel", () => {
+      const agent = createMockAgent({
+        config: {
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          persona: "default",
+          tools: [],
+          summarizerModel: "garbage",
+        },
+      });
+      const result = selectSummarizerModel(agent);
+      expect(result.config).toEqual({ provider: "openai", model: "gpt-4" });
+      expect(result.warning).toContain("garbage");
+    });
+  });
+
+  describe("summarizeHistory model selection", () => {
+    it("builds the summarizer agent with the configured summarizer model", async () => {
+      let capturedAgent: Agent | undefined;
+      const mockRunner: RecursiveRunner = (options) => {
+        capturedAgent = options.agent;
+        return Effect.succeed({
+          content: "Summary",
+          conversationId: "test-conv",
+        } as AgentResponse);
+      };
+
+      const agent = createMockAgent({
+        config: {
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          persona: "default",
+          tools: [],
+          summarizerModel: "anthropic/claude-3-5-haiku-latest",
+        },
+      });
+      const messages: ChatMessage[] = [{ role: "user", content: "Test" }];
+
+      await Effect.runPromise(
+        Summarizer.summarizeHistory(messages, agent, "session-1", "conv-1", mockRunner).pipe(
+          Effect.provide(createTestLayer()),
+        ) as Effect.Effect<ChatMessage, Error, never>,
+      );
+
+      expect(capturedAgent?.config.llmProvider).toBe("anthropic");
+      expect(capturedAgent?.config.llmModel).toBe("claude-3-5-haiku-latest");
+    });
+
+    it("builds the summarizer agent with the parent model by default", async () => {
+      let capturedAgent: Agent | undefined;
+      const mockRunner: RecursiveRunner = (options) => {
+        capturedAgent = options.agent;
+        return Effect.succeed({
+          content: "Summary",
+          conversationId: "test-conv",
+        } as AgentResponse);
+      };
+
+      const agent = createMockAgent();
+      const messages: ChatMessage[] = [{ role: "user", content: "Test" }];
+
+      await Effect.runPromise(
+        Summarizer.summarizeHistory(messages, agent, "session-1", "conv-1", mockRunner).pipe(
+          Effect.provide(createTestLayer()),
+        ) as Effect.Effect<ChatMessage, Error, never>,
+      );
+
+      expect(capturedAgent?.config.llmProvider).toBe("openai");
+      expect(capturedAgent?.config.llmModel).toBe("gpt-4");
+    });
+  });
+
   describe("summarizeHistory", () => {
     it("should return empty message for empty history", async () => {
       const mockRunner = createMockRecursiveRunner("This should not be called");

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -161,6 +161,36 @@ describe("Summarizer", () => {
       expect(result.config).toEqual({ provider: "openai", model: "gpt-4" });
       expect(result.warning).toContain("garbage");
     });
+
+    it("treats a null summarizerModel as unset (parent model, no warning)", () => {
+      const agent = createMockAgent({
+        config: {
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          persona: "default",
+          tools: [],
+          summarizerModel: null as unknown as string,
+        },
+      });
+      const result = selectSummarizerModel(agent);
+      expect(result.config).toEqual({ provider: "openai", model: "gpt-4" });
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("falls back and warns on a non-string summarizerModel without throwing", () => {
+      const agent = createMockAgent({
+        config: {
+          llmProvider: "openai",
+          llmModel: "gpt-4",
+          persona: "default",
+          tools: [],
+          summarizerModel: 42 as unknown as string,
+        },
+      });
+      const result = selectSummarizerModel(agent);
+      expect(result.config).toEqual({ provider: "openai", model: "gpt-4" });
+      expect(result.warning).toContain("number");
+    });
   });
 
   describe("summarizeHistory model selection", () => {

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -1,16 +1,14 @@
 import { Effect } from "effect";
 import type { ProviderName } from "@/core/constants/models";
-import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
+import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
-import { LLMServiceTag } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { PresentationService } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types";
-import type { LLMConfig } from "@/core/types/config";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
-import { getMetadataFromMap, getModelsDevMap } from "@/core/utils/models-dev-client";
+import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
 import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
@@ -20,115 +18,41 @@ function modelHintFromAgent(agent: Agent): ModelHint {
   return { provider: agent.config.llmProvider, modelId: agent.config.llmModel };
 }
 
-/**
- * Fallback cheap models for each static provider if models.dev lookup fails.
- */
-const FALLBACK_CHEAP_MODELS: Partial<Record<ProviderName, string>> = {
-  openai: "gpt-5-mini",
-  anthropic: "claude-3-5-haiku-latest",
-  google: "gemini-3-lite-preview",
-  mistral: "mistral-small-latest",
-  xai: "grok-4.1-fast",
-};
-
-/**
- * Static providers that support model selection for summarization.
- */
-const STATIC_PROVIDERS = new Set<ProviderName>(["openai", "anthropic", "google", "mistral", "xai"]);
-
 interface SummarizerModelConfig {
   provider: ProviderName;
   model: string;
 }
 
 /**
- * Find the cheapest model for a given provider using models.dev pricing data.
- */
-async function findCheapestModelForProvider(
-  provider: string,
-  availableModels: readonly string[],
-): Promise<string | null> {
-  try {
-    const modelsDevMap = await getModelsDevMap();
-    if (!modelsDevMap) return null;
-
-    let cheapestModel: string | null = null;
-    let lowestCost = Infinity;
-
-    for (const modelId of availableModels) {
-      const meta = getMetadataFromMap(modelsDevMap, modelId, provider);
-      if (meta?.inputPricePerMillion !== undefined && meta?.outputPricePerMillion !== undefined) {
-        // Use average of input/output price as cost metric
-        const avgCost = (meta.inputPricePerMillion + meta.outputPricePerMillion) / 2;
-        if (avgCost < lowestCost) {
-          lowestCost = avgCost;
-          cheapestModel = modelId;
-        }
-      }
-    }
-
-    return cheapestModel;
-  } catch {
-    return null; // Fallback to hardcoded on any error
-  }
-}
-
-/**
- * Select the best model for summarization based on cost priority.
+ * Choose the model for background summarization.
  *
- * Priority order:
- * 1. OpenRouter free tier if configured
- * 2. Cheapest model from parent provider (via models.dev pricing)
- * 3. Fallback to hardcoded cheap models for static providers
- * 4. Parent agent's model (for dynamic providers like ollama, groq)
+ * Uses the agent's configured `summarizerModel` ("provider/model") when set and
+ * parseable; otherwise falls back to the agent's own provider/model. When a
+ * configured value is unusable it returns a `warning` for the caller to log.
  */
-function selectSummarizerModel(
-  parentAgent: Agent,
-  llmConfig: LLMConfig | undefined,
-): Effect.Effect<SummarizerModelConfig, never, LLMService> {
-  return Effect.gen(function* () {
-    const llmService = yield* LLMServiceTag;
+export function selectSummarizerModel(parentAgent: Agent): {
+  config: SummarizerModelConfig;
+  warning?: string;
+} {
+  const parentConfig: SummarizerModelConfig = {
+    provider: parentAgent.config.llmProvider,
+    model: parentAgent.config.llmModel,
+  };
 
-    // Priority 1: OpenRouter free tier if configured
-    if (llmConfig?.openrouter?.api_key) {
-      return { provider: "openrouter", model: "openrouter/free" };
-    }
+  const configured = parentAgent.config.summarizerModel;
+  if (configured === undefined) {
+    return { config: parentConfig };
+  }
 
-    // Get parent provider
-    const parentProvider = parentAgent.config.llmProvider;
+  const parsed = parseProviderModel(configured);
+  if (parsed) {
+    return { config: parsed };
+  }
 
-    // Priority 2 & 3: For static providers, try to find cheapest model
-    if (STATIC_PROVIDERS.has(parentProvider)) {
-      // Try to get available models for this provider
-      const providerInfoResult = yield* llmService.getProvider(parentProvider).pipe(Effect.either);
-
-      if (providerInfoResult._tag === "Right") {
-        const providerInfo = providerInfoResult.right;
-        const modelIds = providerInfo.supportedModels.map((m) => m.id);
-
-        // Try models.dev lookup for cheapest model
-        const cheapestModel = yield* Effect.promise(() =>
-          findCheapestModelForProvider(parentProvider, modelIds),
-        );
-
-        if (cheapestModel) {
-          return { provider: parentProvider, model: cheapestModel };
-        }
-      }
-
-      // Fallback to hardcoded cheap models if models.dev lookup failed
-      const fallbackModel = FALLBACK_CHEAP_MODELS[parentProvider];
-      if (fallbackModel) {
-        return { provider: parentProvider, model: fallbackModel };
-      }
-    }
-
-    // Priority 4: Use parent model for dynamic providers (ollama, groq, etc.)
-    return {
-      provider: parentAgent.config.llmProvider,
-      model: parentAgent.config.llmModel,
-    };
-  });
+  return {
+    config: parentConfig,
+    warning: `Invalid summarizerModel "${configured}" — falling back to parent model ${parentConfig.provider}/${parentConfig.model}`,
+  };
 }
 
 /**
@@ -367,11 +291,8 @@ export const Summarizer = {
    * Summarizes a portion of the conversation history using a specialized sub-agent.
    * Returns a single assistant message containing the summary.
    *
-   * Uses a cheaper model for summarization when available:
-   * - OpenRouter free tier if configured
-   * - Cheapest model from parent provider (via models.dev pricing)
-   * - Fallback to hardcoded cheap models for static providers
-   * - Parent agent's model for dynamic providers (ollama, groq, etc.)
+   * Uses the agent's configured `summarizerModel` if set and valid, otherwise
+   * falls back to the agent's own provider/model (see `selectSummarizerModel`).
    *
    * @param runRecursive - Injected runner function to execute the summarizer sub-agent
    */
@@ -393,18 +314,15 @@ export const Summarizer = {
   > {
     return Effect.gen(function* () {
       const logger = yield* LoggerServiceTag;
-      const configService = yield* AgentConfigServiceTag;
 
       if (messagesToSummarize.length === 0) {
         return { role: "assistant", content: "No history to summarize." };
       }
 
-      // Get LLM config for model selection
-      const appConfig = yield* configService.appConfig;
-      const llmConfig = appConfig.llm;
-
-      // Select cheaper model for summarization
-      const summarizerModelConfig = yield* selectSummarizerModel(agent, llmConfig);
+      const { config: summarizerModelConfig, warning } = selectSummarizerModel(agent);
+      if (warning) {
+        yield* logger.warn(warning, { agentId: agent.id });
+      }
 
       yield* logger.debug("Starting background context summarization", {
         messageCount: messagesToSummarize.length,
@@ -429,7 +347,7 @@ export const Summarizer = {
         "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +
         historyText;
 
-      // Define specialized summarizer agent on the fly with cheaper model
+      // Define specialized summarizer agent on the fly with the selected model
       const summarizerModel =
         `${summarizerModelConfig.provider}/${summarizerModelConfig.model}` as `${string}/${string}`;
       const summarizer: Agent = {

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -39,9 +39,16 @@ export function selectSummarizerModel(parentAgent: Agent): {
     model: parentAgent.config.llmModel,
   };
 
-  const configured = parentAgent.config.summarizerModel;
-  if (configured === undefined) {
+  const configured: unknown = parentAgent.config.summarizerModel;
+  if (configured === undefined || configured === null) {
     return { config: parentConfig };
+  }
+
+  if (typeof configured !== "string") {
+    return {
+      config: parentConfig,
+      warning: `Invalid summarizerModel type "${typeof configured}" — falling back to parent model ${parentConfig.provider}/${parentConfig.model}`,
+    };
   }
 
   const parsed = parseProviderModel(configured);

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -52,6 +52,12 @@ export interface AgentConfig {
   readonly persona: string;
   readonly llmProvider: ProviderName;
   readonly llmModel: string;
+  /**
+   * Model used for background context summarization, as "provider/model"
+   * (e.g. "anthropic/claude-3-5-haiku-latest"). Defaults to the agent's own
+   * provider/model when unset or unparseable.
+   */
+  readonly summarizerModel?: string;
   /** Optional per-agent API key overrides by provider. Falls back to global config, then env vars. */
   readonly llmApiKeys?: Partial<Record<ProviderName, string>>;
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";

--- a/src/core/utils/provider-model.test.ts
+++ b/src/core/utils/provider-model.test.ts
@@ -23,6 +23,17 @@ describe("parseProviderModel", () => {
     });
   });
 
+  it("trims whitespace around each segment", () => {
+    expect(parseProviderModel("openai / gpt-4")).toEqual({
+      provider: "openai",
+      model: "gpt-4",
+    });
+  });
+
+  it("returns null when the model segment is only whitespace", () => {
+    expect(parseProviderModel("openai/   ")).toBeNull();
+  });
+
   it("returns null when there is no slash", () => {
     expect(parseProviderModel("gpt-4")).toBeNull();
   });

--- a/src/core/utils/provider-model.test.ts
+++ b/src/core/utils/provider-model.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { parseProviderModel } from "./provider-model";
+
+describe("parseProviderModel", () => {
+  it("parses a simple provider/model pair", () => {
+    expect(parseProviderModel("anthropic/claude-3-5-haiku-latest")).toEqual({
+      provider: "anthropic",
+      model: "claude-3-5-haiku-latest",
+    });
+  });
+
+  it("splits on the first slash so slash-bearing model ids survive", () => {
+    expect(parseProviderModel("openrouter/anthropic/claude-3.5")).toEqual({
+      provider: "openrouter",
+      model: "anthropic/claude-3.5",
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseProviderModel("  openai/gpt-4  ")).toEqual({
+      provider: "openai",
+      model: "gpt-4",
+    });
+  });
+
+  it("returns null when there is no slash", () => {
+    expect(parseProviderModel("gpt-4")).toBeNull();
+  });
+
+  it("returns null when the model segment is empty", () => {
+    expect(parseProviderModel("anthropic/")).toBeNull();
+  });
+
+  it("returns null when the provider segment is empty", () => {
+    expect(parseProviderModel("/gpt-4")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseProviderModel("")).toBeNull();
+  });
+
+  it("returns null when the provider is not a known provider", () => {
+    expect(parseProviderModel("notaprovider/some-model")).toBeNull();
+  });
+});

--- a/src/core/utils/provider-model.ts
+++ b/src/core/utils/provider-model.ts
@@ -1,0 +1,24 @@
+import { AVAILABLE_PROVIDERS, type ProviderName } from "@/core/constants/models";
+
+/**
+ * Parse a "provider/model" string into its parts.
+ *
+ * Splits on the first "/" so slash-bearing model ids (e.g. OpenRouter's
+ * "openrouter/anthropic/claude-3.5") keep their full model segment. Returns
+ * null when the shape is malformed or the provider is not a known provider.
+ */
+export function parseProviderModel(
+  value: string,
+): { provider: ProviderName; model: string } | null {
+  const trimmed = value.trim();
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+    return null;
+  }
+  const provider = trimmed.slice(0, slashIndex);
+  const model = trimmed.slice(slashIndex + 1);
+  if (!(AVAILABLE_PROVIDERS as readonly string[]).includes(provider)) {
+    return null;
+  }
+  return { provider: provider as ProviderName, model };
+}

--- a/src/core/utils/provider-model.ts
+++ b/src/core/utils/provider-model.ts
@@ -4,19 +4,24 @@ import { AVAILABLE_PROVIDERS, type ProviderName } from "@/core/constants/models"
  * Parse a "provider/model" string into its parts.
  *
  * Splits on the first "/" so slash-bearing model ids (e.g. OpenRouter's
- * "openrouter/anthropic/claude-3.5") keep their full model segment. Returns
- * null when the shape is malformed or the provider is not a known provider.
+ * "openrouter/anthropic/claude-3.5") keep their full model segment. Each
+ * segment is trimmed so values like "openai / gpt-4" normalize cleanly.
+ * Returns null when the shape is malformed or the provider is not a known
+ * provider.
  */
 export function parseProviderModel(
   value: string,
 ): { provider: ProviderName; model: string } | null {
   const trimmed = value.trim();
   const slashIndex = trimmed.indexOf("/");
-  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+  if (slashIndex <= 0) {
     return null;
   }
-  const provider = trimmed.slice(0, slashIndex);
-  const model = trimmed.slice(slashIndex + 1);
+  const provider = trimmed.slice(0, slashIndex).trim();
+  const model = trimmed.slice(slashIndex + 1).trim();
+  if (!provider || !model) {
+    return null;
+  }
   if (!(AVAILABLE_PROVIDERS as readonly string[]).includes(provider)) {
     return null;
   }

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -562,6 +562,14 @@ describe("AgentService", () => {
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();
     });
 
+    it("accepts a null summarizerModel as a cleared field", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        summarizerModel: null as unknown as string,
+      });
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
     it("rejects a summarizerModel with no slash", async () => {
       const program = service.validateAgentConfig({
         ...baseConfig,

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -542,6 +542,53 @@ describe("AgentService", () => {
     });
   });
 
+  describe("validateAgentConfig summarizerModel", () => {
+    const baseConfig: AgentConfig = {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+    };
+
+    it("accepts a valid summarizerModel", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        summarizerModel: "anthropic/claude-3-5-haiku-latest",
+      });
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("accepts config with no summarizerModel", async () => {
+      const program = service.validateAgentConfig(baseConfig);
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("rejects a summarizerModel with no slash", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        summarizerModel: "gpt-4",
+      });
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+
+    it("rejects a summarizerModel with an unknown provider", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        summarizerModel: "notaprovider/some-model",
+      });
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    });
+  });
+
   describe("deleteAgent", () => {
     it("should delete an agent", async () => {
       // @ts-expect-error - mocking

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -13,6 +13,7 @@ import {
 } from "@/core/types/errors";
 import { type Agent, type AgentConfig, type CustomToolDefinition } from "@/core/types/index";
 import { CommonSuggestions } from "@/core/utils/error-handler";
+import { parseProviderModel } from "@/core/utils/provider-model";
 
 export class AgentServiceImpl implements AgentService {
   constructor(private readonly storage: StorageService) {}
@@ -180,6 +181,23 @@ export class AgentServiceImpl implements AgentService {
               }),
             );
           }
+        }
+      }
+
+      if (config.summarizerModel !== undefined) {
+        if (
+          typeof config.summarizerModel !== "string" ||
+          parseProviderModel(config.summarizerModel) === null
+        ) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.summarizerModel",
+              message: `Invalid summarizerModel "${String(config.summarizerModel)}"`,
+              suggestion:
+                'Use "provider/model" with a known provider, e.g. "anthropic/claude-3-5-haiku-latest", or remove the field to use the agent\'s own model.',
+            }),
+          );
         }
       }
 

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -184,16 +184,14 @@ export class AgentServiceImpl implements AgentService {
         }
       }
 
-      if (config.summarizerModel !== undefined) {
-        if (
-          typeof config.summarizerModel !== "string" ||
-          parseProviderModel(config.summarizerModel) === null
-        ) {
+      const summarizerModel: unknown = config.summarizerModel;
+      if (summarizerModel !== undefined && summarizerModel !== null) {
+        if (typeof summarizerModel !== "string" || parseProviderModel(summarizerModel) === null) {
           return yield* Effect.fail(
             new AgentConfigurationError({
               agentId: "unknown",
               field: "config.summarizerModel",
-              message: `Invalid summarizerModel "${String(config.summarizerModel)}"`,
+              message: `Invalid summarizerModel ${JSON.stringify(summarizerModel)}`,
               suggestion:
                 'Use "provider/model" with a known provider, e.g. "anthropic/claude-3-5-haiku-latest", or remove the field to use the agent\'s own model.',
             }),


### PR DESCRIPTION
## What this PR delivers

Background context summarization (the auto-compaction that fires when a conversation approaches the model's context window) now uses a **predictable model** instead of a bespoke "pick the cheapest model" oracle.

By default, summarization uses the agent's **own** provider/model. Agents that want cheaper summarization can opt in with a new optional per-agent config field, `summarizerModel: "provider/model"`. The old automatic selection — which silently rerouted to `openrouter/free` whenever an OpenRouter key was present, otherwise ranked models by a mis-weighted price average, otherwise fell back to a hardcoded model list — is removed entirely.

Alongside the behaviour change: a small reusable `parseProviderModel` utility, config-time validation of the new field, and deletion of the now-dead selection code (~90 lines out).

## Why this matters

**For operators:** summarization is now predictable and controllable. Previously, having an OpenRouter key anywhere in your config silently sent every summary through a free model of unknown quality, and the "cheapest model" ranking averaged input and output price even though summarization is overwhelmingly input-dominated — so it frequently mis-ranked. You now get your own model by default, or exactly the model you name.

**For maintainers:** removes a network call to models.dev on the summarization path, a rotting hardcoded `FALLBACK_CHEAP_MODELS` list, and a provider-branching oracle. `selectSummarizerModel` becomes a pure function, trivially unit-testable without an Effect runtime or service mocks.

## How summarization behaviour changes

| Case | Change |
|---|---|
| Agent with no `summarizerModel` set | **Intentional change:** summaries now use the agent's own model. Agents that previously got `openrouter/free` or a "cheapest" model now summarize with their parent model — higher quality, higher per-compaction cost. |
| Agent with a valid `summarizerModel` | Summaries use exactly that `provider/model`. |
| Agent with an invalid `summarizerModel` (loaded from hand-edited JSON) | Falls back to the parent model and logs a `warn`; never throws. |
| OpenRouter key present | **No longer hijacks summarization.** The key is used only where explicitly configured. |
| Runtime summarizer failure handling | No change — a failing summarizer run propagates exactly as before (no catch was added or removed). |

## UX changes operators will notice

- A `warn` log line if an agent's `summarizerModel` is set to an unparseable value (falls back to parent model): `Invalid summarizerModel "…" — falling back to parent model …`.
- `jazz agent` create/update rejects a malformed `summarizerModel` with a clear `AgentConfigurationError` instead of accepting it silently.
- Otherwise invisible during normal use — no CLI or output-format changes.

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| `AgentConfig` | — | adds optional `readonly summarizerModel?: string` (`"provider/model"`) |
| `selectSummarizerModel` (summarizer.ts) | `(agent, llmConfig) => Effect<SummarizerModelConfig, never, LLMService>` | `(agent) => { config: SummarizerModelConfig; warning?: string }` — now **pure and exported** |
| `parseProviderModel` (new) | — | `(value: string) => { provider: ProviderName; model: string } \| null` in `@/core/utils/provider-model` |
| Removed | `FALLBACK_CHEAP_MODELS`, `STATIC_PROVIDERS`, `findCheapestModelForProvider` | deleted |

## Tests

- 1384 tests pass across 79 files (0 fail); `typecheck`, `lint`, and `build` all clean.
- `src/core/utils/provider-model.test.ts` — 8 cases pin the parser contract: happy path, slash-bearing model ids (`openrouter/anthropic/claude-3.5` → model keeps the trailing segment), whitespace trim, and each malformed/unknown-provider rejection.
- `src/core/agent/context/summarizer.test.ts` — pins selection (default→parent, valid→parsed, invalid→parent+warning) and that `summarizeHistory` builds the summarizer sub-agent with the configured vs. parent model.
- `src/services/agent-service.test.ts` — pins config validation (valid accepted, absent accepted, no-slash and unknown-provider rejected).

### Edge cases to verify in a staging session

1. Agent with `summarizerModel` pointed at a provider whose API key is **not** configured — expected: the summarizer sub-agent fails at run time like any misconfigured provider (surfaced, not silent). It inherits the parent's `llmApiKeys`, so same-provider configs keep working.
2. Hand-edit an agent JSON to `"summarizerModel": "not-a-provider/x"` and trigger a long conversation that compacts — expected: warn logged, summary produced with the parent model.
3. An existing agent that previously relied on implicit cheap summarization — expected: summaries now come from the parent model (confirm the cost/quality shift is acceptable for your setup).

## Notes for reviewers

- `parseProviderModel` is the single source of truth for both config-time validation and runtime selection, so a value can never pass validation but break selection (or vice-versa). Read `provider-model.ts` first.
- The parent-model default and the never-throw runtime fallback are the two load-bearing invariants; the summarizer's runtime error propagation is **intentionally unchanged**.
