### PR TITLE
fix(cli): route the AI SDK's warning banner to stderr instead of stdout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,19 @@
 import { Effect } from "effect";
 import { createCLIApp } from "./cli/cli-app";
 
+// The `ai` SDK's default warning logger writes its one-time banner via console.info, which is
+// STDOUT — this corrupts `jazz run --json`'s output contract (stdout must be JSON only), and
+// crashes JSON.parse for any consumer parsing it. Route warnings to stderr instead, where CLI
+// diagnostics belong and where they can't break structured output.
+globalThis.AI_SDK_LOG_WARNINGS = (options) => {
+  console.error(
+    "AI SDK warning:",
+    JSON.stringify(options.warnings),
+    options.provider,
+    options.model,
+  );
+};
+
 /**
  * Main entry point for the Jazz CLI
  */


### PR DESCRIPTION
## What this PR does
`jazz run --json`'s output contract is that stdout carries JSON only. The `ai` SDK's default warning logger breaks that: the first time any run logs a warning, it prints a one-time banner (`AI SDK Warning System: To turn off warning logging, set the AI_SDK_LOG_WARNINGS global to false.`) via `console.info` — which is stdout, not stderr (`node_modules/ai/dist/index.js`, `logWarnings`).

Found this by reproducing a real consumer failure (ksyl-bot, a Google Chat gateway built on jazz): a run that called `execute_command` and hit a `reasoning parts not supported for Ollama responses` warning produced perfectly valid output, but the consumer's `JSON.parse(stdout.trim())` failed at character 0 because that banner line came first. It looked exactly like the run's answer had been truncated mid-generation, which sent debugging in the wrong direction for a while before I ran the exact failing invocation directly and inspected raw stdout.

## Why
`globalThis.AI_SDK_LOG_WARNINGS` is the SDK's own documented extensibility point for exactly this (see its JSDoc in `ai/dist/index.d.ts`) — assigning a custom logger function bypasses the `console.info` banner entirely, since `logWarnings` returns early once a function is installed. `src/main.ts` now installs one that logs to `console.error` (stderr) instead, keeping warning visibility for interactive/debugging use without ever touching stdout.

## How to test
- `bun run typecheck`, `bun run lint`, `bun test` (1567 pass, 6 skip, 10 todo — unchanged) all green.
- `bun run build` succeeds.
- Edge case: any consumer parsing `jazz run --json` stdout as JSON should no longer fail on a run whose first-ever warning happens to fire mid-run — previously this depended on whether the process had logged a warning before (`hasLoggedBefore` in the SDK is a module-level flag), so it was intermittent and hard to reproduce without a fresh process.