### PR TITLE
fix(cli): wrap long links at separators, keep full URL intact

### DIFF
--- a/src/cli/presentation/markdown-formatter.test.ts
+++ b/src/cli/presentation/markdown-formatter.test.ts
@@ -320,6 +320,94 @@ describe("markdown-formatter", () => {
     });
   });
 
+  describe("wrapToWidth — long hyperlink (URL) wrapping", () => {
+    /** Non-empty OSC 8 targets (excludes the empty `\x1b]8;;\x07` closer). */
+    const linkTargets = (text: string): string[] => {
+      // eslint-disable-next-line no-control-regex
+      const matches = [...text.matchAll(/\x1b\]8;;([^\x07]*)\x07/g)];
+      return matches.map((m) => m[1]!).filter((t) => t !== "");
+    };
+    /** Visible text with wrap newlines removed — what the URL "reads as" unwrapped. */
+    const visibleUnwrapped = (text: string): string => stripAnsiCodes(text).replace(/\n/g, "");
+
+    // A real-world offender: a very long slug with only a handful of separators.
+    const sparseUrl =
+      "https://www.mediacongo.net/publireportage-reportage-114852fpilafermeavicolecongoufdelubumbashimerite-ladiversificationdesesactivitesmartinmudimutshisekedi.html";
+    // A separator-rich slug that should break cleanly at hyphens.
+    const hyphenUrl =
+      "https://en.wikipedia.org/wiki/List-of-the-largest-suspension-bridges-in-the-world-by-total-length";
+
+    it("keeps every OSC 8 target byte-for-byte identical to the source URL (no A-shows-B)", () => {
+      for (const url of [sparseUrl, hyphenUrl]) {
+        for (const width of [30, 50, 80, 120]) {
+          const wrapped = wrapToWidth(formatMarkdown(`Source: ${url}`), width);
+          const targets = linkTargets(wrapped);
+          expect(targets.length).toBeGreaterThan(0);
+          for (const target of targets) expect(target).toBe(url);
+        }
+      }
+    });
+
+    it("preserves the full URL in the visible text (never truncates or relabels)", () => {
+      for (const url of [sparseUrl, hyphenUrl]) {
+        for (const width of [30, 50, 80, 120]) {
+          const wrapped = wrapToWidth(formatMarkdown(`Source: ${url}`), width);
+          expect(visibleUnwrapped(wrapped)).toBe(`Source: ${url}`);
+        }
+      }
+    });
+
+    it("keeps every wrapped line within the width", () => {
+      for (const url of [sparseUrl, hyphenUrl]) {
+        for (const width of [30, 50, 80, 120]) {
+          const wrapped = wrapToWidth(formatMarkdown(`Source: ${url}`), width);
+          for (const line of stripAnsiCodes(wrapped).split("\n")) {
+            expect(line.length).toBeLessThanOrEqual(width);
+          }
+        }
+      }
+    });
+
+    it("prefers separator boundaries over arbitrary mid-token breaks", () => {
+      const wrapped = wrapToWidth(formatMarkdown(`Source: ${hyphenUrl}`), 50);
+      const lines = stripAnsiCodes(wrapped).split("\n");
+      // More than one line (it must wrap) and every non-final line ends at a separator.
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines.slice(0, -1)) {
+        expect("/-._~?#&=+,;@%").toContain(line.at(-1)!);
+      }
+    });
+
+    it("still hard-breaks a separator-free run that exceeds the width", () => {
+      const noSep = "https://example.com/" + "a".repeat(200);
+      const wrapped = wrapToWidth(formatMarkdown(noSep), 40);
+      const lines = stripAnsiCodes(wrapped).split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) expect(line.length).toBeLessThanOrEqual(40);
+      expect(visibleUnwrapped(wrapped)).toBe(noSep);
+      expect(linkTargets(wrapped).every((t) => t === noSep)).toBe(true);
+    });
+
+    it("leaves a URL that fits as a single unbroken hyperlink", () => {
+      const shortUrl = "https://example.com/page";
+      const wrapped = wrapToWidth(formatMarkdown(`See ${shortUrl}`), 80);
+      expect(wrapped.split("\n")).toHaveLength(1);
+      expect(linkTargets(wrapped)).toEqual([shortUrl]);
+    });
+
+    it("does not apply separator-preference to non-link text (only hyperlinks)", () => {
+      // A long, separator-rich token that is NOT a hyperlink must still hard-break
+      // at the column boundary — separator-preference is scoped to OSC 8 links.
+      const token = "a-b-c-d-".repeat(20); // 160 chars, hyphens every 2 chars, no URL scheme
+      const wrapped = wrapToWidth(token, 40);
+      expect(countOsc8(wrapped)).toBe(0);
+      const lines = wrapped.split("\n");
+      // Hard break fills lines to the full width (would be shorter if it broke at hyphens).
+      expect(lines[0]!.length).toBe(40);
+      expect(wrapped.replace(/\n/g, "")).toBe(token);
+    });
+  });
+
   describe("getTerminalWidth", () => {
     it("should return a positive number", () => {
       const width = getTerminalWidth();

--- a/src/cli/presentation/markdown-formatter.ts
+++ b/src/cli/presentation/markdown-formatter.ts
@@ -670,6 +670,129 @@ export function formatItalic(text: string): string {
 const MIN_WRAP_WIDTH = 20;
 
 /**
+ * Matches a complete OSC 8 hyperlink span as emitted by {@link terminalHyperlink}:
+ * opener `\x1b]8;;URL\x07`, the (styled) display text, and closer `\x1b]8;;\x07`.
+ * Group 1 is the target URL; group 2 is the display text (styling + visible text).
+ */
+// eslint-disable-next-line no-control-regex
+const OSC8_LINK_SPAN_REGEX = /\x1b\]8;;([^\x07]*)\x07([\s\S]*?)\x1b\]8;;\x07/g;
+
+/** Leading / trailing runs of SGR color escapes around a hyperlink's display text. */
+// eslint-disable-next-line no-control-regex
+const LEADING_SGR_REGEX = /^(?:\x1b\[[0-9;]*m)+/;
+// eslint-disable-next-line no-control-regex
+const TRAILING_SGR_REGEX = /(?:\x1b\[[0-9;]*m)+$/;
+
+/**
+ * Separators after which a long, otherwise-unbreakable URL or path may wrap.
+ * Breaking here keeps the token readable while leaving it byte-for-byte intact —
+ * we never truncate or relabel a link, so the visible text can never disagree
+ * with where the link actually points.
+ */
+const URL_BREAK_AFTER = new Set("/-._~?#&=+,;@%".split(""));
+
+/** Visible width of the final line of `text` (everything after the last newline). */
+function trailingLineWidth(text: string): number {
+  const lastNewline = text.lastIndexOf("\n");
+  return visibleWidth(lastNewline === -1 ? text : text.slice(lastNewline + 1));
+}
+
+/**
+ * Split a visible string into pieces no wider than the given per-line budgets,
+ * preferring to break immediately after a URL/path separator so wraps land on
+ * meaningful boundaries. Falls back to a hard character break only when a single
+ * separator-free run is itself wider than the budget. Concatenating the pieces
+ * reproduces the input exactly — no characters are added or removed.
+ */
+function splitVisibleAtSeparators(
+  visible: string,
+  firstWidth: number,
+  restWidth: number,
+): string[] {
+  const chars = [...visible];
+  const pieces: string[] = [];
+  let start = 0;
+  while (start < chars.length) {
+    const budget = Math.max(1, pieces.length === 0 ? firstWidth : restWidth);
+    if (chars.length - start <= budget) {
+      pieces.push(chars.slice(start).join(""));
+      break;
+    }
+    const windowEnd = start + budget;
+    let breakAt = -1;
+    for (let position = windowEnd; position > start; position--) {
+      if (URL_BREAK_AFTER.has(chars[position - 1]!)) {
+        breakAt = position;
+        break;
+      }
+    }
+    if (breakAt === -1) breakAt = windowEnd;
+    pieces.push(chars.slice(start, breakAt).join(""));
+    start = breakAt;
+  }
+  return pieces;
+}
+
+/**
+ * Split the display text of a hyperlink into (leading styling, visible text,
+ * trailing styling). Our links style the whole URL in one span, so the visible
+ * text is a single contiguous run. Returns `null` if styling is interleaved with
+ * visible characters (unexpected), signalling the caller to leave the span alone.
+ */
+function partitionLinkDisplay(
+  display: string,
+): { open: string; visible: string; close: string } | null {
+  let rest = display;
+  const open = rest.match(LEADING_SGR_REGEX)?.[0] ?? "";
+  rest = rest.slice(open.length);
+  const close = rest.match(TRAILING_SGR_REGEX)?.[0] ?? "";
+  rest = rest.slice(0, rest.length - close.length);
+  if (stripAnsiCodes(rest) !== rest) return null;
+  return { open, visible: rest, close };
+}
+
+/**
+ * Pre-break over-long hyperlink spans at separator boundaries before wrapping.
+ *
+ * wrap-ansi hard-wraps a link's visible URL at an arbitrary column, which reads
+ * as broken (`…merite-ladi` / `versification…`). Here we split any hyperlink
+ * whose visible text exceeds the width into separator-aligned fragments, each
+ * re-wrapped as its own complete OSC 8 hyperlink pointing at the *same,
+ * untouched* target. The result is fed to wrap-ansi, which leaves the now-short
+ * fragments alone. Non-link text is untouched and wraps exactly as before.
+ */
+function breakLongLinkSpans(text: string, width: number): string {
+  OSC8_LINK_SPAN_REGEX.lastIndex = 0;
+  if (!OSC8_LINK_SPAN_REGEX.test(text)) return text;
+  OSC8_LINK_SPAN_REGEX.lastIndex = 0;
+
+  let result = "";
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = OSC8_LINK_SPAN_REGEX.exec(text)) !== null) {
+    const [span, url, display] = match;
+    result += text.slice(cursor, match.index);
+    cursor = match.index + span.length;
+
+    const offset = trailingLineWidth(result);
+    const parts = partitionLinkDisplay(display ?? "");
+    if (parts === null || visibleWidth(display ?? "") <= width) {
+      result += span;
+      continue;
+    }
+
+    const firstWidth = width - offset;
+    const pieces = splitVisibleAtSeparators(parts.visible, firstWidth, width);
+    const target = url ?? "";
+    result += pieces
+      .map((piece) => `\x1b]8;;${target}\x07${parts.open}${piece}${parts.close}\x1b]8;;\x07`)
+      .join("\n");
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
+/**
  * Pre-wrap ANSI-formatted text to fit the terminal width.
  *
  * This is necessary because Ink's Yoga layout engine intermittently computes
@@ -681,13 +804,17 @@ const MIN_WRAP_WIDTH = 20;
  * still set as a safety net but becomes a no-op since lines are already short
  * enough to fit.
  *
+ * Long hyperlinks are first pre-broken at separator boundaries (see
+ * {@link breakLongLinkSpans}) so URLs wrap at `/`, `-`, `.` rather than mid-token,
+ * while remaining byte-for-byte intact and clickable.
+ *
  * @param text - ANSI-formatted text to wrap (handles escape codes correctly)
  * @param availableWidth - number of visible character columns available
  */
 export function wrapToWidth(text: string, availableWidth: number): string {
   if (!text || text.length === 0) return text;
   const width = Math.max(availableWidth, MIN_WRAP_WIDTH);
-  return wrapAnsi(text, width, { trim: false, hard: true });
+  return wrapAnsi(breakLongLinkSpans(text, width), width, { trim: false, hard: true });
 }
 
 /**


### PR DESCRIPTION
## What changed

Long hyperlinks in the transcript were hard-wrapped **mid-token** at an arbitrary column, so a URL rendered as if it were broken/mangled. Now over-long links wrap at meaningful boundaries (`/ - . _ ? # & = …`):

## Why the full URL is always shown (security)

We deliberately **never truncate or relabel** the URL. A shortened display (`https://site/…tail.html`) could disagree with the link's real target — the classic "shows link A, opens link B" ambiguity. Keeping the visible text byte-for-byte equal to the destination means what you read is always what you click.

## How it works

`wrapToWidth` gets a small pre-pass, `breakLongLinkSpans`, that runs *before* `wrap-ansi`:

- It finds OSC 8 hyperlink spans (`\x1b]8;;URL\x07…\x1b]8;;\x07`) whose visible text exceeds the width.
- It splits the visible URL at the **last separator** that still fits, falling back to a hard character break only inside a genuinely separator-free run.
- Each fragment is re-emitted as its own complete OSC 8 hyperlink pointing at the **same, untouched target**, so every fragment stays clickable to the full URL.
- Non-link text is left entirely to `wrap-ansi` — prose wrapping is unchanged.

`wrap-ansi` still runs afterwards as the safety net, so **every line is guaranteed to be within the width** even if the first-line offset estimate is imperfect. Why not just coax `wrap-ansi`? It only breaks words on ASCII spaces and hard-breaks at exact columns — zero-width break hints are a proven no-op (verified against its source).

## Verification

- 7 new tests in `markdown-formatter.test.ts` assert, across widths 30–120:
  - every OSC 8 target equals the source URL (no A-shows-B),
  - the visible text reconstructs the exact URL (no chars added/lost),
  - every wrapped line is within the width,
  - non-final lines end on a separator (separator-preference),
  - separator-free runs still hard-break,
  - short URLs stay a single unbroken hyperlink,
  - non-link long tokens are unaffected.
- Full suite green (`1520 pass`), `bun run typecheck`, `bun run lint`, `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)