### PR TITLE
feat(telegram): nightly auto-update script (health-gated + rollback)

### DIFF
--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -137,6 +137,28 @@ over HTTPS and set `TELEGRAM_MODE=webhook`, `TELEGRAM_WEBHOOK_SECRET`
 Add a `ports:` mapping to `docker-compose.yml` to expose the port. The bridge calls
 `setWebhook` on startup and verifies Telegram's secret header.
 
+## Updating Jazz
+
+The image builds Jazz **from this repo's source** at `docker compose up --build`
+time, so the deployed version is pinned to the checkout's commit — it does **not**
+update on its own. To update manually:
+
+```sh
+cd <repo> && git pull origin main
+cd integrations/telegram-bot && docker compose -p jazz-telegram up -d --build
+```
+
+**Nightly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
+rebuilds only if it changed, and rolls back if the new build isn't healthy.
+Install it (as the deploy user):
+
+```sh
+(crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/telegram-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+```
+
+It tracks `main` (bleeding edge); the health-gated rollback guards against a bad
+commit. Check `~/jazz-autoupdate.log` for the run history.
+
 ## Security notes
 
 - Only `TELEGRAM_ALLOWED_CHAT_IDS` are answered; everyone else is ignored.

--- a/integrations/telegram-bot/auto-update.sh
+++ b/integrations/telegram-bot/auto-update.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Nightly auto-update for the Jazz Telegram bridge.
+#
+# Fast-forwards the checkout to the latest origin/main, rebuilds only if it
+# actually changed, and rolls back to the previous commit if the new build
+# doesn't come up healthy. Safe to run from cron. Install (as the deploy user):
+#
+#   (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/telegram-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+#
+# Paths are derived from the script's own location, so it works wherever the
+# repo lives.
+set -eu
+
+PATH=/usr/local/bin:/usr/bin:/bin
+export PATH
+
+DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO=$(cd -- "$DIR/../.." && pwd)
+PROJECT=jazz-telegram
+STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+cd "$REPO"
+git fetch -q origin main
+PREV=$(git rev-parse HEAD)
+LATEST=$(git rev-parse origin/main)
+
+if [ "$PREV" = "$LATEST" ]; then
+  echo "$STAMP up-to-date ($PREV)"
+  exit 0
+fi
+
+echo "$STAMP updating ${PREV} -> ${LATEST}"
+# Fast-forward only: never silently discard local commits/divergence.
+git merge --ff-only origin/main
+
+cd "$DIR"
+docker compose -p "$PROJECT" up -d --build
+
+# Health gate — give it up to a minute to report healthy.
+attempt=0
+while [ "$attempt" -lt 12 ]; do
+  status=$(docker inspect -f '{{.State.Health.Status}}' "$PROJECT" 2>/dev/null || echo none)
+  if [ "$status" = "healthy" ]; then
+    echo "$STAMP updated to ${LATEST} (healthy)"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
+echo "$STAMP update to ${LATEST} did not become healthy — rolling back to ${PREV}"
+cd "$REPO"
+git reset --hard "$PREV"
+cd "$DIR"
+docker compose -p "$PROJECT" up -d --build
+exit 1


### PR DESCRIPTION
The bot's image builds Jazz from the repo checkout, so it doesn't self-update. This adds `auto-update.sh` for a hands-off nightly refresh:

- Fast-forwards to latest `origin/main` (`--ff-only`, never discards local commits).
- Rebuilds **only if the commit changed** (no needless restarts).
- **Health-gated rollback**: if the new build doesn't report `healthy` within ~1 min, it `git reset --hard` to the previous commit and rebuilds — so a bad `main` commit can't leave the bot down.
- Paths derived from the script's location; logs to stdout (cron → `~/jazz-autoupdate.log`).

README documents the manual update command and the cron install line. shellcheck + `sh -n` clean.