### PR TITLE
feat(telegram): optional Brave web search via BRAVE_API_KEY

### DIFF
--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -37,6 +37,10 @@ OPENAI_API_KEY=
 # DEEPSEEK_API_KEY=
 # XAI_API_KEY=
 
+# --- Web search (optional) ---
+# Brave Search API key. If set, the agent's web_search tool uses Brave.
+# BRAVE_API_KEY=
+
 # Reasoning effort: disable | low | medium | high. Reasoning-capable models
 # (gpt-5.4, qwen3, …) can use medium/high; models without it (mistral-small,
 # gemma, …) 400 unless this is "disable".

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -79,6 +79,7 @@ run Ollama; cloud users typically just keep the default.)
 | `JAZZ_TELEGRAM_PROVIDER` | `openai` | LLM provider — `openai`, `openrouter`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `ollama`, … |
 | `JAZZ_TELEGRAM_MODEL` | `gpt-5.4` | Default model id for the provider. |
 | `OPENAI_API_KEY` (or provider's key) | — | API key for the chosen provider (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, …). Not needed for `ollama`. |
+| `BRAVE_API_KEY` | — | If set, `web_search` uses Brave (configured as the provider in `config.json`). |
 | `JAZZ_REASONING` | `medium` | `disable`\|`low`\|`medium`\|`high`. |
 | `OLLAMA_BASE_URL` | `http://host.docker.internal:11434/api` | Ollama endpoint (only for `provider=ollama` / `/model`). |
 | `JAZZ_APPROVAL_POLICY` | `low-risk` | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`. |

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -12,10 +12,18 @@ AGENT_TEMPLATE="/app/integrations/telegram-bot/agent.telegram.json"
 
 mkdir -p "${JAZZ_HOME}/agents"
 
-# Enable streaming so `jazz run --events` actually emits live-progress events.
-# Without this, non-TTY runs (like this bridge) fall back to batch mode and
-# emit nothing, and the progress bubble would never update.
-printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+# Write config.json. Streaming is required so `jazz run --events` emits
+# live-progress events (non-TTY runs otherwise fall back to batch mode and emit
+# nothing). When BRAVE_API_KEY is set, also configure Brave as the web_search
+# provider — the key comes from the environment so it's never baked into the image.
+if [ -n "${BRAVE_API_KEY:-}" ]; then
+  cat > "${JAZZ_HOME}/config.json" <<JSON
+{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
+JSON
+  echo "Configured Brave web search"
+else
+  printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+fi
 
 # Seed / refresh the template agent that per-chat agents are cloned from.
 sed -e "s#__JAZZ_PROVIDER__#${JAZZ_TELEGRAM_PROVIDER}#g" \


### PR DESCRIPTION
Sets Brave as the `web_search` provider when `BRAVE_API_KEY` is present.

The entrypoint writes `web_search.provider=brave` + the key into `JAZZ_HOME/config.json` (alongside the streaming flag). The key is read from the environment (`.env`), so it's never committed or baked into the image. Without the var, `config.json` carries only the streaming flag as before.

Verified the generated `config.json` is valid JSON in both the with-key and without-key paths. `.env.example` and the config table document `BRAVE_API_KEY`.