### PR TITLE
feat(events): tool event sink + 'subagent' --events category

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -88,7 +88,7 @@ function registerRunCommand(program: Command): void {
     )
     .option(
       "--events <categories>",
-      "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,all). stdout stays the clean payload.",
+      "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,subagent,all). stdout stays the clean payload.",
     )
     .option(
       "--reasoning <effort>",
@@ -516,7 +516,7 @@ function registerWorkflowCommands(program: Command): void {
     )
     .option(
       "--events <categories>",
-      "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,all). stdout stays the clean payload.",
+      "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,subagent,all). stdout stays the clean payload.",
     )
     .action(
       (

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -121,6 +121,8 @@ describe("parseEventCategories", () => {
       "complete",
       "approval_required",
       "approval_resolved",
+      "subagent_start",
+      "subagent_complete",
     ];
     expect([...result.types].sort()).toEqual(expected.sort());
   });
@@ -148,7 +150,7 @@ describe("parseEventCategories", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBe(
-      'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, approval, all.',
+      'Invalid --events category "bogus". Expected: tools, reasoning, text, usage, approval, subagent, all.',
     );
   });
 

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -163,6 +163,7 @@ const EVENT_CATEGORY_TYPES = {
   text: ["text_start", "text_chunk"],
   usage: ["stream_start", "usage_update", "complete"],
   approval: ["approval_required", "approval_resolved"],
+  subagent: ["subagent_start", "subagent_complete"],
 } as const satisfies Record<string, readonly StreamEvent["type"][]>;
 
 type EventCategory = keyof typeof EVENT_CATEGORY_TYPES;
@@ -197,7 +198,7 @@ export function parseEventCategories(
     if (!isEventCategory(category)) {
       return {
         ok: false,
-        error: `Invalid --events category "${category}". Expected: tools, reasoning, text, usage, approval, all.`,
+        error: `Invalid --events category "${category}". Expected: tools, reasoning, text, usage, approval, subagent, all.`,
       };
     }
     for (const eventType of EVENT_CATEGORY_TYPES[category]) {

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -476,6 +476,8 @@ export function reduceEvent(
     case "usage_update":
     case "approval_required":
     case "approval_resolved":
+    case "subagent_start":
+    case "subagent_complete":
       return { activity: null, outputs };
 
     // ---- Error ----------------------------------------------------------

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -10,6 +10,7 @@ import type { ChatMessage, ConversationMessages } from "@/core/types";
 import type { ChatCompletionResponse } from "@/core/types/chat";
 import { LLMRateLimitError } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
+import type { StreamEvent } from "@/core/types/streaming";
 import { getModelsDevMetadata } from "@/core/utils/models-dev-client";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
 import type { AgentLoopObserver } from "./agent-loop-observer";
@@ -310,6 +311,7 @@ function handleToolPhase(
       state.recentToolCalls.length = 0;
     }
 
+    const toolRenderer = strategy.getRenderer();
     const contextWithTokenStats = {
       ...context,
       tokenStats: {
@@ -328,13 +330,18 @@ function handleToolPhase(
       recordChildCost: (costUSD: number) => {
         runMetrics.childCostUSD += costUSD;
       },
+      // Let tools surface live progress (e.g. spawn_subagent lifecycle) through
+      // the same event stream, when a streaming renderer is present.
+      ...(toolRenderer
+        ? { emitEvent: (event: StreamEvent) => toolRenderer.handleEvent(event) }
+        : {}),
     };
 
     const toolResults = yield* ToolExecutor.executeToolCalls(
       toolCalls,
       contextWithTokenStats,
       displayConfig,
-      strategy.getRenderer(),
+      toolRenderer,
       runMetrics,
       agent.id,
       actualConversationId,

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -142,6 +142,14 @@ Rules:
 TASK:
 ${args.task}`;
 
+          if (context.emitEvent) {
+            yield* context.emitEvent({
+              type: "subagent_start",
+              task: taskPreview,
+              agentName: subagentLabel,
+            });
+          }
+
           const response = yield* AgentRunner.runRecursive({
             agent: subAgent,
             userInput: wrappedTask,
@@ -181,6 +189,10 @@ ${args.task}`;
                   durationMs: Date.now() - startedAt,
                 }),
               ),
+            ),
+            // Bracket the sub-run for --events consumers, whatever the outcome.
+            Effect.ensuring(
+              context.emitEvent ? context.emitEvent({ type: "subagent_complete" }) : Effect.void,
             ),
           );
 

--- a/src/core/types/streaming.ts
+++ b/src/core/types/streaming.ts
@@ -87,7 +87,11 @@ export type StreamEvent =
 
   // Tool approval flow (headless consumers can surface gated/declined tools)
   | { type: "approval_required"; toolName: string; riskLevel?: string; autoApprovePolicy?: string }
-  | { type: "approval_resolved"; toolName: string; approved: boolean; auto: boolean };
+  | { type: "approval_resolved"; toolName: string; approved: boolean; auto: boolean }
+
+  // Sub-agent lifecycle (delegated spawn_subagent runs)
+  | { type: "subagent_start"; task?: string; agentName?: string }
+  | { type: "subagent_complete" };
 
 export interface StreamingResult {
   readonly stream: Stream.Stream<StreamEvent, LLMError>;

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -3,6 +3,7 @@ import type z from "zod";
 import type { ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types/agent";
 import type { ChatMessage } from "@/core/types/message";
+import type { StreamEvent } from "@/core/types/streaming";
 
 // Re-export ToolRiskLevel from tool-registry interface
 export type { ToolRiskLevel } from "@/core/interfaces/tool-registry";
@@ -220,5 +221,13 @@ export interface ToolExecutionContext {
    * The chat service uses this to add the tool to the auto-approved list.
    */
   readonly onAutoApproveTool?: (toolName: string) => void;
+  /**
+   * Emit a live stream event from within a tool — e.g. spawn_subagent emitting
+   * subagent_start/complete, or any long-running tool reporting progress.
+   * Wired to the executor's streaming renderer when one exists; undefined in
+   * non-streaming contexts. Lets tools surface live progress to `--events`
+   * consumers without holding a renderer reference themselves.
+   */
+  readonly emitEvent?: (event: StreamEvent) => Effect.Effect<void, never>;
   readonly [key: string]: unknown;
 }


### PR DESCRIPTION
## What

Adds a **general tool event sink** and a `subagent` `--events` category on top of it.

- **`ToolExecutionContext.emitEvent(event)`** — any tool can now surface live `StreamEvent`s. It's wired in `agent-loop` from `strategy.getRenderer()` (undefined in non-streaming contexts), so tools never hold a renderer reference themselves.
- **`spawn_subagent`** uses it to emit `subagent_start` (task + agent name) before the delegated run and `subagent_complete` via `Effect.ensuring` (fires on success, error, *and* interrupt).
- New `StreamEvent`s `subagent_start`/`subagent_complete`; `subagent` category added to `--events`.

## Why the sink (not a one-off flag)

The alternative — a dedicated `subagentTask` option threaded through the runner — would only serve subagents, and `internal: true` alone can't distinguish subagents from the history-summarizer. The sink is a reusable primitive: the next tool that wants live progress (long fetches, batch ops, custom/MCP tools) just calls `context.emitEvent`, no new plumbing.

## Notes

- Emitted only when a streaming renderer exists — consistent with `--events` requiring streaming (see #288). The TUI reducer no-ops the new events; approval events (#289) stay emitted by the executor directly.

## Verified

`bun run typecheck` + lint clean; `run-agent` + `subagent-tools` tests (28) pass. Live: `jazz run --stream --events subagent` on a forced `spawn_subagent` emitted `subagent_start{task:"what is 5 plus 5", agentName:"Simple Math Researcher"}` → `subagent_complete`, answer correct.
