### PR TITLE
feat(ui): recall queued messages into the input with arrow-up

### DIFF
--- a/src/cli/ui/QueueInput.tsx
+++ b/src/cli/ui/QueueInput.tsx
@@ -2,7 +2,13 @@ import { Box, Text, useInput } from "ink";
 import React, { useCallback } from "react";
 import { ChatInput } from "./components/ChatInput";
 import { getGlyphs } from "./glyphs";
-import { useTextInput } from "./hooks/use-input-service";
+import {
+  InputResults,
+  useInputHandler,
+  useInputService,
+  useTextInput,
+} from "./hooks/use-input-service";
+import { composeRecalledBuffer, isCursorOnFirstLine } from "./queue-recall";
 import { store } from "./store";
 import { PADDING, THEME } from "./theme";
 
@@ -13,6 +19,11 @@ const ENTRY_PREVIEW_MAX_CHARS = 80;
 
 /** Show at most this many entries; older ones become a `+N more` line. */
 const MAX_VISIBLE_ENTRIES = 5;
+
+// Between command-suggestions (50, Prompt.tsx) and TEXT_INPUT (100): recall
+// must win the ↑ key over single-line text editing but stay below
+// system/modal/prompt layers.
+const QUEUE_RECALL_PRIORITY = 60;
 
 function truncateEntry(entry: string): string {
   // Collapse newlines inside a single queued entry so each entry occupies one
@@ -28,7 +39,9 @@ function truncateEntry(entry: string): string {
  * Each Enter appends a new entry to the in-memory message queue. The queue
  * preview shows entries stacked one per line; on agent completion the chat
  * loop drains the queue (joining with `\n`) and sends it as a single
- * combined turn. `Ctrl-X` clears the queue when the input buffer is empty.
+ * combined turn. `↑` recalls the whole queue into the input for editing
+ * (any typed draft is kept below the recalled text). `Ctrl-X` clears the
+ * queue when the input buffer is empty.
  */
 export function QueueInput({
   queue,
@@ -48,6 +61,26 @@ export function QueueInput({
     onSubmit: (val) => {
       handleSubmit(val);
       setValue("", 0);
+    },
+  });
+
+  const inputService = useInputService();
+
+  useInputHandler({
+    id: "queue-recall",
+    priority: QUEUE_RECALL_PRIORITY,
+    isActive: queue.length > 0,
+    onInput: (action) => {
+      if (action.type !== "up") return InputResults.ignored();
+      const current = inputService.getTextInputState("text-input");
+      if (!isCursorOnFirstLine(current.value, current.cursor)) {
+        return InputResults.ignored();
+      }
+      const queueText = store.takeQueue();
+      if (queueText.length === 0) return InputResults.ignored();
+      const recalled = composeRecalledBuffer(queueText, current.value);
+      setValue(recalled.value, recalled.cursor);
+      return InputResults.consumed();
     },
   });
 
@@ -80,7 +113,7 @@ export function QueueInput({
           marginTop={1}
           flexDirection="column"
         >
-          <Text dimColor>Queued ({queue.length}) · Ctrl-X to clear</Text>
+          <Text dimColor>Queued ({queue.length}) · ↑ edit · Ctrl-X clear</Text>
           {overflowCount > 0 && <Text dimColor> …and {overflowCount} earlier</Text>}
           {visibleEntries.map((entry, index) => (
             <Text

--- a/src/cli/ui/queue-recall.test.ts
+++ b/src/cli/ui/queue-recall.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { composeRecalledBuffer, isCursorOnFirstLine } from "./queue-recall";
+
+describe("isCursorOnFirstLine", () => {
+  test("true for an empty buffer", () => {
+    expect(isCursorOnFirstLine("", 0)).toBe(true);
+  });
+
+  test("true anywhere in a single-line buffer", () => {
+    expect(isCursorOnFirstLine("hello", 0)).toBe(true);
+    expect(isCursorOnFirstLine("hello", 3)).toBe(true);
+    expect(isCursorOnFirstLine("hello", 5)).toBe(true);
+  });
+
+  test("true on the first line of a multiline buffer, including at the newline", () => {
+    expect(isCursorOnFirstLine("ab\ncd", 0)).toBe(true);
+    expect(isCursorOnFirstLine("ab\ncd", 2)).toBe(true);
+  });
+
+  test("false once the cursor is past the first newline", () => {
+    expect(isCursorOnFirstLine("ab\ncd", 3)).toBe(false);
+    expect(isCursorOnFirstLine("ab\ncd", 5)).toBe(false);
+  });
+});
+
+describe("composeRecalledBuffer", () => {
+  test("queue only: buffer is the queue text, cursor at end", () => {
+    expect(composeRecalledBuffer("first\nsecond", "")).toEqual({
+      value: "first\nsecond",
+      cursor: "first\nsecond".length,
+    });
+  });
+
+  test("queue + draft: draft is preserved below the queue text, cursor at end", () => {
+    expect(composeRecalledBuffer("queued", "my draft")).toEqual({
+      value: "queued\nmy draft",
+      cursor: "queued\nmy draft".length,
+    });
+  });
+
+  test("multiline queue + draft keeps chronological order", () => {
+    expect(composeRecalledBuffer("one\ntwo", "three")).toEqual({
+      value: "one\ntwo\nthree",
+      cursor: "one\ntwo\nthree".length,
+    });
+  });
+});

--- a/src/cli/ui/queue-recall.ts
+++ b/src/cli/ui/queue-recall.ts
@@ -1,0 +1,14 @@
+export interface RecalledBuffer {
+  readonly value: string;
+  readonly cursor: number;
+}
+
+export function isCursorOnFirstLine(value: string, cursor: number): boolean {
+  const firstNewline = value.indexOf("\n");
+  return firstNewline === -1 || cursor <= firstNewline;
+}
+
+export function composeRecalledBuffer(queueText: string, draft: string): RecalledBuffer {
+  const value = draft.length > 0 ? `${queueText}\n${draft}` : queueText;
+  return { value, cursor: value.length };
+}


### PR DESCRIPTION
## What this PR delivers

While the agent is busy, messages you type are queued and sent as one combined turn when the agent finishes. Until now the only control over that queue was Ctrl-X, which clears everything. This PR makes the queue editable: pressing **↑** pulls the entire queue into the input box as multiline text (and clears the queue), you edit it with the normal editor, and Enter re-queues the result. Any partial draft you had already typed is preserved below the recalled text — nothing you typed is ever lost.

The implementation is a pure, unit-tested helper module (`src/cli/ui/queue-recall.ts`) plus one input handler in `QueueInput.tsx`. There are no store changes: `store.takeQueue()` already joins, clears, and notifies the UI, so it doubles as the recall primitive.

## Why this matters

For users: a typo in a queued message previously meant clearing the whole queue with Ctrl-X and retyping everything. Now it's ↑, fix, Enter — the same muscle memory as editing a shell command.

For maintainers: the recall logic lives in a pure module with its own tests, and the keybinding is layered through the existing InputService priority registry — no new state, no new store API.

## How queue-input behaviour changes

| Path | Change |
|---|---|
| ↑ while busy, queue non-empty, cursor on first line of buffer | **New:** entire queue is recalled into the input (entries joined with `\n`), queue cleared; existing draft kept below recalled text, cursor at end. |
| ↑ while busy, queue empty | No behavioural change (no-op, as before). |
| ↑ in a multiline buffer with cursor below the first line | No behavioural change: line navigation wins; recall never steals it (first-line guard). |
| ↑ while idle (normal prompt) | No behavioural change. |
| Queue drain (turn end or mid-turn `checkQueuedMessage`) | No behavioural change. Recall vs. drain is race-safe: both are synchronous single-tick operations; whichever runs first wins and the other no-ops — no message loss or duplication in any interleaving. |
| Ctrl-X clear | No behavioural change (still only acts on an empty input buffer, so it can't clobber an in-progress edit). |
| Enter in the queue input | Same mechanism as before; an edited multiline text re-queues as a single entry. |

## UX changes operators will notice

- Queue panel header changes from `Queued (N) · Ctrl-X to clear` to `Queued (N) · ↑ edit · Ctrl-X clear`.
- Pressing ↑ while busy makes the queue panel disappear and fills the input with the queued entries, one per line.
- If the agent finishes while you're mid-edit, nothing is auto-sent (the queue is already empty); your buffer carries over into the idle prompt and Enter sends it as the next message.

## Tests

- 7 new unit tests in `src/cli/ui/queue-recall.test.ts` (first-line guard boundaries, recall composition with/without draft). Full suite on the branch head: **1385 pass / 0 fail**; typecheck and lint clean.
- End-to-end verification: the real TUI was driven through a pty (expect script) against a live agent — observed `Queued (2)` render, multi-entry recall into a multiline buffer, no re-recall on a second ↑, Enter re-queueing as a single `first ↵ second` entry, and draft preservation (`mydraft` kept below the recalled lines).

### Edge cases to verify in a staging session

1. Queue two messages while busy, press ↑ — expected: panel disappears, both entries appear as separate lines in the input, cursor at end.
2. Type a partial draft, then press ↑ with a non-empty queue — expected: recalled text above, draft below, nothing lost.
3. Recall, then let the agent finish before pressing Enter — expected: nothing is auto-sent; the buffer survives into the idle prompt.
4. In the recalled multiline buffer, move the cursor to line 2 and press ↑ — expected: cursor moves up a line; no recall.

## Notes for reviewers

- The handler reads buffer state via `inputService.getTextInputState("text-input")` *inside* the handler, not from the render-scoped `value`/`cursor` — input dispatch runs outside React's render cycle, so the render snapshot can be stale. This mirrors how `useTextInput`'s own handler reads state.
- Priority 60 sits between command-suggestions (50, only active while idle) and `TEXT_INPUT` (100): recall wins ↑ on single-line buffers, and the first-line guard makes it yield whenever multiline line-navigation should win. The two guards (`cursor <= firstNewline` here, `lastIndexOf("\n", cursor - 1) === -1` in `useTextInput`) are complementary at every boundary.
- Known benign edge accepted in review: `isActive: queue.length > 0` uses a render-captured ref, so if an Enter and a ↑ arrive in the same stdin chunk the recall can be skipped once (the next ↑ works; nothing is lost). The `takeQueue() === ""` guard already neutralises the inverse (stale-true) case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
