### PR TITLE
feat(telegram): /new command for a fresh conversation (breakpoints)

### DIFF
--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -62,6 +62,7 @@ Message your bot: it shows a "typing…" indicator, then the agent's reply.
 | _(any message)_ | Answered by your agent |
 | `/model` | Inline keyboard of models pulled in Ollama — pick one (switches you to that local model) |
 | `/persona` | Inline keyboard of available personas |
+| `/new` (`/reset`) | Start a fresh conversation — clears earlier context; keeps your model/persona |
 | `/help` | Usage |
 
 Each Telegram user gets an independent agent (`tg_<chat_id>.json`, cloned from the

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -184,6 +184,38 @@ function ensureChatAgent(config: BridgeConfig, chatId: number): AgentFile {
   return template;
 }
 
+// --- Per-chat conversation sessions ---------------------------------------
+// A DM has one chat id, so history would grow forever. A per-chat "epoch"
+// lets /new rotate to a fresh conversation key (a breakpoint) while the chat's
+// agent — and thus its model/persona — stays put. Old segments remain on disk.
+
+function sessionsPath(config: BridgeConfig): string {
+  return join(config.jazzHome, "tg-sessions.json");
+}
+
+function readSessionEpochs(config: BridgeConfig): Record<string, number> {
+  try {
+    const path = sessionsPath(config);
+    if (!existsSync(path)) return {};
+    return JSON.parse(readFileSync(path, "utf8")) as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+/** Conversation key for the chat's current session (epoch 0 keeps the raw id). */
+function conversationKey(config: BridgeConfig, chatId: number): string {
+  const epoch = readSessionEpochs(config)[String(chatId)] ?? 0;
+  return epoch > 0 ? `${chatId}-${epoch}` : String(chatId);
+}
+
+/** Bump the chat's session epoch so the next run starts a fresh conversation. */
+function startNewConversation(config: BridgeConfig, chatId: number): void {
+  const epochs = readSessionEpochs(config);
+  epochs[String(chatId)] = (epochs[String(chatId)] ?? 0) + 1;
+  writeFileSync(sessionsPath(config), `${JSON.stringify(epochs, null, 2)}\n`);
+}
+
 // --- Ollama model discovery -----------------------------------------------
 
 async function listOllamaModels(config: BridgeConfig): Promise<string[]> {
@@ -492,7 +524,7 @@ async function runJazz(
       "--approval-policy",
       config.approvalPolicy,
       "--conversation",
-      String(chatId),
+      conversationKey(config, chatId),
       "--timeout",
       String(config.runTimeoutMs),
       prompt,
@@ -588,6 +620,7 @@ const HELP_TEXT = [
   "Commands:",
   "/model — pick which Ollama model I use (just for you)",
   "/persona — pick my persona / style",
+  "/new — start a fresh conversation (clears earlier context)",
   "/help — show this",
 ].join("\n");
 
@@ -604,6 +637,16 @@ function keyboardFrom(options: string[], current: string, prefix: string): Inlin
 
 async function handleCommand(config: BridgeConfig, chatId: number, command: string): Promise<void> {
   const agent = ensureChatAgent(config, chatId);
+
+  if (command === "new" || command === "reset") {
+    startNewConversation(config, chatId);
+    await sendReply(
+      config,
+      chatId,
+      "🆕 Fresh conversation — I've cleared the earlier context. Your model and persona stay the same.",
+    );
+    return;
+  }
 
   if (command === "model") {
     const models = await listOllamaModels(config);

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -16,7 +16,14 @@
  * Runs on Bun. All configuration is via environment variables (see .env.example).
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -193,27 +200,44 @@ function sessionsPath(config: BridgeConfig): string {
   return join(config.jazzHome, "tg-sessions.json");
 }
 
-function readSessionEpochs(config: BridgeConfig): Record<string, number> {
+/** Parse the epoch map; returns null when the file is missing or unreadable. */
+function loadSessionEpochs(config: BridgeConfig): Record<string, number> | null {
+  const path = sessionsPath(config);
+  if (!existsSync(path)) return null;
   try {
-    const path = sessionsPath(config);
-    if (!existsSync(path)) return {};
-    return JSON.parse(readFileSync(path, "utf8")) as Record<string, number>;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, number>;
+    }
   } catch {
-    return {};
+    // fall through to null (treated as unreadable)
   }
+  return null;
 }
 
 /** Conversation key for the chat's current session (epoch 0 keeps the raw id). */
 function conversationKey(config: BridgeConfig, chatId: number): string {
-  const epoch = readSessionEpochs(config)[String(chatId)] ?? 0;
+  const epoch = loadSessionEpochs(config)?.[String(chatId)] ?? 0;
   return epoch > 0 ? `${chatId}-${epoch}` : String(chatId);
 }
 
 /** Bump the chat's session epoch so the next run starts a fresh conversation. */
 function startNewConversation(config: BridgeConfig, chatId: number): void {
-  const epochs = readSessionEpochs(config);
-  epochs[String(chatId)] = (epochs[String(chatId)] ?? 0) + 1;
-  writeFileSync(sessionsPath(config), `${JSON.stringify(epochs, null, 2)}\n`);
+  const path = sessionsPath(config);
+  const epochs = loadSessionEpochs(config);
+  if (epochs === null && existsSync(path)) {
+    // File exists but couldn't be parsed — preserve it rather than clobber
+    // every other chat's epoch on the write below.
+    try {
+      renameSync(path, `${path}.corrupt`);
+      console.error(`Corrupt ${path} preserved as ${path}.corrupt`);
+    } catch {
+      // best effort
+    }
+  }
+  const next = epochs ?? {};
+  next[String(chatId)] = (next[String(chatId)] ?? 0) + 1;
+  writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`);
 }
 
 // --- Ollama model discovery -----------------------------------------------


### PR DESCRIPTION
Adds `/new` (alias `/reset`) so a user can start a clean conversation in their DM — Telegram has no threads in DMs, so a command is the way.

- Per-chat **session epoch** stored in `JAZZ_HOME/tg-sessions.json`; `/new` bumps it.
- The `--conversation` key becomes `‹chatid›-‹epoch›` (epoch 0 keeps the raw id, so existing chats are unaffected), giving a fresh context.
- The chat's **agent stays put** — model and persona survive `/new`; only conversation memory resets. Old segments remain on disk (breakpoint, not a wipe).

Bridge-only; typecheck + lint + prettier clean. `/help` and the README command table updated.