### PR TITLE
feat(run): add --conversation flag for per-chat memory in jazz run

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -94,6 +94,10 @@ function registerRunCommand(program: Command): void {
       "--reasoning <effort>",
       "Reasoning effort for this run: low | medium | high | disable (overrides the agent's config)",
     )
+    .option(
+      "--conversation <id>",
+      "Stable conversation key (e.g. a Telegram chat id). Loads prior history for this key before the run and saves the updated transcript after, giving repeated invocations shared memory. Omit for a stateless one-shot run.",
+    )
     .action(
       (
         prompt: string | undefined,
@@ -105,6 +109,7 @@ function registerRunCommand(program: Command): void {
           maxIterations?: number;
           events?: string;
           reasoning?: string;
+          conversation?: string;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -164,6 +169,7 @@ function registerRunCommand(program: Command): void {
               ? { maxIterations: options.maxIterations }
               : {}),
             ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
+            ...(options.conversation !== undefined ? { conversationId: options.conversation } : {}),
           }),
           {
             verbose: opts.verbose,

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { ChatMessage } from "@/core/types/message";
 import {
+  loadConversation,
+  saveConversation,
+  type ConversationRecord,
+} from "@/services/history/conversation-history-service";
+import {
+  buildConversationRecord,
   formatOneShotError,
   formatOneShotResult,
   isApprovalPolicyFlag,
@@ -147,6 +159,156 @@ describe("parseEventCategories", () => {
       expect(result.error).toContain("Invalid --events category");
     },
   );
+});
+
+describe("--conversation persistence", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-run-conversation-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runEffect<A>(eff: Effect.Effect<A, unknown, NodeFileSystem.NodeFileSystem["Type"]>) {
+    return Effect.runPromise(eff.pipe(Effect.provide(NodeFileSystem.layer)));
+  }
+
+  // Mirrors what runAgentOnceCommand does around AgentRunner.run for a
+  // `--conversation` invocation: load prior record, run, persist the turn.
+  async function simulateTurn(params: {
+    conversationId: string;
+    prompt: string;
+    responseContent: string;
+    responseMessages?: ChatMessage[];
+  }): Promise<ConversationRecord | null> {
+    const priorRecord = await runEffect(loadConversation("agent-1", params.conversationId, tmpDir));
+    const record = buildConversationRecord({
+      agentId: "agent-1",
+      conversationId: params.conversationId,
+      prompt: params.prompt,
+      priorRecord,
+      responseContent: params.responseContent,
+      responseMessages: params.responseMessages,
+      now: new Date().toISOString(),
+    });
+    await runEffect(saveConversation(record, tmpDir));
+    return priorRecord;
+  }
+
+  it("a fresh conversation id creates a persisted conversation", async () => {
+    const priorRecord = await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "Remember my name is Ada",
+      responseContent: "Noted, Ada!",
+    });
+
+    expect(priorRecord).toBeNull();
+    const saved = await runEffect(loadConversation("agent-1", "telegram-42", tmpDir));
+    expect(saved).not.toBeNull();
+    expect(saved?.conversationId).toBe("telegram-42");
+    expect(saved?.title).toBe("Remember my name is Ada");
+    expect(saved?.messages).toEqual([
+      { role: "user", content: "Remember my name is Ada" },
+      { role: "assistant", content: "Noted, Ada!" },
+    ]);
+  });
+
+  it("a second call with the same id sees the prior turn as context", async () => {
+    await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "Remember my name is Ada",
+      responseContent: "Noted, Ada!",
+    });
+
+    const priorRecord = await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "What is my name?",
+      responseContent: "Your name is Ada.",
+    });
+
+    expect(priorRecord?.messages).toEqual([
+      { role: "user", content: "Remember my name is Ada" },
+      { role: "assistant", content: "Noted, Ada!" },
+    ]);
+
+    const saved = await runEffect(loadConversation("agent-1", "telegram-42", tmpDir));
+    expect(saved?.messages).toHaveLength(4);
+    expect(saved?.messages.at(-1)).toEqual({ role: "assistant", content: "Your name is Ada." });
+  });
+
+  it("repeated turns upsert a single record instead of duplicating", async () => {
+    await simulateTurn({ conversationId: "telegram-42", prompt: "one", responseContent: "1" });
+    await simulateTurn({ conversationId: "telegram-42", prompt: "two", responseContent: "2" });
+    await simulateTurn({ conversationId: "telegram-7", prompt: "other", responseContent: "x" });
+
+    const historyFile = JSON.parse(fs.readFileSync(path.join(tmpDir, "agent-1.json"), "utf-8")) as {
+      conversations: ConversationRecord[];
+    };
+    const ids = historyFile.conversations.map((conversation) => conversation.conversationId);
+    expect(ids).toEqual(["telegram-7", "telegram-42"]);
+  });
+
+  it("different conversation ids stay isolated", async () => {
+    await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "I like jazz",
+      responseContent: "Cool!",
+    });
+
+    const otherChat = await runEffect(loadConversation("agent-1", "telegram-99", tmpDir));
+    expect(otherChat).toBeNull();
+  });
+
+  it("prefers the runner's full transcript over the append fallback", async () => {
+    const transcript: ChatMessage[] = [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ];
+    await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "hi",
+      responseContent: "hello",
+      responseMessages: transcript,
+    });
+
+    const saved = await runEffect(loadConversation("agent-1", "telegram-42", tmpDir));
+    expect(saved?.messages).toEqual(transcript);
+    expect(saved?.messageCount).toBe(3);
+  });
+
+  it("keeps the original title and startedAt across turns", async () => {
+    await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "first message",
+      responseContent: "ok",
+    });
+    const first = await runEffect(loadConversation("agent-1", "telegram-42", tmpDir));
+
+    await simulateTurn({
+      conversationId: "telegram-42",
+      prompt: "second message",
+      responseContent: "ok again",
+    });
+    const second = await runEffect(loadConversation("agent-1", "telegram-42", tmpDir));
+
+    expect(second?.title).toBe("first message");
+    expect(second?.startedAt).toBe(first?.startedAt ?? "");
+  });
+
+  it("json envelope shape is unchanged by conversation runs", () => {
+    const output = formatOneShotResult(baseResult, { json: true });
+    expect(Object.keys(JSON.parse(output))).toEqual([
+      "ok",
+      "answer",
+      "costUSD",
+      "tokenUsage",
+      "toolCalls",
+    ]);
+  });
 });
 
 describe("isReasoningEffortFlag", () => {

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -3,9 +3,15 @@ import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
 import { AgentNotFoundError } from "@/core/types/errors";
+import type { ChatMessage } from "@/core/types/message";
 import type { StreamEvent } from "@/core/types/streaming";
 import type { AutoApprovePolicy } from "@/core/types/tools";
 import { CommonSuggestions, getErrorMessage } from "@/core/utils/error-handler";
+import {
+  loadConversation,
+  saveConversation,
+  type ConversationRecord,
+} from "@/services/history/conversation-history-service";
 
 /**
  * One-shot, non-interactive agent invocation — designed to be driven from
@@ -17,6 +23,11 @@ import { CommonSuggestions, getErrorMessage } from "@/core/utils/error-handler";
  * (status notices, tool chatter, the `◉ Agent:` header, the `✔ completed`
  * footer) is routed to stderr so stdout carries only the answer (plain mode)
  * or exactly one JSON object (`--json`).
+ *
+ * With `--conversation <id>` the run gains memory: prior history stored under
+ * the caller-supplied key is loaded before the run and the updated transcript
+ * is saved back after, so a webhook bridge that passes its chat id gets
+ * per-chat context across invocations without storing anything itself.
  */
 
 export interface OneShotTokenUsage {
@@ -95,6 +106,50 @@ export interface RunAgentOnceOptions {
   readonly timeoutMs?: number | undefined;
   readonly maxIterations?: number | undefined;
   readonly eventTypes?: ReadonlySet<StreamEvent["type"]> | undefined;
+  /**
+   * Caller-supplied stable conversation key (e.g. a Telegram chat id). When
+   * set, prior history for this conversation is loaded before the run and the
+   * updated transcript is saved back after — giving stateless webhook bridges
+   * per-chat memory across invocations. Absent = one-shot (no persistence).
+   */
+  readonly conversationId?: string | undefined;
+}
+
+/**
+ * Build the conversation record to persist after a `--conversation` run.
+ *
+ * Prefers the runner's full message transcript (which includes tool calls and
+ * the system message — the prompt builder filters system messages back out on
+ * the next load). Falls back to appending the user/assistant pair to the prior
+ * transcript when the runner returned no messages array.
+ */
+export function buildConversationRecord(params: {
+  readonly agentId: string;
+  readonly conversationId: string;
+  readonly prompt: string;
+  readonly priorRecord: ConversationRecord | null;
+  readonly responseContent: string;
+  readonly responseMessages: ChatMessage[] | undefined;
+  readonly now: string;
+}): ConversationRecord {
+  const messages: ChatMessage[] =
+    params.responseMessages && params.responseMessages.length > 0
+      ? params.responseMessages
+      : [
+          ...(params.priorRecord?.messages ?? []),
+          { role: "user", content: params.prompt },
+          { role: "assistant", content: params.responseContent },
+        ];
+
+  return {
+    conversationId: params.conversationId,
+    title: params.priorRecord?.title ?? params.prompt.trim().slice(0, 80),
+    agentId: params.agentId,
+    startedAt: params.priorRecord?.startedAt ?? params.now,
+    endedAt: params.now,
+    messageCount: messages.length,
+    messages,
+  };
 }
 
 const EVENT_CATEGORY_TYPES = {
@@ -232,13 +287,22 @@ export function runAgentOnceCommand(
         ? { ...agent, config: { ...agent.config, reasoningEffort: options.reasoningEffort } }
         : agent;
 
+    const conversationKey = options.conversationId?.trim();
+    if (conversationKey !== undefined && conversationKey.length === 0) {
+      return yield* failOneShot("Invalid --conversation id: must be non-empty.", outputOptions);
+    }
+
+    const priorRecord =
+      conversationKey !== undefined ? yield* loadConversation(agent.id, conversationKey) : null;
+
     const autoApprovePolicy: AutoApprovePolicy | undefined = options.approvalPolicy;
     const runId = `run-${agent.id}-${Date.now()}`;
     const runEffect = AgentRunner.run({
       agent: agentForRun,
       userInput: prompt,
       sessionId: runId,
-      conversationId: runId,
+      conversationId: conversationKey ?? runId,
+      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
     });
@@ -251,6 +315,29 @@ export function runAgentOnceCommand(
           }),
         )
       : runEffect;
+
+    if (conversationKey !== undefined) {
+      const record = buildConversationRecord({
+        agentId: agent.id,
+        conversationId: conversationKey,
+        prompt,
+        priorRecord,
+        responseContent: runResult.content,
+        responseMessages: runResult.messages,
+        now: new Date().toISOString(),
+      });
+      // A failed save must not discard the answer the run already produced —
+      // warn on stderr (stdout stays the clean payload) and continue.
+      yield* saveConversation(record).pipe(
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            process.stderr.write(
+              `Warning: failed to save conversation "${conversationKey}": ${getErrorMessage(error)}\n`,
+            );
+          }),
+        ),
+      );
+    }
 
     const promptTokens = runResult.usage?.promptTokens ?? 0;
     const completionTokens = runResult.usage?.completionTokens ?? 0;

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -10,8 +10,15 @@ export const TOOL_TIMEOUT_MS = 3 * 60 * 1000;
 /** Maximum number of workflow run history records to keep */
 export const MAX_RUN_HISTORY_RECORDS = 100;
 
-/** Maximum number of conversation history records to keep per agent */
-export const MAX_CONVERSATION_HISTORY_PER_AGENT = 5;
+/**
+ * Maximum number of conversation history records to keep per agent.
+ *
+ * Saves are LRU (an updated conversation moves to the front), so this bounds
+ * how many distinct conversations an agent can remember. Headless bridges
+ * (`jazz run --conversation`) keep one conversation per external chat, so the
+ * cap must comfortably exceed the number of concurrently active chats.
+ */
+export const MAX_CONVERSATION_HISTORY_PER_AGENT = 100;
 
 /** Default maximum age for workflow catch-up runs in seconds (24 hours) */
 export const DEFAULT_MAX_CATCH_UP_AGE_SECONDS = 60 * 60 * 24;

--- a/src/services/history/conversation-history-service.test.ts
+++ b/src/services/history/conversation-history-service.test.ts
@@ -4,9 +4,11 @@ import * as path from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Effect } from "effect";
+import { MAX_CONVERSATION_HISTORY_PER_AGENT } from "@/core/constants/agent";
 import type { ChatMessage } from "@/core/types/message";
 import {
   saveConversation,
+  loadConversation,
   loadHistory,
   type ConversationRecord,
 } from "./conversation-history-service";
@@ -67,13 +69,39 @@ describe("saveConversation", () => {
     expect(conversations[1].conversationId).toBe("conv-1");
   });
 
-  test("evicts oldest when count exceeds 5", async () => {
-    for (let i = 1; i <= 6; i++) {
+  test("evicts oldest when count exceeds the cap", async () => {
+    for (let i = 1; i <= MAX_CONVERSATION_HISTORY_PER_AGENT + 1; i++) {
       await runEffect(saveConversation(makeRecord({ conversationId: `conv-${i}` }), tmpDir));
     }
     const { conversations } = await runEffect(loadHistory("agent-1", tmpDir));
-    expect(conversations).toHaveLength(5);
+    expect(conversations).toHaveLength(MAX_CONVERSATION_HISTORY_PER_AGENT);
     expect(conversations.map((c) => c.conversationId)).not.toContain("conv-1");
+  });
+
+  test("saving an existing conversationId upserts and moves it to the front", async () => {
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-1" }), tmpDir));
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-2" }), tmpDir));
+    await runEffect(
+      saveConversation(makeRecord({ conversationId: "conv-1", title: "Updated" }), tmpDir),
+    );
+    const { conversations } = await runEffect(loadHistory("agent-1", tmpDir));
+    expect(conversations.map((c) => c.conversationId)).toEqual(["conv-1", "conv-2"]);
+    expect(conversations[0].title).toBe("Updated");
+  });
+});
+
+describe("loadConversation", () => {
+  test("returns the record matching the conversationId", async () => {
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-1" }), tmpDir));
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-2" }), tmpDir));
+    const record = await runEffect(loadConversation("agent-1", "conv-1", tmpDir));
+    expect(record?.conversationId).toBe("conv-1");
+  });
+
+  test("returns null when the conversation does not exist", async () => {
+    await runEffect(saveConversation(makeRecord({ conversationId: "conv-1" }), tmpDir));
+    expect(await runEffect(loadConversation("agent-1", "conv-9", tmpDir))).toBeNull();
+    expect(await runEffect(loadConversation("no-such-agent", "conv-1", tmpDir))).toBeNull();
   });
 });
 

--- a/src/services/history/conversation-history-service.ts
+++ b/src/services/history/conversation-history-service.ts
@@ -153,10 +153,12 @@ export function saveConversation(
       dir,
       Effect.gen(function* () {
         const history = yield* readHistory(record.agentId, dir);
-        const updated = [record, ...history.conversations].slice(
-          0,
-          MAX_CONVERSATION_HISTORY_PER_AGENT,
+        // Upsert by conversationId: saving an existing conversation replaces
+        // its record and moves it to the front (LRU), instead of duplicating.
+        const others = history.conversations.filter(
+          (conversation) => conversation.conversationId !== record.conversationId,
         );
+        const updated = [record, ...others].slice(0, MAX_CONVERSATION_HISTORY_PER_AGENT);
         yield* writeHistory({ agentId: record.agentId, conversations: updated }, dir);
       }),
     );
@@ -168,4 +170,19 @@ export function loadHistory(
   dir?: string,
 ): Effect.Effect<AgentConversationHistory, Error, FileSystem.FileSystem> {
   return readHistory(agentId, dir);
+}
+
+export function loadConversation(
+  agentId: string,
+  conversationId: string,
+  dir?: string,
+): Effect.Effect<ConversationRecord | null, Error, FileSystem.FileSystem> {
+  return readHistory(agentId, dir).pipe(
+    Effect.map(
+      (history) =>
+        history.conversations.find(
+          (conversation) => conversation.conversationId === conversationId,
+        ) ?? null,
+    ),
+  );
 }


### PR DESCRIPTION
## What changes for users

`jazz run` gains an optional `--conversation <id>` flag. When a caller passes a stable key (e.g. a Telegram chat id), prior history stored under that key is loaded before the run and the updated transcript is saved back after — so repeated invocations share memory:

```bash
jazz run --agent support --conversation "tg-${CHAT_ID}" --json "$text"
```

This is the missing piece for headless webhook bridges (Telegram/WhatsApp/Slack calling `jazz run` per incoming message): previously every invocation minted a fresh conversation id, so bridges had no memory and had to reconstruct history themselves. The id is caller-minted with upsert semantics — first call creates the conversation, later calls append — so bridges need no state of their own (no create/use handshake, no id mapping table).

**Without the flag, behavior is unchanged** (stateless one-shot, fresh id per run). The `--json` envelope shape is untouched: `ok, answer, costUSD, tokenUsage, toolCalls`.

## Behavioural changes

- `src/cli/commands/run-agent.ts`: when `--conversation` is set, loads the prior `ConversationRecord`, passes its messages as `conversationHistory` to `AgentRunner.run`, and persists the updated transcript after the run (same storage `/resume` reads). A failed save warns on stderr instead of discarding the answer; an empty id fails fast with a clear error.
- `saveConversation` now **upserts** by `conversationId` (replace existing record, move to front) instead of blindly prepending. This also fixes a latent bug where saving a resumed interactive conversation duplicated its record.
- `MAX_CONVERSATION_HISTORY_PER_AGENT` raised 5 → 100. With upsert, saves are LRU; a cap of 5 would evict constantly for any bridge serving more than five chats. Side effect: interactive `/resume` now retains up to 100 conversations per agent.
- New `loadConversation(agentId, conversationId)` helper in the history service.

## Verification

- `bun test`: 1417 pass, 0 fail. New tests cover: fresh id creates a persisted conversation; a second call with the same id sees the prior turn as context; repeated turns upsert a single record; ids stay isolated; runner transcript preferred over append fallback; title/`startedAt` stable across turns; JSON envelope keys locked; history-service upsert + `loadConversation`.
- `bun run typecheck` and `bun run lint` clean.
- Live end-to-end: ran an agent twice with the same `--conversation` id — told it a fact in call one, asked for it in call two, and it recalled the fact; `--json` envelope unchanged.

## Reviewer notes

- Saved records store the runner's full message transcript (including the system message), mirroring what interactive chat persists; the prompt builder filters system messages back out on the next load.
- `sessionId` still gets a fresh run id per invocation — only the conversation identity is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)