### PR TITLE
fix(telegram): faster contextual CTAs (tool-less generation agent)

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -22,6 +22,7 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -1064,6 +1065,7 @@ const SUGGEST_AGENT_ID = "tg_suggest";
  * button upgrade lands in a couple of seconds instead of ~20.
  */
 function ensureSuggestAgent(config: BridgeConfig): void {
+  if (existsSync(agentPath(config, SUGGEST_AGENT_ID))) return;
   const template = readAgentFile(config, config.baseAgentId);
   template.id = SUGGEST_AGENT_ID;
   template.name = SUGGEST_AGENT_ID;
@@ -1610,6 +1612,9 @@ async function pollLoop(config: BridgeConfig): Promise<void> {
 
 async function start(): Promise<void> {
   const config = loadConfig();
+  // Drop the cached CTA agent so it re-seeds from the current template (picks
+  // up a changed default model on redeploy); ensureSuggestAgent recreates it.
+  rmSync(agentPath(config, SUGGEST_AGENT_ID), { force: true });
   startHealthServer(config);
   startReminderSweep(config);
   console.log(

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -1056,13 +1056,29 @@ async function jazzJson(
   }
 }
 
+const SUGGEST_AGENT_ID = "tg_suggest";
+
+/**
+ * A tool-less clone of the template agent used only to generate CTAs. Dropping
+ * the tool schemas cuts the prompt from ~11k tokens to a few hundred, so the
+ * button upgrade lands in a couple of seconds instead of ~20.
+ */
+function ensureSuggestAgent(config: BridgeConfig): void {
+  const template = readAgentFile(config, config.baseAgentId);
+  template.id = SUGGEST_AGENT_ID;
+  template.name = SUGGEST_AGENT_ID;
+  template.config.tools = [];
+  template.config.reasoningEffort = "disable";
+  writeAgentFile(config, template);
+}
+
 /** Ask the model for 2-4 contextual next-step CTAs based on the exchange. */
 async function generateSuggestions(
   config: BridgeConfig,
-  chatId: number,
   question: string,
   answer: string,
 ): Promise<Suggestion[]> {
+  ensureSuggestAgent(config);
   const metaPrompt =
     `Conversation:\nUser: ${question.slice(0, 500)}\nAssistant: ${answer.slice(0, 1200)}\n\n` +
     "Propose 2-4 useful next actions the user might tap. Reply with ONLY a JSON array — no prose, " +
@@ -1070,7 +1086,7 @@ async function generateSuggestions(
     '[{"label":"short button text, <=24 chars, may start with an emoji","prompt":"the message to ' +
     'send if tapped, written first-person as the user"}]\n' +
     'Make them specific to THIS exchange. Include one "🔍 Go deeper" style option.';
-  const envelope = await jazzJson(config, agentIdForChat(chatId), metaPrompt, [
+  const envelope = await jazzJson(config, SUGGEST_AGENT_ID, metaPrompt, [
     "--reasoning",
     "disable",
     "--max-iterations",
@@ -1078,7 +1094,7 @@ async function generateSuggestions(
     "--approval-policy",
     "read-only",
     "--timeout",
-    "90000",
+    "60000",
   ]);
   if (!envelope.ok) return [];
 
@@ -1120,7 +1136,8 @@ async function upgradeToDynamicCtas(
   answer: string,
 ): Promise<void> {
   try {
-    const items = await generateSuggestions(config, chatId, question, answer);
+    const items = await generateSuggestions(config, question, answer);
+    console.log(`[cta] chat ${chatId}: ${items.length} contextual suggestion(s)`);
     if (items.length === 0) return; // keep the static fallback already attached
     const token = storeSuggestions(items);
     await callTelegram(config, "editMessageReplyMarkup", {


### PR DESCRIPTION
The contextual-CTA generation reused the chat agent, so each suggestion call included all 34 tool schemas — ~11k prompt tokens — making the button upgrade lag ~10-20s (likely why it looked like it 'didn't happen'). Now it uses a stripped clone (`tg_suggest`, `tools: []`, reasoning disabled), cutting the prompt to a few hundred tokens so the upgrade lands in a second or two. Added a `[cta] chat <id>: N suggestion(s)` log so the upgrade is observable. Typecheck + lint clean.