### PR TITLE
feat(cli): confirm before agent delete, add --yes/--force

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -236,13 +236,20 @@ function registerAgentCommands(program: Command): void {
     .alias("remove")
     .alias("rm")
     .description("Delete an agent")
-    .action((agentId: string) => {
+    .option("-y, --yes", "Delete without asking for confirmation")
+    .option("-f, --force", "Alias for --yes")
+    .action((agentId: string, options: { yes?: boolean; force?: boolean }) => {
       const opts = program.opts<CliOptions>();
-      runCliEffect(deleteAgentCommand(agentId), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
+      runCliEffect(
+        deleteAgentCommand(agentId, {
+          skipConfirmation: options.yes === true || options.force === true,
+        }),
+        {
+          verbose: opts.verbose,
+          debug: opts.debug,
+          configPath: opts.config,
+        },
+      );
     });
 
   agentCommand

--- a/src/cli/commands/agent-management.test.ts
+++ b/src/cli/commands/agent-management.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it, mock } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Cause, Effect, Exit, Layer, Option } from "effect";
 import { listAgentsCommand, deleteAgentCommand } from "./agent-management";
 import { AgentConfigServiceTag, type AgentConfigService } from "../../core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "../../core/interfaces/agent-service";
 import { CLIOptionsTag, type CLIOptions } from "../../core/interfaces/cli-options";
 import { TerminalServiceTag, type TerminalService } from "../../core/interfaces/terminal";
+import { CLIError } from "../../core/types/errors";
 import { type Agent, type AppConfig } from "../../core/types/index";
+
+const testAgent = {
+  id: "a1",
+  name: "agent1",
+  config: { llmProvider: "anthropic", llmModel: "claude-sonnet-5" },
+} as Agent;
 
 // Mock dependencies
 const mockAgentService = {
@@ -56,20 +63,78 @@ describe("Agent Management Commands", () => {
     expect(mockTerminal.info).toHaveBeenCalledWith(expect.stringContaining("No agents found"));
   });
 
-  it("should delete an agent by identifier", async () => {
-    const agent = { id: "a1", name: "agent1" } as Agent;
+  it("should delete an agent after interactive confirmation", async () => {
     // @ts-expect-error - mocking
-    mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(agent));
+    mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(testAgent));
     // @ts-expect-error - mocking
     mockAgentService.deleteAgent.mockReturnValueOnce(Effect.void);
+    // @ts-expect-error - mocking
+    mockTerminal.confirm.mockReturnValueOnce(Effect.succeed(true));
 
-    const program = deleteAgentCommand("agent1");
+    const program = deleteAgentCommand("agent1", { interactive: true });
     const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
     await Effect.runPromise(runnable);
 
+    expect(mockTerminal.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('Delete agent "agent1" (anthropic/claude-sonnet-5)?'),
+      false,
+    );
     expect(mockAgentService.deleteAgent).toHaveBeenCalledWith("a1");
     expect(mockTerminal.success).toHaveBeenCalledWith(
       expect.stringContaining("deleted successfully"),
     );
+  });
+
+  it("should not delete when confirmation is declined", async () => {
+    // @ts-expect-error - mocking
+    mockAgentService.deleteAgent.mockClear();
+    // @ts-expect-error - mocking
+    mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(testAgent));
+    // @ts-expect-error - mocking
+    mockTerminal.confirm.mockReturnValueOnce(Effect.succeed(false));
+
+    const program = deleteAgentCommand("agent1", { interactive: true });
+    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+    await Effect.runPromise(runnable);
+
+    expect(mockAgentService.deleteAgent).not.toHaveBeenCalled();
+    expect(mockTerminal.info).toHaveBeenCalledWith(expect.stringContaining("cancelled"));
+  });
+
+  it("should delete without prompting when skipConfirmation is set", async () => {
+    // @ts-expect-error - mocking
+    mockTerminal.confirm.mockClear();
+    // @ts-expect-error - mocking
+    mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(testAgent));
+    // @ts-expect-error - mocking
+    mockAgentService.deleteAgent.mockReturnValueOnce(Effect.void);
+
+    const program = deleteAgentCommand("agent1", { skipConfirmation: true, interactive: false });
+    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+    await Effect.runPromise(runnable);
+
+    expect(mockTerminal.confirm).not.toHaveBeenCalled();
+    expect(mockAgentService.deleteAgent).toHaveBeenCalledWith("a1");
+  });
+
+  it("should fail with CLIError in non-interactive sessions without --yes", async () => {
+    // @ts-expect-error - mocking
+    mockAgentService.deleteAgent.mockClear();
+    // @ts-expect-error - mocking
+    mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(testAgent));
+
+    const program = deleteAgentCommand("agent1", { interactive: false });
+    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+    const exit = await Effect.runPromiseExit(runnable);
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(CLIError);
+      }
+    }
+    expect(mockAgentService.deleteAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/agent-management.test.ts
+++ b/src/cli/commands/agent-management.test.ts
@@ -22,6 +22,7 @@ const mockAgentService = {
 } as unknown as AgentService;
 
 const mockTerminal = {
+  isInteractive: true,
   info: mock(() => Effect.void),
   log: mock(() => Effect.void),
   success: mock(() => Effect.void),
@@ -29,6 +30,11 @@ const mockTerminal = {
   warn: mock(() => Effect.void),
   ask: mock(() => Effect.succeed("")),
   confirm: mock(() => Effect.succeed(true)),
+} as unknown as TerminalService;
+
+const mockPlainTerminal = {
+  ...mockTerminal,
+  isInteractive: false,
 } as unknown as TerminalService;
 
 const mockCLIOptions = {
@@ -71,7 +77,7 @@ describe("Agent Management Commands", () => {
     // @ts-expect-error - mocking
     mockTerminal.confirm.mockReturnValueOnce(Effect.succeed(true));
 
-    const program = deleteAgentCommand("agent1", { interactive: true });
+    const program = deleteAgentCommand("agent1");
     const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
     await Effect.runPromise(runnable);
 
@@ -93,7 +99,7 @@ describe("Agent Management Commands", () => {
     // @ts-expect-error - mocking
     mockTerminal.confirm.mockReturnValueOnce(Effect.succeed(false));
 
-    const program = deleteAgentCommand("agent1", { interactive: true });
+    const program = deleteAgentCommand("agent1");
     const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
     await Effect.runPromise(runnable);
 
@@ -109,7 +115,7 @@ describe("Agent Management Commands", () => {
     // @ts-expect-error - mocking
     mockAgentService.deleteAgent.mockReturnValueOnce(Effect.void);
 
-    const program = deleteAgentCommand("agent1", { skipConfirmation: true, interactive: false });
+    const program = deleteAgentCommand("agent1", { skipConfirmation: true });
     const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
     await Effect.runPromise(runnable);
 
@@ -123,8 +129,18 @@ describe("Agent Management Commands", () => {
     // @ts-expect-error - mocking
     mockAgentService.getAgent.mockReturnValueOnce(Effect.succeed(testAgent));
 
-    const program = deleteAgentCommand("agent1", { interactive: false });
-    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+    const plainLayer = Layer.mergeAll(
+      Layer.succeed(AgentServiceTag, mockAgentService),
+      Layer.succeed(TerminalServiceTag, mockPlainTerminal),
+      Layer.succeed(CLIOptionsTag, mockCLIOptions),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+    );
+    const program = deleteAgentCommand("agent1");
+    const runnable = program.pipe(Effect.provide(plainLayer)) as Effect.Effect<
+      void,
+      unknown,
+      never
+    >;
     const exit = await Effect.runPromiseExit(runnable);
 
     expect(Exit.isFailure(exit)).toBe(true);

--- a/src/cli/commands/agent-management.ts
+++ b/src/cli/commands/agent-management.ts
@@ -209,7 +209,6 @@ export function listAgentsCommand(): Effect.Effect<
  * @param agentIdentifier - The agent ID or name to delete
  * @param options - Deletion options
  * @param options.skipConfirmation - Delete without prompting (for `--yes`/`--force`)
- * @param options.interactive - Override TTY detection (used by tests)
  * @returns An Effect that resolves when the agent is deleted successfully
  *
  * @throws {StorageError} When there's an error accessing storage
@@ -221,7 +220,6 @@ export function deleteAgentCommand(
   agentIdentifier: string,
   options: {
     readonly skipConfirmation?: boolean;
-    readonly interactive?: boolean;
   } = {},
 ): Effect.Effect<
   void,
@@ -236,12 +234,10 @@ export function deleteAgentCommand(
     const agent = yield* getAgentByIdentifier(agentIdentifier);
 
     if (options.skipConfirmation !== true) {
-      const interactive =
-        options.interactive ?? (process.stdout.isTTY === true && process.stdin.isTTY === true);
-
-      // PlainTerminalService.confirm resolves to the default (false) without
-      // asking, which would silently abort — require an explicit --yes instead.
-      if (!interactive) {
+      // A non-interactive terminal (non-TTY, quiet mode, JAZZ_NO_TUI) resolves
+      // confirm() with the default (false) without asking, which would silently
+      // abort — require an explicit --yes instead.
+      if (terminal.isInteractive !== true) {
         return yield* Effect.fail(
           new CLIError({
             command: "agent delete",

--- a/src/cli/commands/agent-management.ts
+++ b/src/cli/commands/agent-management.ts
@@ -14,7 +14,7 @@ import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interface
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { CLIOptionsTag, type CLIOptions } from "@/core/interfaces/cli-options";
 import { ink, TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
-import { StorageError, StorageNotFoundError } from "@/core/types/errors";
+import { CLIError, StorageError, StorageNotFoundError } from "@/core/types/errors";
 import { sortAgents } from "@/core/utils/agent-sort";
 import { formatProviderDisplayName } from "@/core/utils/string";
 import { AgentDetailsCard } from "../ui/AgentDetailsCard";
@@ -206,22 +206,62 @@ export function listAgentsCommand(): Effect.Effect<
  * This operation is irreversible and will permanently delete the agent
  * and all its associated data.
  *
- * @param agentId - The unique identifier of the agent to delete
+ * @param agentIdentifier - The agent ID or name to delete
+ * @param options - Deletion options
+ * @param options.skipConfirmation - Delete without prompting (for `--yes`/`--force`)
+ * @param options.interactive - Override TTY detection (used by tests)
  * @returns An Effect that resolves when the agent is deleted successfully
  *
  * @throws {StorageError} When there's an error accessing storage
  * @throws {StorageNotFoundError} When the agent with the given ID doesn't exist
+ * @throws {CLIError} When confirmation is required but the session is non-interactive
  *
  */
 export function deleteAgentCommand(
   agentIdentifier: string,
-): Effect.Effect<void, StorageError | StorageNotFoundError, AgentService | TerminalService> {
+  options: {
+    readonly skipConfirmation?: boolean;
+    readonly interactive?: boolean;
+  } = {},
+): Effect.Effect<
+  void,
+  StorageError | StorageNotFoundError | CLIError,
+  AgentService | TerminalService
+> {
   return Effect.gen(function* () {
     const agentService = yield* AgentServiceTag;
     const terminal = yield* TerminalServiceTag;
 
     // Resolve identifier (ID first, then fall back to matching by name)
     const agent = yield* getAgentByIdentifier(agentIdentifier);
+
+    if (options.skipConfirmation !== true) {
+      const interactive =
+        options.interactive ?? (process.stdout.isTTY === true && process.stdin.isTTY === true);
+
+      // PlainTerminalService.confirm resolves to the default (false) without
+      // asking, which would silently abort — require an explicit --yes instead.
+      if (!interactive) {
+        return yield* Effect.fail(
+          new CLIError({
+            command: "agent delete",
+            message: `deleting agent "${agent.name}" requires confirmation, but this session is not interactive`,
+            suggestion: "Pass --yes (or --force) to delete without a confirmation prompt.",
+          }),
+        );
+      }
+
+      const model = `${agent.config.llmProvider}/${agent.config.llmModel}`;
+      const confirmed = yield* terminal.confirm(
+        `Delete agent "${agent.name}" (${model})? This cannot be undone.`,
+        false,
+      );
+
+      if (!confirmed) {
+        yield* terminal.info("Deletion cancelled.");
+        return;
+      }
+    }
 
     // Delete the agent
     yield* agentService.deleteAgent(agent.id);

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -247,6 +247,8 @@ export function wizardCommand() {
                 }),
               ),
             );
+            // Pause so the outcome (deleted/cancelled) is visible before the clear
+            yield* terminal.ask("Press Enter to continue...", { hidden: true });
             yield* terminal.clear();
           }
           break;

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -324,6 +324,7 @@ function PromptComponent({
               { label: "Yes", value: true },
               { label: "No", value: false },
             ]}
+            initialIndex={prompt.options?.["defaultValue"] === true ? 0 : 1}
             pageSize={10}
             onSelect={(value) => prompt.resolve(value)}
             onCancel={() => prompt.reject?.()}

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -18,6 +18,14 @@ const G = getGlyphs();
 
 const COMMAND_SUGGESTIONS_PRIORITY = 50;
 
+// Stable reference: an inline literal would retrigger ScrollableSelect's
+// reset-on-options-change effect on every re-render, wiping the user's
+// current selection (e.g. on terminal resize or background output).
+const CONFIRM_OPTIONS = [
+  { label: "Yes", value: true },
+  { label: "No", value: false },
+] as const;
+
 interface CommandSuggestionItemProps {
   command: ChatCommandInfo;
   isSelected: boolean;
@@ -320,10 +328,7 @@ function PromptComponent({
         )}
         {prompt.type === "confirm" && (
           <ScrollableSelect
-            options={[
-              { label: "Yes", value: true },
-              { label: "No", value: false },
-            ]}
+            options={CONFIRM_OPTIONS}
             initialIndex={prompt.options?.["defaultValue"] === true ? 0 : 1}
             pageSize={10}
             onSelect={(value) => prompt.resolve(value)}

--- a/src/cli/ui/components/ScrollableSelect.tsx
+++ b/src/cli/ui/components/ScrollableSelect.tsx
@@ -6,6 +6,7 @@ import type { Choice } from "../types";
 interface ScrollableSelectProps<T = unknown> {
   readonly options: readonly Choice<T>[];
   readonly pageSize?: number;
+  readonly initialIndex?: number;
   readonly onSelect: (value: T) => void;
   readonly onCancel?: () => void;
 }
@@ -18,22 +19,27 @@ interface ScrollableSelectProps<T = unknown> {
 export function ScrollableSelect<T = unknown>({
   options,
   pageSize = 10,
+  initialIndex = 0,
   onSelect,
   onCancel,
 }: ScrollableSelectProps<T>): React.ReactElement {
-  const [cursorIndex, setCursorIndex] = useState(0);
-  const [windowStart, setWindowStart] = useState(0);
-
   const effectivePageSize = Math.max(1, Math.min(pageSize, options.length || 1));
+
+  const clampedInitialIndex = Math.max(0, Math.min(options.length - 1, initialIndex));
+  const initialWindowStart = Math.max(0, clampedInitialIndex - (effectivePageSize - 1));
+
+  const [cursorIndex, setCursorIndex] = useState(clampedInitialIndex);
+  const [windowStart, setWindowStart] = useState(initialWindowStart);
+
   const windowEndExclusive = Math.min(options.length, windowStart + effectivePageSize);
   const hasMoreAbove = windowStart > 0;
   const hasMoreBelow = windowEndExclusive < options.length;
 
   // Reset state when options change (new prompt)
   useEffect(() => {
-    setCursorIndex(0);
-    setWindowStart(0);
-  }, [options]);
+    setCursorIndex(clampedInitialIndex);
+    setWindowStart(initialWindowStart);
+  }, [options, clampedInitialIndex, initialWindowStart]);
 
   function clampCursor(nextIndex: number): number {
     if (options.length === 0) return 0;

--- a/src/core/interfaces/terminal.ts
+++ b/src/core/interfaces/terminal.ts
@@ -33,6 +33,15 @@ export function ink(node: unknown): TerminalInkNode {
  */
 export interface TerminalService {
   /**
+   * Whether this terminal can actually prompt the user for input.
+   *
+   * False for plain/non-TTY terminals whose prompt methods resolve
+   * immediately with defaults instead of asking. Callers gating
+   * destructive actions on a prompt must check this first.
+   */
+  readonly isInteractive?: boolean;
+
+  /**
    * Display an informational message
    */
   readonly info: (message: string) => Effect.Effect<void, never>;

--- a/src/core/interfaces/terminal.ts
+++ b/src/core/interfaces/terminal.ts
@@ -39,7 +39,7 @@ export interface TerminalService {
    * immediately with defaults instead of asking. Callers gating
    * destructive actions on a prompt must check this first.
    */
-  readonly isInteractive?: boolean;
+  readonly isInteractive: boolean;
 
   /**
    * Display an informational message

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -80,6 +80,8 @@ function printUserMessage(message: string): void {
  * Creating a second instance while one is active will throw an error.
  */
 export class InkTerminalService implements TerminalService {
+  readonly isInteractive = true;
+
   private inkInstance: ReturnType<typeof render> | null = null;
 
   constructor() {
@@ -494,6 +496,8 @@ export class InkTerminalService implements TerminalService {
  * Interactive prompts return sensible defaults (empty string, false, first choice).
  */
 export class PlainTerminalService implements TerminalService {
+  readonly isInteractive = false;
+
   private write(message: string): void {
     process.stdout.write(`${message}\n`);
   }


### PR DESCRIPTION
## What this PR delivers

`jazz agent delete` (and its `remove`/`rm` aliases) now asks for confirmation before deleting an agent, instead of deleting immediately. New `-y/--yes` and `-f/--force` flags skip the prompt for scripted use. In sessions that cannot prompt (non-TTY, quiet mode, `JAZZ_NO_TUI`), delete without `--yes` fails with a clear error instead of silently resolving the prompt with a default.

It also fixes the underlying confirm prompt so it honors its default value (previously the Yes/No selector always started on "Yes" regardless of the default passed in).

## Why this matters

Agent deletion is irreversible — the agent and all its associated data are permanently removed. Before this change a typo'd `jazz agent rm <name>` destroyed the agent with no chance to back out.

## How delete behaviour changes

| Path | Change |
|---|---|
| Interactive terminal, no flag | Prompts `Delete agent "name" (provider/model)? This cannot be undone.` with **No** preselected. Declining prints "Deletion cancelled." and deletes nothing. |
| `--yes` / `--force` | Deletes immediately, no prompt — same as the old behaviour. |
| Non-interactive session (non-TTY, quiet, `JAZZ_NO_TUI`), no flag | Fails with a `CLIError` suggesting `--yes`, instead of the prompt silently resolving to its default. Nothing is deleted. |
| Wizard delete flow | After deleting/cancelling, waits for Enter before clearing the screen so the outcome message stays visible. |
| All other agent commands | No behavioural change. |

## Migration — scripts that delete agents

| Old | New |
|---|---|
| `jazz agent delete <id>` in CI/scripts | Add `--yes` (or `--force`) — otherwise the command now exits with an error in non-interactive sessions. |

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| `deleteAgentCommand` | `(agentIdentifier)` | `(agentIdentifier, { skipConfirmation? })`, error channel now includes `CLIError` |
| `TerminalService` | — | optional `isInteractive` flag (`true` on `InkTerminalService`, `false` on `PlainTerminalService`) |
| `ScrollableSelect` | always starts at index 0 | new `initialIndex` prop (clamped, window scrolled into view) |

## Tests

New coverage in `src/cli/commands/agent-management.test.ts`:

- confirm → delete proceeds, with the exact prompt text pinned
- decline → nothing deleted, "cancelled" message shown
- `skipConfirmation` → no prompt, delete proceeds
- non-interactive without `--yes` → fails with `CLIError`, nothing deleted

### Edge cases to verify manually

1. `jazz agent rm <name>` in a real terminal, press Enter on the default — expected: cancelled, agent still listed.
2. `jazz agent delete <name> | cat` (non-TTY) — expected: error suggesting `--yes`, agent untouched.
3. Delete from the wizard — expected: outcome message visible until Enter is pressed.
