### PR TITLE
feat(ui): UI/UX overhaul phases 1-2 — default polish and reasoning visibility

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-preload.ts"]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ export default [
   ...tseslint.configs.recommendedTypeChecked.map((config) => ({
     ...config,
     files: ["**/*.{ts,tsx}"],
-    ignores: ["**/*.test.ts"],
+    ignores: ["**/*.test.ts", "test-preload.ts"],
   })),
   prettierConfig,
   nodePlugin.configs["flat/recommended-script"],
@@ -35,7 +35,7 @@ export default [
   },
   {
     files: ["**/*.{ts,tsx}"],
-    ignores: ["**/*.test.ts"],
+    ignores: ["**/*.test.ts", "test-preload.ts"],
     languageOptions: {
       parserOptions: {
         project: ["./tsconfig.json", "./tsconfig.build.json"],

--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import React from "react";
 import { AWAITING_LABELS, createAccumulator, reduceEvent } from "./activity-reducer";
 import type { ReducerAccumulator } from "./activity-reducer";
+import { getGlyphs } from "../ui/glyphs";
 
 /** Stub ink renderer — returns the string tag for assertions. */
 const stubInk = (node: unknown) => `[ink:${typeof node}]`;
@@ -354,10 +355,11 @@ describe("activity-reducer", () => {
       );
 
       expect(result.outputs).toHaveLength(2);
+      const glyphs = getGlyphs();
       const outputText = nodes.map((node) => extractText(node)).join("\n");
       expect(outputText).toContain("Todo list");
-      expect(outputText).toContain("✓ Check status");
-      expect(outputText).toContain("◐ Push branch");
+      expect(outputText).toContain(`${glyphs.success} Check status`);
+      expect(outputText).toContain(`${glyphs.proposed} Push branch`);
       expect(outputText).not.toMatch(/manage_todos done/);
     });
   });

--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -61,12 +61,13 @@ describe("activity-reducer", () => {
   // -------------------------------------------------------------------------
 
   describe("stream_start", () => {
-    test("emits info log, stores provider/model, transitions to awaiting phase", () => {
+    test("emits agent turn header, stores provider/model, transitions to awaiting phase", () => {
       const a = acc();
+      const { nodes, render } = createCapturingInk();
       const result = reduceEvent(
         a,
         { type: "stream_start", provider: "openai", model: "gpt-4", timestamp: Date.now() },
-        stubInk,
+        render,
       );
 
       expect(result.activity).not.toBeNull();
@@ -78,9 +79,10 @@ describe("activity-reducer", () => {
         expect(AWAITING_LABELS).toContain(result.activity.label);
       }
       expect(result.outputs).toHaveLength(1);
-      expect(result.outputs[0]!.type).toBe("info");
-      expect(result.outputs[0]!.message).toContain("TestAgent");
-      expect(result.outputs[0]!.message).toContain("openai/gpt-4");
+      expect(result.outputs[0]!.type).toBe("log");
+      const headerText = nodes.map((node) => extractText(node)).join("");
+      expect(headerText).toContain("TestAgent");
+      expect(headerText).toContain("openai/gpt-4");
       expect(a.lastAgentHeaderWritten).toBe(true);
       expect(a.currentProvider).toBe("openai");
       expect(a.currentModel).toBe("gpt-4");

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -425,7 +425,14 @@ export function reduceEvent(
                 React.createElement(
                   Box,
                   { key: `tool-result-line-${index}` },
-                  React.createElement(Text, { dimColor: true }, line),
+                  // Lines that already carry ANSI styling (diff +/- coloring,
+                  // syntax highlighting) render as-is: layering dim over them
+                  // washes the colors out.
+                  React.createElement(
+                    Text,
+                    line.includes("\u001b[") ? {} : { dimColor: true },
+                    line,
+                  ),
                 ),
               ),
             ),

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -19,6 +19,7 @@ import type { TerminalOutput } from "@/core/interfaces/terminal";
 import type { StreamEvent } from "@/core/types/streaming";
 import { formatToolArguments, formatToolResult } from "./format-utils";
 import type { ActiveTool, ActivityState } from "../ui/activity-state";
+import { getGlyphs } from "../ui/glyphs";
 import { PADDING, THEME } from "../ui/theme";
 import type { OutputEntry } from "../ui/types";
 
@@ -199,17 +200,18 @@ function findLatestTodoSnapshot(
 }
 
 function formatTodoSnapshotForOutput(todoSnapshot: TodoSnapshotItem[]): string {
+  const glyphs = getGlyphs();
   const lines = todoSnapshot.map((todo) => {
     switch (todo.status) {
       case "completed":
-        return `✓ ${todo.content}`;
+        return `${glyphs.success} ${todo.content}`;
       case "in_progress":
-        return `◐ ${todo.content}`;
+        return `${glyphs.proposed} ${todo.content}`;
       case "cancelled":
-        return `✗ ${todo.content}`;
+        return `${glyphs.error} ${todo.content}`;
       case "pending":
       default:
-        return `○ ${todo.content}`;
+        return `${glyphs.pending} ${todo.content}`;
     }
   });
   return lines.join("\n");
@@ -405,7 +407,7 @@ export function reduceEvent(
               React.createElement(
                 Box,
                 null,
-                React.createElement(Text, { color: THEME.success }, "✔ "),
+                React.createElement(Text, { color: THEME.success }, `${getGlyphs().success} `),
                 React.createElement(Text, { color: THEME.agent }, headerLine),
                 React.createElement(Text, { dimColor: true }, ` (${event.durationMs}ms)`),
               ),
@@ -429,7 +431,7 @@ export function reduceEvent(
             React.createElement(
               Box,
               { paddingLeft: PADDING.content },
-              React.createElement(Text, { color: THEME.success }, "✔ "),
+              React.createElement(Text, { color: THEME.success }, `${getGlyphs().success} `),
               React.createElement(Text, { color: THEME.agent }, singleLineSummary),
               React.createElement(Text, { dimColor: true }, ` (${event.durationMs}ms)`),
             ),

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -238,9 +238,19 @@ export function reduceEvent(
       acc.lastAppliedTextSequence = -1;
       acc.isThinking = false;
 
+      // Agent-colored turn header (same visual language as AgentResponseCard)
+      // instead of a generic info line — marks where each agent turn begins.
       outputs.push({
-        type: "info",
-        message: `${acc.agentName} (${event.provider}/${event.model})`,
+        type: "log",
+        message: inkRender(
+          React.createElement(
+            Box,
+            null,
+            React.createElement(Text, { color: THEME.agent }, `${getGlyphs().diamond} `),
+            React.createElement(Text, { color: THEME.agent, bold: true }, acc.agentName),
+            React.createElement(Text, { dimColor: true }, ` (${event.provider}/${event.model})`),
+          ),
+        ),
         timestamp: new Date(),
       });
 

--- a/src/cli/presentation/format-utils.ts
+++ b/src/cli/presentation/format-utils.ts
@@ -16,6 +16,7 @@ import {
   formatToolArguments as formatToolArgumentsCore,
   formatToolResult as formatToolResultCore,
 } from "@/core/utils/tool-formatter";
+import { getGlyphs } from "../ui/glyphs";
 import { CHALK_THEME } from "../ui/theme";
 
 // ---------------------------------------------------------------------------
@@ -43,27 +44,27 @@ export function formatToolResult(toolName: string, result: string): string {
 
 export function formatThinking(agentName: string, isFirstIteration: boolean = false): string {
   const message = isFirstIteration ? "thinking..." : "processing results...";
-  return CHALK_THEME.primary(`◉  ${agentName} is ${message}`);
+  return CHALK_THEME.primary(`${getGlyphs().active}  ${agentName} is ${message}`);
 }
 
 export function formatCompletion(agentName: string): string {
-  return chalk.greenBright(`✔  ${agentName} completed successfully`);
+  return chalk.greenBright(`${getGlyphs().success}  ${agentName} completed successfully`);
 }
 
 export function formatWarning(agentName: string, message: string): string {
-  return chalk.yellowBright(`⚠  ${agentName}: ${message}`);
+  return chalk.yellowBright(`${getGlyphs().warn}  ${agentName}: ${message}`);
 }
 
 export function formatToolExecutionStart(toolName: string, argsStr: string): string {
-  return `\n${chalk.cyanBright("▸")} Executing tool: ${chalk.cyanBright.bold(toolName)}${chalk.cyan(argsStr)}...`;
+  return `\n${chalk.cyanBright(getGlyphs().arrow)} Executing tool: ${chalk.cyanBright.bold(toolName)}${chalk.cyan(argsStr)}...`;
 }
 
 export function formatToolExecutionComplete(summary: string | null, durationMs: number): string {
-  return ` ${chalk.greenBright("✔")}${summary ? ` ${summary}` : ""} ${chalk.dim(`(${durationMs}ms)`)}\n`;
+  return ` ${chalk.greenBright(getGlyphs().success)}${summary ? ` ${summary}` : ""} ${chalk.dim(`(${durationMs}ms)`)}\n`;
 }
 
 export function formatToolExecutionError(errorMessage: string, durationMs: number): string {
-  return ` ${chalk.redBright("✖")} ${chalk.redBright(`(${errorMessage})`)} ${chalk.dim(`(${durationMs}ms)`)}\n`;
+  return ` ${chalk.redBright(getGlyphs().error)} ${chalk.redBright(`(${errorMessage})`)} ${chalk.dim(`(${durationMs}ms)`)}\n`;
 }
 
 /**
@@ -97,7 +98,7 @@ export function formatToolsDetected(
       return name;
     })
     .join(", ");
-  return `\n${chalk.yellow("⌁")} ${chalk.yellow(agentName)} is using tools: ${CHALK_THEME.primary(formattedTools)}\n`;
+  return `\n${chalk.yellow(getGlyphs().arrow)} ${chalk.yellow(agentName)} is using tools: ${CHALK_THEME.primary(formattedTools)}\n`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { Effect } from "effect";
+import React from "react";
 import { InkStreamingRenderer } from "./ink-presentation-service";
 import type { ActivityState } from "../ui/activity-state";
 import { store } from "../ui/store";
 import type { OutputEntry } from "../ui/types";
+
+/** Recursively extract the text content of a React element tree. */
+function extractNodeText(node: unknown): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (!React.isValidElement(node)) return "";
+  const children = (node.props as { children?: unknown }).children;
+  if (Array.isArray(children)) return children.map(extractNodeText).join("");
+  return extractNodeText(children);
+}
 
 // Large-base-text size for the seenLength regression test below. The exact
 // value isn't load-bearing — anything large enough to make a delta-mismatch
@@ -574,11 +584,17 @@ describe("InkStreamingRenderer", () => {
         }),
       );
 
-      // Streaming path should not render the AgentResponseCard
+      // Streaming path should not render the AgentResponseCard. The turn
+      // header emitted at stream_start is an ink node too, so assert on
+      // content: no ink log may carry the response body.
       const inkLogs = printOutputCalls.filter(
         (e) => e.type === "log" && typeof e.message === "object" && e.message !== null,
       );
-      expect(inkLogs.length).toBe(0);
+      const cardLogs = inkLogs.filter((e) => {
+        const node = (e.message as { node?: unknown }).node;
+        return extractNodeText(node).includes("response");
+      });
+      expect(cardLogs.length).toBe(0);
     });
   });
 

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -111,7 +111,21 @@ export class InkStreamingRenderer implements StreamingRenderer {
 
   private toolTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
   private static readonly TOOL_WARNING_MS = 30_000;
-  private static readonly REASONING_PANEL_LINES = 8;
+  private static readonly MIN_REASONING_PANEL_LINES = 8;
+  private static readonly MAX_REASONING_PANEL_LINES = 24;
+
+  /**
+   * Reasoning panel height adapts to the terminal: roughly a quarter of the
+   * rows, clamped so short terminals still get a useful window and tall ones
+   * don't drown the transcript in live planning text.
+   */
+  private static reasoningPanelLines(): number {
+    const rows = process.stdout.rows ?? 24;
+    return Math.min(
+      InkStreamingRenderer.MAX_REASONING_PANEL_LINES,
+      Math.max(InkStreamingRenderer.MIN_REASONING_PANEL_LINES, Math.floor(rows / 4)),
+    );
+  }
 
   /**
    * Buffered streaming deltas, flushed at `textBufferMs` cadence. Without
@@ -375,7 +389,9 @@ export class InkStreamingRenderer implements StreamingRenderer {
     const seconds = (durationMs / 1000).toFixed(1);
     const tokenSegment = tokens !== undefined ? ` · ${tokens} tokens` : "";
     const line = chalk.dim(
-      chalk.italic(`${getGlyphs().success} Reasoning · ${seconds}s${tokenSegment}`),
+      chalk.italic(
+        `${getGlyphs().success} Reasoning · ${seconds}s${tokenSegment} · ctrl+r to expand`,
+      ),
     );
 
     store.collapseEphemeral(this.reasoningRegionId, {
@@ -425,7 +441,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
             this.reasoningRegionId = store.openEphemeral(
               "reasoning",
               "Reasoning",
-              InkStreamingRenderer.REASONING_PANEL_LINES,
+              InkStreamingRenderer.reasoningPanelLines(),
             );
             this.reasoningFullText = "";
             this.reasoningStartedAt = Date.now();
@@ -446,7 +462,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
               this.reasoningRegionId = store.openEphemeral(
                 "reasoning",
                 "Reasoning",
-                InkStreamingRenderer.REASONING_PANEL_LINES,
+                InkStreamingRenderer.reasoningPanelLines(),
               );
               this.reasoningStartedAt = Date.now();
               this.reasoningFullText = "";

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -708,15 +708,21 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   private setupToolTimeout(toolCallId: string, toolName: string): void {
-    const timeoutId = setTimeout(() => {
-      if (this.acc.activeTools.has(toolCallId)) {
-        store.printOutput({
-          type: "warn",
-          message: `⏱️ Tool ${toolName} is taking longer than expected...`,
-          timestamp: new Date(),
-        });
-      }
-    }, InkStreamingRenderer.TOOL_WARNING_MS);
+    const startedAt = Date.now();
+    const warn = (): void => {
+      if (!this.acc.activeTools.has(toolCallId)) return;
+      const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+      store.printOutput({
+        type: "warn",
+        message: `Tool ${toolName} still running after ${elapsedSeconds}s (press Esc twice to interrupt)`,
+        timestamp: new Date(),
+      });
+      // Re-arm so multi-minute tools keep reassuring the user instead of
+      // going silent after a single warning.
+      const timeoutId = setTimeout(warn, InkStreamingRenderer.TOOL_WARNING_MS);
+      this.toolTimeouts.set(toolCallId, timeoutId);
+    };
+    const timeoutId = setTimeout(warn, InkStreamingRenderer.TOOL_WARNING_MS);
     this.toolTimeouts.set(toolCallId, timeoutId);
   }
 

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -413,6 +413,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         this.seenLength = 0;
         this.hasStreamedText = false;
         store.updateRunStats({ provider: event.provider, model: event.model });
+        this.resolveContextWindow(event.provider, event.model);
       }
 
       if (this.displayConfig.showThinking) {
@@ -705,6 +706,27 @@ export class InkStreamingRenderer implements StreamingRenderer {
           /* pricing unavailable — omit cost line */
         });
     }
+  }
+
+  /**
+   * Resolve the model's context window and publish it to the footer so
+   * tokens-in-context renders as `12.3k/200k` instead of a bare count.
+   */
+  private resolveContextWindow(provider: string, model: string): void {
+    const cached = getModelsDevMetadataSync(model, provider);
+    if (cached !== undefined) {
+      store.updateRunStats({ maxContextTokens: cached.contextWindow });
+      return;
+    }
+    void getModelsDevMetadata(model, provider)
+      .then((meta) => {
+        if (meta !== undefined) {
+          store.updateRunStats({ maxContextTokens: meta.contextWindow });
+        }
+      })
+      .catch(() => {
+        /* context window unavailable — footer shows the bare count */
+      });
   }
 
   private setupToolTimeout(toolCallId: string, toolName: string): void {

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -36,6 +36,7 @@ import {
 import { formatMarkdown, formatMarkdownHybrid } from "./markdown-formatter";
 import { isInsideOpenStructure } from "./markdown-split";
 import { AgentResponseCard } from "../ui/AgentResponseCard";
+import { getGlyphs } from "../ui/glyphs";
 import { store } from "../ui/store";
 import { CHALK_THEME, PADDING, THEME } from "../ui/theme";
 
@@ -373,7 +374,9 @@ export class InkStreamingRenderer implements StreamingRenderer {
     const durationMs = Date.now() - this.reasoningStartedAt;
     const seconds = (durationMs / 1000).toFixed(1);
     const tokenSegment = tokens !== undefined ? ` · ${tokens} tokens` : "";
-    const line = chalk.dim(chalk.italic(`✓ Reasoning · ${seconds}s${tokenSegment}`));
+    const line = chalk.dim(
+      chalk.italic(`${getGlyphs().success} Reasoning · ${seconds}s${tokenSegment}`),
+    );
 
     store.collapseEphemeral(this.reasoningRegionId, {
       line,
@@ -888,7 +891,7 @@ class InkPresentationService implements PresentationService {
 
   presentAgentResponse(agentName: string, content: string): Effect.Effect<void, never> {
     return Effect.sync(() => {
-      const header = CHALK_THEME.primaryBold(`◉ ${agentName}:`);
+      const header = CHALK_THEME.primaryBold(`${getGlyphs().active} ${agentName}:`);
       const rendered = this.formatMarkdownText(content);
       store.printOutput({
         type: "log",
@@ -974,12 +977,13 @@ class InkPresentationService implements PresentationService {
     level: "info" | "success" | "warning" | "error" | "progress",
   ): Effect.Effect<void, never> {
     return Effect.sync(() => {
+      const glyphs = getGlyphs();
       const icons: Record<typeof level, { icon: string; color: string }> = {
-        info: { icon: "ℹ", color: "blue" },
-        success: { icon: "✓", color: "green" },
-        warning: { icon: "⚠", color: "yellow" },
-        error: { icon: "✗", color: "red" },
-        progress: { icon: "⏳", color: "cyan" },
+        info: { icon: glyphs.info, color: "blue" },
+        success: { icon: glyphs.success, color: "green" },
+        warning: { icon: glyphs.warn, color: "yellow" },
+        error: { icon: glyphs.error, color: "red" },
+        progress: { icon: glyphs.pending, color: "cyan" },
       };
       const { icon, color } = icons[level];
       const colorFn = chalk[color as keyof typeof chalk] as (s: string) => string;

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -22,6 +22,7 @@ import type { ApprovalRequest, ApprovalOutcome } from "@/core/types/tools";
 import { resolveDisplayConfig } from "@/core/utils/display-config";
 import { getModelsDevMetadata, getModelsDevMetadataSync } from "@/core/utils/models-dev-client";
 import { extractCommandApprovalKey } from "@/core/utils/shell-utils";
+import { expandableToolResultPayload } from "@/core/utils/tool-formatter";
 import { createAccumulator, reduceEvent } from "./activity-reducer";
 import {
   formatToolArguments,
@@ -780,14 +781,22 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   private storeExpandableDiff(toolName: string | undefined, result: string): void {
-    if (
-      toolName !== "edit_file" &&
-      toolName !== "execute_edit_file" &&
-      toolName !== "write_file" &&
-      toolName !== "execute_write_file"
-    ) {
+    const isDiffTool =
+      toolName === "edit_file" ||
+      toolName === "execute_edit_file" ||
+      toolName === "write_file" ||
+      toolName === "execute_write_file";
+
+    if (!isDiffTool) {
+      // Generic tools: when the on-screen summary truncates the result, keep
+      // the full text expandable via the same Ctrl+O affordance as diffs.
+      const payload = expandableToolResultPayload(result);
+      if (payload !== null) {
+        store.setExpandableDiff(payload);
+      }
       return;
     }
+
     try {
       const parsed: unknown = JSON.parse(result);
       if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {

--- a/src/cli/ui/ActivityView.tsx
+++ b/src/cli/ui/ActivityView.tsx
@@ -1,11 +1,48 @@
 import { Box, Text } from "ink";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { ActivityState } from "./activity-state";
 import { AnimatedEllipsis } from "./components/AnimatedEllipsis";
 import { getGlyphs } from "./glyphs";
 import { PADDING, THEME } from "./theme";
 
 const G = getGlyphs();
+
+/** Seconds before the elapsed counter appears (avoids a "0s" flash). */
+const ELAPSED_VISIBLE_AFTER_S = 2;
+
+export function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return `${minutes}m ${rest.toString().padStart(2, "0")}s`;
+}
+
+/**
+ * Self-ticking elapsed counter. Resets whenever `resetKey` changes; when
+ * `externalStart` is provided (e.g. a tool's real start timestamp) it wins
+ * over the phase-entry time. Ticks once a second so long waits visibly
+ * advance instead of looking hung.
+ */
+function useElapsedSeconds(resetKey: string, externalStart?: number): number {
+  const startRef = useRef(Date.now());
+  const keyRef = useRef(resetKey);
+  if (keyRef.current !== resetKey) {
+    keyRef.current = resetKey;
+    startRef.current = Date.now();
+  }
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((tick) => tick + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  const start = externalStart ?? startRef.current;
+  return Math.max(0, Math.floor((Date.now() - start) / 1000));
+}
+
+function ElapsedText({ seconds }: { seconds: number }): React.ReactElement | null {
+  if (seconds < ELAPSED_VISIBLE_AFTER_S) return null;
+  return <Text dimColor> · {formatElapsed(seconds)}</Text>;
+}
 
 function todoStatusGlyph(status: "pending" | "in_progress" | "completed" | "cancelled"): string {
   switch (status) {
@@ -41,10 +78,12 @@ function AgentHeader({
   agentName,
   label,
   animated = false,
+  elapsedSeconds,
 }: {
   agentName: string;
   label: string;
   animated?: boolean;
+  elapsedSeconds?: number;
 }): React.ReactElement {
   return (
     <Box>
@@ -63,6 +102,7 @@ function AgentHeader({
           color={THEME.agent}
         />
       ) : null}
+      {elapsedSeconds !== undefined ? <ElapsedText seconds={elapsedSeconds} /> : null}
     </Box>
   );
 }
@@ -76,6 +116,12 @@ export const ActivityView = React.memo(function ActivityView({
 }: {
   activity: ActivityState;
 }): React.ReactElement | null {
+  const earliestToolStart =
+    activity.phase === "tool-execution" && activity.tools.length > 0
+      ? Math.min(...activity.tools.map((tool) => tool.startedAt))
+      : undefined;
+  const elapsedSeconds = useElapsedSeconds(activity.phase, earliestToolStart);
+
   switch (activity.phase) {
     case "idle":
     case "complete":
@@ -106,6 +152,7 @@ export const ActivityView = React.memo(function ActivityView({
               {" "}
               ({activity.provider}/{activity.model})
             </Text>
+            <ElapsedText seconds={elapsedSeconds} />
           </Box>
         </Box>
       );
@@ -124,6 +171,7 @@ export const ActivityView = React.memo(function ActivityView({
             agentName={activity.agentName}
             label="is thinking"
             animated
+            elapsedSeconds={elapsedSeconds}
           />
         </Box>
       );
@@ -139,6 +187,7 @@ export const ActivityView = React.memo(function ActivityView({
             agentName={activity.agentName}
             label="is responding"
             animated
+            elapsedSeconds={elapsedSeconds}
           />
         </Box>
       );
@@ -158,10 +207,13 @@ export const ActivityView = React.memo(function ActivityView({
           marginTop={1}
           paddingX={PADDING.content}
         >
-          <AnimatedEllipsis
-            label={label}
-            color={THEME.agent}
-          />
+          <Box>
+            <AnimatedEllipsis
+              label={label}
+              color={THEME.agent}
+            />
+            <ElapsedText seconds={elapsedSeconds} />
+          </Box>
           {activity.todoSnapshot && activity.todoSnapshot.length > 0 ? (
             <Box
               marginTop={1}

--- a/src/cli/ui/AgentResponseCard.tsx
+++ b/src/cli/ui/AgentResponseCard.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import React from "react";
 import { TerminalText } from "./components/TerminalText";
+import { getGlyphs } from "./glyphs";
 import { PADDING, THEME } from "./theme";
 
 /**
@@ -22,7 +23,7 @@ export function AgentResponseCard({
       paddingX={PADDING.content}
     >
       <Box>
-        <Text color={THEME.agent}>◆</Text>
+        <Text color={THEME.agent}>{getGlyphs().diamond}</Text>
         <Text> </Text>
         <Text
           bold

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -118,17 +118,20 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
   // we don't duplicate it here (avoids conflicting with the prompt's
   // single-slot wd setter).
   const [runStats, setRunStats] = React.useState<RunStats>({});
+  const [modeIsYolo, setModeIsYolo] = React.useState(false);
   const initializedRef = useRef(false);
 
   if (!initializedRef.current) {
     store.registerRunStatsSetter(setRunStats);
     setRunStats(store.getRunStatsSnapshot());
+    store.registerModeSetter(setModeIsYolo);
     initializedRef.current = true;
   }
 
   useEffect(() => {
     return () => {
       store.registerRunStatsSetter(() => {});
+      store.registerModeSetter(null);
     };
   }, []);
 
@@ -137,6 +140,7 @@ function StatusFooterIslandComponent(): React.ReactElement | null {
       status={null}
       workingDirectory={null}
       runStats={runStats}
+      modeIsYolo={modeIsYolo}
     />
   );
 }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -325,7 +325,13 @@ export function App(): React.ReactElement {
       }
       // User-initiated abort — drop any open ephemeral panels (subagents,
       // reasoning) and any queued chat message so nothing gets stuck after
-      // the run is interrupted.
+      // the run is interrupted. Print immediate feedback: the loop's own
+      // "generation stopped" line can lag behind a mid-flight tool.
+      store.printOutput({
+        type: "warn",
+        message: "Interrupting…",
+        timestamp: new Date(),
+      });
       store.collapseAllEphemeral();
       store.clearQueue();
       interruptHandlerRef.current();

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -376,7 +376,7 @@ export function App(): React.ReactElement {
       if (!payload) {
         store.printOutput({
           type: "warn",
-          message: "No truncated diff available to expand.",
+          message: "No truncated output available to expand.",
           timestamp: new Date(),
         });
         return InputResults.consumed();

--- a/src/cli/ui/EphemeralPanel.tsx
+++ b/src/cli/ui/EphemeralPanel.tsx
@@ -4,6 +4,7 @@ import { PreWrappedText } from "./components/PreWrappedText";
 import { getGlyphs } from "./glyphs";
 import type { EphemeralRegion } from "./store";
 import { PADDING, PADDING_BUDGET, THEME } from "./theme";
+import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
 import { formatMarkdown, wrapToWidth } from "../presentation/markdown-formatter";
 import { getTerminalWidth } from "../utils/string-utils";
 
@@ -41,7 +42,11 @@ export function EphemeralPanel({ region }: { region: EphemeralRegion }): React.R
   // already get raw output (their content can be anything — JSON, search
   // results, code) so we leave that untouched.
   const rawTail = region.tail.join("\n");
-  const formattedTail = region.kind === "reasoning" ? formatMarkdown(rawTail) : rawTail;
+  // Reasoning renders markdown but dimmed/italic — the live panel should read
+  // as quiet planning text, matching the settled scrollback styling, instead
+  // of competing with the response for attention.
+  const formattedTail =
+    region.kind === "reasoning" ? dimReasoningMarkdownOutput(formatMarkdown(rawTail)) : rawTail;
   const wrappedTail = wrapToWidth(formattedTail, availableWidth);
 
   return (

--- a/src/cli/ui/EphemeralPanel.tsx
+++ b/src/cli/ui/EphemeralPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "ink";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { PreWrappedText } from "./components/PreWrappedText";
 import { getGlyphs } from "./glyphs";
 import type { EphemeralRegion } from "./store";
@@ -24,6 +24,14 @@ function elapsed(startedAt: number): string {
  * character-by-character wrapping under load.
  */
 export function EphemeralPanel({ region }: { region: EphemeralRegion }): React.ReactElement {
+  // Tick once a second so the elapsed header keeps advancing even when the
+  // region receives no new content — a stalled panel otherwise looks hung.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((tick) => tick + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
   const headerColor = region.kind === "reasoning" ? THEME.reasoning : THEME.agent;
   const tailColor = region.kind === "reasoning" ? THEME.reasoning : "white";
 

--- a/src/cli/ui/OutputEntryView.tsx
+++ b/src/cli/ui/OutputEntryView.tsx
@@ -1,10 +1,12 @@
 import { Box, Text } from "ink";
 import React from "react";
+import { PreWrappedText } from "./components/PreWrappedText";
 import { getGlyphs } from "./glyphs";
-import { PADDING, THEME } from "./theme";
+import { PADDING, PADDING_BUDGET, THEME } from "./theme";
 import type { OutputEntryWithId, OutputType } from "./types";
 import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
-import { formatMarkdown } from "../presentation/markdown-formatter";
+import { formatMarkdown, wrapToWidth } from "../presentation/markdown-formatter";
+import { getTerminalWidth } from "../utils/string-utils";
 
 // Icons routed through the glyph module so they degrade to ASCII when the
 // user's font/terminal don't render Unicode dingbats reliably. Computed
@@ -66,13 +68,17 @@ export const OutputEntryView = React.memo(function OutputEntryView({
     const formatted = formatMarkdown(raw);
     const kind = entry.meta?.["kind"];
     const display = kind === "reasoning" ? dimReasoningMarkdownOutput(formatted) : formatted;
+    // Pre-wrap + PreWrappedText (wrap="truncate"), same as the pending tail in
+    // App.tsx: a bare <Text wrap="wrap"> lets Yoga re-wrap settled slices,
+    // which degenerates into char-by-char wrapping under live re-render load.
+    const width = Math.max(20, getTerminalWidth() - PADDING_BUDGET - PADDING.content);
     return (
       <Box
         marginTop={0}
         marginBottom={0}
         paddingLeft={PADDING.content}
       >
-        <Text>{display}</Text>
+        <PreWrappedText>{wrapToWidth(display, width)}</PreWrappedText>
       </Box>
     );
   }
@@ -85,7 +91,12 @@ export const OutputEntryView = React.memo(function OutputEntryView({
           marginBottom={1}
           paddingLeft={PADDING.content}
         >
-          <Text color={THEME.primary}>You:</Text>
+          <Text
+            color={THEME.primary}
+            bold
+          >
+            {G.promptCursor} You:
+          </Text>
           <Text> </Text>
           <Text
             color="white"

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -125,6 +125,16 @@ function PromptComponent({
     [commandSuggestionsEnabled, suggestionPrefix, value],
   );
   const suggestionsVisible = filteredCommands.length > 0;
+  const suggestionWindowStart = Math.min(
+    Math.max(0, selectedSuggestionIndex - MAX_VISIBLE_SUGGESTIONS + 1),
+    Math.max(0, filteredCommands.length - MAX_VISIBLE_SUGGESTIONS),
+  );
+  const visibleSuggestions = filteredCommands.slice(
+    suggestionWindowStart,
+    suggestionWindowStart + MAX_VISIBLE_SUGGESTIONS,
+  );
+  const hiddenSuggestionsBelow =
+    filteredCommands.length - suggestionWindowStart - visibleSuggestions.length;
 
   // Keep selected index in bounds when list changes
   useEffect(() => {
@@ -278,38 +288,26 @@ function PromptComponent({
                 />
               </Box>
             </Box>
-            {suggestionsVisible &&
-              (() => {
-                const windowStart = Math.min(
-                  Math.max(0, selectedSuggestionIndex - MAX_VISIBLE_SUGGESTIONS + 1),
-                  Math.max(0, filteredCommands.length - MAX_VISIBLE_SUGGESTIONS),
-                );
-                const visibleCommands = filteredCommands.slice(
-                  windowStart,
-                  windowStart + MAX_VISIBLE_SUGGESTIONS,
-                );
-                const hiddenBelow = filteredCommands.length - windowStart - visibleCommands.length;
-                return (
-                  <Box
-                    marginTop={1}
-                    flexDirection="column"
-                  >
-                    <Text dimColor>Commands (↑/↓ select · Tab complete · Enter run):</Text>
-                    {visibleCommands.map((cmd, index) => (
-                      <CommandSuggestionItem
-                        key={cmd.name}
-                        command={cmd}
-                        isSelected={windowStart + index === selectedSuggestionIndex}
-                      />
-                    ))}
-                    {hiddenBelow > 0 && (
-                      <Box marginLeft={1}>
-                        <Text dimColor> …and {hiddenBelow} more</Text>
-                      </Box>
-                    )}
+            {suggestionsVisible && (
+              <Box
+                marginTop={1}
+                flexDirection="column"
+              >
+                <Text dimColor>Commands (↑/↓ select · Tab complete · Enter run):</Text>
+                {visibleSuggestions.map((cmd, index) => (
+                  <CommandSuggestionItem
+                    key={cmd.name}
+                    command={cmd}
+                    isSelected={suggestionWindowStart + index === selectedSuggestionIndex}
+                  />
+                ))}
+                {hiddenSuggestionsBelow > 0 && (
+                  <Box marginLeft={1}>
+                    <Text dimColor> …and {hiddenSuggestionsBelow} more</Text>
                   </Box>
-                );
-              })()}
+                )}
+              </Box>
+            )}
             {validationError && (
               <Box marginTop={1}>
                 <Text

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -18,6 +18,12 @@ const G = getGlyphs();
 
 const COMMAND_SUGGESTIONS_PRIORITY = 50;
 
+/**
+ * Cap the dropdown height. Tall live frames are the trigger for Ink's
+ * shrinking-region erase bug, and a 20-row dropdown is unscannable anyway.
+ */
+const MAX_VISIBLE_SUGGESTIONS = 8;
+
 interface CommandSuggestionItemProps {
   command: ChatCommandInfo;
   isSelected: boolean;
@@ -131,9 +137,11 @@ function PromptComponent({
   const setSelectedSuggestionIndexRef = useRef(setSelectedSuggestionIndex);
   const filteredCommandsRef = useRef(filteredCommands);
   const selectedSuggestionIndexRef = useRef(selectedSuggestionIndex);
+  const valueRef = useRef(value);
   setSelectedSuggestionIndexRef.current = setSelectedSuggestionIndex;
   filteredCommandsRef.current = filteredCommands;
   selectedSuggestionIndexRef.current = selectedSuggestionIndex;
+  valueRef.current = value;
 
   useInputHandler({
     id: "chat-command-suggestions",
@@ -150,7 +158,20 @@ function PromptComponent({
         setSelectedSuggestionIndexRef.current(Math.min(commands.length - 1, idx + 1));
         return InputResults.consumed();
       }
+      if (action.type === "tab" && commands[idx]) {
+        const nextValue = "/" + commands[idx].name + " ";
+        setValueRef.current(nextValue, nextValue.length);
+        setSelectedSuggestionIndexRef.current(0);
+        return InputResults.consumed();
+      }
       if (action.type === "submit" && commands[idx]) {
+        // A fully typed command submits on the first Enter — only incomplete
+        // prefixes get completed in place (second Enter then submits).
+        const typed = valueRef.current.trim();
+        const isExactCommand = commands.some((cmd) => "/" + cmd.name === typed);
+        if (isExactCommand) {
+          return InputResults.ignored();
+        }
         const nextValue = "/" + commands[idx].name + " ";
         setValueRef.current(nextValue, nextValue.length);
         setSelectedSuggestionIndexRef.current(0);
@@ -257,21 +278,38 @@ function PromptComponent({
                 />
               </Box>
             </Box>
-            {suggestionsVisible && (
-              <Box
-                marginTop={1}
-                flexDirection="column"
-              >
-                <Text dimColor>Commands (↑/↓ select, Enter to pick):</Text>
-                {filteredCommands.map((cmd, index) => (
-                  <CommandSuggestionItem
-                    key={cmd.name}
-                    command={cmd}
-                    isSelected={index === selectedSuggestionIndex}
-                  />
-                ))}
-              </Box>
-            )}
+            {suggestionsVisible &&
+              (() => {
+                const windowStart = Math.min(
+                  Math.max(0, selectedSuggestionIndex - MAX_VISIBLE_SUGGESTIONS + 1),
+                  Math.max(0, filteredCommands.length - MAX_VISIBLE_SUGGESTIONS),
+                );
+                const visibleCommands = filteredCommands.slice(
+                  windowStart,
+                  windowStart + MAX_VISIBLE_SUGGESTIONS,
+                );
+                const hiddenBelow = filteredCommands.length - windowStart - visibleCommands.length;
+                return (
+                  <Box
+                    marginTop={1}
+                    flexDirection="column"
+                  >
+                    <Text dimColor>Commands (↑/↓ select · Tab complete · Enter run):</Text>
+                    {visibleCommands.map((cmd, index) => (
+                      <CommandSuggestionItem
+                        key={cmd.name}
+                        command={cmd}
+                        isSelected={windowStart + index === selectedSuggestionIndex}
+                      />
+                    ))}
+                    {hiddenBelow > 0 && (
+                      <Box marginLeft={1}>
+                        <Text dimColor> …and {hiddenBelow} more</Text>
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })()}
             {validationError && (
               <Box marginTop={1}>
                 <Text

--- a/src/cli/ui/StatusFooter.tsx
+++ b/src/cli/ui/StatusFooter.tsx
@@ -67,10 +67,12 @@ function StatusFooter({
   status,
   workingDirectory,
   runStats,
+  modeIsYolo = false,
 }: {
   status: string | null;
   workingDirectory: string | null;
   runStats: RunStats;
+  modeIsYolo?: boolean;
 }) {
   const hasRunStats =
     runStats.model !== undefined ||
@@ -115,10 +117,24 @@ function StatusFooter({
             label={status}
             color={THEME.primary}
           />
-        ) : statLine.length > 0 ? (
-          <Text dimColor>{statLine}</Text>
         ) : (
-          <Text dimColor> </Text>
+          <Box>
+            {/* Yolo mode auto-approves every tool call — keep it loudly and
+                persistently visible, not just in the 2s toast. */}
+            {modeIsYolo ? (
+              <Text
+                color={THEME.warning}
+                bold
+              >
+                yolo{statLine.length > 0 ? " · " : ""}
+              </Text>
+            ) : null}
+            {statLine.length > 0 ? (
+              <Text color={THEME.secondary}>{statLine}</Text>
+            ) : (
+              <Text dimColor> </Text>
+            )}
+          </Box>
         )}
       </Box>
       <Box flexShrink={0}>{wd && <Text dimColor>{wd}</Text>}</Box>

--- a/src/cli/ui/glyphs.test.ts
+++ b/src/cli/ui/glyphs.test.ts
@@ -1,43 +1,97 @@
 import { describe, expect, it } from "bun:test";
 import { getGlyphs, GLYPHS, resolveGlyphMode } from "./glyphs";
 
+const ENV_KEYS = [
+  "JAZZ_UI_GLYPHS",
+  "TERM",
+  "TERM_PROGRAM",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LANG",
+  "WT_SESSION",
+] as const;
+
+function withEnv(overrides: Record<string, string | undefined>, run: () => void): void {
+  const saved = new Map<string, string | undefined>();
+  for (const key of ENV_KEYS) {
+    saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+  try {
+    run();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
 describe("glyphs", () => {
   describe("resolveGlyphMode", () => {
-    it("defaults to ascii when env is unset", () => {
-      const original = process.env["JAZZ_UI_GLYPHS"];
-      delete process.env["JAZZ_UI_GLYPHS"];
-      try {
-        expect(resolveGlyphMode()).toBe("ascii");
-      } finally {
-        if (original !== undefined) process.env["JAZZ_UI_GLYPHS"] = original;
-      }
-    });
-
     it("returns unicode when JAZZ_UI_GLYPHS=unicode (any case)", () => {
-      const original = process.env["JAZZ_UI_GLYPHS"];
-      try {
-        process.env["JAZZ_UI_GLYPHS"] = "unicode";
-        expect(resolveGlyphMode()).toBe("unicode");
-        process.env["JAZZ_UI_GLYPHS"] = "UNICODE";
-        expect(resolveGlyphMode()).toBe("unicode");
-        process.env["JAZZ_UI_GLYPHS"] = "Unicode";
-        expect(resolveGlyphMode()).toBe("unicode");
-      } finally {
-        if (original === undefined) delete process.env["JAZZ_UI_GLYPHS"];
-        else process.env["JAZZ_UI_GLYPHS"] = original;
+      for (const value of ["unicode", "UNICODE", "Unicode"]) {
+        withEnv({ JAZZ_UI_GLYPHS: value, TERM: "dumb" }, () => {
+          expect(resolveGlyphMode()).toBe("unicode");
+        });
       }
     });
 
-    it("falls back to ascii for any other value", () => {
-      const original = process.env["JAZZ_UI_GLYPHS"];
-      try {
-        for (const v of ["fancy", "emoji", "minimal", "", "truecolor"]) {
-          process.env["JAZZ_UI_GLYPHS"] = v;
+    it("returns ascii when JAZZ_UI_GLYPHS=ascii even on a capable terminal", () => {
+      withEnv({ JAZZ_UI_GLYPHS: "ascii", LANG: "en_US.UTF-8" }, () => {
+        expect(resolveGlyphMode()).toBe("ascii");
+      });
+    });
+
+    it("detects unicode from a UTF-8 locale", () => {
+      withEnv({ LANG: "en_US.UTF-8" }, () => {
+        expect(resolveGlyphMode()).toBe("unicode");
+      });
+      withEnv({ LC_ALL: "fr_FR.utf8" }, () => {
+        expect(resolveGlyphMode()).toBe("unicode");
+      });
+    });
+
+    it("detects unicode from a known-capable TERM_PROGRAM without a locale", () => {
+      for (const program of ["iTerm.app", "WezTerm", "vscode", "ghostty", "Apple_Terminal"]) {
+        withEnv({ TERM_PROGRAM: program }, () => {
+          expect(resolveGlyphMode()).toBe("unicode");
+        });
+      }
+    });
+
+    it("detects unicode in Windows Terminal via WT_SESSION", () => {
+      withEnv({ WT_SESSION: "some-guid" }, () => {
+        expect(resolveGlyphMode()).toBe("unicode");
+      });
+    });
+
+    it("falls back to ascii on dumb/linux terminals even with UTF-8 locale", () => {
+      withEnv({ TERM: "dumb", LANG: "en_US.UTF-8" }, () => {
+        expect(resolveGlyphMode()).toBe("ascii");
+      });
+      withEnv({ TERM: "linux", LANG: "en_US.UTF-8" }, () => {
+        expect(resolveGlyphMode()).toBe("ascii");
+      });
+    });
+
+    it("falls back to ascii when nothing signals unicode support", () => {
+      withEnv({}, () => {
+        expect(resolveGlyphMode()).toBe("ascii");
+      });
+    });
+
+    it("treats unrecognized JAZZ_UI_GLYPHS values as unset (detection applies)", () => {
+      for (const value of ["fancy", "emoji", "minimal", "", "truecolor"]) {
+        withEnv({ JAZZ_UI_GLYPHS: value }, () => {
           expect(resolveGlyphMode()).toBe("ascii");
-        }
-      } finally {
-        if (original === undefined) delete process.env["JAZZ_UI_GLYPHS"];
-        else process.env["JAZZ_UI_GLYPHS"] = original;
+        });
+        withEnv({ JAZZ_UI_GLYPHS: value, LANG: "en_US.UTF-8" }, () => {
+          expect(resolveGlyphMode()).toBe("unicode");
+        });
       }
     });
   });
@@ -74,6 +128,11 @@ describe("glyphs", () => {
         "arrow",
         "pending",
         "proposed",
+        "active",
+        "diamond",
+        "gridFilled",
+        "gridEmpty",
+        "gridReserved",
       ];
       for (const k of fields) {
         const v = set[k] as string;
@@ -97,25 +156,22 @@ describe("glyphs", () => {
   });
 
   describe("getGlyphs picks the active set", () => {
-    it("returns ascii by default", () => {
-      const original = process.env["JAZZ_UI_GLYPHS"];
-      delete process.env["JAZZ_UI_GLYPHS"];
-      try {
+    it("returns ascii when nothing signals unicode support", () => {
+      withEnv({}, () => {
         expect(getGlyphs()).toBe(GLYPHS.ascii);
-      } finally {
-        if (original !== undefined) process.env["JAZZ_UI_GLYPHS"] = original;
-      }
+      });
     });
 
     it("returns unicode when env opts in", () => {
-      const original = process.env["JAZZ_UI_GLYPHS"];
-      process.env["JAZZ_UI_GLYPHS"] = "unicode";
-      try {
+      withEnv({ JAZZ_UI_GLYPHS: "unicode" }, () => {
         expect(getGlyphs()).toBe(GLYPHS.unicode);
-      } finally {
-        if (original === undefined) delete process.env["JAZZ_UI_GLYPHS"];
-        else process.env["JAZZ_UI_GLYPHS"] = original;
-      }
+      });
+    });
+
+    it("returns unicode on a detected UTF-8 terminal", () => {
+      withEnv({ LANG: "en_US.UTF-8" }, () => {
+        expect(getGlyphs()).toBe(GLYPHS.unicode);
+      });
     });
   });
 });

--- a/src/cli/ui/glyphs.ts
+++ b/src/cli/ui/glyphs.ts
@@ -11,10 +11,11 @@
  * everything that depends on column math (tables, progress bars, anything
  * inside a Box).
  *
- * Solution: route every UI glyph through this module, default to ASCII
- * (every monospace font has had `+`, `-`, `|`, `*`, `>` since the 1970s),
- * and let users opt into the Unicode set via `JAZZ_UI_GLYPHS=unicode`
- * once they've confirmed their font handles it cleanly.
+ * Solution: route every UI glyph through this module, detect whether the
+ * terminal can render Unicode (UTF-8 locale or a known-capable emulator),
+ * and fall back to ASCII (every monospace font has had `+`, `-`, `|`, `*`,
+ * `>` since the 1970s) when uncertain. `JAZZ_UI_GLYPHS=unicode|ascii`
+ * overrides detection either way.
  *
  * Scope of this module: visual chrome only. The markdown renderer's
  * inline emphasis (bold/italic/strikethrough) and color choices are
@@ -65,6 +66,15 @@ export interface GlyphSet {
   /** Spinner animation frames */ readonly spinnerFrames: readonly string[];
   /** Pending / paused indicator */ readonly pending: string;
   /** Pending tool call (proposed but not yet approved/run) */ readonly proposed: string;
+  /** Active / connected indicator (status dot on) */ readonly active: string;
+
+  // ─── Markers ─────────────────────────────────────────────────────────
+  /** Agent response header marker */ readonly diamond: string;
+
+  // ─── Context-usage grid cells ────────────────────────────────────────
+  /** Grid cell: used tokens */ readonly gridFilled: string;
+  /** Grid cell: free tokens */ readonly gridEmpty: string;
+  /** Grid cell: reserved/buffer tokens */ readonly gridReserved: string;
 }
 
 const ASCII: GlyphSet = {
@@ -108,6 +118,13 @@ const ASCII: GlyphSet = {
   spinnerFrames: ["|", "/", "-", "\\", "|", "/", "-", "\\"],
   pending: "o",
   proposed: "?",
+  active: "*",
+
+  diamond: "*",
+
+  gridFilled: "#",
+  gridEmpty: ".",
+  gridReserved: "~",
 };
 
 const UNICODE: GlyphSet = {
@@ -145,10 +162,23 @@ const UNICODE: GlyphSet = {
   spinnerFrames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
   pending: "○",
   proposed: "◐",
+  active: "●",
+
+  diamond: "◆",
+
+  gridFilled: "█",
+  gridEmpty: "░",
+  gridReserved: "▒",
 };
 
 /**
- * Resolve the active glyph mode from env. Default `ascii`.
+ * Resolve the active glyph mode.
+ *
+ * `JAZZ_UI_GLYPHS=unicode|ascii` is an explicit override; otherwise the mode
+ * is detected from the environment: a UTF-8 locale or a known-capable
+ * terminal emulator gets the Unicode set, and anything uncertain (TERM=dumb,
+ * TERM=linux console, legacy Windows console, no UTF-8 hint) falls back to
+ * ASCII.
  *
  * Read each call rather than memoizing so tests / runtime overrides take
  * effect immediately. Glyph selection is on the cold path of UI rendering
@@ -158,6 +188,35 @@ const UNICODE: GlyphSet = {
 export function resolveGlyphMode(): GlyphMode {
   const raw = (process.env["JAZZ_UI_GLYPHS"] ?? "").toLowerCase();
   if (raw === "unicode") return "unicode";
+  if (raw === "ascii") return "ascii";
+  return detectGlyphMode();
+}
+
+/** Terminal emulators known to render the Unicode set at correct widths. */
+const UNICODE_CAPABLE_TERM_PROGRAMS = new Set([
+  "apple_terminal",
+  "ghostty",
+  "hyper",
+  "iterm.app",
+  "kitty",
+  "tabby",
+  "vscode",
+  "wezterm",
+]);
+
+function detectGlyphMode(): GlyphMode {
+  const term = (process.env["TERM"] ?? "").toLowerCase();
+  if (term === "dumb" || term === "linux") return "ascii";
+
+  const locale = process.env["LC_ALL"] ?? process.env["LC_CTYPE"] ?? process.env["LANG"] ?? "";
+  if (/utf-?8/i.test(locale)) return "unicode";
+
+  const termProgram = (process.env["TERM_PROGRAM"] ?? "").toLowerCase();
+  if (UNICODE_CAPABLE_TERM_PROGRAMS.has(termProgram)) return "unicode";
+
+  // Windows Terminal exposes no locale vars but handles Unicode fine.
+  if (process.env["WT_SESSION"] !== undefined) return "unicode";
+
   return "ascii";
 }
 

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -406,7 +406,34 @@ describe("UIStore", () => {
       return Promise.resolve().then(() => {
         expect(printed).toHaveLength(1);
         expect(printed[0]!.type).toBe("streamContent");
-        expect(printed[0]!.message).toBe("full reasoning body");
+        expect(printed[0]!.message).toContain("full reasoning body");
+        expect(printed[0]!.message).toContain("Reasoning · 1.0s");
+        expect(s.getExpandableReasoningSnapshot()).toBeNull();
+      });
+    });
+
+    test("expandLastReasoning walks back through multiple collapsed blocks", () => {
+      const s = new UIStore();
+      const printed: OutputEntry[] = [];
+      s.registerPrintOutput((eOrBatch) => {
+        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
+        printed.push(...arr);
+        return arr[0]?.id ?? "id";
+      });
+
+      const first = s.openEphemeral("reasoning", "Reasoning", 8);
+      s.collapseEphemeral(first, { durationMs: 500, fullText: "first block" });
+      const second = s.openEphemeral("reasoning", "Reasoning", 8);
+      s.collapseEphemeral(second, { durationMs: 700, fullText: "second block" });
+
+      s.expandLastReasoning();
+      s.expandLastReasoning();
+      s.expandLastReasoning(); // stack empty — no-op
+
+      return Promise.resolve().then(() => {
+        expect(printed).toHaveLength(2);
+        expect(printed[0]!.message).toContain("second block");
+        expect(printed[1]!.message).toContain("first block");
         expect(s.getExpandableReasoningSnapshot()).toBeNull();
       });
     });

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -133,6 +133,7 @@ export class UIStore {
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
+  private frameClearHandler: (() => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -190,7 +191,15 @@ export class UIStore {
   };
 
   setPrompt = (prompt: PromptState | null): void => {
+    const dismissing = this.promptSnapshot !== null && prompt === null;
     this.promptSnapshot = prompt;
+    // Erase the painted prompt frame (input line + suggestion dropdown)
+    // before React swaps in the shorter busy-phase UI. Under heavy <Static>
+    // churn Ink does not reliably erase lines freed by a shrinking live
+    // region, which left the dropdown visible until the turn completed.
+    if (dismissing && this.frameClearHandler) {
+      this.frameClearHandler();
+    }
     if (this.promptSetter) {
       this.promptSetter(prompt);
     }
@@ -510,6 +519,15 @@ export class UIStore {
 
   registerPromptSetter(setter: (prompt: PromptState | null) => void): void {
     this.promptSetter = setter;
+  }
+
+  /**
+   * Register a callback that erases Ink's current dynamic frame from the
+   * terminal (the Ink instance's `clear()`). Invoked when a prompt is
+   * dismissed so stale prompt chrome never lingers on screen.
+   */
+  registerFrameClearHandler(handler: (() => void) | null): void {
+    this.frameClearHandler = handler;
   }
 
   registerWorkingDirectorySetter(setter: (wd: string | null) => void): void {

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -133,6 +133,7 @@ export class UIStore {
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
+  private modeSetter: ((isYolo: boolean) => void) | null = null;
   private frameClearHandler: (() => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
@@ -342,14 +343,26 @@ export class UIStore {
   toggleMode = (): void => {
     const nextMode = this.currentModeIsYolo ? "safe" : "yolo";
     this.currentModeIsYolo = !this.currentModeIsYolo;
+    this.modeSetter?.(this.currentModeIsYolo);
     this.requestModeSwitch(nextMode);
   };
 
   setModeIsYolo = (isYolo: boolean): void => {
     this.currentModeIsYolo = isYolo;
+    this.modeSetter?.(isYolo);
   };
 
   getModeIsYolo = (): boolean => this.currentModeIsYolo;
+
+  /**
+   * Subscribe the footer (or any island) to approval-mode changes so the
+   * current safe/yolo state stays persistently visible, not just in the
+   * 2-second toast.
+   */
+  registerModeSetter = (setter: ((isYolo: boolean) => void) | null): void => {
+    this.modeSetter = setter;
+    setter?.(this.currentModeIsYolo);
+  };
 
   registerModeToastSetter = (setter: ((message: string | null) => void) | null): void => {
     this.modeToastSetter = setter;

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -472,11 +472,22 @@ export class UIStore {
   }
 
   /**
-   * Collapse every open region — used on errors and /clear so panels don't
-   * get stuck. Emits no per-region summary; just removes them.
+   * Collapse every open region — used on errors, interrupts, and /clear so
+   * panels don't get stuck. Emits no per-region summary, but open reasoning
+   * regions are preserved into the expandable stack (their visible tail is
+   * the best content available here — the full text lives in the renderer),
+   * so an interrupt doesn't silently destroy in-flight reasoning.
    */
   collapseAllEphemeral = (): void => {
     if (this.ephemeralRegions.size === 0) return;
+    for (const region of this.ephemeralRegions.values()) {
+      if (region.kind !== "reasoning" || region.tail.length === 0) continue;
+      this.pushExpandableReasoning({
+        fullText: region.tail.join("\n"),
+        label: region.label,
+        durationMs: Date.now() - region.startedAt,
+      });
+    }
     this.ephemeralRegions.clear();
     this.publishEphemeralRegions();
   };

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -48,8 +48,10 @@ export interface EphemeralRegion {
 }
 
 /**
- * Snapshot of the most recently collapsed reasoning, available for
- * Ctrl-R expansion. Replaced on every new collapse; cleared once expanded.
+ * Snapshot of a collapsed reasoning block, available for Ctrl-R expansion.
+ * Collapsed blocks accumulate in a bounded stack — each Ctrl-R press pops
+ * and expands the most recent unexpanded block, so earlier reasoning from
+ * a multi-step turn stays recoverable instead of being overwritten.
  */
 export interface ExpandableReasoning {
   readonly fullText: string;
@@ -57,6 +59,9 @@ export interface ExpandableReasoning {
   readonly durationMs: number;
   readonly tokens?: number;
 }
+
+/** Upper bound on retained collapsed-reasoning blocks. */
+const MAX_EXPANDABLE_REASONING = 20;
 
 /** Caller-supplied summary when collapsing a region. */
 export interface CollapseEphemeralSummary {
@@ -116,6 +121,7 @@ export class UIStore {
   private runStatsSnapshot: RunStats = {};
   private ephemeralRegionsSnapshot: readonly EphemeralRegion[] = [];
   private expandableReasoningSnapshot: ExpandableReasoning | null = null;
+  private expandableReasoningStack: ExpandableReasoning[] = [];
   private messageQueueSnapshot: readonly string[] = [];
   private chatBusySnapshot: boolean = false;
 
@@ -448,7 +454,7 @@ export class UIStore {
     }
 
     if (region.kind === "reasoning" && summary.fullText) {
-      this.setExpandableReasoning({
+      this.pushExpandableReasoning({
         fullText: summary.fullText,
         label: region.label,
         durationMs: summary.durationMs,
@@ -456,6 +462,14 @@ export class UIStore {
       });
     }
   };
+
+  private pushExpandableReasoning(value: ExpandableReasoning): void {
+    this.expandableReasoningStack.push(value);
+    if (this.expandableReasoningStack.length > MAX_EXPANDABLE_REASONING) {
+      this.expandableReasoningStack.shift();
+    }
+    this.setExpandableReasoning(value);
+  }
 
   /**
    * Collapse every open region — used on errors and /clear so panels don't
@@ -468,19 +482,21 @@ export class UIStore {
   };
 
   /**
-   * If a most-recently-collapsed reasoning is available, emit it as a
-   * streamContent entry into scrollback and clear the slot. No-op otherwise.
+   * Pop the most recent unexpanded reasoning block and emit it into
+   * scrollback. Pressing Ctrl-R repeatedly walks backwards through the
+   * turn's collapsed reasoning blocks. No-op once the stack is empty.
    */
   expandLastReasoning = (): void => {
-    const value = this.expandableReasoningSnapshot;
+    const value = this.expandableReasoningStack.pop();
     if (!value) return;
+    const seconds = (value.durationMs / 1000).toFixed(1);
     this.printOutput({
       type: "streamContent",
-      message: value.fullText,
+      message: `*${value.label} · ${seconds}s*\n\n${value.fullText}`,
       meta: { kind: "reasoning" },
       timestamp: new Date(),
     });
-    this.setExpandableReasoning(null);
+    this.setExpandableReasoning(this.expandableReasoningStack.at(-1) ?? null);
   };
 
   appendStream = (kind: StreamKind, delta: string): void => {

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -531,6 +531,11 @@ export class UIStore {
     this.outputBatch = [];
     this.batchFlushScheduled = false;
 
+    // Reasoning from before the clear is stale context — drop it so Ctrl+R
+    // can't resurrect output the user just wiped.
+    this.expandableReasoningStack = [];
+    this.setExpandableReasoning(null);
+
     if (!this.clearOutputsHandler) {
       this._pendingClear = true;
       this.pendingOutputQueue.length = 0;

--- a/src/cli/utils/list-format.ts
+++ b/src/cli/utils/list-format.ts
@@ -13,14 +13,13 @@
  */
 
 import chalk from "chalk";
+import { getGlyphs } from "../ui/glyphs";
 import { CHALK_THEME } from "../ui/theme";
 
 // ── Indentation & symbols ────────────────────────────────────────────
 
 const INDENT = "   ";
 const ITEM_INDENT = "      ";
-const BULLET = "•";
-const ARROW = "▸";
 
 // ── Heading ──────────────────────────────────────────────────────────
 
@@ -55,7 +54,7 @@ export function section(label: string, count?: number, unit?: string): string {
  * Example: `      • shell_exec`
  */
 export function item(name: string): string {
-  return `${ITEM_INDENT}${CHALK_THEME.secondary(BULLET)} ${CHALK_THEME.primary(name)}`;
+  return `${ITEM_INDENT}${CHALK_THEME.secondary(getGlyphs().bullet)} ${CHALK_THEME.primary(name)}`;
 }
 
 /**
@@ -64,7 +63,7 @@ export function item(name: string): string {
  * Example: `      • git-commit - Commit staged changes`
  */
 export function itemWithDesc(name: string, description: string): string {
-  return `${ITEM_INDENT}${CHALK_THEME.secondary(BULLET)} ${CHALK_THEME.primary(name)} ${CHALK_THEME.secondary("-")} ${CHALK_THEME.secondary(description)}`;
+  return `${ITEM_INDENT}${CHALK_THEME.secondary(getGlyphs().bullet)} ${CHALK_THEME.primary(name)} ${CHALK_THEME.secondary("-")} ${CHALK_THEME.secondary(description)}`;
 }
 
 /**
@@ -74,7 +73,7 @@ export function itemWithDesc(name: string, description: string): string {
  */
 export function labeledItem(name: string, suffix?: string): string {
   const sfx = suffix ? ` ${CHALK_THEME.secondary(suffix)}` : "";
-  return `${INDENT}${CHALK_THEME.primary(ARROW)} ${CHALK_THEME.primaryBold(name)}${sfx}`;
+  return `${INDENT}${CHALK_THEME.primary(getGlyphs().arrow)} ${CHALK_THEME.primaryBold(name)}${sfx}`;
 }
 
 /**
@@ -117,7 +116,7 @@ export function keyValueCompact(key: string, value: string, width = 14): string 
  * Example: `   ● my-server`
  */
 export function statusConnected(name: string): string {
-  return `${INDENT}${chalk.green("●")} ${CHALK_THEME.primaryBold(name)}`;
+  return `${INDENT}${chalk.green(getGlyphs().active)} ${CHALK_THEME.primaryBold(name)}`;
 }
 
 /**
@@ -126,7 +125,7 @@ export function statusConnected(name: string): string {
  * Example: `   ○ my-server`
  */
 export function statusDisconnected(name: string): string {
-  return `${INDENT}${CHALK_THEME.secondary("○")} ${CHALK_THEME.white(name)}`;
+  return `${INDENT}${CHALK_THEME.secondary(getGlyphs().pending)} ${CHALK_THEME.white(name)}`;
 }
 
 // ── Footer / totals ──────────────────────────────────────────────────

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { Effect } from "effect";
 import { z } from "zod";
+import { getGlyphs } from "@/cli/ui/glyphs";
 import { store } from "@/cli/ui/store";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
 import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
@@ -154,7 +155,20 @@ ${args.task}`;
             Effect.tapError(() =>
               Effect.sync(() =>
                 store.collapseEphemeral(regionId, {
-                  line: chalk.dim(chalk.italic(`✗ ${subagentLabel} failed`)),
+                  line: chalk.dim(chalk.italic(`${getGlyphs().error} ${subagentLabel} failed`)),
+                  durationMs: Date.now() - startedAt,
+                }),
+              ),
+            ),
+            // Interruption is not a typed error, so tapError never sees it.
+            // Without this, any abort that doesn't go through the double-Esc
+            // handler leaves the subagent panel stuck live.
+            Effect.onInterrupt(() =>
+              Effect.sync(() =>
+                store.collapseEphemeral(regionId, {
+                  line: chalk.dim(
+                    chalk.italic(`${getGlyphs().error} ${subagentLabel} interrupted`),
+                  ),
                   durationMs: Date.now() - startedAt,
                 }),
               ),
@@ -180,7 +194,9 @@ ${args.task}`;
 
           const durationMs = Date.now() - startedAt;
           const seconds = (durationMs / 1000).toFixed(1);
-          const summaryLine = chalk.dim(chalk.italic(`✓ ${subagentLabel} completed · ${seconds}s`));
+          const summaryLine = chalk.dim(
+            chalk.italic(`${getGlyphs().success} ${subagentLabel} completed · ${seconds}s`),
+          );
           store.collapseEphemeral(regionId, { line: summaryLine, durationMs });
 
           const fullResult = result?.trim() || "No output";

--- a/src/core/utils/tool-formatter.ts
+++ b/src/core/utils/tool-formatter.ts
@@ -363,6 +363,26 @@ function formatLoadSkillSectionStringBody(body: string): string {
 }
 
 /**
+ * If a tool result is large enough that the displayed summary truncates it,
+ * return the full (pretty-printed when JSON) text for Ctrl+O expansion.
+ * Returns null when the result fits on screen untruncated.
+ */
+export function expandableToolResultPayload(result: string): string | null {
+  const normalized = result.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return null;
+  let pretty = normalized;
+  try {
+    pretty = JSON.stringify(JSON.parse(normalized), null, 2);
+  } catch {
+    // Not JSON — expand the raw text as-is.
+  }
+  const withinCaps =
+    pretty.split("\n").length <= MAX_RESULT_DISPLAY_LINES &&
+    pretty.length <= MAX_RESULT_DISPLAY_CHARS;
+  return withinCaps ? null : pretty;
+}
+
+/**
  * Format tool result for display
  * Shows relevant summary information for each tool type
  */
@@ -376,11 +396,15 @@ export function formatToolResult(toolName: string, result: string): string {
     const omittedLines = lines.length - visibleLines.length;
 
     let output = visibleLines.join("\n");
+    let charTruncated = false;
     if (output.length > MAX_RESULT_DISPLAY_CHARS) {
       output = output.slice(0, MAX_RESULT_DISPLAY_CHARS).trimEnd() + "…";
+      charTruncated = true;
     }
     if (omittedLines > 0) {
-      output += `\n… ${omittedLines} more line${omittedLines === 1 ? "" : "s"}`;
+      output += `\n… ${omittedLines} more line${omittedLines === 1 ? "" : "s"} · ctrl+o to expand`;
+    } else if (charTruncated) {
+      output += `\n… output capped · ctrl+o to expand`;
     }
     return output;
   }

--- a/src/core/utils/tool-formatter.ts
+++ b/src/core/utils/tool-formatter.ts
@@ -3,6 +3,9 @@ import { safeString } from "./string";
 
 const MAX_RESULT_DISPLAY_LINES = 12;
 const MAX_RESULT_DISPLAY_CHARS = 1200;
+// Ctrl+O expansion prints the full payload through Ink — cap it so expanding
+// a multi-megabyte tool result can't hang the renderer.
+const MAX_EXPANDABLE_CHARS = 100_000;
 
 /**
  * Utility functions for formatting tool arguments and results
@@ -379,7 +382,11 @@ export function expandableToolResultPayload(result: string): string | null {
   const withinCaps =
     pretty.split("\n").length <= MAX_RESULT_DISPLAY_LINES &&
     pretty.length <= MAX_RESULT_DISPLAY_CHARS;
-  return withinCaps ? null : pretty;
+  if (withinCaps) return null;
+  if (pretty.length > MAX_EXPANDABLE_CHARS) {
+    return pretty.slice(0, MAX_EXPANDABLE_CHARS).trimEnd() + "\n… output capped at 100k characters";
+  }
+  return pretty;
 }
 
 /**

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
+import { getGlyphs } from "@/cli/ui/glyphs";
 import * as fmt from "@/cli/utils/list-format";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
@@ -1403,12 +1404,18 @@ function handleModeCommand(
 // Context Command Utilities
 // ============================================================================
 
-/** Symbols for context visualization */
-const CONTEXT_SYMBOLS = {
-  used: "⛁",
-  free: "⛶",
-  buffer: "⛝",
-} as const;
+/**
+ * Symbols for context visualization. Resolved per call so the glyph mode
+ * (unicode block shades vs portable ASCII) is honored at render time.
+ */
+function contextSymbols(): { used: string; free: string; buffer: string } {
+  const glyphs = getGlyphs();
+  return {
+    used: glyphs.gridFilled,
+    free: glyphs.gridEmpty,
+    buffer: glyphs.gridReserved,
+  };
+}
 
 /** Grid dimensions for visualization (10x10 = 100 cells) */
 const GRID_SIZE = 10;
@@ -1559,13 +1566,14 @@ function generateContextGrid(usage: ContextUsageBreakdown): string[] {
   }
 
   // Build the grid string
+  const symbols = contextSymbols();
   const cells: string[] = [];
-  for (let i = 0; i < usedCells; i++) cells.push(CONTEXT_SYMBOLS.used);
-  for (let i = 0; i < Math.max(0, adjustedFreeCells); i++) cells.push(CONTEXT_SYMBOLS.free);
-  for (let i = 0; i < bufferCells; i++) cells.push(CONTEXT_SYMBOLS.buffer);
+  for (let i = 0; i < usedCells; i++) cells.push(symbols.used);
+  for (let i = 0; i < Math.max(0, adjustedFreeCells); i++) cells.push(symbols.free);
+  for (let i = 0; i < bufferCells; i++) cells.push(symbols.buffer);
 
   // Pad or trim to exactly 100 cells
-  while (cells.length < TOTAL_CELLS) cells.push(CONTEXT_SYMBOLS.free);
+  while (cells.length < TOTAL_CELLS) cells.push(symbols.free);
   cells.length = TOTAL_CELLS;
 
   // Format into rows
@@ -1621,6 +1629,7 @@ function handleContextCommand(
 
     // Generate visual grid
     const gridRows = generateContextGrid(adjustedUsage);
+    const symbols = contextSymbols();
 
     // Display header
     yield* terminal.log(fmt.heading("Context Usage"));
@@ -1633,22 +1642,22 @@ function handleContextCommand(
     yield* terminal.log(`   ${gridRows[1]}`);
     yield* terminal.log(`   ${gridRows[2]}   Estimated usage by category`);
     yield* terminal.log(
-      `   ${gridRows[3]}   ${CONTEXT_SYMBOLS.used} System prompt: ${formatTokenCount(adjustedUsage.systemPromptTokens)} tokens (${systemPercent}%)`,
+      `   ${gridRows[3]}   ${symbols.used} System prompt: ${formatTokenCount(adjustedUsage.systemPromptTokens)} tokens (${systemPercent}%)`,
     );
     yield* terminal.log(
-      `   ${gridRows[4]}   ${CONTEXT_SYMBOLS.used} System tools: ${formatTokenCount(adjustedUsage.toolsTokens)} tokens (${toolsPercent}%)`,
+      `   ${gridRows[4]}   ${symbols.used} System tools: ${formatTokenCount(adjustedUsage.toolsTokens)} tokens (${toolsPercent}%)`,
     );
     yield* terminal.log(
-      `   ${gridRows[5]}   ${CONTEXT_SYMBOLS.used} Skills: ${formatTokenCount(adjustedUsage.skillsTokens)} tokens (${skillsPercent}%)`,
+      `   ${gridRows[5]}   ${symbols.used} Skills: ${formatTokenCount(adjustedUsage.skillsTokens)} tokens (${skillsPercent}%)`,
     );
     yield* terminal.log(
-      `   ${gridRows[6]}   ${CONTEXT_SYMBOLS.used} Messages: ${formatTokenCount(adjustedUsage.messagesTokens)} tokens (${messagesPercent}%)`,
+      `   ${gridRows[6]}   ${symbols.used} Messages: ${formatTokenCount(adjustedUsage.messagesTokens)} tokens (${messagesPercent}%)`,
     );
     yield* terminal.log(
-      `   ${gridRows[7]}   ${CONTEXT_SYMBOLS.free} Free space: ${formatTokenCount(adjustedUsage.freeSpace)} (${freePercent}%)`,
+      `   ${gridRows[7]}   ${symbols.free} Free space: ${formatTokenCount(adjustedUsage.freeSpace)} (${freePercent}%)`,
     );
     yield* terminal.log(
-      `   ${gridRows[8]}   ${CONTEXT_SYMBOLS.buffer} Autocompact buffer: ${formatTokenCount(adjustedUsage.autocompactBuffer)} tokens (${bufferPercent}%)`,
+      `   ${gridRows[8]}   ${symbols.buffer} Autocompact buffer: ${formatTokenCount(adjustedUsage.autocompactBuffer)} tokens (${bufferPercent}%)`,
     );
     yield* terminal.log(`   ${gridRows[9]}`);
     yield* terminal.log("");

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -103,6 +103,9 @@ export class InkTerminalService implements TerminalService {
       ),
       INK_RENDER_OPTIONS,
     );
+    store.registerFrameClearHandler(() => {
+      this.inkInstance?.clear();
+    });
     instanceExists = true;
   }
 
@@ -111,6 +114,7 @@ export class InkTerminalService implements TerminalService {
    * Called when the command completes
    */
   cleanup(): void {
+    store.registerFrameClearHandler(null);
     if (this.inkInstance) {
       this.inkInstance.unmount();
       this.inkInstance = null;

--- a/test-preload.ts
+++ b/test-preload.ts
@@ -1,0 +1,10 @@
+/**
+ * Bun test preload — runs before every test file.
+ *
+ * Pin the glyph mode so rendering assertions are deterministic regardless of
+ * the host environment: CI runners export a UTF-8 locale (which the runtime
+ * detection maps to unicode glyphs) while local shells may not. Tests that
+ * exercise the detection itself (glyphs.test.ts) manage the env var
+ * explicitly per-test, so this default doesn't constrain them.
+ */
+process.env["JAZZ_UI_GLYPHS"] ??= "ascii";


### PR DESCRIPTION
## What this PR delivers

The first two phases of the UI/UX overhaul that came out of a five-subagent flaw hunt across the Jazz terminal UI (55 flaws catalogued). Phase 1 makes the interface feel alive and honest — the polished unicode chrome ships by default, every waiting state shows real elapsed time, and the input line stops fighting the user. Phase 2 makes reasoning a first-class, recoverable artifact instead of ephemeral text that vanishes on collapse or interrupt.

It also fixes the reported bug where the slash-command suggestion dropdown stayed painted on screen for the whole duration of the agent's response.

## Why this matters

For users: the CLI previously shipped ASCII `+ | - o ?` chrome even in terminals that render `✓ ✗ ❯ ⠋` perfectly; long tool runs and thinking phases were indistinguishable from hangs (no elapsed time anywhere); typing `/clear` + Enter did nothing until a second Enter; yolo mode became invisible 2 seconds after toggling it — a genuine safety hazard; and reasoning older than the last block was permanently unrecoverable.

For maintainers: the worst raw-glyph literals (`✔ ◆ ⛁⛶⛝ ● •`) now route through the `glyphs.ts` module that existed precisely to gate them, so ASCII terminals stop getting tofu and future glyph changes have one home.

## How UI behaviour changes

| Surface | Change |
|---|---|
| Glyph mode | Auto-detects unicode (UTF-8 locale, known terminal, or `WT_SESSION`); falls back to ASCII on `TERM=dumb`/`linux` or no signal. `JAZZ_UI_GLYPHS=ascii\|unicode` still overrides both ways. Pinned by `glyphs.test.ts`. |
| Slash suggestions | Dropdown frame is erased on prompt dismissal (Ink instance `clear()` via new `registerFrameClearHandler`); dropdown capped at 8 rows with an `…and N more` overflow (tall frames were what broke Ink's erase). |
| Enter on a command | `/clear` + Enter runs on the first Enter when the typed value exactly matches a command; incomplete prefixes still complete in place. Tab now accepts the highlighted suggestion (was a dead key). |
| Waiting states | Awaiting/thinking/streaming/tool-execution all show a live `· 12s` elapsed counter (appears after 2s); ephemeral panel headers self-tick every second instead of freezing when content stalls; the 30s slow-tool warning re-arms periodically and names the interrupt shortcut. |
| Streamed turns | Each turn starts with a `◆ AgentName (provider/model)` agent-colored header instead of a generic info line. Settled stream slices render pre-wrapped (`PreWrappedText`), closing the remaining Yoga char-by-char wrap path. |
| Footer | Persistent `yolo` indicator (warning-colored, bold) whenever auto-approve is on; context shows `12.3k/200k` — the denominator resolves from the models.dev cache at stream start (was dead code, never populated); stats line uses readable secondary color instead of dim. |
| Reasoning | Live panel renders dim/italic (matches settled styling — no more bright-then-dim jump); panel height adapts to terminal rows (¼ of rows, clamped 8–24, was fixed 8); collapsed blocks accumulate in a 20-deep stack so repeated Ctrl+R walks back through a whole multi-step turn (was single slot, earlier blocks lost); collapse line now says `· ctrl+r to expand`. |
| Interrupt (double-Esc) | Prints `Interrupting…` immediately; open reasoning is preserved into the Ctrl+R stack instead of destroyed; subagent panels collapse on interruption via `Effect.onInterrupt` (previously orphaned on non-Esc aborts). |
| Tool results | Lines carrying their own ANSI styling (diff +/- colors, syntax highlighting) are no longer wrapped in `dimColor`; truncated results of any tool are expandable with Ctrl+O (was diff-only) and the truncation notice says so. |
| `/context` grid | Uses width-safe `█ ░ ▒` (unicode) / `# . ~` (ascii) instead of ambiguous-width `⛁ ⛶ ⛝`. |

## UX changes operators will notice

- Out of the box on a modern terminal: braille spinner, `✓ ✗ ⚠ •` status marks, `❯` prompt cursor.
- Your own messages read `❯ You:` in bold primary color — scannable when scrolling back.
- Every "the agent is doing something" state has a visible, advancing timer.
- The footer always tells you when you're in yolo mode and how full the context window is.
- After a turn with several reasoning phases, pressing Ctrl+R repeatedly re-emits each block, newest first, labeled with its duration.

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| `GlyphSet` | — | new fields `active`, `diamond`, `gridFilled`, `gridEmpty`, `gridReserved` |
| `store` | `setExpandableReasoning` single slot | bounded stack (`MAX_EXPANDABLE_REASONING = 20`); `expandLastReasoning()` pops |
| `store` | — | `registerFrameClearHandler(handler)` + `registerModeSetter(setter)` |
| `tool-formatter` | — | exported `expandableToolResultPayload(result)` |
| `stream_start` output | `info` entry (plain string) | `log` entry (ink node header) |

## Tests

- 1414 passing across 83 files (5 new tests; 4 existing tests updated to match the new header/glyph/expansion contracts).
- `src/cli/ui/glyphs.test.ts` — canonical pin for the detection matrix (override, UTF-8 locale, TERM_PROGRAM allowlist, WT_SESSION, dumb/linux fallback).
- `src/cli/ui/store.test.ts` — pins the reasoning stack walk-back (`expandLastReasoning walks back through multiple collapsed blocks`).
- `src/cli/presentation/ink-presentation-service.test.ts` — pins that streaming never renders the response card (now content-based, tolerant of the turn header).

### Edge cases to verify in a staging session

1. Type `/` while an agent is responding, then send — expected: no suggestion rows linger above the streaming output.
2. Type `/clear` and press Enter once — expected: screen clears immediately (no second Enter needed).
3. `JAZZ_UI_GLYPHS=ascii jazz …` in a UTF-8 terminal — expected: pure ASCII chrome everywhere, including todo checklists and the `/context` grid.
4. Run a tool that takes >60s — expected: warning lines at ~30s and ~60s naming the Esc-Esc interrupt, elapsed counter advancing next to the tool label.
5. Interrupt mid-reasoning with double-Esc — expected: `Interrupting…` prints at once and Ctrl+R afterwards recovers the partial reasoning tail.
6. Toggle yolo via Shift+Tab and wait out the toast — expected: `yolo` stays visible in the footer until toggled back.

## Notes for reviewers

- The suggestion-dropdown fix is terminal-plumbing, not React state: `setPrompt(null)` already unmounted the dropdown synchronously, but Ink doesn't reliably erase lines freed by a shrinking live region under heavy `<Static>` churn. The fix erases the painted frame (`inkInstance.clear()`) at dismissal time; the 8-row dropdown cap reduces the trigger surface.
- `collapseAllEphemeral()` preserves only the visible tail of an interrupted reasoning region (the full text lives in the renderer, which is being torn down at that moment) — partial recovery is intentional, not an oversight.
- The un-dim heuristic in the tool-result card checks each line for the ANSI escape prefix (`ESC [`) — any line already styled renders as-is; unstyled lines keep the dim treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
