### PR TITLE
feat(telegram): live progress bubble (thinking + tools), notify on final answer

### DIFF
--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -18,6 +18,7 @@ Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --jso
 - 🔌 **Bring your own model** — OpenAI `gpt-5.4` out of the box, or any provider Jazz supports (including local Ollama, no keys/cost).
 - 🎛️ **Per-person `/model` and `/persona`** — each user picks their own via inline keyboards; choices persist.
 - ♻️ **Auto reasoning** — switching to an Ollama model reads its advertised capabilities and enables/disables thinking so non-thinking models don't error.
+- 📡 **Live progress** — a status bubble updates in real time with what the agent is thinking and which tools it's calling; the final answer lands as a new message, so it pushes a notification.
 - 💬 **Per-chat memory**, ✍️ **Markdown rendering** (with plain-text fallback), 🔒 **allowlist-gated**, 🐳 **one-command Docker deploy**.
 
 ## Requirements

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -26,6 +26,10 @@ const TELEGRAM_SPLIT_LENGTH = 3500;
 const GETUPDATES_TIMEOUT_SECONDS = 30;
 const POLL_ERROR_BACKOFF_MS = 5_000;
 const ALLOWED_UPDATES = ["message", "callback_query"];
+// Telegram rate-limits message edits; don't refresh the progress bubble faster.
+const PROGRESS_MIN_INTERVAL_MS = 2_000;
+const PROGRESS_MAX_TOOLS_SHOWN = 8;
+const PROGRESS_REASONING_CHARS = 180;
 
 type TransportMode = "polling" | "webhook";
 
@@ -340,12 +344,113 @@ async function sendReply(config: BridgeConfig, chatId: number, text: string): Pr
   }
 }
 
+// --- Live progress --------------------------------------------------------
+
+// A subset of Jazz's NDJSON stream events (jazz run --events); other fields ignored.
+interface JazzEvent {
+  readonly type: string;
+  readonly toolName?: string;
+  readonly content?: string;
+}
+
+/** Read a byte stream and invoke onLine for each newline-delimited line. */
+async function streamLines(
+  stream: ReadableStream<Uint8Array>,
+  onLine: (line: string) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      onLine(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+  if (buffer.length > 0) onLine(buffer);
+}
+
+/**
+ * Live-updates one Telegram message ("🤔 Working…") from Jazz stream events:
+ * current thinking, tools being called, and the writing phase. Edits are
+ * throttled and serialized so we never spam or race Telegram's edit API.
+ */
+function createProgressReporter(config: BridgeConfig, chatId: number, messageId: number) {
+  const tools: string[] = [];
+  let reasoning = "";
+  let writing = false;
+  let lastText = "";
+  let lastEditAt = 0;
+  let editing = false;
+
+  const render = (): string => {
+    const lines = ["🤔 <b>Working…</b>"];
+    if (reasoning) lines.push(`💭 ${escapeHtml(reasoning)}`);
+    for (const tool of tools.slice(-PROGRESS_MAX_TOOLS_SHOWN)) {
+      lines.push(`🔧 <code>${escapeHtml(tool)}</code>`);
+    }
+    if (writing) lines.push("✍️ writing the answer…");
+    return lines.join("\n");
+  };
+
+  const edit = async (text: string): Promise<void> => {
+    if (text === lastText || editing) return;
+    editing = true;
+    lastText = text;
+    lastEditAt = Date.now();
+    try {
+      await callTelegram(config, "editMessageText", {
+        chat_id: chatId,
+        message_id: messageId,
+        text,
+        parse_mode: "HTML",
+        link_preview_options: { is_disabled: true },
+      });
+    } finally {
+      editing = false;
+    }
+  };
+
+  return {
+    onEvent(event: JazzEvent): void {
+      switch (event.type) {
+        case "thinking_chunk":
+          if (typeof event.content === "string") {
+            reasoning = (reasoning + event.content)
+              .replace(/\s+/g, " ")
+              .trim()
+              .slice(-PROGRESS_REASONING_CHARS);
+          }
+          break;
+        case "tool_execution_start":
+          if (typeof event.toolName === "string") tools.push(event.toolName);
+          break;
+        case "text_start":
+        case "text_chunk":
+          writing = true;
+          break;
+      }
+      if (Date.now() - lastEditAt >= PROGRESS_MIN_INTERVAL_MS) {
+        void edit(render());
+      }
+    },
+    finish: (summary: string): Promise<void> => edit(summary),
+    toolsUsed: (): string[] => [...new Set(tools)],
+  };
+}
+
 // --- Jazz invocation ------------------------------------------------------
 
 async function runJazz(
   config: BridgeConfig,
   chatId: number,
   prompt: string,
+  onEvent: (event: JazzEvent) => void,
 ): Promise<JazzEnvelope> {
   const child = Bun.spawn(
     [
@@ -353,6 +458,8 @@ async function runJazz(
       "run",
       "--no-tui",
       "--json",
+      "--events",
+      "tools,reasoning,text",
       "--agent",
       agentIdForChat(chatId),
       "--approval-policy",
@@ -367,9 +474,22 @@ async function runJazz(
   );
 
   const timeout = setTimeout(() => child.kill(), config.runTimeoutMs + 15_000);
-  const [stdout, stderr, exitCode] = await Promise.all([
+  const stderrTail: string[] = [];
+  const stderrDone = streamLines(child.stderr, (line) => {
+    if (stderrTail.length < 50) stderrTail.push(line);
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) return;
+    try {
+      const event = JSON.parse(trimmed) as JazzEvent;
+      if (typeof event.type === "string") onEvent(event);
+    } catch {
+      // Non-event stderr line (plain log chatter) — ignore.
+    }
+  });
+
+  const [stdout, , exitCode] = await Promise.all([
     new Response(child.stdout).text(),
-    new Response(child.stderr).text(),
+    stderrDone,
     child.exited,
   ]);
   clearTimeout(timeout);
@@ -381,7 +501,9 @@ async function runJazz(
     .at(-1);
 
   if (lastJsonLine === undefined) {
-    console.error(`Jazz produced no JSON envelope (exit ${exitCode}). stderr:\n${stderr}`);
+    console.error(
+      `Jazz produced no JSON envelope (exit ${exitCode}). stderr:\n${stderrTail.join("\n")}`,
+    );
     return { ok: false, error: "Jazz did not return a response." };
   }
 
@@ -397,10 +519,29 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
   ensureChatAgent(config, chatId);
   await callTelegram(config, "sendChatAction", { chat_id: chatId, action: "typing" });
 
-  const envelope = await runJazz(config, chatId, text);
+  // A live-updated progress bubble. The final answer is sent as a *new* message
+  // so it pushes a notification (edits don't).
+  const sent = (await callTelegram(config, "sendMessage", {
+    chat_id: chatId,
+    text: "🤔 <b>Working…</b>",
+    parse_mode: "HTML",
+  })) as { result?: { message_id?: number } } | undefined;
+  const messageId = sent?.result?.message_id;
+  const reporter =
+    typeof messageId === "number" ? createProgressReporter(config, chatId, messageId) : undefined;
+
+  const envelope = await runJazz(config, chatId, text, (event) => reporter?.onEvent(event));
+
   if (envelope.ok) {
+    const used = reporter?.toolsUsed() ?? [];
+    const summary =
+      used.length > 0
+        ? `✅ <b>Done</b> · ${used.map((tool) => `<code>${escapeHtml(tool)}</code>`).join(" ")}`
+        : "✅ <b>Done</b>";
+    await reporter?.finish(summary);
     await sendReply(config, chatId, envelope.answer);
   } else {
+    await reporter?.finish("⚠️ <b>Failed</b>");
     await sendReply(config, chatId, `⚠️ ${envelope.error}`);
   }
 }

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -361,18 +361,22 @@ async function streamLines(
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    let newlineIndex = buffer.indexOf("\n");
-    while (newlineIndex >= 0) {
-      onLine(buffer.slice(0, newlineIndex));
-      buffer = buffer.slice(newlineIndex + 1);
-      newlineIndex = buffer.indexOf("\n");
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        onLine(buffer.slice(0, newlineIndex));
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf("\n");
+      }
     }
+    if (buffer.length > 0) onLine(buffer);
+  } finally {
+    reader.releaseLock();
   }
-  if (buffer.length > 0) onLine(buffer);
 }
 
 /**

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -12,6 +12,11 @@ AGENT_TEMPLATE="/app/integrations/telegram-bot/agent.telegram.json"
 
 mkdir -p "${JAZZ_HOME}/agents"
 
+# Enable streaming so `jazz run --events` actually emits live-progress events.
+# Without this, non-TTY runs (like this bridge) fall back to batch mode and
+# emit nothing, and the progress bubble would never update.
+printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+
 # Seed / refresh the template agent that per-chat agents are cloned from.
 sed -e "s#__JAZZ_PROVIDER__#${JAZZ_TELEGRAM_PROVIDER}#g" \
     -e "s#__JAZZ_MODEL__#${JAZZ_TELEGRAM_MODEL}#g" \


### PR DESCRIPTION
## What

Adds a **live progress bubble** to the Telegram bridge. Instead of a static "typing…", the bot posts a status message that updates in real time with what the agent is thinking and which tools it's calling, then sends the final answer as a **new message** (so it pushes a notification — edits don't).

## How

- `runJazz` now passes `--events tools,reasoning,text` and **streams** jazz's stderr NDJSON line-by-line, forwarding each event to a `createProgressReporter`.
- The reporter renders a compact bubble (💭 thinking snippet · 🔧 tool calls · ✍️ writing) and `editMessageText`s it, **throttled** (≥2s) and **serialized** (no concurrent/racing edits) to respect Telegram's edit limits.
- On completion it edits the bubble to `✅ Done · <tools used>` and sends the answer as a fresh message.

## The non-obvious bit

`jazz run --events` only emits events when **streaming** is on, and streaming auto-disables for non-TTY processes (exactly how this bridge runs). So the entrypoint writes `JAZZ_HOME/config.json` with `output.streaming.enabled=true` to force it. Verified end-to-end: with that config, a piped `jazz run --events` emits `thinking_*`/`text_*`/`tool_execution_*` NDJSON; without it, stderr is empty.

## Verified

`docker build` OK; bridge typechecks + lint/prettier pass; confirmed events actually stream from a real `jazz run` against local Ollama.
