### PR TITLE
fix(cli): remove stray indent on chat startup Description line

### DIFF
--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -375,7 +375,7 @@ function startChatWithAgent(
       `${agent.model} - Reasoning: ${agent.config.reasoningEffort ?? "disabled"}`,
     );
     if (agent.description) {
-      yield* terminal.log(`   Description: ${agent.description}`);
+      yield* terminal.log(`Description: ${agent.description}`);
     }
     yield* terminal.log("");
     yield* terminal.info("Type '/help' to see available special commands.");


### PR DESCRIPTION
## What

The `Description:` line printed at chat startup (`Starting chat with: …`) was hardcoded with a 3-space prefix, while the model/reasoning line directly above it has no indent. This made `Description` appear visibly indented for no reason.

## Before
```
Starting chat with: nano
openai/gpt-5.4-nano - Reasoning: high
   Description: nano
```

## After
```
Starting chat with: nano
openai/gpt-5.4-nano - Reasoning: high
Description: nano
```

## Notes
Only the chat-startup banner in `wizard.ts` is touched. Other `   Description:` usages (create-agent, edit-agent, persona confirmation summaries) are left alone — those live in indented summary blocks where the indent is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)