### PR TITLE
feat(ollama): per-agent context window + keep-alive

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -158,13 +158,18 @@ You can set or update your API keys in config by running `jazz` -> `update confi
   "llm": {
     "ollama": {
       "base_url": "http://localhost:11434/api",
-      "api_key": "optional-bearer-token"
+      "api_key": "optional-bearer-token",
+      "keep_alive": "30m"
     }
   }
 }
 ```
 
-Both fields are optional. When `base_url` is omitted, Jazz uses `http://localhost:11434/api`. You can also set `OLLAMA_BASE_URL` (config takes precedence over env).
+All fields are optional. When `base_url` is omitted, Jazz uses `http://localhost:11434/api`. You can also set `OLLAMA_BASE_URL` (config takes precedence over env).
+
+**Context window**: When you create an Ollama agent, Jazz asks you to pick a context window from a list capped to the model's real maximum. Ollama otherwise caps the runtime context to a small default (~4096 tokens) and silently truncates long conversations regardless of the model's trained size. The choice is stored per agent (`numCtx`) and sent as `num_ctx` on every request; change it later with `jazz agent edit`.
+
+**Keep-alive**: Set `keep_alive` (e.g. `"30m"`, or `"-1"` to keep the model resident indefinitely) to avoid model-reload latency between agent turns. When unset, Ollama's own default (5 minutes) applies.
 
 Running on a server without internet access? See the [Airgapped & Self-Hosted guide](../guide/airgapped.md) — set `JAZZ_OFFLINE=1` to disable all outbound requests Jazz makes on its own.
 

--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -16,6 +16,7 @@ import {
   WEB_SEARCH_CATEGORY,
 } from "@/core/agent/tools/register-tools";
 import type { ProviderName } from "@/core/constants/models";
+import { buildOllamaContextChoices, defaultOllamaContextWindow } from "@/core/constants/ollama";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -92,6 +93,7 @@ interface AIAgentCreationAnswers {
   llmProvider: ProviderName;
   llmModel: string;
   reasoningEffort?: "disable" | "low" | "medium" | "high";
+  numCtx?: number;
   tools: string[];
   webSearchProvider?: WebSearchProviderName;
 }
@@ -300,6 +302,7 @@ export function createAgentCommand(): Effect.Effect<
       llmProvider: agentAnswers.llmProvider,
       llmModel: selectedModel,
       ...(agentAnswers.reasoningEffort && { reasoningEffort: agentAnswers.reasoningEffort }),
+      ...(typeof agentAnswers.numCtx === "number" && { numCtx: agentAnswers.numCtx }),
       ...(uniqueToolNames.length > 0 && { tools: uniqueToolNames }),
       ...(agentAnswers.webSearchProvider && { webSearchProvider: agentAnswers.webSearchProvider }),
     };
@@ -322,6 +325,9 @@ export function createAgentCommand(): Effect.Effect<
     yield* terminal.log(`   LLM Provider: ${formatProviderDisplayName(config.llmProvider)}`);
     yield* terminal.log(`   LLM Model: ${config.llmModel}`);
     yield* terminal.log(`   Reasoning: ${config.reasoningEffort}`);
+    if (typeof config.numCtx === "number") {
+      yield* terminal.log(`   Context Window: ${config.numCtx.toLocaleString()} tokens`);
+    }
     yield* terminal.log(`   Tool Categories: ${agentAnswers.tools.join(", ") || "None"}`);
     yield* terminal.log(`   Total Tools: ${uniqueToolNames.length}`);
     yield* terminal.log(`   Created: ${agent.createdAt.toISOString()}`);
@@ -339,6 +345,7 @@ type WizardStep =
   | "provider"
   | "model"
   | "reasoning"
+  | "ollamaContext"
   | "persona"
   | "name"
   | "description"
@@ -354,6 +361,8 @@ interface WizardState {
   llmProvider?: ProviderName;
   llmModel?: string;
   reasoningEffort?: "disable" | "low" | "medium" | "high";
+  numCtx?: number;
+  detectedContextWindow?: number;
   persona?: string;
   name?: string;
   description?: string;
@@ -364,6 +373,17 @@ interface WizardState {
   providerInfo?: LLMProvider;
   isReasoningModel?: boolean;
   supportsTools?: boolean;
+}
+
+/** After model/reasoning, Ollama agents pick a context window before the persona. */
+function stepAfterReasoning(state: WizardState): WizardStep {
+  return state.llmProvider === "ollama" ? "ollamaContext" : "persona";
+}
+
+/** Where the persona step goes when the user presses ESC to go back. */
+function personaBackStep(state: WizardState): WizardStep {
+  if (state.llmProvider === "ollama") return "ollamaContext";
+  return state.isReasoningModel ? "reasoning" : "model";
 }
 
 /**
@@ -499,8 +519,11 @@ async function promptForAgentInfo(
         const selectedModel = state.providerInfo!.supportedModels.find((m) => m.id === result);
         state.isReasoningModel = selectedModel?.isReasoningModel ?? false;
         state.supportsTools = selectedModel?.supportsTools ?? false;
+        if (typeof selectedModel?.contextWindow === "number") {
+          state.detectedContextWindow = selectedModel.contextWindow;
+        }
 
-        state.step = state.isReasoningModel ? "reasoning" : "persona";
+        state.step = state.isReasoningModel ? "reasoning" : stepAfterReasoning(state);
         break;
       }
 
@@ -532,6 +555,28 @@ async function promptForAgentInfo(
         }
 
         state.reasoningEffort = result;
+        state.step = stepAfterReasoning(state);
+        break;
+      }
+
+      // ═══════════════════════════════════════════════════════════════════════
+      // STEP 3b: Ollama context window (only for Ollama agents)
+      // ═══════════════════════════════════════════════════════════════════════
+      case "ollamaContext": {
+        const choices = buildOllamaContextChoices(state.detectedContextWindow);
+        const result = await Effect.runPromise(
+          terminal.select<number>(`What context window should this agent use? ${hint}`, {
+            choices,
+            default: state.numCtx ?? defaultOllamaContextWindow(state.detectedContextWindow),
+          }),
+        );
+
+        if (result === undefined) {
+          state.step = state.isReasoningModel ? "reasoning" : "model";
+          break;
+        }
+
+        state.numCtx = result;
         state.step = "persona";
         break;
       }
@@ -548,7 +593,7 @@ async function promptForAgentInfo(
         );
 
         if (result === undefined) {
-          state.step = state.isReasoningModel ? "reasoning" : "model";
+          state.step = personaBackStep(state);
           break;
         }
 
@@ -791,6 +836,7 @@ async function promptForAgentInfo(
     llmProvider: state.llmProvider!,
     llmModel: state.llmModel!,
     ...(state.reasoningEffort && { reasoningEffort: state.reasoningEffort }),
+    ...(typeof state.numCtx === "number" && { numCtx: state.numCtx }),
     persona: state.persona!,
     name: state.name!,
     ...(state.description && { description: state.description }),

--- a/src/cli/commands/edit-agent.ts
+++ b/src/cli/commands/edit-agent.ts
@@ -17,6 +17,7 @@ import {
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import { AVAILABLE_PROVIDERS } from "@/core/constants/models";
 import type { ProviderName } from "@/core/constants/models";
+import { buildOllamaContextChoices, defaultOllamaContextWindow } from "@/core/constants/ollama";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -55,6 +56,7 @@ interface AgentEditAnswers {
   llmApiKeyProvider?: ProviderName;
   llmApiKeyValue?: string;
   reasoningEffort?: "disable" | "low" | "medium" | "high";
+  numCtx?: number;
   tools?: string[];
   webSearchProvider?: WebSearchProviderName;
 }
@@ -184,6 +186,9 @@ export function editAgentCommand(
           value: "tools",
           disabled: !supportsTools,
         },
+        ...(agent.config.llmProvider === "ollama"
+          ? [{ name: "Context Window", value: "contextWindow" }]
+          : []),
       ],
     });
 
@@ -480,6 +485,7 @@ export function editAgentCommand(
       ...(editAnswers.llmProvider && { llmProvider: editAnswers.llmProvider }),
       ...(editAnswers.llmModel && { llmModel: editAnswers.llmModel }),
       ...(editAnswers.reasoningEffort && { reasoningEffort: editAnswers.reasoningEffort }),
+      ...(typeof editAnswers.numCtx === "number" && { numCtx: editAnswers.numCtx }),
       ...(editAnswers.tools &&
         editAnswers.tools.length > 0 && { tools: Array.from(new Set(editAnswers.tools)) }),
       ...(editAnswers.webSearchProvider && { webSearchProvider: editAnswers.webSearchProvider }),
@@ -883,6 +889,21 @@ async function promptForAgentUpdates(
 
   if (fieldToUpdate === "reasoningEffort") {
     answers.reasoningEffort = await promptForReasoningEffort(terminal, currentAgent);
+  }
+
+  if (fieldToUpdate === "contextWindow") {
+    const detectedContextWindow = currentProviderInfo?.supportedModels.find(
+      (model) => model.id === currentAgent.config.llmModel,
+    )?.contextWindow;
+    const result = await Effect.runPromise(
+      terminal.select<number>("What context window should this agent use?", {
+        choices: buildOllamaContextChoices(detectedContextWindow),
+        default: currentAgent.config.numCtx ?? defaultOllamaContextWindow(detectedContextWindow),
+      }),
+    );
+    if (result !== undefined) {
+      answers.numCtx = result;
+    }
   }
 
   return answers;

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -80,6 +80,7 @@ export function executeWithoutStreaming(
             ...(typeof agent.config.temperature === "number"
               ? { temperature: agent.config.temperature }
               : {}),
+            ...(typeof agent.config.numCtx === "number" ? { num_ctx: agent.config.numCtx } : {}),
             ...(agent.config.llmApiKeys ? { providerApiKeys: agent.config.llmApiKeys } : {}),
           };
 

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -110,6 +110,7 @@ export function executeWithStreaming(
             ...(typeof agent.config.temperature === "number"
               ? { temperature: agent.config.temperature }
               : {}),
+            ...(typeof agent.config.numCtx === "number" ? { num_ctx: agent.config.numCtx } : {}),
             ...(agent.config.llmApiKeys ? { providerApiKeys: agent.config.llmApiKeys } : {}),
           };
 

--- a/src/core/constants/ollama.test.ts
+++ b/src/core/constants/ollama.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { buildOllamaContextChoices, defaultOllamaContextWindow } from "./ollama";
+
+describe("buildOllamaContextChoices", () => {
+  it("offers the full ladder when the model context is unknown", () => {
+    const values = buildOllamaContextChoices().map((choice) => choice.value);
+    expect(values).toEqual([4096, 8192, 16384, 32768, 65536, 131072]);
+  });
+
+  it("caps choices to the model's detected context window", () => {
+    const values = buildOllamaContextChoices(32768).map((choice) => choice.value);
+    expect(values).toEqual([4096, 8192, 16384, 32768]);
+    expect(values).not.toContain(65536);
+  });
+
+  it("appends the exact model maximum when it falls between ladder rungs", () => {
+    const values = buildOllamaContextChoices(40960).map((choice) => choice.value);
+    expect(values).toEqual([4096, 8192, 16384, 32768, 40960]);
+    expect(buildOllamaContextChoices(40960).at(-1)?.name).toContain("model maximum");
+  });
+
+  it("always offers at least one choice for a tiny context window", () => {
+    const values = buildOllamaContextChoices(2048).map((choice) => choice.value);
+    expect(values).toEqual([2048]);
+  });
+});
+
+describe("defaultOllamaContextWindow", () => {
+  it("prefers 32K when the model can accommodate it", () => {
+    expect(defaultOllamaContextWindow(131072)).toBe(32768);
+    expect(defaultOllamaContextWindow()).toBe(32768);
+  });
+
+  it("clamps to the model maximum when smaller than the preferred default", () => {
+    expect(defaultOllamaContextWindow(8192)).toBe(8192);
+    expect(defaultOllamaContextWindow(6000)).toBe(6000);
+  });
+
+  it("always coincides with an offered choice", () => {
+    for (const detected of [undefined, 2048, 6000, 8192, 40960, 131072, 200000]) {
+      const choices = buildOllamaContextChoices(detected).map((choice) => choice.value);
+      expect(choices).toContain(defaultOllamaContextWindow(detected));
+    }
+  });
+});

--- a/src/core/constants/ollama.ts
+++ b/src/core/constants/ollama.ts
@@ -1,0 +1,62 @@
+/**
+ * Ollama caps the *runtime* context window (`num_ctx`) to a small default
+ * (~4096 tokens) regardless of the model's trained size, silently truncating
+ * long conversations. Jazz therefore lets each Ollama agent pick its context
+ * window explicitly from a fixed ladder, capped to the model's real maximum.
+ */
+const OLLAMA_CONTEXT_WINDOW_LADDER = [4096, 8192, 16384, 32768, 65536, 131072] as const;
+
+/** Preferred default context window when the model can accommodate it. */
+const OLLAMA_DEFAULT_CONTEXT_WINDOW = 32768;
+
+export interface ContextWindowChoice {
+  readonly name: string;
+  readonly value: number;
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens % 1024 === 0) {
+    return `${tokens / 1024}K`;
+  }
+  return `${tokens}`;
+}
+
+/**
+ * Build the selectable context-window options for an Ollama agent, capped to the
+ * model's detected maximum. The exact model maximum is always offered (even when
+ * it falls between ladder rungs) so users can use the model's full context.
+ */
+export function buildOllamaContextChoices(detectedContextWindow?: number): ContextWindowChoice[] {
+  const max =
+    typeof detectedContextWindow === "number" && detectedContextWindow > 0
+      ? detectedContextWindow
+      : undefined;
+
+  const values: number[] = OLLAMA_CONTEXT_WINDOW_LADDER.filter((value) => !max || value <= max);
+  if (max && !values.includes(max)) {
+    values.push(max);
+  }
+  if (values.length === 0) {
+    values.push(max ?? OLLAMA_CONTEXT_WINDOW_LADDER[0]);
+  }
+
+  const unique = Array.from(new Set(values)).sort((first, second) => first - second);
+  return unique.map((value) => ({
+    value,
+    name:
+      max && value === max
+        ? `${formatTokenCount(value)} — ${value.toLocaleString()} tokens (model maximum)`
+        : `${formatTokenCount(value)} — ${value.toLocaleString()} tokens`,
+  }));
+}
+
+/**
+ * The recommended default selection: the preferred window, clamped to what the
+ * model actually supports. Always coincides with one of the built choices.
+ */
+export function defaultOllamaContextWindow(detectedContextWindow?: number): number {
+  if (typeof detectedContextWindow !== "number" || detectedContextWindow <= 0) {
+    return OLLAMA_DEFAULT_CONTEXT_WINDOW;
+  }
+  return Math.min(OLLAMA_DEFAULT_CONTEXT_WINDOW, detectedContextWindow);
+}

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -61,6 +61,12 @@ export interface AgentConfig {
   /** Optional per-agent API key overrides by provider. Falls back to global config, then env vars. */
   readonly llmApiKeys?: Partial<Record<ProviderName, string>>;
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
+  /**
+   * Ollama runtime context window (`num_ctx`) in tokens, chosen when the agent
+   * is created. Ollama otherwise truncates conversations to a small default
+   * regardless of the model's trained context. Only meaningful for Ollama agents.
+   */
+  readonly numCtx?: number;
   readonly temperature?: number;
   readonly tools?: readonly string[];
   readonly webSearchProvider?: WebSearchProviderName;

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -40,6 +40,12 @@ export interface ChatCompletionOptions {
   toolChoice?: "auto" | "none" | { type: "function"; function: { name: string } };
   stream?: boolean;
   reasoning_effort?: "disable" | "low" | "medium" | "high";
+  /**
+   * Ollama runtime context window (`num_ctx`). Passed through to Ollama so long
+   * conversations are not silently truncated to its small default. Ignored by
+   * providers other than Ollama.
+   */
+  num_ctx?: number;
   /** Optional per-request API key overrides by provider (typically from agent config). */
   providerApiKeys?: Partial<Record<ProviderName, string>>;
 }

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -75,6 +75,13 @@ export interface LLMProviderConfig {
 export interface OllamaProviderConfig {
   readonly api_key?: string;
   readonly base_url?: string;
+  /**
+   * How long Ollama keeps the model loaded in memory after a request, e.g.
+   * "30m" or "-1" to keep it resident indefinitely. When set, it is sent as
+   * `keep_alive` on every Ollama chat request, avoiding model reload latency
+   * between agent turns. Unset leaves Ollama's own default (5m) in place.
+   */
+  readonly keep_alive?: string;
 }
 
 export interface LlamaCppProviderConfig {

--- a/src/services/llm/ai-sdk-service.test.ts
+++ b/src/services/llm/ai-sdk-service.test.ts
@@ -20,7 +20,12 @@ import {
 import type { AppConfig, LLMConfig, StreamEvent } from "../../core/types/index";
 import { AgentConfigServiceImpl } from "../config";
 import { createLoggerLayer } from "../logger";
-import { buildProviderOptions, createAISDKServiceLayer, toCoreMessages } from "./ai-sdk-service";
+import {
+  buildProviderOptions,
+  createAISDKServiceLayer,
+  makeOllamaKeepAliveFetch,
+  toCoreMessages,
+} from "./ai-sdk-service";
 import { PROVIDER_MODELS } from "./models";
 
 // Bun module mocks are process-global: snapshot the real exports so afterAll can
@@ -991,6 +996,83 @@ describe("buildProviderOptions - ollama reasoning", () => {
   it("sends think:true when reasoning effort is low", () => {
     const result = buildProviderOptions("ollama", ollamaOptions("low"));
     expect(result).toEqual({ ollama: { think: true } });
+  });
+
+  it("nests num_ctx under options when the agent has a context window", () => {
+    const result = buildProviderOptions("ollama", {
+      ...ollamaOptions("disable"),
+      num_ctx: 32768,
+    });
+    expect(result).toEqual({ ollama: { think: false, options: { num_ctx: 32768 } } });
+  });
+
+  it("keeps think and num_ctx together when both are set", () => {
+    const result = buildProviderOptions("ollama", {
+      ...ollamaOptions("high"),
+      num_ctx: 8192,
+    });
+    expect(result).toEqual({ ollama: { think: true, options: { num_ctx: 8192 } } });
+  });
+
+  it("omits options when num_ctx is not a positive number", () => {
+    expect(buildProviderOptions("ollama", { ...ollamaOptions("low"), num_ctx: 0 })).toEqual({
+      ollama: { think: true },
+    });
+  });
+});
+
+describe("makeOllamaKeepAliveFetch", () => {
+  function capturingFetch() {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push({
+        url,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+      });
+      return Promise.resolve(new Response("{}"));
+    }) as typeof globalThis.fetch;
+    return { calls, restore: () => (globalThis.fetch = original) };
+  }
+
+  it("injects keep_alive into /api/chat request bodies", async () => {
+    const { calls, restore } = capturingFetch();
+    try {
+      const wrapped = makeOllamaKeepAliveFetch("30m");
+      await wrapped("http://localhost:11434/api/chat", {
+        method: "POST",
+        body: JSON.stringify({ model: "qwen3", messages: [] }),
+      });
+      expect(calls[0]!.body).toMatchObject({ model: "qwen3", keep_alive: "30m" });
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not override a keep_alive already present", async () => {
+    const { calls, restore } = capturingFetch();
+    try {
+      const wrapped = makeOllamaKeepAliveFetch("30m");
+      await wrapped("http://localhost:11434/api/chat", {
+        method: "POST",
+        body: JSON.stringify({ model: "qwen3", keep_alive: "-1" }),
+      });
+      expect((calls[0]!.body as { keep_alive: string }).keep_alive).toBe("-1");
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves non-chat requests untouched", async () => {
+    const { calls, restore } = capturingFetch();
+    try {
+      const wrapped = makeOllamaKeepAliveFetch("30m");
+      await wrapped("http://localhost:11434/api/tags", { method: "GET" });
+      expect(calls[0]!.body).toBeUndefined();
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -41,7 +41,7 @@ import {
   type TypedToolCall,
 } from "ai";
 import { Chunk, Effect, Layer, Option, Stream } from "effect";
-import { createOllama, type OllamaCompletionProviderOptions } from "ollama-ai-provider-v2";
+import { createOllama } from "ollama-ai-provider-v2";
 import shortUUID from "short-uuid";
 import { minimax } from "vercel-minimax-ai-provider";
 import { z } from "zod";
@@ -661,7 +661,14 @@ function selectModel(
         ? { Authorization: `Bearer ${llmConfig.ollama.api_key}` }
         : {};
       const baseURL = resolveLocalProviderBaseUrl("ollama", llmConfig);
-      const ollamaInstance = createOllama({ baseURL, headers });
+      const keepAlive = llmConfig?.ollama?.keep_alive;
+      const ollamaInstance = createOllama({
+        baseURL,
+        headers,
+        // ollama-ai-provider-v2 drops keep_alive on the chat path, so inject it
+        // into the request body via a fetch middleware when configured.
+        ...(keepAlive ? { fetch: makeOllamaKeepAliveFetch(keepAlive) } : {}),
+      });
       model = ollamaInstance(modelId);
       break;
     }
@@ -714,13 +721,43 @@ function selectModel(
   return model;
 }
 
+/**
+ * Wrap fetch to add Ollama's `keep_alive` to chat request bodies. The
+ * ollama-ai-provider-v2 chat model builds the body as `{model, messages, think,
+ * options}` and drops `keep_alive`, so we splice it in here. Only touches POST
+ * requests to `/api/chat` with a JSON body, and never overrides an existing value.
+ */
+export function makeOllamaKeepAliveFetch(keepAlive: string): typeof globalThis.fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (init?.method === "POST" && typeof init.body === "string") {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/api/chat")) {
+        try {
+          const parsedBody: unknown = JSON.parse(init.body);
+          if (
+            parsedBody &&
+            typeof parsedBody === "object" &&
+            (parsedBody as Record<string, unknown>)["keep_alive"] === undefined
+          ) {
+            (parsedBody as Record<string, unknown>)["keep_alive"] = keepAlive;
+            return fetch(input, { ...init, body: JSON.stringify(parsedBody) });
+          }
+        } catch {
+          // Non-JSON body — forward unchanged.
+        }
+      }
+    }
+    return fetch(input, init);
+  };
+}
+
 function buildProviderCacheFingerprint(providerName: ProviderName, llmConfig?: LLMConfig): string {
   if (!llmConfig) return "";
 
   switch (providerName) {
     case "ollama": {
       const cfg = llmConfig.ollama;
-      return `${cfg?.api_key ?? ""}|${cfg?.base_url ?? ""}`;
+      return `${cfg?.api_key ?? ""}|${cfg?.base_url ?? ""}|${cfg?.keep_alive ?? ""}`;
     }
     case "llamacpp": {
       const cfg = llmConfig.llamacpp;
@@ -812,21 +849,21 @@ export function buildProviderOptions(
       break;
     }
     case "ollama": {
-      if (options.reasoning_effort && options.reasoning_effort !== "disable") {
-        return {
-          ollama: {
-            think: true,
-          } satisfies OllamaCompletionProviderOptions,
-        };
-      }
       // Thinking-capable ollama models default thinking ON when no flag is sent,
       // which makes the ai-sdk ollama provider emit reasoning into a separate
       // field and return empty content/no tool calls. Disabling reasoning must
       // therefore explicitly turn thinking off.
+      const think = !!(options.reasoning_effort && options.reasoning_effort !== "disable");
+      // num_ctx must be nested under `options` (Ollama's runtime request options).
+      // Without it Ollama caps the context to a small default and silently
+      // truncates long conversations regardless of the model's trained size.
+      const numCtx =
+        typeof options.num_ctx === "number" && options.num_ctx > 0 ? options.num_ctx : undefined;
       return {
         ollama: {
-          think: false,
-        } satisfies OllamaCompletionProviderOptions,
+          think,
+          ...(numCtx ? { options: { num_ctx: numCtx } } : {}),
+        },
       };
     }
     case "openrouter": {


### PR DESCRIPTION
## What & why

Two improvements that bring Ollama to parity with the other providers.

### 1. Per-agent context window (`num_ctx`) — fixes silent truncation

Ollama caps the **runtime** context window to a small default (~4096 tokens) regardless of the model's trained size, silently truncating long agent conversations mid-run. jazz already detected the model's real context window but never told Ollama to use it.

Now, when you **create an Ollama agent**, jazz asks you to pick a context window from a fixed ladder (4K–128K), **capped to the model's real maximum** — a selection, not free-text. The choice is stored per agent (`AgentConfig.numCtx`), threaded through `ChatCompletionOptions.num_ctx`, and emitted under Ollama's `options.num_ctx`. Editable later via `jazz agent edit`.

### 2. Keep-alive

New optional `llm.ollama.keep_alive` config (e.g. `"30m"`, or `"-1"` to keep the model resident indefinitely) to avoid model-reload latency between agent turns. Since `ollama-ai-provider-v2` drops `keep_alive` on the chat path, it's injected into `/api/chat` request bodies via a fetch middleware. Unset leaves Ollama's own default (5m).

## Operator-facing changes

| Before | After |
|---|---|
| Long conversations silently truncated to ~4K on Ollama | Context window chosen per agent at creation, sent as `num_ctx` |
| Model reloaded between turns after idle | Optional `keep_alive` keeps it resident |

New optional fields only (`AgentConfig.numCtx`, `OllamaProviderConfig.keep_alive`) — no migration required.

## Reviewer notes

- Context-window choices are capped to the model's detected max, and the exact max is always offered even between ladder rungs (`buildOllamaContextChoices`).
- Added to both the create and edit agent wizards (edit shows a "Context Window" field for Ollama agents).

## Verification

- `bun run typecheck` / `bun run lint` — clean
- `bun test` — full suite green; added unit tests for the context-choice ladder, `num_ctx` provider-option nesting, and the keep-alive fetch injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
