### PR TITLE
feat(telegram): per-sender timezone for reminders

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "react": "^19.2.7",
         "semver": "^7.8.4",
         "short-uuid": "^6.0.3",
+        "tz-lookup": "^6.1.25",
         "vercel-minimax-ai-provider": "^0.0.2",
         "wrap-ansi": "^10.0.0",
         "zhipu-ai-provider": "^0.3.1",
@@ -910,6 +911,8 @@
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.61.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.61.1", "@typescript-eslint/parser": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw=="],
+
+    "tz-lookup": ["tz-lookup@6.1.25", "", {}, "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="],
 
     "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
 

--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -62,3 +62,7 @@ JAZZ_RUN_TIMEOUT_MS=300000
 
 # Host port the /health server listens on.
 PORT=8080
+
+# Fallback timezone for reminder times when a chat hasn't set its own (via /tz
+# or by sharing a location). IANA name, e.g. Europe/Paris. Defaults to UTC.
+# TZ=UTC

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -8,7 +8,7 @@ Markdown rendering.
 Works with any Jazz provider. **Defaults to OpenAI `gpt-5.4`**; point it at a
 local [Ollama](https://ollama.com) instead for fully self-hosted, no-cloud use.
 
-```
+```text
 Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --json──▶  OpenAI / Ollama / …
 ```
 
@@ -19,6 +19,8 @@ Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --jso
 - 🎛️ **Per-person `/model` and `/persona`** — each user picks their own via inline keyboards; choices persist.
 - ♻️ **Auto reasoning** — switching to an Ollama model reads its advertised capabilities and enables/disables thinking so non-thinking models don't error.
 - 📡 **Live progress** — a status bubble updates in real time with the agent's thinking, tool calls, sub-agents (🤖), and tools awaiting approval (⛔); it closes with a `✅ Done · tools · tokens · $cost` summary, and the answer lands as a new message (so it notifies).
+- ⏰ **Reminders** — `/remind 30m …` or plain language ("remind me next friday at 2pm …"), resolved in your own timezone (`/tz`, or auto-set from a shared location) and delivered even across restarts.
+- 📍 **Location aware** — share a pin to get oriented, find nearby places, and set your timezone automatically.
 - 💬 **Per-chat memory**, ✍️ **Markdown rendering** (with plain-text fallback), 🔒 **allowlist-gated**, 🐳 **one-command Docker deploy**.
 
 ## Requirements
@@ -57,17 +59,18 @@ Message your bot: it shows a "typing…" indicator, then the agent's reply.
 
 ## Commands
 
-| Command | What it does |
-|---|---|
-| _(any message)_ | Answered by your agent |
-| `/model` | Inline keyboard of models pulled in Ollama — pick one (switches you to that local model) |
-| `/persona` | Inline keyboard of available personas |
-| `/new` (`/reset`) | Start a fresh conversation — clears earlier context; keeps your model/persona |
-| `/remind <when> <text>` | Schedule a reminder DM. `<when>` = `30m`, `1h30m`, `90s`, `2d`, `18:00`, or `tomorrow 09:00` |
-| _(natural language)_ | Just say it — "remind me to call the dentist in 2 hours", "send reminder next friday at 2pm for the review", "send reminder september 23rd for Sam's birthday". The model resolves the date/time and schedules it. |
-| `/reminders` | List your pending reminders; tap one to cancel |
-| `/status` | Current model, today's runs/tokens/cost, daily cap, uptime |
-| `/help` | Usage |
+| Command                 | What it does                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| _(any message)_         | Answered by your agent                                                                                                                                                                                             |
+| `/model`                | Inline keyboard of models pulled in Ollama — pick one (switches you to that local model)                                                                                                                           |
+| `/persona`              | Inline keyboard of available personas                                                                                                                                                                              |
+| `/new` (`/reset`)       | Start a fresh conversation — clears earlier context; keeps your model/persona                                                                                                                                      |
+| `/remind <when> <text>` | Schedule a reminder DM. `<when>` = `30m`, `1h30m`, `90s`, `2d`, `18:00`, or `tomorrow 09:00`                                                                                                                       |
+| _(natural language)_    | Just say it — "remind me to call the dentist in 2 hours", "send reminder next friday at 2pm for the review", "send reminder september 23rd for Sam's birthday". The model resolves the date/time and schedules it. |
+| `/reminders`            | List your pending reminders (in your timezone); tap one to cancel                                                                                                                                                  |
+| `/tz [zone]`            | Show or set your timezone (IANA name, e.g. `/tz Europe/Paris`) so reminder times are local                                                                                                                         |
+| `/status`               | Current model, your timezone, today's runs/tokens/cost, daily cap, uptime                                                                                                                                          |
+| `/help`                 | Usage                                                                                                                                                                                                              |
 
 While a message is processing, the progress bubble carries a **⏹ Cancel** button
 that kills the run. Each answer gets **contextual follow-up buttons** — a quick
@@ -80,38 +83,44 @@ Set `JAZZ_DAILY_COST_CAP_USD` to cap total spend per day (0 = no cap).
 
 **Location.** Share a location (📎 → Location) and the bot reverse-geocodes it
 (OpenStreetMap Nominatim) and hands the agent the coordinates + address, so you
-can ask "where am I", "nearest pharmacy", or "directions to …". The coordinates
-are stored in the conversation history (plaintext) and sent to the geocoder — set
-`NOMINATIM_BASE_URL=""` to disable reverse-geocoding (coords still passed to the
-agent), or point it at a self-hosted Nominatim.
+can ask "where am I", "nearest pharmacy", or "directions to …". It also sets your
+timezone from the coordinates (offline, via `tz-lookup`) so reminders land at the
+right local time. The coordinates are stored in the conversation history
+(plaintext) and sent to the geocoder — set `NOMINATIM_BASE_URL=""` to disable
+reverse-geocoding (coords still passed to the agent), or point it at a self-hosted
+Nominatim.
+
+**Timezone.** Reminder times are resolved per person: an explicit `/tz` choice, a
+zone auto-detected from a shared location, the container's `TZ`, then UTC (in that
+order). So "next friday at 2pm" and `18:00` mean 2pm/6pm where the sender is,
+across DST. Each chat's zone is stored in `tg-tz.json`.
 
 Reminders are persisted in `tg-reminders.json` and delivered by a sweep, so they
 survive restarts (a reminder due while the bridge was down fires on next start,
-marked `(delayed)`). Clock times (`18:00`, `tomorrow 09:00`) use the container's
-timezone — set `TZ` in `.env` to your own; relative durations are unambiguous.
+marked `(delayed)`). Relative durations (`30m`, `2h`) are timezone-independent.
 
 Each Telegram user gets an independent agent (`tg_<chat_id>.json`, cloned from the
-`telegram` template on first contact), so `/model` and `/persona` change only *your*
+`telegram` template on first contact), so `/model` and `/persona` change only _your_
 experience. `JAZZ_TELEGRAM_PROVIDER` / `JAZZ_TELEGRAM_MODEL` / `JAZZ_REASONING` set
 the defaults new chats start from. (`/model` lists Ollama models — handy when you
 run Ollama; cloud users typically just keep the default.)
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `TELEGRAM_BOT_TOKEN` | — | **Required.** Bot token from @BotFather. |
-| `TELEGRAM_ALLOWED_CHAT_IDS` | — | **Required.** Comma-separated chat ids allowed to use the bot. |
-| `JAZZ_TELEGRAM_PROVIDER` | `openai` | LLM provider — `openai`, `openrouter`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `ollama`, … |
-| `JAZZ_TELEGRAM_MODEL` | `gpt-5.4` | Default model id for the provider. |
-| `OPENAI_API_KEY` (or provider's key) | — | API key for the chosen provider (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, …). Not needed for `ollama`. |
-| `BRAVE_API_KEY` | — | If set, `web_search` uses Brave (configured as the provider in `config.json`). |
-| `JAZZ_REASONING` | `medium` | `disable`\|`low`\|`medium`\|`high`. |
-| `OLLAMA_BASE_URL` | `http://host.docker.internal:11434/api` | Ollama endpoint (only for `provider=ollama` / `/model`). |
-| `JAZZ_APPROVAL_POLICY` | `low-risk` | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`. |
-| `JAZZ_RUN_TIMEOUT_MS` | `300000` | Per-message agent timeout. |
-| `TELEGRAM_MODE` | `polling` | `polling` or `webhook`. |
-| `PORT` | `8080` | In-container health-check port. |
+| Variable                             | Default                                 | Purpose                                                                                                  |
+| ------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `TELEGRAM_BOT_TOKEN`                 | —                                       | **Required.** Bot token from @BotFather.                                                                 |
+| `TELEGRAM_ALLOWED_CHAT_IDS`          | —                                       | **Required.** Comma-separated chat ids allowed to use the bot.                                           |
+| `JAZZ_TELEGRAM_PROVIDER`             | `openai`                                | LLM provider — `openai`, `openrouter`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `ollama`, …    |
+| `JAZZ_TELEGRAM_MODEL`                | `gpt-5.4`                               | Default model id for the provider.                                                                       |
+| `OPENAI_API_KEY` (or provider's key) | —                                       | API key for the chosen provider (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, …). Not needed for `ollama`. |
+| `BRAVE_API_KEY`                      | —                                       | If set, `web_search` uses Brave (configured as the provider in `config.json`).                           |
+| `JAZZ_REASONING`                     | `medium`                                | `disable`\|`low`\|`medium`\|`high`.                                                                      |
+| `OLLAMA_BASE_URL`                    | `http://host.docker.internal:11434/api` | Ollama endpoint (only for `provider=ollama` / `/model`).                                                 |
+| `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`.                                          |
+| `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                               |
+| `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                  |
+| `PORT`                               | `8080`                                  | In-container health-check port.                                                                          |
 
 > **Model ↔ reasoning:** reasoning-capable models (`gpt-5.4`, qwen3, …) work with
 > `medium`/`high`; models without it (mistral-small, gemma, …) error unless
@@ -121,7 +130,7 @@ run Ollama; cloud users typically just keep the default.)
 
 For each allowed message the bridge runs:
 
-```
+```sh
 jazz run --no-tui --json --agent tg_<chat_id> --conversation <chat_id> "<text>"
 ```
 

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -26,6 +26,16 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import tzlookup from "tz-lookup";
+import {
+  formatWhen,
+  hasChatTz,
+  isValidTimeZone,
+  setTzForChat,
+  tzForChat,
+  wallClockToEpoch,
+  zonedDateParts,
+} from "./timezone";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 // Telegram's hard limit is 4096; split lower so HTML tags/entities added by
@@ -391,10 +401,10 @@ const DURATION_UNIT_MS: Record<string, number> = {
 /**
  * Parse a "when" spec into an absolute epoch-ms, or null if unparseable.
  * Supports relative durations (30m, 2h, 1h30m, 90s, 1d), a 24h clock time
- * (HH:MM → next occurrence), and "tomorrow HH:MM". Clock times use the
- * container's timezone — set TZ in .env to your own.
+ * (HH:MM → next occurrence), and "tomorrow HH:MM". Clock times are interpreted
+ * in the caller's `tz` so "18:00" means 6pm where the sender is.
  */
-function parseWhen(spec: string, now: number): number | null {
+function parseWhen(spec: string, now: number, tz: string): number | null {
   const trimmed = spec.trim().toLowerCase();
 
   const tomorrow = /^tomorrow\s+(\d{1,2}):(\d{2})$/.exec(trimmed);
@@ -403,11 +413,20 @@ function parseWhen(spec: string, now: number): number | null {
     const hours = Number(clock[1]);
     const minutes = Number(clock[2]);
     if (hours > 23 || minutes > 59) return null;
-    const when = new Date(now);
-    if (tomorrow) when.setDate(when.getDate() + 1);
-    when.setHours(hours, minutes, 0, 0);
-    if (!tomorrow && when.getTime() <= now) when.setDate(when.getDate() + 1);
-    return when.getTime();
+    const today = zonedDateParts(now, tz);
+    const dayOffset = tomorrow ? 1 : 0;
+    let fireAt = wallClockToEpoch(
+      today.year,
+      today.month,
+      today.day + dayOffset,
+      hours,
+      minutes,
+      tz,
+    );
+    if (!tomorrow && fireAt <= now) {
+      fireAt = wallClockToEpoch(today.year, today.month, today.day + 1, hours, minutes, tz);
+    }
+    return fireAt;
   }
 
   let totalMs = 0;
@@ -478,12 +497,38 @@ async function reverseGeocode(
 }
 
 /** Turn a shared location into a prompt and run it through the normal pipeline. */
+/** Best-effort: set the chat's timezone from shared coordinates, and tell them. */
+async function maybeSetTzFromLocation(
+  config: BridgeConfig,
+  chatId: number,
+  latitude: number,
+  longitude: number,
+): Promise<void> {
+  let detected: string;
+  try {
+    detected = tzlookup(latitude, longitude);
+  } catch {
+    return; // outside the lookup's coverage — leave the zone as-is
+  }
+  if (!isValidTimeZone(detected)) return;
+  const previous = setTzForChat(config.jazzHome, chatId, detected);
+  if (previous === detected) return; // already on this zone — nothing to announce
+  const hadZone = typeof previous === "string" && isValidTimeZone(previous);
+  await sendReply(
+    config,
+    chatId,
+    `🌍 ${hadZone ? "Updated" : "Set"} your timezone to <code>${escapeHtml(detected)}</code> ` +
+      "from this location — reminders will use it. Change it anytime with <code>/tz</code>.",
+  );
+}
+
 async function handleLocation(
   config: BridgeConfig,
   chatId: number,
   latitude: number,
   longitude: number,
 ): Promise<void> {
+  await maybeSetTzFromLocation(config, chatId, latitude, longitude);
   const address = await reverseGeocode(config, latitude, longitude);
   const mapLink = `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=17/${latitude}/${longitude}`;
   const prompt =
@@ -931,13 +976,14 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
   // 2pm for X") are handled here instead of a full agent turn. If the time can't
   // be parsed, fall through to a normal answer (so "remind me what X is" works).
   if (looksLikeReminderRequest(text)) {
-    const reminder = await parseReminderNL(config, text, Date.now());
+    const now = Date.now();
+    const reminder = await parseReminderNL(config, text, now, tzForChat(config.jazzHome, chatId));
     if (reminder) {
       addReminder(config, chatId, reminder.fireAt, reminder.text);
       await sendReply(
         config,
         chatId,
-        reminderConfirmation(reminder.fireAt, Date.now(), reminder.text),
+        reminderConfirmation(config, chatId, reminder.fireAt, now, reminder.text),
       );
       return;
     }
@@ -1085,7 +1131,7 @@ function ensureSuggestAgent(config: BridgeConfig): void {
   const template = readAgentFile(config, config.baseAgentId);
   template.id = SUGGEST_AGENT_ID;
   template.name = SUGGEST_AGENT_ID;
-  template.config.tools = [];
+  template.config["tools"] = [];
   template.config.reasoningEffort = "disable";
   writeAgentFile(config, template);
 }
@@ -1180,10 +1226,11 @@ const HELP_TEXT = [
   "/remind <when> <text> — e.g. /remind 30m take pizza out",
   "  …or just say it: “remind me to call the dentist in 2 hours”, “send reminder next friday 2pm for review”",
   "/reminders — list & cancel your reminders",
+  "/tz — set your timezone so reminder times are local (e.g. /tz Europe/Paris)",
   "/status — model, today's usage, uptime",
   "/help — show this",
   "",
-  "📍 Share your location (📎 → Location) and I'll tell you where you are and find nearby places.",
+  "📍 Share your location (📎 → Location) and I'll tell you where you are, find nearby places, and set your timezone.",
 ].join("\n");
 
 interface InlineButton {
@@ -1197,21 +1244,17 @@ function keyboardFrom(options: string[], current: string, prefix: string): Inlin
   ]);
 }
 
-function formatWhen(fireAt: number): string {
-  const tz = process.env["TZ"]?.trim() || "UTC";
-  try {
-    return new Date(fireAt).toLocaleString("en-GB", {
-      timeZone: tz,
-      dateStyle: "medium",
-      timeStyle: "short",
-    });
-  } catch {
-    return `${new Date(fireAt).toISOString().replace("T", " ").slice(0, 16)} UTC`;
-  }
-}
-
-function reminderConfirmation(fireAt: number, now: number, text: string): string {
-  return `⏰ Reminder set for ${formatWhen(fireAt)} (in ${formatUptime(fireAt - now)}).\n“${escapeHtml(text)}”`;
+function reminderConfirmation(
+  config: BridgeConfig,
+  chatId: number,
+  fireAt: number,
+  now: number,
+  text: string,
+): string {
+  const tz = tzForChat(config.jazzHome, chatId);
+  const base = `⏰ Reminder set for ${formatWhen(fireAt, tz)} <i>(${escapeHtml(tz)})</i> — in ${formatUptime(fireAt - now)}.\n“${escapeHtml(text)}”`;
+  if (hasChatTz(config.jazzHome, chatId)) return base;
+  return `${base}\n\n🌍 Times are in <code>${escapeHtml(tz)}</code>. Set yours with <code>/tz Europe/Paris</code> or share your location.`;
 }
 
 /** True when a free-text message reads like a request to schedule a reminder. */
@@ -1231,11 +1274,13 @@ async function parseReminderNL(
   config: BridgeConfig,
   request: string,
   now: number,
+  tz: string,
 ): Promise<{ fireAt: number; text: string } | null> {
   ensureSuggestAgent(config);
-  const tz = process.env["TZ"]?.trim() || "UTC";
+  const localNow = formatWhen(now, tz);
   const prompt =
-    `Current date and time: ${new Date(now).toISOString()} (timezone: ${tz}).\n` +
+    `Current date and time: ${new Date(now).toISOString()} — that is ${localNow} in the user's ` +
+    `timezone (${tz}).\n` +
     `The user wants a reminder. Their request: "${request}"\n\n` +
     "Work out the absolute time it should fire and what to remind them about. Reply with ONLY " +
     "JSON, no prose or code fences:\n" +
@@ -1282,23 +1327,28 @@ async function handleRemind(config: BridgeConfig, chatId: number, args: string):
   }
 
   const now = Date.now();
+  const tz = tzForChat(config.jazzHome, chatId);
   let fireAt: number | null = null;
   let text = "";
   if (words.length >= 2 && words[0]?.toLowerCase() === "tomorrow") {
-    fireAt = parseWhen(`tomorrow ${words[1]}`, now);
+    fireAt = parseWhen(`tomorrow ${words[1]}`, now, tz);
     if (fireAt !== null) text = words.slice(2).join(" ");
   }
   if (fireAt === null) {
-    fireAt = parseWhen(words[0] ?? "", now);
+    fireAt = parseWhen(words[0] ?? "", now, tz);
     if (fireAt !== null) text = words.slice(1).join(" ");
   }
 
   // Structured parse failed — fall back to natural-language understanding.
   if (fireAt === null) {
-    const nl = await parseReminderNL(config, args, now);
+    const nl = await parseReminderNL(config, args, now, tz);
     if (nl) {
       addReminder(config, chatId, nl.fireAt, nl.text);
-      await sendReply(config, chatId, reminderConfirmation(nl.fireAt, now, nl.text));
+      await sendReply(
+        config,
+        chatId,
+        reminderConfirmation(config, chatId, nl.fireAt, now, nl.text),
+      );
       return;
     }
     await sendReply(config, chatId, `I couldn't work out when to remind you.\n${usage}`);
@@ -1314,7 +1364,41 @@ async function handleRemind(config: BridgeConfig, chatId: number, args: string):
   }
 
   addReminder(config, chatId, fireAt, text.trim());
-  await sendReply(config, chatId, reminderConfirmation(fireAt, now, text.trim()));
+  await sendReply(config, chatId, reminderConfirmation(config, chatId, fireAt, now, text.trim()));
+}
+
+async function handleTz(config: BridgeConfig, chatId: number, args: string): Promise<void> {
+  const requested = args.trim();
+  if (requested.length === 0) {
+    const current = tzForChat(config.jazzHome, chatId);
+    const suffix = hasChatTz(config.jazzHome, chatId) ? "" : " (default — not set by you yet)";
+    await sendReply(
+      config,
+      chatId,
+      `🌍 Your timezone: <code>${escapeHtml(current)}</code>${suffix}\n` +
+        `Local time now: ${formatWhen(Date.now(), current)}\n\n` +
+        "Change it with <code>/tz Europe/Paris</code> (an IANA name like " +
+        "<code>America/New_York</code>, <code>Asia/Tokyo</code>), or just share your location " +
+        "(📎 → Location) and I'll set it for you.",
+    );
+    return;
+  }
+  if (!isValidTimeZone(requested)) {
+    await sendReply(
+      config,
+      chatId,
+      `I don't recognise “${escapeHtml(requested)}”. Use an IANA name such as ` +
+        "<code>Europe/Paris</code>, <code>America/New_York</code>, or <code>Asia/Tokyo</code>.",
+    );
+    return;
+  }
+  setTzForChat(config.jazzHome, chatId, requested);
+  await sendReply(
+    config,
+    chatId,
+    `✅ Timezone set to <code>${escapeHtml(requested)}</code>. Local time now: ` +
+      `${formatWhen(Date.now(), requested)}.\nReminders will use this from now on.`,
+  );
 }
 
 async function handleCommand(
@@ -1330,6 +1414,11 @@ async function handleCommand(
     return;
   }
 
+  if (command === "tz" || command === "timezone") {
+    await handleTz(config, chatId, args);
+    return;
+  }
+
   if (command === "reminders") {
     const mine = readReminders(config)
       .filter((reminder) => reminder.chatId === chatId)
@@ -1342,15 +1431,16 @@ async function handleCommand(
       );
       return;
     }
+    const tz = tzForChat(config.jazzHome, chatId);
     const rows = mine.map((reminder) => [
       {
-        text: `❌ ${new Date(reminder.fireAt).toISOString().slice(5, 16).replace("T", " ")} — ${reminder.text.slice(0, 24)}`,
+        text: `❌ ${formatWhen(reminder.fireAt, tz)} — ${reminder.text.slice(0, 24)}`,
         callback_data: `r:${reminder.id}`,
       },
     ]);
     await callTelegram(config, "sendMessage", {
       chat_id: chatId,
-      text: "Pending reminders (tap to cancel · times UTC):",
+      text: `Pending reminders (tap to cancel · times in ${tz}):`,
       reply_markup: { inline_keyboard: rows },
     });
     return;
@@ -1372,6 +1462,7 @@ async function handleCommand(
     const lines = [
       "📊 <b>Status</b>",
       `Model: <code>${escapeHtml(agent.config.llmProvider)}/${escapeHtml(agent.config.llmModel)}</code> (reasoning: ${escapeHtml(agent.config.reasoningEffort)})`,
+      `Timezone: <code>${escapeHtml(tzForChat(config.jazzHome, chatId))}</code>${hasChatTz(config.jazzHome, chatId) ? "" : " (default)"}`,
       `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}`,
       `Daily cap: ${cap > 0 ? `$${cap.toFixed(2)}` : "none"}`,
       `Uptime: ${formatUptime(Date.now() - BRIDGE_STARTED_AT)}`,

--- a/integrations/telegram-bot/timezone.ts
+++ b/integrations/telegram-bot/timezone.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-chat timezone support.
+ *
+ * Telegram never sends the sender's timezone, so each chat's zone is resolved
+ * from (in order): an explicit `/tz` choice, one auto-detected from a shared
+ * location, the container's `TZ`, then UTC. Everything time-related — reminder
+ * parsing, clock times, confirmations — runs against the resolved zone so
+ * "next friday at 2pm" means 2pm where the sender is.
+ *
+ * Store functions take the data directory (Jazz's home) rather than the bridge
+ * config, so this module stays free of any dependency on bridge.ts.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function tzStorePath(dataDir: string): string {
+  return join(dataDir, "tg-tz.json");
+}
+
+function readTzStore(dataDir: string): Record<string, string> {
+  try {
+    const path = tzStorePath(dataDir);
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // ignore — treat as unset
+  }
+  return {};
+}
+
+function writeTzStore(dataDir: string, store: Record<string, string>): void {
+  try {
+    writeFileSync(tzStorePath(dataDir), `${JSON.stringify(store, null, 2)}\n`);
+  } catch (error) {
+    console.error(`Failed to write timezone store: ${String(error)}`);
+  }
+}
+
+export function isValidTimeZone(tz: string): boolean {
+  if (tz.length === 0) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True when this chat has an explicitly stored, valid zone (vs. falling back). */
+export function hasChatTz(dataDir: string, chatId: number): boolean {
+  const stored = readTzStore(dataDir)[String(chatId)];
+  return typeof stored === "string" && isValidTimeZone(stored);
+}
+
+/** Resolve the effective IANA zone for a chat, with fallbacks. */
+export function tzForChat(dataDir: string, chatId: number): string {
+  const stored = readTzStore(dataDir)[String(chatId)];
+  if (typeof stored === "string" && isValidTimeZone(stored)) return stored;
+  const fromEnv = process.env["TZ"]?.trim() ?? "";
+  return isValidTimeZone(fromEnv) ? fromEnv : "UTC";
+}
+
+/** Persist an explicit zone for a chat. Returns the previously stored value. */
+export function setTzForChat(dataDir: string, chatId: number, tz: string): string | undefined {
+  const store = readTzStore(dataDir);
+  const previous = store[String(chatId)];
+  store[String(chatId)] = tz;
+  writeTzStore(dataDir, store);
+  return previous;
+}
+
+/** Format an instant for display in `tz` (e.g. "23 Sep 2026, 14:00"). */
+export function formatWhen(fireAt: number, tz: string): string {
+  try {
+    return new Date(fireAt).toLocaleString("en-GB", {
+      timeZone: tz,
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return `${new Date(fireAt).toISOString().replace("T", " ").slice(0, 16)} UTC`;
+  }
+}
+
+/** Offset (ms) that must be subtracted from a UTC instant to reach wall time in `tz`. */
+function tzOffsetMs(epoch: number, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(new Date(epoch));
+  const field: Record<string, number> = {};
+  for (const part of parts) {
+    if (part.type !== "literal") field[part.type] = Number(part.value);
+  }
+  const asIfUtc = Date.UTC(
+    field["year"] ?? 1970,
+    (field["month"] ?? 1) - 1,
+    field["day"] ?? 1,
+    field["hour"] ?? 0,
+    field["minute"] ?? 0,
+    field["second"] ?? 0,
+  );
+  return asIfUtc - epoch;
+}
+
+/** The calendar Y/M/D that `epoch` falls on in `tz`. */
+export function zonedDateParts(
+  epoch: number,
+  tz: string,
+): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(epoch));
+  const field: Record<string, number> = {};
+  for (const part of parts) {
+    if (part.type !== "literal") field[part.type] = Number(part.value);
+  }
+  return { year: field["year"] ?? 1970, month: field["month"] ?? 1, day: field["day"] ?? 1 };
+}
+
+/** Convert a wall-clock time in `tz` to an epoch, settling DST with a refine pass. */
+export function wallClockToEpoch(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  tz: string,
+): number {
+  const guess = Date.UTC(year, month - 1, day, hour, minute, 0);
+  const firstPass = guess - tzOffsetMs(guess, tz);
+  return guess - tzOffsetMs(firstPass, tz);
+}

--- a/integrations/telegram-bot/tz-lookup.d.ts
+++ b/integrations/telegram-bot/tz-lookup.d.ts
@@ -1,0 +1,5 @@
+// `tz-lookup` ships no type declarations. It exports a single function that
+// maps coordinates to an IANA timezone name (e.g. "Europe/Paris").
+declare module "tz-lookup" {
+  export default function tzlookup(latitude: number, longitude: number): string;
+}

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react": "^19.2.7",
     "semver": "^7.8.4",
     "short-uuid": "^6.0.3",
+    "tz-lookup": "^6.1.25",
     "vercel-minimax-ai-provider": "^0.0.2",
     "wrap-ansi": "^10.0.0",
     "zhipu-ai-provider": "^0.3.1",


### PR DESCRIPTION
## What

Reminder times are now resolved **per sender**, not against the container clock.

Telegram doesn't include the sender's timezone in messages, so previously "next friday at 2pm" / `18:00` were interpreted in the container's `TZ` (UTC unless set) — potentially hours off. This change resolves a timezone for each chat:

- **`/tz [zone]`** — show or set an IANA zone (e.g. `/tz Europe/Paris`), validated via `Intl`.
- **Auto-detect from a shared location** — sharing a pin (📎 → Location) now also sets the chat's timezone, offline via [`tz-lookup`](https://www.npmjs.com/package/tz-lookup) (zero-dependency, coordinate → IANA name).
- **Resolution order:** explicit `/tz` → location-detected → container `TZ` → UTC.

Clock-time and natural-language reminders parse and display in the resolved zone, correct across DST (two-pass wall-clock→epoch conversion using `Intl` offsets). `/status`, `/reminders`, and confirmation messages show the active zone; chats with no zone set get a one-line hint.

## Structure

Timezone logic (per-chat store + `Intl` date math) lives in a new `integrations/telegram-bot/timezone.ts` module rather than growing `bridge.ts`. A small `tz-lookup.d.ts` supplies types for the untyped package.

## Verification

- `tsc --noEmit` clean on `bridge.ts` + `timezone.ts` (strict settings).
- Bundles cleanly under Bun (`bun build --target=bun`).
- markdownlint + prettier clean.
- Validated the time math: Paris/NYC wall-clock → correct UTC in both summer (CEST) and winter (CET), and day-boundary handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)