### PR TITLE
refactor(config): separate runtime UI state from user config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ data/
 jazz.config.json
 jazz.config.*.json
 
+# Worktrees
+.worktrees/
+
 # AI agents
 CLAUDE.md
 .kiro/

--- a/examples/jazz.config.example.json
+++ b/examples/jazz.config.example.json
@@ -1,53 +1,121 @@
 {
+  "storage": {
+    "type": "file",
+    "path": "~/.jazz"
+  },
+  "logging": {
+    "level": "info",
+    "format": "plain"
+  },
   "llm": {
-    "openai": {
-      "api_key": "sk-openai-..."
+    "ai_gateway": {
+      "api_key": "vck-..."
+    },
+    "alibaba": {
+      "api_key": "sk-..."
     },
     "anthropic": {
       "api_key": "sk-ant-..."
     },
-    "google": {
-      "api_key": "AIza-..."
-    },
-    "mistral": {
-      "api_key": "Mb9hE..."
-    },
-    "xai": {
-      "api_key": "xai-..."
+    "cerebras": {
+      "api_key": "csk-..."
     },
     "deepseek": {
       "api_key": "sk-..."
     },
+    "fireworks": {
+      "api_key": "fw-..."
+    },
+    "google": {
+      "api_key": "AIza-..."
+    },
+    "groq": {
+      "api_key": "gsk_..."
+    },
+    "llamacpp": {
+      "api_key": "",
+      "base_url": "http://localhost:8080/v1"
+    },
+    "minimax": {
+      "api_key": "sk-..."
+    },
+    "mistral": {
+      "api_key": "..."
+    },
+    "moonshotai": {
+      "api_key": "sk-..."
+    },
     "ollama": {
-      "api_key": "ollama-..."
+      "api_key": "",
+      "base_url": "http://localhost:11434/api"
+    },
+    "openai": {
+      "api_key": "sk-..."
     },
     "openrouter": {
       "api_key": "sk-or-v1-..."
+    },
+    "togetherai": {
+      "api_key": "..."
+    },
+    "xai": {
+      "api_key": "xai-..."
     }
   },
-  "google": {
-    "clientId": "1234567890.apps.googleusercontent.com",
-    "clientSecret": "1234567890"
-  },
-  "mcpServers": {
-    "notionMCP": { "enabled": true },
-    "slack": { "enabled": false }
-  },
   "web_search": {
-    "priority_order": ["parallel", "exa", "tivaly"],
-    "parallel": {
-      "api_key": "your-parallel-api-key-here"
+    "provider": "parallel",
+    "brave": {
+      "api_key": "your-brave-api-key-here"
     },
     "exa": {
       "api_key": "your-exa-api-key-here"
     },
-    "tivaly": {
+    "linkup": {
       "api_key": "your-linkup-api-key-here"
+    },
+    "parallel": {
+      "api_key": "your-parallel-api-key-here"
+    },
+    "perplexity": {
+      "api_key": "your-perplexity-api-key-here"
+    },
+    "tavily": {
+      "api_key": "your-tavily-api-key-here"
     }
   },
   "output": {
+    "mode": "hybrid",
+    "colorProfile": "full",
     "showThinking": true,
     "showToolExecution": true,
-    "showMetrics": true
+    "showMetrics": true,
+    "streaming": {
+      "enabled": "auto",
+      "textBufferMs": 50
+    }
+  },
+  "notifications": {
+    "enabled": true,
+    "sound": true
+  },
+  "telemetry": {
+    "enabled": true,
+    "storagePath": "~/.jazz/telemetry",
+    "bufferSize": 100,
+    "flushIntervalMs": 30000,
+    "retentionDays": 90
+  },
+  "maxRetries": 3,
+  "autoApprovedCommands": [
+    "git status",
+    "git diff"
+  ],
+  "mcpServers": {
+    "notionMCP": {
+      "enabled": true
+    },
+    "slack": {
+      "enabled": false
+    }
   }
 }

--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -26,6 +26,7 @@ import { createAgentServiceLayer } from "./services/agent-service";
 import { createChatServiceLayer } from "./services/chat-service";
 import { createConfigLayer } from "./services/config";
 import { createFileSystemContextServiceLayer } from "./services/fs";
+import { createJazzStateServiceLayer } from "./services/jazz-state";
 import { createAISDKServiceLayer } from "./services/llm/ai-sdk-service";
 import { createLoggerLayer, setLogFormat, setLogLevel } from "./services/logger";
 import { createMCPServerManagerLayer } from "./services/mcp/mcp-server-manager";
@@ -99,6 +100,7 @@ export function createAppLayer(config: AppLayerConfig = {}) {
   const { debug, configPath } = config;
   const fileSystemLayer = NodeFileSystem.layer;
   const configLayer = createConfigLayer(debug, configPath).pipe(Layer.provide(fileSystemLayer));
+  const jazzStateLayer = createJazzStateServiceLayer().pipe(Layer.provide(fileSystemLayer));
   const loggerLayer = createLoggerLayer();
 
   const logFormatLayer = Layer.effectDiscard(
@@ -184,6 +186,7 @@ export function createAppLayer(config: AppLayerConfig = {}) {
     logFormatLayer,
     terminalLayer,
     storageLayer,
+    jazzStateLayer,
     llmLayer,
     toolRegistryLayer,
     shellLayer,

--- a/src/cli/commands/agent-management.test.ts
+++ b/src/cli/commands/agent-management.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { listAgentsCommand, deleteAgentCommand } from "./agent-management";
-import { AgentConfigServiceTag, type AgentConfigService } from "../../core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "../../core/interfaces/agent-service";
 import { CLIOptionsTag, type CLIOptions } from "../../core/interfaces/cli-options";
+import { JazzStateServiceTag, type JazzStateService } from "../../core/interfaces/jazz-state";
 import { TerminalServiceTag, type TerminalService } from "../../core/interfaces/terminal";
-import { type Agent, type AppConfig } from "../../core/types/index";
+import { type Agent } from "../../core/types/index";
 
 // Mock dependencies
 const mockAgentService = {
@@ -28,21 +28,19 @@ const mockCLIOptions = {
   verbose: false,
 } as unknown as CLIOptions;
 
-const mockAgentConfigService = {
-  get: () => Effect.succeed(null),
-  getOrElse: (_key: string, fallback: unknown) => Effect.succeed(fallback),
-  getOrFail: () => Effect.fail(new Error("not found")),
-  has: () => Effect.succeed(false),
+const mockJazzStateService = {
+  get: () => Effect.succeed(undefined),
   set: () => Effect.void,
-  appConfig: Effect.succeed({} as AppConfig),
-} as unknown as AgentConfigService;
+  load: () => Effect.succeed({}),
+  persist: () => Effect.void,
+} as unknown as JazzStateService;
 
 describe("Agent Management Commands", () => {
   const testLayer = Layer.mergeAll(
     Layer.succeed(AgentServiceTag, mockAgentService),
     Layer.succeed(TerminalServiceTag, mockTerminal),
     Layer.succeed(CLIOptionsTag, mockCLIOptions),
-    Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+    Layer.succeed(JazzStateServiceTag, mockJazzStateService),
   );
 
   it("should list agents and show info if empty", async () => {

--- a/src/cli/commands/agent-management.ts
+++ b/src/cli/commands/agent-management.ts
@@ -10,9 +10,9 @@ import {
   wrapCommaList,
 } from "@/cli/utils/string-utils";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
-import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { CLIOptionsTag, type CLIOptions } from "@/core/interfaces/cli-options";
+import { JazzStateServiceTag, type JazzStateService } from "@/core/interfaces/jazz-state";
 import { ink, TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import { StorageError, StorageNotFoundError } from "@/core/types/errors";
 import { sortAgents } from "@/core/utils/agent-sort";
@@ -162,7 +162,7 @@ function formatAgentsListBlock(
 export function listAgentsCommand(): Effect.Effect<
   void,
   StorageError,
-  AgentService | TerminalService | CLIOptions | AgentConfigService
+  AgentService | TerminalService | CLIOptions | JazzStateService
 > {
   return Effect.gen(function* () {
     const agentsUnsorted = yield* listAllAgents();
@@ -175,8 +175,8 @@ export function listAgentsCommand(): Effect.Effect<
     }
 
     // Sort with last-used agent first, then alphabetically
-    const configService = yield* AgentConfigServiceTag;
-    const lastUsedAgentId = yield* configService.get("wizard.lastUsedAgentId").pipe(
+    const jazzState = yield* JazzStateServiceTag;
+    const lastUsedAgentId = yield* jazzState.get("wizard.lastUsedAgentId").pipe(
       Effect.map((value) => (typeof value === "string" ? value : null)),
       Effect.catchAll(() => Effect.succeed(null)),
     );

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -3,6 +3,7 @@ import React from "react";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag } from "@/core/interfaces/agent-service";
 import { ChatServiceTag } from "@/core/interfaces/chat-service";
+import { JazzStateServiceTag } from "@/core/interfaces/jazz-state";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/index";
 import type { ChatMessage } from "@/core/types/message";
@@ -50,8 +51,9 @@ export function wizardCommand() {
       // Get all agents for the menu
       const agents = yield* agentService.listAgents();
 
-      // Get last used agent ID from config
-      const lastUsedAgentId = yield* configService.get("wizard.lastUsedAgentId").pipe(
+      // Get last used agent ID from runtime state
+      const jazzState = yield* JazzStateServiceTag;
+      const lastUsedAgentId = yield* jazzState.get("wizard.lastUsedAgentId").pipe(
         Effect.map((value) => (typeof value === "string" ? value : null)),
         Effect.catchAll(() => Effect.succeed(null)),
       );
@@ -124,7 +126,7 @@ export function wizardCommand() {
       switch (selection) {
         case "continue": {
           if (lastUsedAgent) {
-            yield* startChatWithAgent(lastUsedAgent, configService);
+            yield* startChatWithAgent(lastUsedAgent);
             yield* terminal.clear();
           }
           break;
@@ -138,14 +140,14 @@ export function wizardCommand() {
             lastUsedAgentId,
           );
           if (selectedAgent) {
-            yield* startChatWithAgent(selectedAgent, configService);
+            yield* startChatWithAgent(selectedAgent);
             yield* terminal.clear();
           }
           break;
         }
 
         case "resume-conversation": {
-          yield* resumeConversation(agents, terminal, configService);
+          yield* resumeConversation(agents, terminal);
           yield* terminal.clear();
           break;
         }
@@ -186,7 +188,7 @@ export function wizardCommand() {
           );
 
           // Start chat with the newly created agent
-          yield* startChatWithAgent(newest, configService).pipe(
+          yield* startChatWithAgent(newest).pipe(
             Effect.catchAll((error) =>
               Effect.gen(function* () {
                 yield* terminal.error(`Failed to start chat with created agent: ${String(error)}`);
@@ -335,14 +337,14 @@ function selectAgent(
  */
 function startChatWithAgent(
   agent: Agent,
-  configService: AgentConfigService,
   options?: { initialHistory?: ChatMessage[]; initialConversationTitle?: string },
 ) {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
+    const jazzState = yield* JazzStateServiceTag;
 
     // Save as last used agent
-    yield* configService
+    yield* jazzState
       .set("wizard.lastUsedAgentId", agent.id)
       .pipe(Effect.catchAll(() => Effect.void));
 
@@ -374,11 +376,7 @@ function startChatWithAgent(
 /**
  * Load all saved conversations across agents, show a selector, and resume the chosen one
  */
-function resumeConversation(
-  agents: readonly Agent[],
-  terminal: TerminalService,
-  configService: AgentConfigService,
-) {
+function resumeConversation(agents: readonly Agent[], terminal: TerminalService) {
   return Effect.gen(function* () {
     type ConversationEntry = {
       agent: Agent;
@@ -427,7 +425,7 @@ function resumeConversation(
     const selected = entries[Number(selectedIdx)];
     if (!selected) return;
 
-    yield* startChatWithAgent(selected.agent, configService, {
+    yield* startChatWithAgent(selected.agent, {
       initialHistory: selected.messages,
       initialConversationTitle: selected.title,
     });

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -7,6 +7,7 @@ import type { WorkflowService } from "@/core/workflows/workflow-service";
 import { AgentConfigServiceTag } from "./agent-config";
 import type { AgentService } from "./agent-service";
 import type { FileSystemContextService } from "./fs";
+import type { JazzStateService } from "./jazz-state";
 import type { LLMService } from "./llm";
 import type { LoggerService } from "./logger";
 import type { PresentationService } from "./presentation";
@@ -46,6 +47,7 @@ export interface ChatService {
     | FileSystemContextService
     | FileSystem.FileSystem
     | typeof AgentConfigServiceTag
+    | JazzStateService
     | ToolRegistry
     | AgentService
     | LLMService

--- a/src/core/interfaces/jazz-state.ts
+++ b/src/core/interfaces/jazz-state.ts
@@ -1,0 +1,20 @@
+import { Context, Effect } from "effect";
+
+export interface JazzState {
+  readonly wizard?: {
+    readonly lastUsedAgentId?: string;
+  };
+}
+
+export interface JazzStateService {
+  /** Get a value from the runtime state by dot-notation key. */
+  readonly get: <A>(key: string) => Effect.Effect<A | undefined, never>;
+  /** Set a value in the runtime state by dot-notation key. */
+  readonly set: <A>(key: string, value: A) => Effect.Effect<void, never>;
+  /** Load the full runtime state. */
+  readonly load: () => Effect.Effect<JazzState, never>;
+  /** Persist the current runtime state. */
+  readonly persist: () => Effect.Effect<void, never>;
+}
+
+export const JazzStateServiceTag = Context.GenericTag<JazzStateService>("JazzStateService");

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -6,6 +6,7 @@ import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { ChatServiceTag, type ChatService } from "@/core/interfaces/chat-service";
 import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
+import { JazzStateServiceTag, type JazzStateService } from "@/core/interfaces/jazz-state";
 import { type LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { MCPServerManagerTag, type MCPServerManager } from "@/core/interfaces/mcp-server";
@@ -62,6 +63,7 @@ export class ChatServiceImpl implements ChatService {
     | FileSystemContextService
     | FileSystem.FileSystem
     | typeof AgentConfigServiceTag
+    | JazzStateService
     | ToolRegistry
     | AgentService
     | LLMService
@@ -122,6 +124,13 @@ export class ChatServiceImpl implements ChatService {
       if (appConfig.autoApprovedCommands?.length) {
         autoApprovedCommands = [...appConfig.autoApprovedCommands];
       }
+
+      // Load last-used agent from runtime state for sorting /agents and /switch
+      const jazzState = yield* JazzStateServiceTag;
+      const lastUsedAgentId = yield* jazzState.get("wizard.lastUsedAgentId").pipe(
+        Effect.map((value) => (typeof value === "string" ? value : null)),
+        Effect.catchAll(() => Effect.succeed(null)),
+      );
 
       // Register mode switch handler for Shift+Tab toggle
       store.registerModeSwitchHandler((mode) => {
@@ -256,6 +265,7 @@ export class ChatServiceImpl implements ChatService {
               sessionId,
               sessionUsage,
               sessionStartedAt,
+              lastUsedAgentId,
               ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
               ...(autoApprovedCommands.length > 0 ? { autoApprovedCommands } : {}),
               ...(latestConfig.autoApprovedCommands?.length
@@ -601,6 +611,7 @@ export function createChatServiceLayer(): Layer.Layer<
   | FileSystemContextService
   | FileSystem.FileSystem
   | typeof AgentConfigServiceTag
+  | JazzStateService
   | typeof ToolRegistryTag
   | typeof AgentServiceTag
 > {

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Effect, Layer } from "effect";
+import { JazzStateServiceTag, type JazzStateService } from "@/core/interfaces/jazz-state";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/agent";
 import type { ChatMessage } from "@/core/types/message";
@@ -88,7 +89,13 @@ describe("handleSpecialCommand resume", () => {
       TerminalServiceTag,
       mockTerminal as unknown as TerminalService,
     );
-    const testLayer = Layer.merge(terminalLayer, NodeFileSystem.layer);
+    const jazzStateLayer = Layer.succeed(JazzStateServiceTag, {
+      get: () => Effect.succeed(undefined),
+      set: () => Effect.void,
+      load: () => Effect.succeed({}),
+      persist: () => Effect.void,
+    } as unknown as JazzStateService);
+    const testLayer = Layer.mergeAll(terminalLayer, jazzStateLayer, NodeFileSystem.layer);
 
     const context: CommandContext = {
       agent: testAgent,

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -84,10 +84,15 @@ export function handleSpecialCommand(
         return yield* handleToolsCommand(terminal, agent);
 
       case "agents":
-        return yield* handleAgentsCommand(terminal, agent);
+        return yield* handleAgentsCommand(terminal, agent, context.lastUsedAgentId ?? null);
 
       case "switch":
-        return yield* handleSwitchCommand(terminal, agent, command.args);
+        return yield* handleSwitchCommand(
+          terminal,
+          agent,
+          command.args,
+          context.lastUsedAgentId ?? null,
+        );
 
       case "compact":
         return yield* handleCompactCommand(
@@ -377,14 +382,10 @@ function resolveWebSearchProviderLabel(
 function handleAgentsCommand(
   terminal: TerminalService,
   currentAgent: CommandContext["agent"],
-): Effect.Effect<
-  CommandResult,
-  StorageError | StorageNotFoundError,
-  AgentService | AgentConfigService
-> {
+  lastUsedAgentId: string | null,
+): Effect.Effect<CommandResult, StorageError | StorageNotFoundError, AgentService> {
   return Effect.gen(function* () {
     const agentService = yield* AgentServiceTag;
-    const configService = yield* AgentConfigServiceTag;
     const allAgentsUnsorted = yield* agentService.listAgents();
 
     yield* terminal.log(fmt.heading("Available Agents"));
@@ -393,10 +394,6 @@ function handleAgentsCommand(
       yield* terminal.warn("No agents found.");
       yield* terminal.info("Create one with: jazz agent create");
     } else {
-      const lastUsedAgentId = yield* configService.get("wizard.lastUsedAgentId").pipe(
-        Effect.map((value) => (typeof value === "string" ? value : null)),
-        Effect.catchAll(() => Effect.succeed(null)),
-      );
       const allAgents = sortAgents(allAgentsUnsorted, lastUsedAgentId);
 
       for (const ag of allAgents) {
@@ -439,11 +436,8 @@ function handleSwitchCommand(
   terminal: TerminalService,
   currentAgent: CommandContext["agent"],
   args: string[],
-): Effect.Effect<
-  CommandResult,
-  StorageError | StorageNotFoundError | Error,
-  AgentService | AgentConfigService
-> {
+  lastUsedAgentId: string | null,
+): Effect.Effect<CommandResult, StorageError | StorageNotFoundError | Error, AgentService> {
   return Effect.gen(function* () {
     const agentService = yield* AgentServiceTag;
 
@@ -518,11 +512,6 @@ function handleSwitchCommand(
     }
 
     // Sort with last-used agent first, then alphabetically
-    const configService = yield* AgentConfigServiceTag;
-    const lastUsedAgentId = yield* configService.get("wizard.lastUsedAgentId").pipe(
-      Effect.map((value) => (typeof value === "string" ? value : null)),
-      Effect.catchAll(() => Effect.succeed(null)),
-    );
     const allAgents = sortAgents(allAgentsUnsorted, lastUsedAgentId);
 
     // Show interactive prompt with history preservation note

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -85,4 +85,6 @@ export interface CommandContext {
   persistedAutoApprovedCommands?: readonly string[];
   /** Currently auto-approved tool names for this session (for /mode display). */
   autoApprovedTools?: readonly string[];
+  /** ID of the agent most recently chatted with, used to sort /agents and /switch. */
+  lastUsedAgentId?: string | null;
 }

--- a/src/services/jazz-state.test.ts
+++ b/src/services/jazz-state.test.ts
@@ -1,0 +1,66 @@
+import { FileSystem } from "@effect/platform";
+import { describe, expect, it, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import { JazzStateServiceTag } from "@/core/interfaces/jazz-state";
+import { createJazzStateServiceLayer } from "./jazz-state";
+
+const mockFS = {
+  exists: mock(() => Effect.succeed(false)),
+  makeDirectory: mock(() => Effect.void),
+  readFileString: mock(() => Effect.succeed("{}")),
+  writeFileString: mock(() => Effect.void),
+} as unknown as FileSystem.FileSystem;
+
+const createService = () =>
+  createJazzStateServiceLayer().pipe(Layer.provide(Layer.succeed(FileSystem.FileSystem, mockFS)));
+
+describe("JazzStateService", () => {
+  it("returns undefined for missing keys", async () => {
+    const layer = createService();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* JazzStateServiceTag;
+        return yield* state.get("wizard.lastUsedAgentId");
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("sets and persists a value", async () => {
+    const layer = createService();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* JazzStateServiceTag;
+        yield* state.set("wizard.lastUsedAgentId", "agent-123");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(mockFS.writeFileString).toHaveBeenCalled();
+    const written = (mockFS.writeFileString as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0][1];
+    expect(written).toContain("agent-123");
+  });
+
+  it("loads previously persisted state", async () => {
+    const fs = {
+      ...mockFS,
+      exists: mock(() => Effect.succeed(true)),
+      readFileString: mock(() =>
+        Effect.succeed(JSON.stringify({ wizard: { lastUsedAgentId: "agent-456" } })),
+      ),
+    } as unknown as FileSystem.FileSystem;
+
+    const layer = createJazzStateServiceLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, fs)),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* JazzStateServiceTag;
+        return yield* state.get("wizard.lastUsedAgentId");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result).toBe("agent-456");
+  });
+});

--- a/src/services/jazz-state.test.ts
+++ b/src/services/jazz-state.test.ts
@@ -1,20 +1,32 @@
 import { FileSystem } from "@effect/platform";
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { JazzStateServiceTag } from "@/core/interfaces/jazz-state";
 import { createJazzStateServiceLayer } from "./jazz-state";
 
+const existsMock = mock(() => Effect.succeed(false));
+const makeDirectoryMock = mock(() => Effect.void);
+const readFileStringMock = mock(() => Effect.succeed("{}"));
+const writeFileStringMock = mock(() => Effect.void);
+
 const mockFS = {
-  exists: mock(() => Effect.succeed(false)),
-  makeDirectory: mock(() => Effect.void),
-  readFileString: mock(() => Effect.succeed("{}")),
-  writeFileString: mock(() => Effect.void),
+  exists: existsMock,
+  makeDirectory: makeDirectoryMock,
+  readFileString: readFileStringMock,
+  writeFileString: writeFileStringMock,
 } as unknown as FileSystem.FileSystem;
 
 const createService = () =>
   createJazzStateServiceLayer().pipe(Layer.provide(Layer.succeed(FileSystem.FileSystem, mockFS)));
 
 describe("JazzStateService", () => {
+  beforeEach(() => {
+    existsMock.mockClear();
+    makeDirectoryMock.mockClear();
+    readFileStringMock.mockClear();
+    writeFileStringMock.mockClear();
+  });
+
   it("returns undefined for missing keys", async () => {
     const layer = createService();
     const result = await Effect.runPromise(
@@ -35,8 +47,8 @@ describe("JazzStateService", () => {
       }).pipe(Effect.provide(layer)),
     );
 
-    expect(mockFS.writeFileString).toHaveBeenCalled();
-    const written = (mockFS.writeFileString as unknown as { mock: { calls: unknown[][] } }).mock
+    expect(writeFileStringMock).toHaveBeenCalled();
+    const written = (writeFileStringMock as unknown as { mock: { calls: unknown[][] } }).mock
       .calls[0][1];
     expect(written).toContain("agent-123");
   });
@@ -62,5 +74,40 @@ describe("JazzStateService", () => {
     );
 
     expect(result).toBe("agent-456");
+  });
+
+  it("falls back to empty state when persisted file is a JSON array", async () => {
+    const fs = {
+      ...mockFS,
+      exists: mock(() => Effect.succeed(true)),
+      readFileString: mock(() => Effect.succeed("[]")),
+    } as unknown as FileSystem.FileSystem;
+
+    const layer = createJazzStateServiceLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, fs)),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* JazzStateServiceTag;
+        yield* state.set("wizard.lastUsedAgentId", "agent-789");
+        return yield* state.get("wizard.lastUsedAgentId");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result).toBe("agent-789");
+  });
+
+  it("ignores prototype-pollution paths", async () => {
+    const layer = createService();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* JazzStateServiceTag;
+        yield* state.set("__proto__.polluted", true);
+        yield* state.set("constructor.prototype.polluted", true);
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
   });
 });

--- a/src/services/jazz-state.ts
+++ b/src/services/jazz-state.ts
@@ -42,7 +42,12 @@ export function createJazzStateServiceLayer(): Layer.Layer<
             .readFileString(statePath)
             .pipe(Effect.catchAll(() => Effect.succeed("{}")));
           const parsed = safeParseJson<JazzState>(content);
-          if (parsed._tag === "Some" && parsed.value && typeof parsed.value === "object") {
+          if (
+            parsed._tag === "Some" &&
+            parsed.value &&
+            typeof parsed.value === "object" &&
+            !Array.isArray(parsed.value)
+          ) {
             state = parsed.value;
           } else {
             state = {};
@@ -79,10 +84,15 @@ export function createJazzStateServiceLayer(): Layer.Layer<
   );
 }
 
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 function deepGet(obj: Record<string, unknown>, path: string): unknown {
   const parts = path.split(".").filter(Boolean);
   let current: unknown = obj;
   for (const part of parts) {
+    if (FORBIDDEN_KEYS.has(part)) {
+      return undefined;
+    }
     if (current && typeof current === "object" && part in (current as Record<string, unknown>)) {
       current = (current as Record<string, unknown>)[part];
     } else {
@@ -97,6 +107,9 @@ function deepSet(obj: Record<string, unknown>, path: string, value: unknown): vo
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length; i++) {
     const key = parts[i] as string;
+    if (FORBIDDEN_KEYS.has(key)) {
+      return;
+    }
     if (i === parts.length - 1) {
       current[key] = value;
     } else {

--- a/src/services/jazz-state.ts
+++ b/src/services/jazz-state.ts
@@ -1,0 +1,110 @@
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import {
+  JazzStateServiceTag,
+  type JazzState,
+  type JazzStateService,
+} from "@/core/interfaces/jazz-state";
+import { safeParseJson } from "@/core/utils/json";
+import { getJazzHomeDirectory } from "@/core/utils/runtime-detection";
+
+export function createJazzStateServiceLayer(): Layer.Layer<
+  JazzStateService,
+  never,
+  FileSystem.FileSystem
+> {
+  return Layer.effect(
+    JazzStateServiceTag,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const statePath = `${getJazzHomeDirectory()}/state.json`;
+      let state: JazzState = {};
+
+      function ensureStateDir(): Effect.Effect<void, never> {
+        return Effect.gen(function* () {
+          const dir = statePath.substring(0, statePath.lastIndexOf("/"));
+          yield* fs
+            .makeDirectory(dir, { recursive: true })
+            .pipe(Effect.catchAll(() => Effect.void));
+        });
+      }
+
+      function loadState(): Effect.Effect<void, never> {
+        return Effect.gen(function* () {
+          const exists = yield* fs
+            .exists(statePath)
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (!exists) {
+            state = {};
+            return;
+          }
+          const content = yield* fs
+            .readFileString(statePath)
+            .pipe(Effect.catchAll(() => Effect.succeed("{}")));
+          const parsed = safeParseJson<JazzState>(content);
+          if (parsed._tag === "Some" && parsed.value && typeof parsed.value === "object") {
+            state = parsed.value;
+          } else {
+            state = {};
+          }
+        });
+      }
+
+      yield* loadState();
+
+      return {
+        get: <A>(key: string): Effect.Effect<A | undefined, never> =>
+          Effect.sync(() => deepGet(state as Record<string, unknown>, key) as A | undefined),
+
+        set: <A>(key: string, value: A): Effect.Effect<void, never> =>
+          Effect.gen(function* () {
+            deepSet(state as Record<string, unknown>, key, value);
+            yield* ensureStateDir();
+            yield* fs
+              .writeFileString(statePath, JSON.stringify(state, null, 2))
+              .pipe(Effect.catchAll(() => Effect.void));
+          }),
+
+        load: (): Effect.Effect<JazzState, never> => Effect.sync(() => state),
+
+        persist: (): Effect.Effect<void, never> =>
+          Effect.gen(function* () {
+            yield* ensureStateDir();
+            yield* fs
+              .writeFileString(statePath, JSON.stringify(state, null, 2))
+              .pipe(Effect.catchAll(() => Effect.void));
+          }),
+      };
+    }),
+  );
+}
+
+function deepGet(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".").filter(Boolean);
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current && typeof current === "object" && part in (current as Record<string, unknown>)) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function deepSet(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split(".").filter(Boolean);
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length; i++) {
+    const key = parts[i] as string;
+    if (i === parts.length - 1) {
+      current[key] = value;
+    } else {
+      const next = current[key];
+      if (!next || typeof next !== "object") {
+        current[key] = {};
+      }
+      current = current[key] as Record<string, unknown>;
+    }
+  }
+}


### PR DESCRIPTION
## What this PR delivers

This PR separates runtime UI state from user-facing configuration in Jazz. It introduces a new `JazzStateService` that persists transient UI metadata (starting with `wizard.lastUsedAgentId`) to a dedicated `~/.jazz/state.json` file, while `~/.jazz/config.json` remains strictly for user-editable settings.

Alongside the state service, the PR updates the wizard, the `jazz agent list` command, and the chat `/agents` and `/switch` commands to read and write the last-used agent through `JazzStateService`. It also refreshes `examples/jazz.config.example.json` to remove the now-obsolete `wizard` block and fix a few stale provider fields (`tivaly` → `tavily`, `priority_order` → `provider`, missing LLM providers, etc.).

## Why this matters

For operators, this keeps configuration files small and stable: API keys, MCP overrides, and logging settings no longer sit next to a field that the CLI mutates on every chat session. That makes `~/.jazz/config.json` easier to version-control, share, or inspect without noisy runtime diffs.

For maintainers, the split creates a clear boundary: `AgentConfigService` owns user config, `JazzStateService` owns runtime UI state. Future transient UI data (recent conversations, last-used providers, onboarding flags) has a natural home instead of leaking into the config service.

## How Jazz config/state behaviour changes

| Code path | Change |
|---|---|
| Wizard menu (`jazz` with no args) | Reads `wizard.lastUsedAgentId` from `JazzStateService` instead of config. |
| Starting a chat | Writes `wizard.lastUsedAgentId` to `~/.jazz/state.json` instead of `~/.jazz/config.json`. |
| `jazz agent list` | Sorts by last-used agent via `JazzStateService`. |
| Chat `/agents` and `/switch` | Receive `lastUsedAgentId` through `CommandContext`; no direct state service access. |
| `~/.jazz/config.json` | No longer written to by the last-used-agent flow. Existing `wizard` keys are ignored. |
| `~/.jazz/state.json` | Created on first state write; stores runtime UI state going forward. |

## UX changes operators will notice

- `~/.jazz/config.json` will no longer contain a `wizard.lastUsedAgentId` field after the next chat or agent selection.
- A new `~/.jazz/state.json` file will appear next to the config file.
- The example config file no longer shows a `wizard` block, reducing confusion about what is user-configurable.

## Migration — config changes required

| Old | New |
|---|---|
| `wizard.lastUsedAgentId` in `~/.jazz/config.json` | Automatically migrated to `~/.jazz/state.json` on first use. No manual action required. |
| `examples/jazz.config.example.json` `wizard` block | Removed from the example. Users can delete the `wizard` block from their own config if they have one. |

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| Runtime UI state | `AgentConfigService` + `config.json` | `JazzStateService` + `~/.jazz/state.json` |
| Service layer | n/a | `createJazzStateServiceLayer()` available in `src/services/jazz-state.ts` |
| Command context | `CommandContext` without last-used state | `CommandContext.lastUsedAgentId?: string \| null` |
| Chat service requirements | `typeof AgentConfigServiceTag` | `typeof AgentConfigServiceTag` + `JazzStateService` |
| App layer | config + chat layers | config + jazz state + chat layers |

## Tests

- Full suite passes: `bun test`, `bun run typecheck`, `bun run lint`, `bun run build`.
- New canonical pin: `src/services/jazz-state.test.ts` covers `get`, `set`, and loading persisted state.
- Updated pins: `src/cli/commands/agent-management.test.ts` and `src/services/chat/commands/handler.test.ts` now provide `JazzStateService` in their test layers.

### Edge cases to verify in a staging session

1. Fresh install with no `~/.jazz/state.json` — expected: the file is created and the last-used agent is saved and surfaced in the wizard menu.
2. Delete `~/.jazz/state.json` mid-session — expected: commands continue to work; the file is recreated on the next write.
3. Existing `~/.jazz/config.json` with a `wizard` block — expected: the block is silently ignored; no startup errors or config migration prompts.

## Notes for reviewers

- `JazzStateService` is intentionally minimal (`get`, `set`, `load`, `persist`) with dot-notation keys. It is meant to grow alongside runtime UI state, not to replace config.
- The `.worktrees/` directory was added to `.gitignore` to support isolated worktree-based PR workflows.
- The chat command handlers no longer directly depend on `JazzStateService`; `startChatSession` reads the value once and passes it through `CommandContext`. This keeps the command handlers testable and avoids a broad dependency on the new service.
