### PR TITLE
fix(review-workflow): distinguish praise from issue severity in review comments

### DIFF
--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -46,7 +46,17 @@ Your output must contain exactly two fenced blocks, in this order, with no text 
    - `line`: target line from the diff
    - `start_line`: optional, for ranges
    - `side`: `RIGHT` for added/modified lines, `LEFT` for deleted
-   - `body`: markdown with severity, explanation, and fix guidance
+   - `body`: markdown starting with a bold label, then explanation and fix guidance
+
+### Comment labels
+
+Use one label per comment, matching what it actually is — never label a positive observation as an issue severity:
+
+- **Critical**: a real bug, security risk, or behavior regression with a concrete failure path. Must include a fix direction.
+- **Warning**: a real but lower-impact correctness or robustness gap (edge case, missing validation) — still a concrete, reachable issue.
+- **Very Good** / **Good** / **Nice**: a deliberate, non-obvious design choice worth calling out positively (e.g. a subtle fix, a well-reasoned tradeoff, a clean boundary). Use sparingly — only when it's genuinely non-obvious, not for routine correct code.
+
+Only emit positive comments alongside real findings or when the verdict text already says the diff looks sound; don't manufacture praise to pad the output.
 
 ### Inline comment line accuracy (GitHub rejects comments on lines outside diff hunks)
 


### PR DESCRIPTION
## Summary
- The CI code-review workflow only documented `**Critical**` as an example label, so the reviewer bot was tagging positive/non-obvious-good-design observations as `Critical` alongside real bugs (see [PR #310 review comment](https://github.com/lvndry/jazz/pull/310#discussion_r3656488982)).
- Added a small severity taxonomy to `.github/jazz/workflows/code-review/WORKFLOW.md`: `Critical`/`Warning` for real issues, `Very Good`/`Good`/`Nice` for genuinely non-obvious positive design calls — with guidance not to manufacture praise just to pad output.

## Test plan
- [ ] Trigger the CI code-review workflow on a PR with both a real issue and a positive design choice, confirm labels are now differentiated.