### PR TITLE
feat(events): add 'approval' --events category (approval_required/resolved)

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -88,7 +88,7 @@ function registerRunCommand(program: Command): void {
     )
     .option(
       "--events <categories>",
-      "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,all). stdout stays the clean payload.",
+      "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,all). stdout stays the clean payload.",
     )
     .option(
       "--reasoning <effort>",
@@ -516,7 +516,7 @@ function registerWorkflowCommands(program: Command): void {
     )
     .option(
       "--events <categories>",
-      "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,all). stdout stays the clean payload.",
+      "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,all). stdout stays the clean payload.",
     )
     .action(
       (

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -119,6 +119,8 @@ describe("parseEventCategories", () => {
       "stream_start",
       "usage_update",
       "complete",
+      "approval_required",
+      "approval_resolved",
     ];
     expect([...result.types].sort()).toEqual(expected.sort());
   });
@@ -146,7 +148,7 @@ describe("parseEventCategories", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBe(
-      'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, all.',
+      'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, approval, all.',
     );
   });
 

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -162,6 +162,7 @@ const EVENT_CATEGORY_TYPES = {
   reasoning: ["thinking_start", "thinking_chunk", "thinking_complete"],
   text: ["text_start", "text_chunk"],
   usage: ["stream_start", "usage_update", "complete"],
+  approval: ["approval_required", "approval_resolved"],
 } as const satisfies Record<string, readonly StreamEvent["type"][]>;
 
 type EventCategory = keyof typeof EVENT_CATEGORY_TYPES;
@@ -196,7 +197,7 @@ export function parseEventCategories(
     if (!isEventCategory(category)) {
       return {
         ok: false,
-        error: `Invalid --events category "${category}". Expected: tools, reasoning, text, usage, all.`,
+        error: `Invalid --events category "${category}". Expected: tools, reasoning, text, usage, approval, all.`,
       };
     }
     for (const eventType of EVENT_CATEGORY_TYPES[category]) {

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -471,9 +471,11 @@ export function reduceEvent(
       return { activity, outputs };
     }
 
-    // ---- Usage updates (no-op) ------------------------------------------
+    // ---- Usage + approval (no-op for the TUI activity view) -------------
 
     case "usage_update":
+    case "approval_required":
+    case "approval_resolved":
       return { activity: null, outputs };
 
     // ---- Error ----------------------------------------------------------

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -212,6 +212,17 @@ export class ToolExecutor {
 
           const isAutoApproved = checkAutoApproved();
 
+          if (renderer) {
+            yield* renderer.handleEvent({
+              type: "approval_required",
+              toolName: name,
+              riskLevel,
+              ...(autoApprovePolicy !== undefined
+                ? { autoApprovePolicy: String(autoApprovePolicy) }
+                : {}),
+            });
+          }
+
           if (isAutoApproved) {
             yield* logger.info("Tool auto-approved by policy", {
               toolName: name,
@@ -243,6 +254,15 @@ export class ToolExecutor {
                 ...(approvalResult.previewDiff ? { previewDiff: approvalResult.previewDiff } : {}),
                 isAutoApproved: checkAutoApproved,
               });
+
+          if (renderer) {
+            yield* renderer.handleEvent({
+              type: "approval_resolved",
+              toolName: name,
+              approved: outcome.approved,
+              auto: isAutoApproved,
+            });
+          }
 
           if (outcome.approved) {
             // Handle "always approve this command" choice (execute_command only)

--- a/src/core/types/streaming.ts
+++ b/src/core/types/streaming.ts
@@ -83,7 +83,11 @@ export type StreamEvent =
     }
 
   // Usage updates (optional, for real-time token tracking)
-  | { type: "usage_update"; usage: TokenUsage };
+  | { type: "usage_update"; usage: TokenUsage }
+
+  // Tool approval flow (headless consumers can surface gated/declined tools)
+  | { type: "approval_required"; toolName: string; riskLevel?: string; autoApprovePolicy?: string }
+  | { type: "approval_resolved"; toolName: string; approved: boolean; auto: boolean };
 
 export interface StreamingResult {
   readonly stream: Stream.Stream<StreamEvent, LLMError>;


### PR DESCRIPTION
Adds an `approval` category to `jazz run --events`, backed by two new `StreamEvent`s emitted from the tool executor's approval flow:

- `approval_required` — { toolName, riskLevel, autoApprovePolicy } when a tool hits the approval gate.
- `approval_resolved` — { toolName, approved, auto } after the decision.

**Why:** under an auto-decline policy (e.g. `low-risk`), high-risk tools are silently declined — a headless consumer (the Telegram bridge, any `--events` user) had no way to know a tool was gated. Now it can surface "wanted to run X, needs approval".

Also updated the category list in the flag help + error message; the TUI reducer no-ops the new events. (`usage` was already a category — no change needed there.)

## Verified

Typecheck + lint clean; `run-agent.test.ts` (27) pass (updated the 'all' and error-message assertions). Live: `jazz run --stream --events approval` on a shell command at `low-risk` emitted `approval_required(execute_command, high-risk, low-risk)` → `approval_resolved(approved:false)`.

## Follow-up

`subagent` events are the remaining ask; they need an event sink threaded into the executor/tool path (the renderer isn't in the tool context), so I'll do that as a separate PR. The Telegram bridge can then subscribe to `approval`/`usage` for richer progress.