### PR TITLE
fix(ui): reflow live streaming text on terminal resize

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -5,6 +5,7 @@ import { ActivityView } from "./ActivityView";
 import { useTerminalOutputAdapter } from "./adapters/terminal-output-adapter";
 import type { PendingStream } from "./adapters/terminal-output-adapter";
 import { PreWrappedText } from "./components/PreWrappedText";
+import { useTerminalDimensions } from "./contexts/TerminalDimensionsContext";
 import { EphemeralPanelIsland } from "./EphemeralPanelIsland";
 import ErrorBoundary from "./ErrorBoundary";
 import { formatMarkdown, wrapToWidth } from "../presentation/markdown-formatter";
@@ -19,7 +20,6 @@ import { PADDING, PADDING_BUDGET, THEME } from "./theme";
 import type { OutputEntryWithId, PromptState } from "./types";
 import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
 import { InputPriority, InputResults } from "../services/input-service";
-import { getTerminalWidth } from "../utils/string-utils";
 
 // ============================================================================
 // Activity Island - Unified state for status + streaming response
@@ -154,7 +154,7 @@ const StatusFooterIsland = React.memo(StatusFooterIslandComponent);
 // Uses TerminalOutputAdapter for two-tier Static/live rendering.
 // ============================================================================
 
-function renderPendingStream(pending: PendingStream): string {
+function renderPendingStream(pending: PendingStream, cols: number): string {
   // The renderer's display config is wired up via store; for this island we
   // default to formatMarkdown. If the user's display config is `hybrid`, the
   // renderer will set its own pending text via store.appendStream — the buffer
@@ -169,13 +169,18 @@ function renderPendingStream(pending: PendingStream): string {
   // in ink-presentation-service.ts.
   const formatted = formatMarkdown(pending.rawTail);
   const dimmed = pending.kind === "reasoning" ? dimReasoningMarkdownOutput(formatted) : formatted;
-  const width = Math.max(20, getTerminalWidth() - PADDING_BUDGET - PADDING.content - RAIL_WIDTH);
+  const width = Math.max(20, cols - PADDING_BUDGET - PADDING.content - RAIL_WIDTH);
   // Same speaker rail as settled slices so the live tail is seamless.
   return railStreamLines(wrapToWidth(dimmed, width), pending.kind);
 }
 
 function OutputIslandComponent(): React.ReactElement {
   const { state, appendStatic, appendStream, finalizeStream, clear } = useTerminalOutputAdapter();
+  // Subscribe to terminal size so the live streaming tail re-wraps when the
+  // window is resized. Ink re-runs Yoga layout on resize but does NOT re-run
+  // React, so a JS-computed wrap width would otherwise stay frozen at its
+  // print-time value until the next stream delta arrives.
+  const { cols } = useTerminalDimensions();
   const initializedRef = useRef(false);
 
   const printOutput = useCallback(
@@ -229,7 +234,7 @@ function OutputIslandComponent(): React.ReactElement {
 
       {pending !== null && (
         <Box paddingLeft={PADDING.content}>
-          <PreWrappedText>{renderPendingStream(pending)}</PreWrappedText>
+          <PreWrappedText>{renderPendingStream(pending, cols)}</PreWrappedText>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## What

Makes the live-rendered terminal UI reflow when the window is resized. Previously, resizing the terminal left streamed text wrapped at its old width — it did not re-fit the new window size.

## Why

Ink 7's resize handler re-runs Yoga layout and reprints the *last* frame, but it does **not** trigger a React re-render (`node_modules/ink/build/ink.js` `resized()`). As a result:

- Fluid boxes (`width="100%"`, `flexGrow`) — the status footer and prompt input — already reflowed, because Yoga recomputes them.
- Any wrap width computed in JS (`getTerminalWidth()`) stayed **frozen**, because the React tree never re-ran. The streaming tail (`renderPendingStream`) computed its width this way, so live streaming text did not re-wrap on resize.

The repo already had a reactive `useTerminalDimensions()` context — with a working debounced `resize` listener, mounted at the root — but **nothing consumed it**, so it was effectively dead code.

## Change

- `OutputIsland` now consumes `useTerminalDimensions()`, so a resize re-renders it.
- `renderPendingStream` takes the reactive `cols` and derives its wrap width from it instead of reading `process.stdout.columns` once at print time.

Net effect: resizing mid-response re-wraps the live streaming tail immediately.

## Scope / known limitation

Already-printed transcript (settled scrollback rendered via Ink's `<Static>`) stays wrapped at its print-time width. `<Static>` writes each entry to the terminal exactly once; reflowing history would require reprinting the whole transcript on every resize, which Ink can only do by re-appending it (duplicating scrollback). This is the standard Ink tradeoff — historical output is owned by the terminal once emitted. So **new/streaming text and the input UI reflow; scrolled-back history does not.**

A deeper follow-up (emitting settled slices as soft-wrapped lines so the terminal reflows history natively) is possible but touches the two-tier `<Static>` rendering design that was built around a Yoga wrapping bug, so it's intentionally out of scope here.

## Testing

- `bun run typecheck` — passes
- `bun run lint` — passes
- Manual: start a chat and drag the window narrower/wider while a response is streaming — the live tail re-wraps to fit.