### PR TITLE
feat(agent): decompose loop behind observer seam + reframe default persona

### DIFF
--- a/personas/default/persona.md
+++ b/personas/default/persona.md
@@ -9,7 +9,7 @@ You are a helpful CLI assistant. You help users accomplish tasks through shell c
 
 # 1. Core Role & Priorities
 
-- Action first: Your primary job is to DO things using tools, skills, and commands — not explain how to do them. Default to executing, not describing.
+- Action-oriented where it fits: for concrete operational tasks (running commands, editing files, using tools), prefer doing over describing. For analytical, advisory, or open-ended requests, prefer thinking and explaining — don't rush to a tool call when the value is in the reasoning.
 - Skill-biased: ALWAYS check for a matching skill first. Skills encode domain best practices and orchestrate tools for you.
 - Tool-biased: ALWAYS prefer dedicated tools over shell commands. If a tool exists for the task, use it.
 - Helpful first: Focus on what the user actually needs, not just what they literally asked.
@@ -43,6 +43,14 @@ If unsure and the operation is risky, ask for clarification. If safe and reversi
 - Be concise and to the point.
 - Be friendly and conversational.
 - Briefly explain what you've done or are about to do and why.
+
+## Personality & Communication
+
+- Be a thoughtful collaborator, not just a task-runner. Match the user's tone, depth, and level of formality.
+- Lead with the answer or outcome, then supporting detail. Concise by default; expand when the task is complex or the user asks.
+- For analytical, planning, research, or open-ended requests, reason through the problem and show your thinking — here a good answer IS the deliverable, not a side effect of running tools.
+- Write clearly: plain language, concrete specifics over vague generalities, no filler or hype.
+- When uncertain, say so and lay out the tradeoffs rather than projecting false confidence.
 
 # 2. System Information
 

--- a/src/core/agent/execution/agent-loop-observer.test.ts
+++ b/src/core/agent/execution/agent-loop-observer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { PresentationService } from "@/core/interfaces/presentation";
+import { makeDefaultObserver } from "./agent-loop-observer";
+
+function recordingPresentation() {
+  const calls: string[] = [];
+  const service = {
+    presentThinking: (agentName: string, isFirst: boolean) =>
+      Effect.sync(() => {
+        calls.push(`thinking:${agentName}:${isFirst}`);
+      }),
+    presentWarning: (agentName: string, message: string) =>
+      Effect.sync(() => {
+        calls.push(`warning:${agentName}:${message}`);
+      }),
+    presentCompletion: (agentName: string) =>
+      Effect.sync(() => {
+        calls.push(`completion:${agentName}`);
+      }),
+  } as unknown as PresentationService;
+  return { service, calls };
+}
+
+describe("makeDefaultObserver", () => {
+  it("maps onThinking to presentThinking", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(makeDefaultObserver(service).onThinking("Agent", true));
+    expect(calls).toEqual(["thinking:Agent:true"]);
+  });
+
+  it("maps onInterrupted, onIterationLimit and onEmptyResponse to presentWarning", async () => {
+    const { service, calls } = recordingPresentation();
+    const observer = makeDefaultObserver(service);
+    await Effect.runPromise(observer.onInterrupted("Agent"));
+    await Effect.runPromise(observer.onIterationLimit("Agent", 80));
+    await Effect.runPromise(observer.onEmptyResponse("Agent"));
+    expect(calls[0]).toBe("warning:Agent:generation stopped by user");
+    expect(calls[1]).toContain("iteration limit reached (80)");
+    expect(calls[2]).toBe("warning:Agent:model returned an empty response");
+  });
+
+  it("maps onCompletion to presentCompletion", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(makeDefaultObserver(service).onCompletion("Agent"));
+    expect(calls).toEqual(["completion:Agent"]);
+  });
+});

--- a/src/core/agent/execution/agent-loop-observer.ts
+++ b/src/core/agent/execution/agent-loop-observer.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+import type { PresentationService } from "@/core/interfaces/presentation";
+
+/**
+ * Lifecycle events the agent loop emits. Kept separate from PresentationService
+ * so the loop is decoupled from the in-process presentation layer — a headless
+ * server (PR 2) implements this to serialize lifecycle events over the wire.
+ */
+export interface AgentLoopObserver {
+  onThinking(agentName: string, isFirstIteration: boolean): Effect.Effect<void, never, never>;
+  onInterrupted(agentName: string): Effect.Effect<void, never, never>;
+  onIterationLimit(agentName: string, maxIterations: number): Effect.Effect<void, never, never>;
+  onEmptyResponse(agentName: string): Effect.Effect<void, never, never>;
+  onCompletion(agentName: string): Effect.Effect<void, never, never>;
+}
+
+/** Default observer: forwards loop lifecycle events to the PresentationService. */
+export function makeDefaultObserver(presentation: PresentationService): AgentLoopObserver {
+  return {
+    onThinking: (agentName, isFirstIteration) =>
+      presentation.presentThinking(agentName, isFirstIteration),
+    onInterrupted: (agentName) =>
+      presentation.presentWarning(agentName, "generation stopped by user"),
+    onIterationLimit: (agentName, maxIterations) =>
+      presentation.presentWarning(
+        agentName,
+        `iteration limit reached (${maxIterations}) - type 'continue' to resume`,
+      ),
+    onEmptyResponse: (agentName) =>
+      presentation.presentWarning(agentName, "model returned an empty response"),
+    onCompletion: (agentName) => presentation.presentCompletion(agentName),
+  };
+}

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -8,6 +8,7 @@ import {
   type CompletionStrategy,
   type TrackedToolCall,
 } from "./agent-loop";
+import { makeDefaultObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { SkillServiceTag } from "../../../core/skills/skill-service";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
@@ -99,6 +100,23 @@ const TestLayer = Layer.mergeAll(
   Layer.succeed(SkillServiceTag, mockSkillService),
 );
 
+const defaultObserver = makeDefaultObserver(mockPresentationService);
+
+// Fake observer that records lifecycle calls.
+function recordingObserver() {
+  const calls: string[] = [];
+  const observer = {
+    onThinking: (name: string, first: boolean) =>
+      Effect.sync(() => void calls.push(`thinking:${name}:${first}`)),
+    onInterrupted: (name: string) => Effect.sync(() => void calls.push(`interrupted:${name}`)),
+    onIterationLimit: (name: string, max: number) =>
+      Effect.sync(() => void calls.push(`limit:${name}:${max}`)),
+    onEmptyResponse: (name: string) => Effect.sync(() => void calls.push(`empty:${name}`)),
+    onCompletion: (name: string) => Effect.sync(() => void calls.push(`completion:${name}`)),
+  };
+  return { observer, calls };
+}
+
 function makeOptions(overrides?: Partial<AgentRunnerOptions>): AgentRunnerOptions {
   return {
     sessionId: "test-session",
@@ -179,9 +197,14 @@ describe("executeAgentLoop", () => {
     };
 
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(TestLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
     );
 
     expect(result.content).toBe("Hello world");
@@ -235,12 +258,21 @@ describe("executeAgentLoop", () => {
         makeRunContext(),
         displayConfig,
         strategy,
+        defaultObserver,
         runRecursive,
       ).pipe(Effect.provide(TestLayer)),
     );
 
     expect(result.content).toBe("Done with tools");
     expect(ToolExecutor.executeToolCalls).toHaveBeenCalled();
+
+    // Confirms the tool-branch ("continue") appended a tool-result message
+    // to the conversation before the loop moved on to the final ("final") response.
+    const toolMessage = result.messages?.find(
+      (message) => message.role === "tool" && message.tool_call_id === "call_1",
+    );
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage?.name).toBe("test_tool");
 
     ToolExecutor.executeToolCalls = originalExecute;
   });
@@ -254,6 +286,7 @@ describe("executeAgentLoop", () => {
         return Effect.void;
       },
     };
+    const trackingObserver = makeDefaultObserver(trackingPresentationService as any);
 
     // Strategy that always returns tool calls (never finishes)
     const strategy: CompletionStrategy = {
@@ -305,6 +338,7 @@ describe("executeAgentLoop", () => {
         makeRunContext(),
         displayConfig,
         strategy,
+        trackingObserver,
         runRecursive,
       ).pipe(Effect.provide(testLayer)),
     );
@@ -315,25 +349,39 @@ describe("executeAgentLoop", () => {
   });
 
   it("should handle interruption from strategy", async () => {
+    let getCompletionCalls = 0;
     const strategy: CompletionStrategy = {
       shouldShowThinking: false,
-      getCompletion: () =>
-        Effect.succeed({
+      getCompletion: () => {
+        getCompletionCalls++;
+        return Effect.succeed({
           completion: { id: "c1", model: "gpt-4", content: "partial" },
           interrupted: true,
-        }),
+        });
+      },
       presentResponse: () => Effect.void,
       onComplete: () => Effect.void,
       getRenderer: () => null,
     };
 
+    const { observer, calls } = recordingObserver();
+
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(TestLayer),
-      ),
+      executeAgentLoop(
+        makeOptions({ maxIterations: 5 }),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        observer,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
     );
 
     expect(result.content).toBe("partial");
+    // Interruption must fire the observer callback and stop the loop immediately
+    // rather than continuing on to further iterations.
+    expect(calls).toContain("interrupted:test-agent");
+    expect(getCompletionCalls).toBe(1);
   });
 
   it("should warn on empty response", async () => {
@@ -345,6 +393,7 @@ describe("executeAgentLoop", () => {
         return Effect.void;
       },
     };
+    const trackingObserver = makeDefaultObserver(trackingPresentationService as any);
 
     const strategy: CompletionStrategy = {
       shouldShowThinking: false,
@@ -372,9 +421,14 @@ describe("executeAgentLoop", () => {
     );
 
     await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(testLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        trackingObserver,
+        runRecursive,
+      ).pipe(Effect.provide(testLayer)),
     );
 
     expect(warningCalls.some((msg) => msg.includes("empty response"))).toBe(true);
@@ -390,6 +444,7 @@ describe("executeAgentLoop", () => {
         return Effect.void;
       },
     };
+    const trackingObserver = makeDefaultObserver(trackingPresentationService as any);
 
     const strategy: CompletionStrategy = {
       shouldShowThinking: false,
@@ -425,9 +480,14 @@ describe("executeAgentLoop", () => {
     );
 
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(testLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        trackingObserver,
+        runRecursive,
+      ).pipe(Effect.provide(testLayer)),
     );
 
     expect(warningCalls.some((msg) => msg.includes("empty response"))).toBe(false);
@@ -456,9 +516,14 @@ describe("executeAgentLoop", () => {
     };
 
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(TestLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
     );
 
     expect(result.usage?.promptTokens).toBe(10);
@@ -484,15 +549,86 @@ describe("executeAgentLoop", () => {
     };
 
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(TestLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
     );
 
     expect(result.toolsDisabled).toBe(true);
   });
 
+  it("returns usage from runMetrics and omits costUSD when pricing metadata is unavailable", async () => {
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: {
+            id: "c1",
+            model: "gpt-4",
+            content: "Final answer",
+            usage: { promptTokens: 42, completionTokens: 17, totalTokens: 59 },
+          },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions(),
+        // Use a provider/model combo absent from models.dev so pricing metadata
+        // resolves to undefined deterministically, without depending on network access.
+        makeRunContext({ provider: "test-provider", model: "totally-fake-model-xyz" }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(result.usage).toEqual({ promptTokens: 42, completionTokens: 17 });
+    expect(result.costUSD).toBeUndefined();
+    expect(result.messages).toBeDefined();
+  });
+
+  it("emits onThinking and onCompletion through the observer for a simple completion", async () => {
+    const { observer, calls } = recordingObserver();
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: true,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: { id: "c1", model: "gpt-4", content: "Hello world" },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        observer,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(calls).toContain("thinking:test-agent:true");
+    expect(calls).toContain("completion:test-agent");
+  });
+
   it("stores reasoning parts on the assistant message in conversation history", async () => {
+    const { observer } = recordingObserver();
     const strategy: CompletionStrategy = {
       shouldShowThinking: false,
       getCompletion: () =>
@@ -517,9 +653,14 @@ describe("executeAgentLoop", () => {
     };
 
     const result = await Effect.runPromise(
-      executeAgentLoop(makeOptions(), makeRunContext(), displayConfig, strategy, runRecursive).pipe(
-        Effect.provide(TestLayer),
-      ),
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext(),
+        displayConfig,
+        strategy,
+        observer,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
     );
 
     const assistantMessage = result.messages?.find((message) => message.role === "assistant");

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -5,7 +5,6 @@ import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { PresentationService, StreamingRenderer } from "@/core/interfaces/presentation";
-import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { ChatMessage, ConversationMessages } from "@/core/types";
 import type { ChatCompletionResponse } from "@/core/types/chat";
@@ -13,6 +12,7 @@ import { LLMRateLimitError } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
 import { getModelsDevMetadata } from "@/core/utils/models-dev-client";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
+import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import {
   ContextWindowManager,
@@ -28,6 +28,7 @@ import {
   recordLLMUsage,
   recordToolDefinitionTokens,
   recordToolResultTokens,
+  type AgentRunMetrics,
 } from "../metrics/agent-run-metrics";
 import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../types";
 
@@ -58,6 +59,32 @@ export function buildBudgetPressureMessage(
 export interface TrackedToolCall {
   name: string;
   arguments: string;
+}
+
+interface LoopState {
+  currentMessages: ConversationMessages;
+  response: AgentResponse;
+  recentToolCalls: TrackedToolCall[];
+  iterationsUsed: number;
+}
+
+interface LoopDeps {
+  agent: AgentRunnerOptions["agent"];
+  options: AgentRunnerOptions;
+  actualConversationId: string;
+  context: AgentRunContext["context"];
+  tools: AgentRunContext["tools"];
+  provider: AgentRunContext["provider"];
+  model: string;
+  runMetrics: AgentRunMetrics;
+  contextWindowMaxTokens: number;
+  runContextWindowManager: ContextWindowManager;
+  displayConfig: DisplayConfig;
+  strategy: CompletionStrategy;
+  observer: AgentLoopObserver;
+  logger: LoggerService;
+  maxIterations: number;
+  runRecursive: RecursiveRunner;
 }
 
 export const MELTDOWN_WINDOW_SIZE = 10;
@@ -138,6 +165,450 @@ export interface CompletionStrategy {
   shouldShowThinking: boolean;
 }
 
+interface FinalizeInput {
+  response: AgentResponse;
+  currentMessages: ConversationMessages;
+  runMetrics: AgentRunMetrics;
+  modelMetadata: { inputPricePerMillion?: number; outputPricePerMillion?: number } | undefined;
+  iterationsUsed: number;
+  finished: boolean;
+  interrupted: boolean;
+}
+
+/**
+ * Post-loop finalization: iteration-limit/empty-response warnings, kicking off
+ * the async metrics/telemetry write (tracked via `finalizeFiberRef` so the caller
+ * can await it during release), cost computation, and `AgentResponse` assembly.
+ */
+function finalizeRun(
+  input: FinalizeInput,
+  observer: AgentLoopObserver,
+  logger: LoggerService,
+  agentName: string,
+  maxIterations: number,
+  finalizeFiberRef: Ref.Ref<Option.Option<Fiber.RuntimeFiber<void, Error>>>,
+): Effect.Effect<AgentResponse, never, LoggerService> {
+  return Effect.gen(function* () {
+    const { response, currentMessages, runMetrics, modelMetadata, finished, interrupted } = input;
+    let iterationsUsed = input.iterationsUsed;
+
+    if (!finished) {
+      iterationsUsed = maxIterations;
+      yield* observer.onIterationLimit(agentName, maxIterations);
+    } else if (
+      !response.content?.trim() &&
+      !response.reasoning?.trim() &&
+      !response.toolCalls &&
+      !interrupted
+    ) {
+      yield* observer.onEmptyResponse(agentName);
+    }
+
+    yield* logger.debug("Finalizing agent run", { interrupted, finished });
+
+    const finalizeFiber = yield* finalizeAgentRun(runMetrics, {
+      iterationsUsed,
+      finished,
+    }).pipe(
+      Effect.catchAll((error) =>
+        logger.warn("Failed to write agent token usage log", { error: error.message }),
+      ),
+      Effect.fork,
+    );
+    yield* Ref.set(finalizeFiberRef, Option.some(finalizeFiber));
+
+    const inputPrice = modelMetadata?.inputPricePerMillion ?? 0;
+    const outputPrice = modelMetadata?.outputPricePerMillion ?? 0;
+    const costUSD =
+      inputPrice > 0 || outputPrice > 0
+        ? parseFloat(
+            (
+              (runMetrics.totalPromptTokens / 1_000_000) * inputPrice +
+              (runMetrics.totalCompletionTokens / 1_000_000) * outputPrice
+            ).toFixed(8),
+          )
+        : undefined;
+
+    return {
+      ...response,
+      messages: currentMessages,
+      usage: {
+        promptTokens: runMetrics.totalPromptTokens,
+        completionTokens: runMetrics.totalCompletionTokens,
+      },
+      ...(costUSD !== undefined ? { costUSD } : {}),
+    };
+  });
+}
+
+/**
+ * Handles the tool-call branch of a single loop iteration: executes the tool
+ * calls, validates every call produced a result, appends tool-result messages,
+ * runs meltdown detection/recovery injection, and applies budget/queued-message
+ * handling. Mutates `state` in place (currentMessages, recentToolCalls, response).
+ */
+function handleToolPhase(
+  state: LoopState,
+  toolCalls: NonNullable<ChatCompletionResponse["toolCalls"]>,
+  reasoningContent: string,
+  iterationIndex: number,
+  deps: LoopDeps,
+): Effect.Effect<
+  void,
+  Error,
+  ToolRegistry | LoggerService | AgentConfigService | ToolRequirements | PresentationService
+> {
+  const {
+    agent,
+    actualConversationId,
+    context,
+    contextWindowMaxTokens,
+    runContextWindowManager,
+    displayConfig,
+    strategy,
+    runMetrics,
+    maxIterations,
+    options,
+    logger,
+  } = deps;
+
+  return Effect.gen(function* () {
+    yield* logger.info("Agent decided to use tools", {
+      agentId: agent.id,
+      conversationId: actualConversationId,
+      iteration: iterationIndex + 1,
+      toolsChosen: toolCalls.map((tc) => tc.function.name),
+      reasoning: reasoningContent,
+    });
+
+    for (const toolCall of toolCalls) {
+      if (toolCall.type === "function") {
+        state.recentToolCalls.push({
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+        });
+      }
+    }
+
+    if (state.recentToolCalls.length > MELTDOWN_WINDOW_SIZE) {
+      state.recentToolCalls.splice(0, state.recentToolCalls.length - MELTDOWN_WINDOW_SIZE);
+    }
+
+    if (detectMeltdown(state.recentToolCalls)) {
+      yield* logger.warn("Meltdown detected — injecting recovery signal", {
+        agentId: agent.id,
+        recentTools: state.recentToolCalls.slice(-10).map((tc) => tc.name),
+      });
+      state.currentMessages.push({
+        role: "user",
+        content:
+          "[MELTDOWN DETECTED: You have been repeating the same tool calls without progress. Stop the current approach. Summarize what you have found so far, identify what is still missing, and either proceed directly to output or try a fundamentally different search strategy. Do not repeat your last action.]",
+      });
+      state.recentToolCalls.length = 0;
+    }
+
+    const contextWithTokenStats = {
+      ...context,
+      tokenStats: {
+        currentTokens: runContextWindowManager.calculateTotalTokens(state.currentMessages),
+        maxTokens: contextWindowMaxTokens,
+      },
+      conversationMessages: state.currentMessages,
+      parentAgent: agent,
+      parentMaxIterations: maxIterations,
+      compactConversation: (compacted: readonly ChatMessage[]) => {
+        state.currentMessages = [
+          state.currentMessages[0],
+          ...compacted.slice(1),
+        ] as typeof state.currentMessages;
+      },
+    };
+
+    const toolResults = yield* ToolExecutor.executeToolCalls(
+      toolCalls,
+      contextWithTokenStats,
+      displayConfig,
+      strategy.getRenderer(),
+      runMetrics,
+      agent.id,
+      actualConversationId,
+      agent.name,
+      strategy.getInterruptSignal?.(),
+    );
+
+    // Validate all tool calls have results
+    const resultMap = new Map(toolResults.map((r) => [r.toolCallId, r.result]));
+    const missingResults: string[] = [];
+    for (const toolCall of toolCalls) {
+      if (toolCall.type === "function" && !resultMap.has(toolCall.id)) {
+        missingResults.push(toolCall.id);
+      }
+    }
+    if (missingResults.length > 0) {
+      yield* logger.error("Missing tool results for some tool calls", {
+        agentId: agent.id,
+        conversationId: actualConversationId,
+        missingToolCallIds: missingResults,
+        expectedCount: toolCalls.length,
+        actualCount: toolResults.length,
+      });
+      return yield* Effect.fail(
+        new Error(
+          `Missing tool results for ${missingResults.length} tool call(s). This indicates a bug in tool execution.`,
+        ),
+      );
+    }
+
+    // Add tool result messages
+    for (const toolCall of toolCalls) {
+      if (toolCall.type === "function") {
+        const result = resultMap.get(toolCall.id);
+        if (result === undefined) {
+          yield* logger.error("Tool result is undefined despite validation", {
+            agentId: agent.id,
+            conversationId: actualConversationId,
+            toolCallId: toolCall.id,
+            toolName: toolCall.function.name,
+          });
+          state.currentMessages.push({
+            role: "tool",
+            name: toolCall.function.name,
+            content: formatToolResultForContext(toolCall.function.name, {
+              error: "Tool execution result was undefined",
+            }),
+            tool_call_id: toolCall.id,
+          });
+        } else {
+          const formattedResult = formatToolResultForContext(toolCall.function.name, result);
+          state.currentMessages.push({
+            role: "tool",
+            name: toolCall.function.name,
+            content: formattedResult,
+            tool_call_id: toolCall.id,
+          });
+          recordToolResultTokens(runMetrics, toolCall.function.name, formattedResult.length);
+        }
+      }
+    }
+
+    state.response = {
+      ...state.response,
+      toolCalls: [...(state.response.toolCalls ?? []), ...toolCalls],
+      toolResults: {
+        ...state.response.toolResults,
+        ...Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
+      },
+    };
+
+    const queuedMessage = options.checkQueuedMessage?.();
+    if (queuedMessage) {
+      state.currentMessages.push({ role: "user", content: queuedMessage });
+    }
+  });
+}
+
+type RunIterationResult = { kind: "continue" } | { kind: "final" } | { kind: "interrupted" };
+
+/**
+ * Runs one full loop iteration: context compaction, LLM request logging,
+ * `strategy.getCompletion`, usage recording, assistant message build + trim,
+ * then either delegates to `handleToolPhase` (tool branch → "continue") or
+ * handles the final-response presentation (→ "final"). An interrupted
+ * completion short-circuits to "interrupted". Mutates `state` in place.
+ */
+function runIteration(
+  state: LoopState,
+  iterationIndex: number,
+  deps: LoopDeps,
+): Effect.Effect<
+  RunIterationResult,
+  LLMRateLimitError | Error,
+  | LLMService
+  | ToolRegistry
+  | LoggerService
+  | AgentConfigService
+  | PresentationService
+  | ToolRequirements
+> {
+  const {
+    agent,
+    options,
+    actualConversationId,
+    tools,
+    provider,
+    model,
+    runMetrics,
+    contextWindowMaxTokens,
+    runContextWindowManager,
+    strategy,
+    observer,
+    logger,
+    maxIterations,
+    runRecursive,
+  } = deps;
+
+  return Effect.gen(function* () {
+    if (!options.internal && strategy.shouldShowThinking) {
+      yield* observer.onThinking(agent.name, iterationIndex === 0);
+    }
+
+    state.currentMessages = yield* Summarizer.compactIfNeeded(
+      state.currentMessages,
+      agent,
+      options.sessionId,
+      actualConversationId,
+      runRecursive,
+      contextWindowMaxTokens,
+    );
+
+    let lastUserContent: string | undefined;
+    for (let j = state.currentMessages.length - 1; j >= 0; j--) {
+      if (state.currentMessages[j]?.role === "user") {
+        lastUserContent = state.currentMessages[j]?.content;
+        break;
+      }
+    }
+
+    yield* logger.debug("Sending LLM request", {
+      agentId: agent.id,
+      conversationId: actualConversationId,
+      iteration: iterationIndex + 1,
+      provider,
+      model,
+      messageCount: state.currentMessages.length,
+      toolsAvailable: tools.length,
+      reasoningEffort: agent.config.reasoningEffort,
+      lastUserMessage: lastUserContent,
+    });
+
+    const budgetMsg = buildBudgetPressureMessage(iterationIndex + 1, maxIterations);
+    const messagesForLLM = budgetMsg
+      ? ([...state.currentMessages, budgetMsg] as typeof state.currentMessages)
+      : state.currentMessages;
+
+    const result = yield* strategy.getCompletion(messagesForLLM, iterationIndex);
+
+    if (result.interrupted) {
+      const completion = result.completion;
+      state.response = {
+        ...state.response,
+        content: completion.content,
+        ...(completion.toolCalls ? { toolCalls: completion.toolCalls } : {}),
+      };
+
+      if (completion.content.length > 0) {
+        state.currentMessages.push({
+          role: "assistant",
+          content: completion.content,
+        });
+      }
+      yield* observer.onInterrupted(agent.name);
+      yield* logger.debug("Interruption handled, breaking loop");
+      return { kind: "interrupted" } as const;
+    }
+
+    const { completion } = result;
+
+    // Log LLM response summary
+    yield* logger.debug("LLM response received", {
+      agentId: agent.id,
+      conversationId: actualConversationId,
+      iteration: iterationIndex + 1,
+      contentLength: completion.content.length,
+      toolCallsCount: completion.toolCalls?.length ?? 0,
+      tokenUsage: completion.usage,
+      contentPreview: completion.content.substring(0, 300),
+    });
+
+    if (completion.usage) {
+      recordLLMUsage(runMetrics, completion.usage);
+
+      calibrateTokenCounter({
+        authoritativePromptTokens: completion.usage.promptTokens,
+        messagesAtCallTime: state.currentMessages,
+        provider,
+        modelId: model,
+      });
+    }
+
+    if (completion.toolDefinitionChars != null) {
+      recordToolDefinitionTokens(
+        runMetrics,
+        estimateTokens(completion.toolDefinitionChars),
+        completion.toolDefinitionCount ?? 0,
+      );
+    }
+
+    if (completion.toolsDisabled) {
+      state.response = { ...state.response, toolsDisabled: true };
+    }
+
+    const assistantMessage = {
+      role: "assistant" as const,
+      content: completion.content,
+      ...(completion.reasoningParts && completion.reasoningParts.length > 0
+        ? { reasoning_parts: completion.reasoningParts }
+        : {}),
+      ...(completion.toolCalls
+        ? {
+            tool_calls: completion.toolCalls.map((tc) => ({
+              id: tc.id,
+              type: tc.type,
+              function: { name: tc.function.name, arguments: tc.function.arguments },
+              ...(tc.thought_signature ? { thought_signature: tc.thought_signature } : {}),
+            })),
+          }
+        : {}),
+    };
+
+    state.currentMessages.push(assistantMessage);
+
+    const trimUpdate = yield* runContextWindowManager.trim(
+      state.currentMessages,
+      logger,
+      agent.id,
+      actualConversationId,
+    );
+    state.currentMessages = trimUpdate.messages;
+
+    if (completion.toolCalls && completion.toolCalls.length > 0) {
+      yield* handleToolPhase(state, completion.toolCalls, completion.content, iterationIndex, deps);
+      return { kind: "continue" } as const;
+    }
+
+    // No tool calls - final response
+    yield* logger.info("Agent provided final response", {
+      agentId: agent.id,
+      conversationId: actualConversationId,
+      iteration: iterationIndex + 1,
+      completionLength: completion.content.length,
+      totalToolsUsed: runMetrics.toolCalls,
+    });
+
+    // If the model produced reasoning but no text content (e.g. llama.cpp
+    // with --jinja routing the entire response into reasoning_content),
+    // surface the reasoning as the visible content so downstream
+    // consumers — conversation history, summarization, batch rendering —
+    // see what the model actually said.
+    const visibleContent = completion.content?.trim().length
+      ? completion.content
+      : (completion.reasoning ?? completion.content);
+    state.response = {
+      ...state.response,
+      content: visibleContent,
+      ...(completion.reasoning ? { reasoning: completion.reasoning } : {}),
+    };
+
+    // Let strategy present the response (batch renders markdown, streaming is already rendered)
+    yield* strategy.presentResponse(agent.name, visibleContent, completion);
+    yield* observer.onCompletion(agent.name);
+    yield* strategy.onComplete(agent.name, completion);
+
+    state.iterationsUsed = iterationIndex + 1;
+    return { kind: "final" } as const;
+  });
+}
+
 /**
  * Shared agent execution loop used by both streaming and batch executors.
  *
@@ -156,6 +627,7 @@ export function executeAgentLoop(
   runContext: AgentRunContext,
   displayConfig: DisplayConfig,
   strategy: CompletionStrategy,
+  observer: AgentLoopObserver,
   runRecursive: RecursiveRunner,
 ): Effect.Effect<
   AgentResponse,
@@ -181,7 +653,6 @@ export function executeAgentLoop(
       Effect.gen(function* () {
         const { agent, maxIterations: maxIter } = options;
         const maxIterations = maxIter ?? DEFAULT_MAX_ITERATIONS;
-        const presentationService = yield* PresentationServiceTag;
         const { actualConversationId, context, tools, messages, runMetrics, provider, model } =
           runContext;
 
@@ -209,372 +680,71 @@ export function executeAgentLoop(
           source: modelMetadata ? "models.dev" : "default",
         });
 
-        let currentMessages: ConversationMessages = [messages[0], ...messages.slice(1)];
-        let response: AgentResponse = {
-          content: "",
-          conversationId: actualConversationId,
+        const state: LoopState = {
+          currentMessages: [messages[0], ...messages.slice(1)],
+          response: {
+            content: "",
+            conversationId: actualConversationId,
+          },
+          recentToolCalls: [],
+          iterationsUsed: 0,
         };
         let finished = false;
         let interrupted = false;
-        let iterationsUsed = 0;
-        const recentToolCalls: TrackedToolCall[] = [];
+
+        const deps: LoopDeps = {
+          agent,
+          options,
+          actualConversationId,
+          context,
+          tools,
+          provider,
+          model,
+          runMetrics,
+          contextWindowMaxTokens,
+          runContextWindowManager,
+          displayConfig,
+          strategy,
+          observer,
+          logger,
+          maxIterations,
+          runRecursive,
+        };
 
         for (let i = 0; i < maxIterations; i++) {
           yield* Effect.sync(() => beginIteration(runMetrics, i + 1));
           try {
-            if (!options.internal && strategy.shouldShowThinking) {
-              yield* presentationService.presentThinking(agent.name, i === 0);
-            }
-
-            currentMessages = yield* Summarizer.compactIfNeeded(
-              currentMessages,
-              agent,
-              options.sessionId,
-              actualConversationId,
-              runRecursive,
-              contextWindowMaxTokens,
-            );
-
-            let lastUserContent: string | undefined;
-            for (let j = currentMessages.length - 1; j >= 0; j--) {
-              if (currentMessages[j]?.role === "user") {
-                lastUserContent = currentMessages[j]?.content;
-                break;
-              }
-            }
-
-            yield* logger.debug("Sending LLM request", {
-              agentId: agent.id,
-              conversationId: actualConversationId,
-              iteration: i + 1,
-              provider,
-              model,
-              messageCount: currentMessages.length,
-              toolsAvailable: tools.length,
-              reasoningEffort: agent.config.reasoningEffort,
-              lastUserMessage: lastUserContent,
-            });
-
-            const budgetMsg = buildBudgetPressureMessage(i + 1, maxIterations);
-            const messagesForLLM = budgetMsg
-              ? ([...currentMessages, budgetMsg] as typeof currentMessages)
-              : currentMessages;
-
-            const result = yield* strategy.getCompletion(messagesForLLM, i);
-
-            if (result.interrupted) {
-              const completion = result.completion;
-              response = {
-                ...response,
-                content: completion.content,
-                ...(completion.toolCalls ? { toolCalls: completion.toolCalls } : {}),
-              };
-
-              if (completion.content.length > 0) {
-                currentMessages.push({
-                  role: "assistant",
-                  content: completion.content,
-                });
-              }
-              yield* presentationService.presentWarning(agent.name, "generation stopped by user");
+            const step = yield* runIteration(state, i, deps);
+            if (step.kind === "interrupted") {
               finished = true;
               interrupted = true;
-              yield* logger.debug("Interruption handled, breaking loop");
               break;
             }
-
-            const { completion } = result;
-
-            // Log LLM response summary
-            yield* logger.debug("LLM response received", {
-              agentId: agent.id,
-              conversationId: actualConversationId,
-              iteration: i + 1,
-              contentLength: completion.content.length,
-              toolCallsCount: completion.toolCalls?.length ?? 0,
-              tokenUsage: completion.usage,
-              contentPreview: completion.content.substring(0, 300),
-            });
-
-            if (completion.usage) {
-              recordLLMUsage(runMetrics, completion.usage);
-
-              calibrateTokenCounter({
-                authoritativePromptTokens: completion.usage.promptTokens,
-                messagesAtCallTime: currentMessages,
-                provider,
-                modelId: model,
-              });
+            if (step.kind === "final") {
+              finished = true;
+              break;
             }
-
-            if (completion.toolDefinitionChars != null) {
-              recordToolDefinitionTokens(
-                runMetrics,
-                estimateTokens(completion.toolDefinitionChars),
-                completion.toolDefinitionCount ?? 0,
-              );
-            }
-
-            if (completion.toolsDisabled) {
-              response = { ...response, toolsDisabled: true };
-            }
-
-            const assistantMessage = {
-              role: "assistant" as const,
-              content: completion.content,
-              ...(completion.reasoningParts && completion.reasoningParts.length > 0
-                ? { reasoning_parts: completion.reasoningParts }
-                : {}),
-              ...(completion.toolCalls
-                ? {
-                    tool_calls: completion.toolCalls.map((tc) => ({
-                      id: tc.id,
-                      type: tc.type,
-                      function: { name: tc.function.name, arguments: tc.function.arguments },
-                      ...(tc.thought_signature ? { thought_signature: tc.thought_signature } : {}),
-                    })),
-                  }
-                : {}),
-            };
-
-            currentMessages.push(assistantMessage);
-
-            const trimUpdate = yield* runContextWindowManager.trim(
-              currentMessages,
-              logger,
-              agent.id,
-              actualConversationId,
-            );
-            currentMessages = trimUpdate.messages;
-
-            if (completion.toolCalls && completion.toolCalls.length > 0) {
-              yield* logger.info("Agent decided to use tools", {
-                agentId: agent.id,
-                conversationId: actualConversationId,
-                iteration: i + 1,
-                toolsChosen: completion.toolCalls.map((tc) => tc.function.name),
-                reasoning: completion.content,
-              });
-
-              for (const toolCall of completion.toolCalls) {
-                if (toolCall.type === "function") {
-                  recentToolCalls.push({
-                    name: toolCall.function.name,
-                    arguments: toolCall.function.arguments,
-                  });
-                }
-              }
-
-              if (recentToolCalls.length > MELTDOWN_WINDOW_SIZE) {
-                recentToolCalls.splice(0, recentToolCalls.length - MELTDOWN_WINDOW_SIZE);
-              }
-
-              if (detectMeltdown(recentToolCalls)) {
-                yield* logger.warn("Meltdown detected — injecting recovery signal", {
-                  agentId: agent.id,
-                  recentTools: recentToolCalls.slice(-10).map((tc) => tc.name),
-                });
-                currentMessages.push({
-                  role: "user",
-                  content:
-                    "[MELTDOWN DETECTED: You have been repeating the same tool calls without progress. Stop the current approach. Summarize what you have found so far, identify what is still missing, and either proceed directly to output or try a fundamentally different search strategy. Do not repeat your last action.]",
-                });
-                recentToolCalls.length = 0;
-              }
-
-              const contextWithTokenStats = {
-                ...context,
-                tokenStats: {
-                  currentTokens: runContextWindowManager.calculateTotalTokens(currentMessages),
-                  maxTokens: contextWindowMaxTokens,
-                },
-                conversationMessages: currentMessages,
-                parentAgent: agent,
-                parentMaxIterations: maxIterations,
-                compactConversation: (compacted: readonly ChatMessage[]) => {
-                  currentMessages = [
-                    currentMessages[0],
-                    ...compacted.slice(1),
-                  ] as typeof currentMessages;
-                },
-              };
-
-              const toolResults = yield* ToolExecutor.executeToolCalls(
-                completion.toolCalls,
-                contextWithTokenStats,
-                displayConfig,
-                strategy.getRenderer(),
-                runMetrics,
-                agent.id,
-                actualConversationId,
-                agent.name,
-                strategy.getInterruptSignal?.(),
-              );
-
-              // Validate all tool calls have results
-              const resultMap = new Map(toolResults.map((r) => [r.toolCallId, r.result]));
-              const missingResults: string[] = [];
-              for (const toolCall of completion.toolCalls) {
-                if (toolCall.type === "function" && !resultMap.has(toolCall.id)) {
-                  missingResults.push(toolCall.id);
-                }
-              }
-              if (missingResults.length > 0) {
-                yield* logger.error("Missing tool results for some tool calls", {
-                  agentId: agent.id,
-                  conversationId: actualConversationId,
-                  missingToolCallIds: missingResults,
-                  expectedCount: completion.toolCalls.length,
-                  actualCount: toolResults.length,
-                });
-                return yield* Effect.fail(
-                  new Error(
-                    `Missing tool results for ${missingResults.length} tool call(s). This indicates a bug in tool execution.`,
-                  ),
-                );
-              }
-
-              // Add tool result messages
-              for (const toolCall of completion.toolCalls) {
-                if (toolCall.type === "function") {
-                  const result = resultMap.get(toolCall.id);
-                  if (result === undefined) {
-                    yield* logger.error("Tool result is undefined despite validation", {
-                      agentId: agent.id,
-                      conversationId: actualConversationId,
-                      toolCallId: toolCall.id,
-                      toolName: toolCall.function.name,
-                    });
-                    currentMessages.push({
-                      role: "tool",
-                      name: toolCall.function.name,
-                      content: formatToolResultForContext(toolCall.function.name, {
-                        error: "Tool execution result was undefined",
-                      }),
-                      tool_call_id: toolCall.id,
-                    });
-                  } else {
-                    const formattedResult = formatToolResultForContext(
-                      toolCall.function.name,
-                      result,
-                    );
-                    currentMessages.push({
-                      role: "tool",
-                      name: toolCall.function.name,
-                      content: formattedResult,
-                      tool_call_id: toolCall.id,
-                    });
-                    recordToolResultTokens(
-                      runMetrics,
-                      toolCall.function.name,
-                      formattedResult.length,
-                    );
-                  }
-                }
-              }
-
-              response = {
-                ...response,
-                toolCalls: [...(response.toolCalls ?? []), ...completion.toolCalls],
-                toolResults: {
-                  ...response.toolResults,
-                  ...Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
-                },
-              };
-
-              const queuedMessage = options.checkQueuedMessage?.();
-              if (queuedMessage) {
-                currentMessages.push({ role: "user", content: queuedMessage });
-              }
-              continue;
-            }
-
-            // No tool calls - final response
-            yield* logger.info("Agent provided final response", {
-              agentId: agent.id,
-              conversationId: actualConversationId,
-              iteration: i + 1,
-              completionLength: completion.content.length,
-              totalToolsUsed: runMetrics.toolCalls,
-            });
-
-            // If the model produced reasoning but no text content (e.g. llama.cpp
-            // with --jinja routing the entire response into reasoning_content),
-            // surface the reasoning as the visible content so downstream
-            // consumers — conversation history, summarization, batch rendering —
-            // see what the model actually said.
-            const visibleContent = completion.content?.trim().length
-              ? completion.content
-              : (completion.reasoning ?? completion.content);
-            response = {
-              ...response,
-              content: visibleContent,
-              ...(completion.reasoning ? { reasoning: completion.reasoning } : {}),
-            };
-
-            // Let strategy present the response (batch renders markdown, streaming is already rendered)
-            yield* strategy.presentResponse(agent.name, visibleContent, completion);
-            yield* presentationService.presentCompletion(agent.name);
-            yield* strategy.onComplete(agent.name, completion);
-
-            iterationsUsed = i + 1;
-            finished = true;
-            break;
           } finally {
             yield* Effect.sync(() => completeIteration(runMetrics));
           }
         }
 
-        // Post-loop cleanup
-        if (!finished) {
-          iterationsUsed = maxIterations;
-          yield* presentationService.presentWarning(
-            agent.name,
-            `iteration limit reached (${maxIterations}) - type 'continue' to resume`,
-          );
-        } else if (
-          !response.content?.trim() &&
-          !response.reasoning?.trim() &&
-          !response.toolCalls &&
-          !interrupted
-        ) {
-          yield* presentationService.presentWarning(agent.name, "model returned an empty response");
-        }
-
-        yield* logger.debug("Finalizing agent run", { interrupted, finished });
-
-        const finalizeFiber = yield* finalizeAgentRun(runMetrics, {
-          iterationsUsed,
-          finished,
-        }).pipe(
-          Effect.catchAll((error) =>
-            logger.warn("Failed to write agent token usage log", { error: error.message }),
-          ),
-          Effect.fork,
-        );
-        yield* Ref.set(finalizeFiberRef, Option.some(finalizeFiber));
-
-        const inputPrice = modelMetadata?.inputPricePerMillion ?? 0;
-        const outputPrice = modelMetadata?.outputPricePerMillion ?? 0;
-        const costUSD =
-          inputPrice > 0 || outputPrice > 0
-            ? parseFloat(
-                (
-                  (runMetrics.totalPromptTokens / 1_000_000) * inputPrice +
-                  (runMetrics.totalCompletionTokens / 1_000_000) * outputPrice
-                ).toFixed(8),
-              )
-            : undefined;
-
-        return {
-          ...response,
-          messages: currentMessages,
-          usage: {
-            promptTokens: runMetrics.totalPromptTokens,
-            completionTokens: runMetrics.totalCompletionTokens,
+        return yield* finalizeRun(
+          {
+            response: state.response,
+            currentMessages: state.currentMessages,
+            runMetrics,
+            modelMetadata,
+            iterationsUsed: state.iterationsUsed,
+            finished,
+            interrupted,
           },
-          ...(costUSD !== undefined ? { costUSD } : {}),
-        };
+          observer,
+          logger,
+          agent.name,
+          maxIterations,
+          finalizeFiberRef,
+        );
       }),
     // Release: cleanup
     ({ logger, finalizeFiberRef }) =>

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -14,6 +14,7 @@ import type { ConversationMessages } from "@/core/types";
 import { LLMRateLimitError } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
+import { makeDefaultObserver } from "./agent-loop-observer";
 import type { RecursiveRunner } from "../context/summarizer";
 import { recordLLMRetry } from "../metrics/agent-run-metrics";
 import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../types";
@@ -165,6 +166,14 @@ export function executeWithoutStreaming(
       },
     };
 
-    return yield* executeAgentLoop(options, runContext, displayConfig, strategy, runRecursive);
+    const observer = makeDefaultObserver(presentationService);
+    return yield* executeAgentLoop(
+      options,
+      runContext,
+      displayConfig,
+      strategy,
+      observer,
+      runRecursive,
+    );
   });
 }

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -22,6 +22,7 @@ import {
 import type { DisplayConfig } from "@/core/types/output";
 import { isRetryableLLMError } from "@/core/utils/llm-error";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
+import { makeDefaultObserver } from "./agent-loop-observer";
 import type { RecursiveRunner } from "../context/summarizer";
 import { recordFirstTokenLatency, recordLLMRetry } from "../metrics/agent-run-metrics";
 import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../types";
@@ -373,11 +374,13 @@ export function executeWithStreaming(
       },
     };
 
+    const observer = makeDefaultObserver(presentationService);
     const response = yield* executeAgentLoop(
       options,
       runContext,
       displayConfig,
       strategy,
+      observer,
       runRecursive,
     ).pipe(Effect.ensuring(renderer.setInterruptHandler(null)));
 


### PR DESCRIPTION
Two related harness improvements, rebased onto current `main`.

## 1. Agent-loop decomposition + observer seam (#3)

Decomposes the ~400-line `executeAgentLoop` into `runIteration` / `handleToolPhase` / `finalizeRun` (shared `LoopState`), and routes the loop's five lifecycle events (thinking / interrupted / iteration-limit / empty-response / completion) through a new **`AgentLoopObserver`** whose default adapter forwards 1:1 to `PresentationService`.

- **Behavior-identical structural refactor.** Same firing conditions, order, and user-facing strings. The big extraction was reviewed line-by-line.
- Completion streaming (`CompletionStrategy` / `StreamEvent` / renderer) untouched.
- Preserves #275's `reasoning_parts` on the assistant history message (re-applied into `runIteration`), with coverage.
- The observer seam is the substrate the planned **client-server split (#5)** will consume — a server implements `AgentLoopObserver` to serialize lifecycle events over the wire.

## 2. Default-persona capability reframe (#2)

Addresses the "same model feels a category below Codex on non-coding tasks" gap, diagnosed as prompt framing (not reasoning effort). In `personas/default/persona.md` (the single source of truth for the default prompt after #271):

- Adds a **Personality & Communication** section — be a thoughtful collaborator, match tone, lead with the answer, *reason and show thinking on analytical/open-ended requests*, state uncertainty.
- **Softens the blanket "action-first" line** — action-oriented for concrete operational tasks, but thinking/explaining for analytical/advisory/open-ended ones, instead of "Default to executing, not describing."

This is an **intentional behavior change** (that's the point). No doctrine removed.

## Tests

Full suite **1411 passing / 0 fail**, typecheck + lint + build clean. New: `agent-loop-observer.test.ts` (adapter mapping with byte-identical strings) and observer/reasoning/finalize cases in `agent-loop.test.ts`.

### Edge cases to verify in a staging session

1. User interrupt mid-generation → identical "generation stopped by user" behavior.
2. Iteration-limit hit → same "iteration limit reached (N)" warning, `finished=false`.
3. A non-coding/analytical prompt → the default agent now reasons/explains rather than rushing to a tool call.

## Notes for reviewers

- Part 1 is behavior-identical; Part 2 deliberately changes default-agent behavior via `persona.md`.
- Deferred (non-blocking) follow-ups: agent-loop branch coverage (meltdown / budget-pressure / compaction / toolsDisabled), an `agent-loop.test.ts` case that makes a live models.dev call, and optional prompt-fragment gating/stable-prefix (lower-value structural polish).
