### PR TITLE
fix(subagent): cap tool activity in the bounded panel

### DIFF
--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -517,6 +517,66 @@ describe("InkStreamingRenderer", () => {
     });
   });
 
+  describe("sub-agent tool routing", () => {
+    test("routes sub-agent tool activity into its ephemeral panel, not scrollback", async () => {
+      const ephemeralAppends: Array<{ id: string; text: string }> = [];
+      const originalAppend = store.appendEphemeral;
+      store.appendEphemeral = (id, text) => {
+        ephemeralAppends.push({ id, text });
+        return originalAppend(id, text);
+      };
+
+      const renderer = new InkStreamingRenderer(
+        "SubAgent",
+        false,
+        { showThinking: true, showToolExecution: true, mode: "rendered", colorProfile: "full" },
+        { textBufferMs: 0 },
+        0,
+        { kind: "ephemeral", regionId: "eph-sub-1" },
+      );
+
+      try {
+        emitStreamStart(renderer);
+        // stream_start writes an agent header to scrollback even for a
+        // sub-agent; baseline here so the assertion below isolates tool cards.
+        const scrollbackBaseline = printOutputCalls.length;
+
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "tool_execution_start",
+            toolName: "read_file",
+            toolCallId: "tc-1",
+            arguments: { path: "a.ts" },
+          }),
+        );
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "tool_execution_complete",
+            toolCallId: "tc-1",
+            result: "ok",
+            durationMs: 42,
+            summary: "read a.ts",
+          }),
+        );
+        await new Promise((r) => setTimeout(r, 0));
+
+        const combined = ephemeralAppends
+          .filter((entry) => entry.id === "eph-sub-1")
+          .map((entry) => entry.text)
+          .join("");
+        expect(combined).toContain("read_file");
+        expect(combined).toContain("read a.ts");
+        expect(combined).toContain("42ms");
+
+        // The bordered tool card must NOT reach the unbounded global scrollback.
+        expect(printOutputCalls.length).toBe(scrollbackBaseline);
+      } finally {
+        store.appendEphemeral = originalAppend;
+        Effect.runSync(renderer.reset());
+      }
+    });
+  });
+
   describe("complete phase", () => {
     test("prints response to Static before clearing activity to idle", async () => {
       const renderer = createRenderer();

--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -537,8 +537,8 @@ describe("InkStreamingRenderer", () => {
 
       try {
         emitStreamStart(renderer);
-        // stream_start writes an agent header to scrollback even for a
-        // sub-agent; baseline here so the assertion below isolates tool cards.
+        // stream_start writes an agent header to scrollback; baseline past it
+        // so the assertion below isolates tool cards.
         const scrollbackBaseline = printOutputCalls.length;
 
         Effect.runSync(
@@ -568,7 +568,6 @@ describe("InkStreamingRenderer", () => {
         expect(combined).toContain("read a.ts");
         expect(combined).toContain("42ms");
 
-        // The bordered tool card must NOT reach the unbounded global scrollback.
         expect(printOutputCalls.length).toBe(scrollbackBaseline);
       } finally {
         store.appendEphemeral = originalAppend;

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -220,6 +220,46 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   /**
+   * Render a sub-agent's tool activity as compact, single-line entries in its
+   * bounded ephemeral panel. Mirrors the scrollback tool cards (a start line,
+   * then a result summary) but as plain text routed through the same buffered
+   * ephemeral path as reasoning/response, so the region's last-N-lines cap
+   * (store.appendEphemeral) crops old tool output exactly the way it crops
+   * reasoning — keeping the panel a fixed height instead of growing forever.
+   *
+   * `tools_detected` is intentionally dropped: the per-tool start lines below
+   * already convey what is running, and the badge is redundant noise in a
+   * height-limited panel. Each line is prefixed with a newline so it always
+   * begins on its own row rather than merging onto a partial reasoning line.
+   */
+  private appendToolActivityToEphemeral(
+    event: StreamEvent,
+    regionId: string,
+    completedToolName: string | undefined,
+  ): void {
+    if (event.type === "tool_execution_start") {
+      const args = formatToolArguments(
+        event.toolName,
+        event.arguments,
+        event.metadata !== undefined ? { metadata: event.metadata } : undefined,
+      );
+      const line = `${event.toolName}${args.length > 0 ? ` ${args}` : ""}`;
+      this.bufferStreamDelta({ target: "ephemeral", regionId, delta: `\n${line}` });
+      return;
+    }
+    if (event.type === "tool_execution_complete") {
+      const summary =
+        event.summary?.trim() ||
+        (completedToolName ? formatToolResult(completedToolName, event.result) : "") ||
+        completedToolName ||
+        "Tool";
+      const firstLine = summary.split("\n")[0] ?? summary;
+      const line = `${getGlyphs().success} ${firstLine} (${event.durationMs}ms)`;
+      this.bufferStreamDelta({ target: "ephemeral", regionId, delta: `\n${line}` });
+    }
+  }
+
+  /**
    * Schedule a flush. The handler checks the open-structure heuristic before
    * flushing: if we're mid-table or mid-code-fence (and within the adaptive
    * wait cap), reschedule for another `textBufferMs` window so partial
@@ -486,19 +526,39 @@ export class InkStreamingRenderer implements StreamingRenderer {
       if (event.type === "tool_execution_start" && !event.longRunning) {
         this.setupToolTimeout(event.toolCallId, event.toolName);
       }
+      // Capture the tool name from the accumulator before the reducer clears
+      // it on completion — the sub-agent panel line needs it to format the
+      // result summary.
+      const completedToolName =
+        event.type === "tool_execution_complete"
+          ? this.acc.activeTools.get(event.toolCallId)?.toolName
+          : undefined;
       if (event.type === "tool_execution_complete") {
         this.clearToolTimeout(event.toolCallId);
-        this.storeExpandableDiff(
-          this.acc.activeTools.get(event.toolCallId)?.toolName,
-          event.result,
-        );
+        this.storeExpandableDiff(completedToolName, event.result);
       }
 
       // Run the pure reducer for activity state + Static side-effects.
       const result = reduceEvent(this.acc, event, ink);
 
-      for (const entry of result.outputs) {
-        store.printOutput(entry);
+      // Sub-agent runs stream into a bounded ephemeral panel. Their tool
+      // activity must share that capped height with their reasoning/response
+      // (both already routed to the region) instead of accumulating unbounded
+      // in the global scrollback — so route tool events into the region as
+      // compact lines and drop the scrollback cards. Non-tool outputs (errors,
+      // headers) still go to scrollback so failures aren't cropped away.
+      const isSubagentToolEvent =
+        this.streamTarget.kind === "ephemeral" &&
+        (event.type === "tools_detected" ||
+          event.type === "tool_execution_start" ||
+          event.type === "tool_execution_complete");
+
+      if (isSubagentToolEvent && this.streamTarget.kind === "ephemeral") {
+        this.appendToolActivityToEphemeral(event, this.streamTarget.regionId, completedToolName);
+      } else {
+        for (const entry of result.outputs) {
+          store.printOutput(entry);
+        }
       }
 
       if (event.type === "text_start") {

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -220,17 +220,10 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   /**
-   * Render a sub-agent's tool activity as compact, single-line entries in its
-   * bounded ephemeral panel. Mirrors the scrollback tool cards (a start line,
-   * then a result summary) but as plain text routed through the same buffered
-   * ephemeral path as reasoning/response, so the region's last-N-lines cap
-   * (store.appendEphemeral) crops old tool output exactly the way it crops
-   * reasoning — keeping the panel a fixed height instead of growing forever.
-   *
-   * `tools_detected` is intentionally dropped: the per-tool start lines below
-   * already convey what is running, and the badge is redundant noise in a
-   * height-limited panel. Each line is prefixed with a newline so it always
-   * begins on its own row rather than merging onto a partial reasoning line.
+   * Render a sub-agent's tool activity as compact plain-text lines in its
+   * bounded ephemeral panel so the region's last-N-lines cap crops them the
+   * same way it crops reasoning, instead of growing unbounded in scrollback.
+   * `tools_detected` is dropped as redundant with the per-tool start lines.
    */
   private appendToolActivityToEphemeral(
     event: StreamEvent,
@@ -244,6 +237,8 @@ export class InkStreamingRenderer implements StreamingRenderer {
         event.metadata !== undefined ? { metadata: event.metadata } : undefined,
       );
       const line = `${event.toolName}${args.length > 0 ? ` ${args}` : ""}`;
+      // Leading newline so the line starts its own row rather than merging
+      // onto a partial reasoning line already in the region.
       this.bufferStreamDelta({ target: "ephemeral", regionId, delta: `\n${line}` });
       return;
     }
@@ -526,9 +521,8 @@ export class InkStreamingRenderer implements StreamingRenderer {
       if (event.type === "tool_execution_start" && !event.longRunning) {
         this.setupToolTimeout(event.toolCallId, event.toolName);
       }
-      // Capture the tool name from the accumulator before the reducer clears
-      // it on completion — the sub-agent panel line needs it to format the
-      // result summary.
+      // Read before reduceEvent clears the entry on completion; the panel
+      // line needs the tool name to format its result summary.
       const completedToolName =
         event.type === "tool_execution_complete"
           ? this.acc.activeTools.get(event.toolCallId)?.toolName
@@ -538,15 +532,11 @@ export class InkStreamingRenderer implements StreamingRenderer {
         this.storeExpandableDiff(completedToolName, event.result);
       }
 
-      // Run the pure reducer for activity state + Static side-effects.
       const result = reduceEvent(this.acc, event, ink);
 
-      // Sub-agent runs stream into a bounded ephemeral panel. Their tool
-      // activity must share that capped height with their reasoning/response
-      // (both already routed to the region) instead of accumulating unbounded
-      // in the global scrollback — so route tool events into the region as
-      // compact lines and drop the scrollback cards. Non-tool outputs (errors,
-      // headers) still go to scrollback so failures aren't cropped away.
+      // Sub-agent tool activity goes into its bounded panel (capped height)
+      // rather than unbounded scrollback; non-tool outputs (errors, headers)
+      // still reach scrollback so failures aren't cropped away.
       const isSubagentToolEvent =
         this.streamTarget.kind === "ephemeral" &&
         (event.type === "tools_detected" ||


### PR DESCRIPTION
## What changed

Sub-agent **tool calls** now render inside the sub-agent's bounded ephemeral panel — using a fixed, capped height with older lines cropped — instead of accumulating without limit in the global scrollback.

## Why

A sub-agent's **reasoning and response** already stream into a bounded ephemeral region (`store.appendEphemeral`, which keeps only the last N lines), so they occupy a fixed height. But the tool-event path in `InkStreamingRenderer.handleEvent` ignored `streamTarget` entirely and pushed the reducer's tool cards straight to `store.printOutput` (permanent, unbounded scrollback). Result: a sub-agent's reasoning stayed neatly capped while its tool calls grew forever — inconsistent, and exactly the opposite of what the panel is for.

## How

In `src/cli/presentation/ink-presentation-service.ts`:

- **Routing** — when `streamTarget.kind === "ephemeral"` (a sub-agent), tool events (`tools_detected`, `tool_execution_start`, `tool_execution_complete`) are routed into the sub-agent's own region via the same buffered ephemeral path reasoning/response use, so they share the capped height and get cropped identically.
- **`appendToolActivityToEphemeral`** renders each tool as compact single lines — a start line (`toolName args`) and a result line (`✓ summary (Nms)`), each prefixed with `\n` so they begin on their own row rather than merging onto a partial reasoning line. The tool name is captured before the reducer clears it so the result summary can still be formatted.
- `tools_detected` is dropped as redundant noise in a height-limited panel; the per-tool start lines already convey what is running.
- **Errors and agent headers still go to scrollback** so a sub-agent failure is visible and not cropped away.

Main-agent (scrollback) rendering is untouched.

## Reviewer notes

- Reasoning, response, and tool lines now **interleave in the one shared sub-agent panel** — this is intentional and matches the requested behavior (everything uses a defined height, the rest is cropped).
- The sub-agent panel height is `SUBAGENT_PANEL_LINES = 12` in `src/core/agent/tools/subagent-tools.ts` if it needs tuning.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun test src/cli/presentation src/cli/ui/store.test.ts` — 227 pass ✅
- Added a test ("routes sub-agent tool activity into its ephemeral panel, not scrollback") asserting tool activity lands in the region and the scrollback count is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
