### PR TITLE
fix(input-service): stale cleanup no longer removes replacement handler

### DIFF
--- a/src/cli/services/input-service.test.ts
+++ b/src/cli/services/input-service.test.ts
@@ -85,6 +85,64 @@ describe("InputService", () => {
     });
   });
 
+  describe("handler registry", () => {
+    test("stale cleanup from a replaced registration does not remove the newer handler", () => {
+      let newerHandlerCalls = 0;
+
+      const staleCleanup = Effect.runSync(
+        service.registerHandler({
+          id: "text-input",
+          priority: 100,
+          isActive: () => true,
+          handle: () => InputResults.ignored(),
+        }),
+      );
+
+      const newerCleanup = Effect.runSync(
+        service.registerHandler({
+          id: "text-input",
+          priority: 100,
+          isActive: () => true,
+          handle: (event) => {
+            if (event.action.type === "char") {
+              newerHandlerCalls += 1;
+              return InputResults.consumed();
+            }
+            return InputResults.ignored();
+          },
+        }),
+      );
+
+      try {
+        staleCleanup();
+
+        expect(Effect.runSync(service.getHandlerIds)).toEqual(["text-input"]);
+
+        processInput(service, "a");
+        expect(newerHandlerCalls).toBe(1);
+      } finally {
+        newerCleanup();
+      }
+
+      expect(Effect.runSync(service.getHandlerIds)).toEqual([]);
+    });
+
+    test("cleanup removes its own registration when not replaced", () => {
+      const cleanup = Effect.runSync(
+        service.registerHandler({
+          id: "solo-handler",
+          priority: 100,
+          isActive: () => true,
+          handle: () => InputResults.ignored(),
+        }),
+      );
+
+      expect(Effect.runSync(service.getHandlerIds)).toEqual(["solo-handler"]);
+      cleanup();
+      expect(Effect.runSync(service.getHandlerIds)).toEqual([]);
+    });
+  });
+
   describe("ordered char application (text input ordering)", () => {
     test("multiple char events applied in order produce correct accumulated value", () => {
       let value = "";

--- a/src/cli/services/input-service.ts
+++ b/src/cli/services/input-service.ts
@@ -243,10 +243,14 @@ export function createInputService(terminalCapabilities: TerminalCapabilities): 
         handlers.set(handler.id, handler);
         handlersDirty = true;
 
-        // Return cleanup function
+        // Return cleanup function.
+        // Only remove the entry if it still belongs to this registration —
+        // a stale cleanup must not delete a newer handler registered under the same id.
         return () => {
-          handlers.delete(handler.id);
-          handlersDirty = true;
+          if (handlers.get(handler.id) === handler) {
+            handlers.delete(handler.id);
+            handlersDirty = true;
+          }
         };
       }),
 


### PR DESCRIPTION
## What changed

`registerHandler` in `src/cli/services/input-service.ts` returns a cleanup function that unconditionally did `handlers.delete(handler.id)`. When a handler is registered under an id that already exists, the old entry is replaced — but the old registration's cleanup closure still targeted that id, so invoking the stale cleanup would delete the **newer** registration.

The cleanup now only deletes when the registry still holds the exact handler object it registered:

```ts
return () => {
  if (handlers.get(handler.id) === handler) {
    handlers.delete(handler.id);
    handlersDirty = true;
  }
};
```

## Why

This is a latent registry bug rather than a live one: current mount ordering (e.g. QueueInput/Prompt sharing the `text-input` id) never overlaps registrations, so the stale-cleanup path is unreachable today. But any future component ordering that registers a replacement before the old component's unmount cleanup runs would silently drop the active input handler. Making cleanup identity-checked removes the footgun.

## Tests

Added a `handler registry` block to `input-service.test.ts`:
- register two handlers under the same id, invoke the first (stale) cleanup, and assert the newer handler is still registered and still receives input
- baseline: an unreplaced registration's cleanup still removes it

Verified locally: `bun test` (1380 pass, 0 fail), `bun run typecheck`, `bun run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)