### PR TITLE
fix(chat): /new clears the screen along with the context

### DIFF
--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -178,6 +178,7 @@ function handleNewCommand(
   agent: CommandContext["agent"],
 ): Effect.Effect<CommandResult, never, never> {
   return Effect.gen(function* () {
+    yield* terminal.clear();
     yield* terminal.info("Starting new conversation...");
     yield* terminal.log(fmt.item("Conversation context cleared"));
     yield* terminal.log(fmt.item("Fresh start with the agent"));


### PR DESCRIPTION
## What this PR does

`/new` now clears the terminal screen when it starts a new conversation, so the previous thread isn't left visible above the fresh start.

## Why

`/new` reset the conversation *context* but left the old thread scrolled up on screen, making it look like nothing happened and burying the "Starting new conversation..." messages under the previous exchange. `/clear` already wipes the screen (via `terminal.clear()`, which also resets the Ink scrollback), so `/new` now does the same before printing its fresh-start output.

The two commands stay distinct: `/clear` wipes the screen and keeps context; `/new` wipes the screen **and** resets context.

## How to test

1. Start a chat and exchange a few messages so the terminal has visible scrollback.
2. Run `/new`.
   - Expected: the screen is wiped and only the "Starting new conversation..." / "Conversation context cleared" messages remain — the prior thread is gone.
3. Ask the agent about something from before `/new`.
   - Expected: it has no memory of it (context was reset).
4. Edge case — run `/clear` instead of `/new`.
   - Expected: screen is wiped **but** the agent still remembers the prior conversation (context preserved).
5. Edge case — run `/new` immediately at the start of a session with no prior messages.
   - Expected: screen clears cleanly with no error, fresh-start messages print.
