### PR TITLE
fix(telegram): progress thought looks first-letter-cropped

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -724,6 +724,19 @@ function formatTokenCount(tokens: number): string {
   return tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : String(tokens);
 }
 
+/**
+ * Show the latest slice of a streaming thought. Short thoughts render whole;
+ * longer ones show the tail from a word boundary with a leading ellipsis, so
+ * the line reads as a continuation rather than a chopped-off first word.
+ */
+function reasoningSnippet(reasoning: string): string {
+  if (reasoning.length <= PROGRESS_REASONING_CHARS) return reasoning;
+  const tail = reasoning.slice(-PROGRESS_REASONING_CHARS);
+  const firstSpace = tail.indexOf(" ");
+  const aligned = firstSpace > 0 && firstSpace < 40 ? tail.slice(firstSpace + 1) : tail;
+  return `… ${aligned}`;
+}
+
 function createProgressReporter(
   config: BridgeConfig,
   chatId: number,
@@ -741,7 +754,7 @@ function createProgressReporter(
 
   const render = (): string => {
     const lines = ["🤔 <b>Working…</b>"];
-    if (reasoning) lines.push(`💭 ${escapeHtml(reasoning)}`);
+    if (reasoning) lines.push(`💭 ${escapeHtml(reasoningSnippet(reasoning))}`);
     for (const tool of tools.slice(-PROGRESS_MAX_TOOLS_SHOWN)) {
       lines.push(`🔧 <code>${escapeHtml(tool)}</code>`);
     }
@@ -779,10 +792,8 @@ function createProgressReporter(
       switch (event.type) {
         case "thinking_chunk":
           if (typeof event.content === "string") {
-            reasoning = (reasoning + event.content)
-              .replace(/\s+/g, " ")
-              .trim()
-              .slice(-PROGRESS_REASONING_CHARS);
+            // Keep the whole thought; render truncates the tail for display.
+            reasoning = (reasoning + event.content).replace(/\s+/g, " ").trim();
           }
           break;
         case "tool_execution_start":

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -730,11 +730,12 @@ function formatTokenCount(tokens: number): string {
  * the line reads as a continuation rather than a chopped-off first word.
  */
 function reasoningSnippet(reasoning: string): string {
-  if (reasoning.length <= PROGRESS_REASONING_CHARS) return reasoning;
-  const tail = reasoning.slice(-PROGRESS_REASONING_CHARS);
+  const normalized = reasoning.replace(/\s+/g, " ").trim();
+  if (normalized.length <= PROGRESS_REASONING_CHARS) return normalized;
+  let tail = normalized.slice(-PROGRESS_REASONING_CHARS).trimStart();
   const firstSpace = tail.indexOf(" ");
-  const aligned = firstSpace > 0 && firstSpace < 40 ? tail.slice(firstSpace + 1) : tail;
-  return `… ${aligned}`;
+  if (firstSpace > 0 && firstSpace < 40) tail = tail.slice(firstSpace + 1);
+  return `… ${tail}`;
 }
 
 function createProgressReporter(
@@ -754,7 +755,8 @@ function createProgressReporter(
 
   const render = (): string => {
     const lines = ["🤔 <b>Working…</b>"];
-    if (reasoning) lines.push(`💭 ${escapeHtml(reasoningSnippet(reasoning))}`);
+    const thought = reasoningSnippet(reasoning);
+    if (thought) lines.push(`💭 ${escapeHtml(thought)}`);
     for (const tool of tools.slice(-PROGRESS_MAX_TOOLS_SHOWN)) {
       lines.push(`🔧 <code>${escapeHtml(tool)}</code>`);
     }
@@ -791,10 +793,9 @@ function createProgressReporter(
     onEvent(event: JazzEvent): void {
       switch (event.type) {
         case "thinking_chunk":
-          if (typeof event.content === "string") {
-            // Keep the whole thought; render truncates the tail for display.
-            reasoning = (reasoning + event.content).replace(/\s+/g, " ").trim();
-          }
+          // Accumulate raw so a lone-space chunk isn't trimmed away (which would
+          // glue the surrounding words); normalization happens at render time.
+          if (typeof event.content === "string") reasoning += event.content;
           break;
         case "tool_execution_start":
           if (typeof event.toolName === "string") tools.push(event.toolName);


### PR DESCRIPTION
The live progress bubble's 💭 line showed `reasoning.slice(-180)` of the streaming thought — so it began mid-word and looked like the first letter/word was cut off (which happens ~always, since reasoning usually exceeds 180 chars).

Now the full thought is kept; `reasoningSnippet` renders short thoughts whole and, for long ones, trims the tail to a word boundary with a leading `…` so it clearly reads as a continuation. Verified: short → shown intact; long → `… <word boundary> …`. Typecheck + lint clean.