### PR TITLE
feat(run): add --stream/--no-stream (fix --events emitting nothing in non-TTY)

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -98,6 +98,11 @@ function registerRunCommand(program: Command): void {
       "--conversation <id>",
       "Stable conversation key (e.g. a Telegram chat id). Loads prior history for this key before the run and saves the updated transcript after, giving repeated invocations shared memory. Omit for a stateless one-shot run.",
     )
+    .option(
+      "--stream",
+      "Force streaming mode. Required for --events to emit in non-TTY contexts (scripts, webhooks), where streaming is otherwise auto-disabled.",
+    )
+    .option("--no-stream", "Disable streaming mode")
     .action(
       (
         prompt: string | undefined,
@@ -110,6 +115,8 @@ function registerRunCommand(program: Command): void {
           events?: string;
           reasoning?: string;
           conversation?: string;
+          stream?: boolean;
+          noStream?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -170,6 +177,11 @@ function registerRunCommand(program: Command): void {
               : {}),
             ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
             ...(options.conversation !== undefined ? { conversationId: options.conversation } : {}),
+            ...(options.noStream === true
+              ? { stream: false }
+              : options.stream === true
+                ? { stream: true }
+                : {}),
           }),
           {
             verbose: opts.verbose,

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -107,6 +107,11 @@ export interface RunAgentOnceOptions {
   readonly maxIterations?: number | undefined;
   readonly eventTypes?: ReadonlySet<StreamEvent["type"]> | undefined;
   /**
+   * Force streaming on/off. Streaming auto-disables for non-TTY stdout, which
+   * suppresses `--events`; setting this true re-enables it for scripts/webhooks.
+   */
+  readonly stream?: boolean | undefined;
+  /**
    * Caller-supplied stable conversation key (e.g. a Telegram chat id). When
    * set, prior history for this conversation is loaded before the run and the
    * updated transcript is saved back after — giving stateless webhook bridges
@@ -305,6 +310,7 @@ export function runAgentOnceCommand(
       ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
+      ...(options.stream !== undefined ? { stream: options.stream } : {}),
     });
 
     const runResult = yield* options.timeoutMs != null


### PR DESCRIPTION
## Problem

`jazz run --events` emits nothing in non-TTY contexts (scripts, webhook bridges) — exactly its intended use. Streaming auto-disables when stdout isn't a TTY (`shouldEnableStreaming`), and events are only produced on the streaming path. `agent chat` has `--stream` to force it; `run` did not, so `--events` was effectively dead for headless consumers. (The Telegram integration worked around this by writing `output.streaming.enabled=true` into config.json.)

## Change

Expose `--stream`/`--no-stream` on `run` (mirroring `chat`) and thread it through `RunAgentOnceOptions` → `AgentRunner.run` (which already accepts a `stream` override). No behavior change without the flag.

## Verified

- `bun run typecheck` + lint clean; `run-agent.test.ts` (27) pass.
- Manually: `jazz run --stream --events reasoning,text` in a piped/non-TTY shell now emits `thinking_*`/`text_*` NDJSON; without `--stream` it emits nothing (unchanged).

## Follow-up

The Telegram bridge can drop its config.json streaming workaround in favor of `--stream` now. Separately, adding `approval` and `subagent` `--events` categories (new StreamEvent types) is planned in another PR.