### PR TITLE
feat(telegram): location support (reverse-geocode + nearby)

### DIFF
--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -72,6 +72,13 @@ While a message is processing, the progress bubble carries a **⏹ Cancel** butt
 that kills the run; each answer offers **🔍 Go deeper** / **✂️ Shorter** follow-ups.
 Set `JAZZ_DAILY_COST_CAP_USD` to cap total spend per day (0 = no cap).
 
+**Location.** Share a location (📎 → Location) and the bot reverse-geocodes it
+(OpenStreetMap Nominatim) and hands the agent the coordinates + address, so you
+can ask "where am I", "nearest pharmacy", or "directions to …". The coordinates
+are stored in the conversation history (plaintext) and sent to the geocoder — set
+`NOMINATIM_BASE_URL=""` to disable reverse-geocoding (coords still passed to the
+agent), or point it at a self-hosted Nominatim.
+
 Reminders are persisted in `tg-reminders.json` and delivered by a sweep, so they
 survive restarts (a reminder due while the bridge was down fires on next start,
 marked `(delayed)`). Clock times (`18:00`, `tomorrow 09:00`) use the container's

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -61,6 +61,8 @@ interface BridgeConfig {
   readonly port: number;
   /** Per-day spend ceiling in USD across all chats; 0 disables the cap. */
   readonly dailyCostCapUsd: number;
+  /** Reverse-geocoder base URL for shared locations; empty string disables it. */
+  readonly geocodeUrl: string;
 }
 
 interface AgentConfig {
@@ -138,6 +140,7 @@ function loadConfig(): BridgeConfig {
     builtinPersonasDir: process.env["JAZZ_BUILTIN_PERSONAS_DIR"]?.trim() || "/opt/jazz/personas",
     port: Number.parseInt(process.env["PORT"]?.trim() || "8080", 10),
     dailyCostCapUsd: Number.parseFloat(process.env["JAZZ_DAILY_COST_CAP_USD"]?.trim() || "0") || 0,
+    geocodeUrl: process.env["NOMINATIM_BASE_URL"]?.trim() ?? "https://nominatim.openstreetmap.org",
   };
 }
 
@@ -441,6 +444,49 @@ function startReminderSweep(config: BridgeConfig): void {
   };
   sweep(); // deliver anything that came due while the bridge was down
   setInterval(sweep, REMINDER_SWEEP_MS);
+}
+
+// --- Location -------------------------------------------------------------
+
+/** Reverse-geocode coordinates to a human address, or null on failure/disabled. */
+async function reverseGeocode(
+  config: BridgeConfig,
+  latitude: number,
+  longitude: number,
+): Promise<string | null> {
+  if (config.geocodeUrl.length === 0) return null;
+  try {
+    const base = config.geocodeUrl.replace(/\/$/, "");
+    const url = `${base}/reverse?format=jsonv2&zoom=18&addressdetails=0&lat=${latitude}&lon=${longitude}`;
+    const response = await fetch(url, {
+      headers: { "user-agent": "jazz-telegram-bot/1.0 (+https://github.com/lvndry/jazz)" },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { display_name?: string };
+    return typeof data.display_name === "string" ? data.display_name : null;
+  } catch (error) {
+    console.error(`Reverse geocode failed: ${String(error)}`);
+    return null;
+  }
+}
+
+/** Turn a shared location into a prompt and run it through the normal pipeline. */
+async function handleLocation(
+  config: BridgeConfig,
+  chatId: number,
+  latitude: number,
+  longitude: number,
+): Promise<void> {
+  const address = await reverseGeocode(config, latitude, longitude);
+  const mapLink = `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=17/${latitude}/${longitude}`;
+  const prompt =
+    "[The user shared their current location.]\n" +
+    `Coordinates: latitude ${latitude}, longitude ${longitude}\n` +
+    (address ? `Approximate address (reverse-geocoded): ${address}\n` : "") +
+    `Map: ${mapLink}\n\n` +
+    "Tell me briefly where this is (neighborhood and a nearby landmark), then ask what I need — " +
+    "directions to a place, the nearest something, etc. Use web search for anything nearby or for routing.";
+  await handleMessage(config, chatId, prompt);
 }
 
 // --- Ollama model discovery -----------------------------------------------
@@ -928,6 +974,8 @@ const HELP_TEXT = [
   "/reminders — list & cancel your reminders",
   "/status — model, today's usage, uptime",
   "/help — show this",
+  "",
+  "📍 Share your location (📎 → Location) and I'll tell you where you are and find nearby places.",
 ].join("\n");
 
 interface InlineButton {
@@ -1198,6 +1246,7 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
 interface TelegramMessage {
   readonly chat?: { readonly id?: number };
   readonly text?: string;
+  readonly location?: { readonly latitude?: number; readonly longitude?: number };
 }
 
 interface TelegramUpdate {
@@ -1215,20 +1264,29 @@ function parseCommand(text: string): { command: string; args: string } | undefin
 
 function dispatchMessage(config: BridgeConfig, message: TelegramMessage | undefined): void {
   const chatId = message?.chat?.id;
-  const text = message?.text?.trim();
-  if (typeof chatId !== "number" || typeof text !== "string" || text.length === 0) {
-    return;
-  }
+  if (typeof chatId !== "number") return;
   if (!config.allowedChatIds.has(chatId)) {
     console.warn(`Ignoring message from non-allowed chat ${chatId}`);
     return;
   }
 
-  const parsed = parseCommand(text);
-  const work =
-    parsed !== undefined
-      ? handleCommand(config, chatId, parsed.command, parsed.args)
-      : handleMessage(config, chatId, text);
+  const text = message?.text?.trim();
+  const location = message?.location;
+
+  let work: Promise<void> | undefined;
+  if (typeof text === "string" && text.length > 0) {
+    const parsed = parseCommand(text);
+    work =
+      parsed !== undefined
+        ? handleCommand(config, chatId, parsed.command, parsed.args)
+        : handleMessage(config, chatId, text);
+  } else if (typeof location?.latitude === "number" && typeof location.longitude === "number") {
+    work = handleLocation(config, chatId, location.latitude, location.longitude);
+  }
+
+  // Other message types (photo, sticker, …) aren't handled yet.
+  if (work === undefined) return;
+
   work.catch((error) => {
     console.error(`Handling failed for chat ${chatId}: ${String(error)}`);
     // Guard the notification itself so a failed reply can't become an

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -460,6 +460,7 @@ async function reverseGeocode(
     const url = `${base}/reverse?format=jsonv2&zoom=18&addressdetails=0&lat=${latitude}&lon=${longitude}`;
     const response = await fetch(url, {
       headers: { "user-agent": "jazz-telegram-bot/1.0 (+https://github.com/lvndry/jazz)" },
+      signal: AbortSignal.timeout(8_000),
     });
     if (!response.ok) return null;
     const data = (await response.json()) as { display_name?: string };
@@ -1271,7 +1272,8 @@ function dispatchMessage(config: BridgeConfig, message: TelegramMessage | undefi
   }
 
   const text = message?.text?.trim();
-  const location = message?.location;
+  const latitude = message?.location?.latitude;
+  const longitude = message?.location?.longitude;
 
   let work: Promise<void> | undefined;
   if (typeof text === "string" && text.length > 0) {
@@ -1280,8 +1282,13 @@ function dispatchMessage(config: BridgeConfig, message: TelegramMessage | undefi
       parsed !== undefined
         ? handleCommand(config, chatId, parsed.command, parsed.args)
         : handleMessage(config, chatId, text);
-  } else if (typeof location?.latitude === "number" && typeof location.longitude === "number") {
-    work = handleLocation(config, chatId, location.latitude, location.longitude);
+  } else if (
+    typeof latitude === "number" &&
+    Number.isFinite(latitude) &&
+    typeof longitude === "number" &&
+    Number.isFinite(longitude)
+  ) {
+    work = handleLocation(config, chatId, latitude, longitude);
   }
 
   // Other message types (photo, sticker, …) aren't handled yet.


### PR DESCRIPTION
Adds location support to the Telegram bot — useful for the "I'm lost" case.

## What
Share a location (📎 → Location) and the bridge:
1. Reverse-geocodes the coordinates → address (OpenStreetMap **Nominatim**, free, no key).
2. Feeds the agent the coords + address + an OSM map link through the normal run pipeline.

Then you can ask follow-ups in text — "where am I", "nearest pharmacy", "directions to Gare de Lyon" — with the location held in the conversation. `dispatchMessage` now routes text vs location and ignores unsupported types (photos/stickers) instead of dropping everything without `text`.

## Config / privacy
- `NOMINATIM_BASE_URL` — defaults to the public Nominatim; set to `""` to **disable** reverse-geocoding (coords still passed to the agent), or point at a self-hosted instance.
- Location is sensitive: coords land in the conversation history (plaintext) and are sent to the geocoder. Documented in the README.

## Verified
Typecheck + lint + prettier clean. Live-checked the reverse-geocode: `48.8584,2.2945` → "Avenue Gustave Eiffel, … Paris 7e, 75007, France".

## Follow-up
"Get me home" still needs a saved home address — a `/home` setting or the broader saved-facts feature. Happy to add next.
