### PR TITLE
fix(cli): stop stripping underscores from paths and URLs in markdown

### DIFF
--- a/src/cli/presentation/markdown-formatter.test.ts
+++ b/src/cli/presentation/markdown-formatter.test.ts
@@ -82,6 +82,39 @@ describe("markdown-formatter", () => {
     });
   });
 
+  describe("underscore italics — intraword underscores are not emphasis", () => {
+    // CommonMark: an underscore flanked by alphanumerics neither opens nor
+    // closes emphasis, so paths and URLs must survive verbatim.
+    const path =
+      "/Users/lvndry/Documents/admin/bail_logement_loue_meuble_a_usage_de_residence_principale.pdf";
+    const url = "https://example.com/foo_bar_baz_qux";
+
+    it("preserves underscores in a file path (rendered mode)", () => {
+      expect(stripAnsiCodes(formatMarkdown(path))).toBe(path);
+    });
+
+    it("preserves underscores in a URL (rendered mode)", () => {
+      expect(stripAnsiCodes(formatMarkdown(url))).toBe(url);
+    });
+
+    it("preserves intraword underscores in prose but still italicises real emphasis", () => {
+      const out = stripAnsiCodes(formatMarkdown("say _hello_ to foo_bar_baz please"));
+      // `_hello_` is real emphasis → markers removed; `foo_bar_baz` is intraword → untouched.
+      expect(out).toBe("say hello to foo_bar_baz please");
+    });
+
+    it("still treats genuine _emphasis_ as italic (markers consumed)", () => {
+      // Rendered mode strips the underscore markers when emphasis is applied;
+      // colour styling itself is env-dependent (chalk is a no-op without a TTY),
+      // so we assert the markers were consumed rather than the ANSI bytes.
+      expect(stripAnsiCodes(formatMarkdown("a _word_ here"))).toBe("a word here");
+    });
+
+    it("preserves underscores in a path in hybrid mode", () => {
+      expect(stripAnsiCodes(formatMarkdownHybrid(path))).toBe(path);
+    });
+  });
+
   describe("formatBlockquotes", () => {
     it("should tint blockquotes with the reasoning accent", () => {
       const input = "> Thinking aloud";

--- a/src/cli/presentation/markdown-formatter.test.ts
+++ b/src/cli/presentation/markdown-formatter.test.ts
@@ -113,6 +113,24 @@ describe("markdown-formatter", () => {
     it("preserves underscores in a path in hybrid mode", () => {
       expect(stripAnsiCodes(formatMarkdownHybrid(path))).toBe(path);
     });
+
+    // Boundary contract, asserted identically for both renderers: emphasis needs
+    // a boundary on BOTH sides. `_word_` closes on end-of-line/whitespace, so it
+    // is emphasis; a lone trailing `word_` has no opener and stays literal.
+    it("documents the word-boundary contract (rendered and hybrid agree)", () => {
+      // `_trailing_` at end-of-line: closer boundary is `$` → emphasis.
+      expect(stripAnsiCodes(formatMarkdown("a _trailing_"))).toBe("a trailing");
+      expect(stripAnsiCodes(formatMarkdownHybrid("a _trailing_"))).toBe("a _trailing_");
+
+      // Lone trailing underscore `trailing_`: no matching opener → left literal.
+      expect(stripAnsiCodes(formatMarkdown("say trailing_"))).toBe("say trailing_");
+      expect(stripAnsiCodes(formatMarkdownHybrid("say trailing_"))).toBe("say trailing_");
+
+      // Intraword underscore after a hyphen (`non-word_test`): the `_` is flanked
+      // by letters → not emphasis in either mode.
+      expect(stripAnsiCodes(formatMarkdown("non-word_test"))).toBe("non-word_test");
+      expect(stripAnsiCodes(formatMarkdownHybrid("non-word_test"))).toBe("non-word_test");
+    });
   });
 
   describe("formatBlockquotes", () => {

--- a/src/cli/presentation/markdown-formatter.ts
+++ b/src/cli/presentation/markdown-formatter.ts
@@ -46,7 +46,15 @@ const STRIKETHROUGH_REGEX = /~~([^~\n]+?)~~/g;
 /** Matches **bold** or __bold__. Each branch only rejects its own delimiter inside the content. */
 const BOLD_REGEX = /\*\*([^*\n]+?)\*\*|__([^_\n]+?)__/g;
 const ITALIC_ASTERISK_REGEX = /(?<!\*)\*([^*\n]+?)\*(?!\*)/g;
-const ITALIC_UNDERSCORE_REGEX = /(?<!_)_([^_\n]+?)_(?!_)/g;
+/**
+ * Underscore italics, matched only at word boundaries. Per CommonMark, an
+ * underscore flanked by alphanumerics does NOT open or close emphasis, so
+ * intraword underscores in file paths (`bail_logement_loue`) and URLs
+ * (`foo_bar_baz`) are left untouched instead of being stripped. The opener must
+ * follow start-of-line / whitespace / `[` / `(`; the closer must precede
+ * end-of-line / whitespace / closing punctuation.
+ */
+const ITALIC_UNDERSCORE_REGEX = /(?<=^|[\s[(])_([^_\n]+?)_(?=$|[\s\].,!?)])/gm;
 const INLINE_CODE_REGEX = /`([^`\n]+?)`/g;
 /**
  * ATX headings: CommonMark allows 0–3 spaces before `#`; models often indent further
@@ -1532,10 +1540,6 @@ export function formatMarkdown(text: string): string {
 // Hybrid Mode Formatting - Preserves markdown syntax while adding styling
 // ============================================================================
 
-// Hybrid regex for safe underscore handling - only match standalone underscores
-// This prevents matching underscores in identifiers like hello_world
-const HYBRID_ITALIC_UNDERSCORE_REGEX = /(?<=^|[\s[(])_([^_\n]+?)_(?=[\s\],.!?)]|$)/gm;
-
 /**
  * Format bold text in hybrid mode - keeps ** markers visible
  */
@@ -1569,7 +1573,7 @@ export function formatItalicHybrid(text: string): string {
 
   // Underscore italics - only match if surrounded by whitespace/punctuation
   formatted = formatted.replace(
-    HYBRID_ITALIC_UNDERSCORE_REGEX,
+    ITALIC_UNDERSCORE_REGEX,
     (_match: string, content: string) => `_${ITALIC_MUTED(content)}_`,
   );
 


### PR DESCRIPTION
## The bug

A file path or URL printed in the transcript came out with its underscores **deleted**:

```
shown:  /Users/lvndry/Documents/admin/baillogementlouemeubleausagederesidenceprincipale…malumba.pdf
actual: /Users/lvndry/Documents/admin/bail_logement_loue_meuble_a_usage_de_residence_principale…malumba.pdf
```

Same for URLs: `https://example.com/foo_bar_baz` rendered as `foobarbaz`. This is silent data corruption — the visible text no longer matches the real path/URL.

## Root cause

Rendered-mode `formatItalic` used a greedy underscore rule, `/(?<!_)_([^_\n]+?)_(?!_)/g`, and in `formatMarkdown` it runs **before** paths/URLs are protected. On `bail_logement_loue_meuble` it matched `_logement_`, `_meuble_`, … as emphasis and stripped those underscores.

This is also wrong per CommonMark: an underscore flanked by alphanumerics does **not** open or close emphasis (`foo_bar_baz` is literal text, not italics).

## Fix

Match underscore italics only at word boundaries — the opener must follow start-of-line / whitespace / `[` / `(`, and the closer must precede end-of-line / whitespace / closing punctuation:

```
/(?<=^|[\s[(])_([^_\n]+?)_(?=$|[\s\].,!?)])/gm
```

Genuine `_emphasis_` still italicises; intraword underscores in paths, URLs, and identifiers are left verbatim. The **hybrid** renderer already used exactly this rule, so both modes now share one regex (`HYBRID_ITALIC_UNDERSCORE_REGEX` removed) instead of keeping two definitions in sync.

## Verification

- New tests in `markdown-formatter.test.ts`: underscores preserved in a real file path and URL (rendered + hybrid), intraword underscores in prose left literal, and genuine `_emphasis_` still processed.
- Full suite green (`1556 pass`), typecheck + lint clean.

## Relationship to #302

Independent of #302 (long-link wrapping) — different code path, separate concern — but the same user-reported theme of "links/paths rendering wrong." Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)