### PR TITLE
Add native per-agent memory tool

### DIFF
--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -96,6 +96,7 @@ Details and conventions: [Code map](./code-map.md).
 | [Context management](./context-management.md) | Two-tier token counting, calibration, turn-aware trimming, 80% compaction, tool-result formatting |
 | [Tools & approval](./tools-and-approval.md) | Registry, risk tiers, two-phase execution, concurrency, timeouts, command allowlisting |
 | [Sub-agents](./subagents.md) | Context isolation, personas, cost roll-up, when the model reaches for one |
+| [Memory](./memory.md) | Per-agent file-backed memory, path-safety choke point, locking, why it's opt-in |
 | [Skills loading](./skills-loading.md) | Progressive disclosure: `find_skills` → `load_skill` → `load_skill_section` |
 | [Providers & models](./providers-and-models.md) | The AI SDK port, model catalog, reasoning normalization, retries, cost |
 | [Evals](./evals.md) | Measuring whether a harness change helped: Pass^k, A/B, grounding checks, judge calibration |

--- a/docs/internals/memory.md
+++ b/docs/internals/memory.md
@@ -1,0 +1,56 @@
+# Memory
+
+**Reader job:** understand where agent memory lives on disk, how it stays safe, and why
+it's opt-in rather than always-on.
+
+Source:
+[`services/memory-service.ts`](../../src/services/memory-service.ts) ·
+[`interfaces/memory-service.ts`](../../src/core/interfaces/memory-service.ts) ·
+[`tools/memory-tools.ts`](../../src/core/agent/tools/memory-tools.ts)
+
+---
+
+## What it is
+
+A native, file-backed memory the agent manages itself via two tools — `view_memory` and
+`manage_memory` (create/str_replace/insert/delete/rename) — mirroring the action surface of
+Anthropic's own memory tool. There is no embedding index or vector search: memory is read in
+full on `view`, which is the right tradeoff at the scale this targets (durable notes about
+the people or projects one agent talks to), not a multi-tenant knowledge base.
+
+Memory is scoped by `Agent.id`, the same identifier that already scopes conversation
+history — so it follows an agent across every surface that invokes it (CLI, a Telegram
+bridge, a Slack bridge), not by session or conversation.
+
+## On disk
+
+```text
+~/.jazz/memory/<agentId>/            agent's memory root, created lazily on first write
+~/.jazz/memory/<agentId>.lock/       directory-mutex, same convention as history's lock
+```
+
+Flat UTF-8 files, agent-organized (e.g. `people/alex.md`, `project-context.md`) — no
+enforced schema. Guardrails cap depth, path-segment length, per-file size, total bytes, and
+file count per agent (`core/constants/memory.ts`).
+
+## Path safety
+
+Every action goes through one function, `resolveMemoryPath`, before touching the
+filesystem: it rejects `..`, null bytes, and absolute-path tricks, and **bans symlinks
+outright** anywhere in the resolved chain — re-checked on every call, not cached, so a
+same-run "create a file, swap it for a symlink, then read through it" race can't slip past a
+one-time check.
+
+Mutating actions (`create`/`str_replace`/`insert`/`delete`/`rename`) share one lock per
+agent — not per file — because the size/count guardrails need a consistent view of the
+whole directory tree, and the guardrail check plus the write happen inside the same lock
+acquisition.
+
+## Why opt-in
+
+`view_memory`/`manage_memory` are registered like `file_management` or `git` — selected per
+agent via `AgentConfig.tools`, not granted to every agent unconditionally. Memory persists
+durable, potentially sensitive facts about a specific person to disk; forcing it on
+everywhere would silently contradict personas (like `researcher`) that promise their tools
+can't write files. Whoever wires up a persistent chat surface (Telegram, Slack) turns memory
+on for that agent specifically.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -15,11 +15,11 @@ and [Security](../../SECURITY.md) for the threat model.
 
 | | Count |
 | --- | --- |
-| **Agent-facing tools** | **43** |
+| **Agent-facing tools** | **45** |
 | Hidden `execute_*` counterparts (the second half of each approval pair) | 15 |
-| Total registered | 58 |
-| `read-only` | 26 |
-| `low-risk` | 2 |
+| Total registered | 60 |
+| `read-only` | 27 |
+| `low-risk` | 3 |
 | `high-risk` | 15 |
 
 Plus, registered per agent rather than globally:
@@ -128,6 +128,15 @@ You never call `execute_*` names yourself; they are hidden from the model's tool
 | --- | --- | --- | --- |
 | `list_todos` | `read-only` | — | Read the current todo list. Returns all items with their status and priority. |
 | `manage_todos` | `low-risk` | — | Create or update the todo list. Send the FULL list of items each time (replaces the previous list). Use thi… |
+
+### Memory
+
+Opt-in per agent (like File Management or Git) rather than always-on — see [Memory](../internals/memory.md).
+
+| Tool | Risk | Approval pair | What it does |
+| --- | --- | --- | --- |
+| `view_memory` | `read-only` | — | Read what you've saved about this person or project from earlier conversations. Call with no pa… |
+| `manage_memory` | `low-risk` | — | Create, edit, rename, or delete files under your persistent memory directory — the durable notes… |
 
 ### Context
 

--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -31,6 +31,7 @@ import { createJazzStateServiceLayer } from "./services/jazz-state";
 import { createAISDKServiceLayer } from "./services/llm/ai-sdk-service";
 import { createLoggerLayer, setLogFormat, setLogLevel } from "./services/logger";
 import { createMCPServerManagerLayer } from "./services/mcp/mcp-server-manager";
+import { createMemoryServiceLayer } from "./services/memory-service";
 import { NotificationServiceLayer } from "./services/notification";
 import { createPersonaServiceLayer } from "./services/persona-service";
 import { FileStorageService } from "./services/storage/file";
@@ -159,6 +160,7 @@ export function createAppLayer(config: AppLayerConfig = {}) {
 
   const agentLayer = createAgentServiceLayer().pipe(Layer.provide(storageLayer));
   const personaLayer = createPersonaServiceLayer();
+  const memoryServiceLayer = createMemoryServiceLayer();
 
   const chatLayer = createChatServiceLayer().pipe(
     Layer.provide(terminalLayer),
@@ -195,6 +197,7 @@ export function createAppLayer(config: AppLayerConfig = {}) {
     toolRegistrationLayer,
     agentLayer,
     personaLayer,
+    memoryServiceLayer,
     chatLayer,
     telemetryLayer,
     presentationLayer,

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -3,7 +3,7 @@ import * as os from "os";
 import { Effect } from "effect";
 import type { PersonaService } from "@/core/interfaces/persona-service";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
-import { ENVIRONMENT_TEMPLATE, SKILLS_INSTRUCTIONS } from "./prompts/shared";
+import { ENVIRONMENT_TEMPLATE, MEMORY_INSTRUCTIONS, SKILLS_INSTRUCTIONS } from "./prompts/shared";
 
 function formatUtcOffsetLabel(date: Date): string {
   const offsetMinutes = -date.getTimezoneOffset();
@@ -147,6 +147,9 @@ export class AgentPromptBuilder {
     // injected detail block is rebuilt whenever the trigger match changes.
     if (options.triggeredSkillNames && options.triggeredSkillNames.length > 0) {
       hash.update(`triggered:${[...options.triggeredSkillNames].sort().join(",")}`);
+    }
+    if (options.toolNames?.includes("view_memory")) {
+      hash.update("memory:1");
     }
     // Invalidate daily since prompts include current date
     hash.update(new Date().toDateString());
@@ -296,6 +299,10 @@ ${indexLines}
 </available_skills>
 ${triggeredBlock}`;
           systemPrompt = systemPrompt + skillsSection;
+        }
+
+        if (options.toolNames?.includes("view_memory")) {
+          systemPrompt = systemPrompt + MEMORY_INSTRUCTIONS;
         }
 
         // Cache the result

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -24,6 +24,18 @@ Skills:
 Note: Prefer skill workflows over ad-hoc handling for matched tasks.
 `;
 
+export const MEMORY_INSTRUCTIONS = `
+# Memory
+
+You persist across separate conversations with the people you talk to — this is not a one-shot session, it is an ongoing relationship. At the start of a conversation, before you do anything else, call view_memory to check what you already know about this person (or, for a project-scoped agent, this project). Do this every time, even if the conversation opens casually — you cannot tell from the first message alone whether this is someone you've talked with before, and answering as if it's a first meeting when it isn't is a worse failure than the cost of one extra read.
+
+Write to memory with manage_memory whenever you learn something durable: a stated preference, a recurring fact about their life or work, a decision they've made, a correction to something you had wrong, a goal they're working toward across multiple sessions. Write it when you learn it, not at the end — you may not get a clean "end of conversation" signal in a chat surface, so treat "I now know something worth keeping" as the trigger, not "the conversation is wrapping up."
+
+Do not write: small talk, one-off task details that only matter for this exchange, anything you could re-derive from context, or anything the person is clearly just thinking out loud about rather than telling you as settled fact. When in doubt, ask yourself: would this still be true and still matter in three weeks? If not, leave it out. If a new fact contradicts something already saved, update or delete the old entry — don't leave both versions sitting in memory for a future you to get confused by.
+
+Never save financial account numbers, passwords, API keys, government ID numbers, or health details unless the person is explicitly asking you to store exactly that for their own later reference.
+`;
+
 export const TOOL_USAGE_GUIDELINES = `
 ## Tool selection priority
 

--- a/src/core/agent/tools/memory-tools.test.ts
+++ b/src/core/agent/tools/memory-tools.test.ts
@@ -1,0 +1,102 @@
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, test, expect } from "bun:test";
+import { Effect } from "effect";
+import type { MemoryService } from "@/core/interfaces/memory-service";
+import { MemoryServiceTag } from "@/core/interfaces/memory-service";
+import type { ToolExecutionContext } from "@/core/types/tools";
+import { createManageMemoryTool, createViewMemoryTool } from "./memory-tools";
+
+const context: ToolExecutionContext = { agentId: "agent-1" };
+
+function runWithFakeMemoryService<A>(
+  fakeService: MemoryService,
+  eff: Effect.Effect<A, Error, MemoryService | import("@effect/platform").FileSystem.FileSystem>,
+) {
+  return Effect.runPromise(
+    eff.pipe(
+      Effect.provideService(MemoryServiceTag, fakeService),
+      Effect.provide(NodeFileSystem.layer),
+    ),
+  );
+}
+
+describe("view_memory tool", () => {
+  test("has the expected shape", () => {
+    const tool = createViewMemoryTool();
+    expect(tool.name).toBe("view_memory");
+    expect(tool.riskLevel).toBe("read-only");
+    expect(tool.hidden).toBe(false);
+  });
+
+  test("formats an empty directory listing", async () => {
+    const fakeService: Partial<MemoryService> = {
+      view: () => Effect.succeed({ kind: "directory", path: "/", entries: [] }),
+    };
+    const tool = createViewMemoryTool();
+    const result = await runWithFakeMemoryService(
+      fakeService as MemoryService,
+      tool.execute({ path: "" }, context),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("surfaces not_found as a failed tool result", async () => {
+    const fakeService: Partial<MemoryService> = {
+      view: () =>
+        Effect.succeed({ kind: "not_found", message: "The path /missing.txt does not exist." }),
+    };
+    const tool = createViewMemoryTool();
+    const result = await runWithFakeMemoryService(
+      fakeService as MemoryService,
+      tool.execute({ path: "missing.txt" }, context),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("does not exist");
+  });
+});
+
+describe("manage_memory tool", () => {
+  test("has the expected shape", () => {
+    const tool = createManageMemoryTool();
+    expect(tool.name).toBe("manage_memory");
+    expect(tool.riskLevel).toBe("low-risk");
+    expect(tool.hidden).toBe(false);
+  });
+
+  test("dispatches create to the service and reports success", async () => {
+    let receivedArgs: unknown[] = [];
+    const fakeService: Partial<MemoryService> = {
+      create: (...args) => {
+        receivedArgs = args;
+        return Effect.succeed({
+          success: true,
+          message: "File created successfully at: /notes.txt",
+        });
+      },
+    };
+    const tool = createManageMemoryTool();
+    const result = await runWithFakeMemoryService(
+      fakeService as MemoryService,
+      tool.execute({ command: "create", path: "notes.txt", file_text: "hi" }, context),
+    );
+    expect(result.success).toBe(true);
+    expect(receivedArgs).toEqual(["agent-1", "notes.txt", "hi"]);
+  });
+
+  test("surfaces a failed mutation as a failed tool result", async () => {
+    const fakeService: Partial<MemoryService> = {
+      strReplace: () =>
+        Effect.succeed({ success: false, message: "No replacement was performed." }),
+    };
+    const tool = createManageMemoryTool();
+    const result = await runWithFakeMemoryService(
+      fakeService as MemoryService,
+      tool.execute(
+        { command: "str_replace", path: "notes.txt", old_str: "x", new_str: "y" },
+        context,
+      ),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No replacement was performed");
+  });
+});

--- a/src/core/agent/tools/memory-tools.ts
+++ b/src/core/agent/tools/memory-tools.ts
@@ -1,0 +1,228 @@
+import { FileSystem } from "@effect/platform";
+import { Effect } from "effect";
+import { z } from "zod";
+import type { MemoryService, MemoryViewOutcome } from "@/core/interfaces/memory-service";
+import { MemoryServiceTag } from "@/core/interfaces/memory-service";
+import type { Tool } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionResult } from "@/core/types/tools";
+import { defineTool, makeZodValidator } from "./base-tool";
+
+type MemoryToolDeps = MemoryService | FileSystem.FileSystem;
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function joinDisplayPath(base: string, name: string): string {
+  return base === "/" ? `/${name}` : `${base}/${name}`;
+}
+
+function formatDirectoryOutcome(
+  outcome: Extract<MemoryViewOutcome, { kind: "directory" }>,
+): string {
+  const header = `Here're the files and directories up to 2 levels deep in ${outcome.path}, excluding hidden items:`;
+  if (outcome.entries.length === 0) {
+    return `${header}\n(empty — nothing saved yet)`;
+  }
+  const lines = outcome.entries.map((entry) =>
+    entry.kind === "directory"
+      ? joinDisplayPath(outcome.path, entry.name)
+      : `${joinDisplayPath(outcome.path, entry.name)}\t(${formatSize(entry.sizeBytes)})`,
+  );
+  return [header, ...lines].join("\n");
+}
+
+function formatFileOutcome(outcome: Extract<MemoryViewOutcome, { kind: "file" }>): string {
+  const lines = outcome.content.length > 0 ? outcome.content.split("\n") : [""];
+  const numbered = lines.map((line, index) => {
+    const lineNumber = outcome.startLine + index;
+    return `${String(lineNumber).padStart(6)}\t${line}`;
+  });
+  const truncationNote = outcome.truncated
+    ? `\n[Content truncated. Re-view with a narrower view_range to see more.]`
+    : "";
+  return `Here's the content of ${outcome.path} with line numbers:\n${numbered.join("\n")}${truncationNote}`;
+}
+
+const viewMemoryParameters = z
+  .object({
+    path: z
+      .string()
+      .default("")
+      .describe(
+        'Path relative to this agent\'s memory root (e.g. "notes.txt" or "people/alex.md"). ' +
+          'Empty string or "/" views the root directory.',
+      ),
+    view_range: z
+      .tuple([z.number().int(), z.number().int()])
+      .optional()
+      .describe(
+        "Optional [start_line, end_line], 1-indexed. Use -1 as end_line for end of file. Ignored for directories.",
+      ),
+  })
+  .strict();
+
+type ViewMemoryArgs = z.infer<typeof viewMemoryParameters>;
+
+export function createViewMemoryTool(): Tool<MemoryToolDeps> {
+  return defineTool<MemoryToolDeps, ViewMemoryArgs>({
+    name: "view_memory",
+    description:
+      "Read what you've saved about this person or project from earlier conversations. " +
+      "Call it with no path to list everything you've stored; call it with a path " +
+      '(e.g. "people/alex.md" or "project-context.md") to read one file\'s full contents. ' +
+      "Call this once, early, whenever you're not certain this is the first time you've talked " +
+      "with this person — before assuming a clean slate. An empty or missing directory just means " +
+      "nothing has been saved yet; that is a normal answer, not an error.",
+    parameters: viewMemoryParameters,
+    riskLevel: "read-only",
+    hidden: false,
+    validate: makeZodValidator(viewMemoryParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const memoryService = yield* MemoryServiceTag;
+        const outcome = yield* memoryService.view(context.agentId, args.path, args.view_range);
+
+        if (outcome.kind === "not_found" || outcome.kind === "too_large") {
+          return {
+            success: false,
+            result: null,
+            error: outcome.message,
+          } satisfies ToolExecutionResult;
+        }
+
+        const formatted =
+          outcome.kind === "directory"
+            ? formatDirectoryOutcome(outcome)
+            : formatFileOutcome(outcome);
+
+        return {
+          success: true,
+          result: { formatted, outcome },
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { outcome: MemoryViewOutcome };
+      if (data.outcome.kind === "directory")
+        return `Listed memory (${data.outcome.entries.length} item(s))`;
+      if (data.outcome.kind === "file")
+        return `Read memory file (${data.outcome.totalLines} line(s))`;
+      return undefined;
+    },
+  });
+}
+
+const manageMemoryParameters = z.discriminatedUnion("command", [
+  z
+    .object({
+      command: z.literal("create"),
+      path: z.string().min(1),
+      file_text: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      command: z.literal("str_replace"),
+      path: z.string().min(1),
+      old_str: z.string().min(1),
+      new_str: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      command: z.literal("insert"),
+      path: z.string().min(1),
+      insert_line: z.number().int().nonnegative(),
+      insert_text: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      command: z.literal("delete"),
+      path: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      command: z.literal("rename"),
+      old_path: z.string().min(1),
+      new_path: z.string().min(1),
+    })
+    .strict(),
+]);
+
+type ManageMemoryArgs = z.infer<typeof manageMemoryParameters>;
+
+export function createManageMemoryTool(): Tool<MemoryToolDeps> {
+  return defineTool<MemoryToolDeps, ManageMemoryArgs>({
+    name: "manage_memory",
+    description:
+      "Create, edit, rename, or delete files under your persistent memory directory — the durable " +
+      "notes about this person or project that survive after this conversation ends. Takes a " +
+      '"command": "create" (path, file_text) writes a new file (errors if the path already exists — ' +
+      'use str_replace or insert to update it instead); "str_replace" (path, old_str, new_str) replaces ' +
+      "one exact, unique snippet in place — use this to correct or update a fact instead of appending a " +
+      'new note about it; "insert" (path, insert_line, insert_text) adds a line at a specific position; ' +
+      '"delete" (path) removes a file entirely; "rename" (old_path, new_path) moves or renames one. ' +
+      "Prefer updating an existing file over creating a new one for the same topic — call view_memory " +
+      "first to check what's already there. Keep the directory small and organized: one file per person " +
+      "or per project, not a running log. Delete or rewrite a file the moment its contents are " +
+      "contradicted or no longer true; stale memory is worse than no memory. Never write transient " +
+      "conversation content, task-specific details, or anything guessable from context — only facts " +
+      "and preferences durable enough to matter three conversations from now.",
+    parameters: manageMemoryParameters,
+    riskLevel: "low-risk",
+    hidden: false,
+    validate: makeZodValidator(manageMemoryParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const memoryService = yield* MemoryServiceTag;
+        const agentId = context.agentId;
+
+        const outcome = yield* (() => {
+          switch (args.command) {
+            case "create":
+              return memoryService.create(agentId, args.path, args.file_text);
+            case "str_replace":
+              return memoryService.strReplace(agentId, args.path, args.old_str, args.new_str);
+            case "insert":
+              return memoryService.insert(agentId, args.path, args.insert_line, args.insert_text);
+            case "delete":
+              return memoryService.delete(agentId, args.path);
+            case "rename":
+              return memoryService.rename(agentId, args.old_path, args.new_path);
+          }
+        })();
+
+        return {
+          success: outcome.success,
+          result: outcome.success ? { message: outcome.message } : null,
+          ...(outcome.success ? {} : { error: outcome.message }),
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { message: string };
+      return data.message;
+    },
+  });
+}

--- a/src/core/agent/tools/register-tools.docs.test.ts
+++ b/src/core/agent/tools/register-tools.docs.test.ts
@@ -16,6 +16,7 @@ import {
   registerFileTools,
   registerGitTools,
   registerHttpTools,
+  registerMemoryTools,
   registerSearchTools,
   registerShellTools,
   registerSubagentTools,
@@ -45,6 +46,7 @@ const collectTools = Effect.gen(function* () {
   yield* registerSearchTools();
   yield* registerHttpTools();
   yield* registerTodoTools();
+  yield* registerMemoryTools();
   yield* registerContextTools();
   yield* registerSubagentTools();
   yield* registerUserInteractionTools();

--- a/src/core/agent/tools/register-tools.ts
+++ b/src/core/agent/tools/register-tools.ts
@@ -17,6 +17,7 @@ import { fs } from "./fs";
 import { git } from "./git";
 import { createHttpRequestTool } from "./http-tools";
 import { registerMCPServerTools } from "./mcp-tools";
+import { createManageMemoryTool, createViewMemoryTool } from "./memory-tools";
 import { createShellCommandTools } from "./shell-tools";
 import { createSkillTools } from "./skill-tools";
 import { createSubagentTools } from "./subagent-tools";
@@ -55,6 +56,7 @@ export function registerAllTools(): Effect.Effect<void, Error, MCPRegistrationDe
     yield* registerSearchTools();
     yield* registerHttpTools();
     yield* registerTodoTools();
+    yield* registerMemoryTools();
     yield* registerContextTools();
     yield* registerSubagentTools();
     yield* registerUserInteractionTools();
@@ -424,6 +426,7 @@ export const SKILLS_CATEGORY: ToolCategory = { id: "skills", displayName: "Skill
 export const CONTEXT_CATEGORY: ToolCategory = { id: "context", displayName: "Context" };
 export const SUBAGENT_CATEGORY: ToolCategory = { id: "subagent", displayName: "Sub Agents" };
 export const TODO_CATEGORY: ToolCategory = { id: "todo", displayName: "Todo" };
+export const MEMORY_CATEGORY: ToolCategory = { id: "memory", displayName: "Memory" };
 export const USER_INTERACTION_CATEGORY: ToolCategory = {
   id: "user_interaction",
   displayName: "User Interaction",
@@ -483,6 +486,7 @@ export const ALL_CATEGORIES: readonly ToolCategory[] = [
   WEB_FETCH_CATEGORY,
   SKILLS_CATEGORY,
   TODO_CATEGORY,
+  MEMORY_CATEGORY,
   CONTEXT_CATEGORY,
   SUBAGENT_CATEGORY,
   USER_INTERACTION_CATEGORY,
@@ -677,6 +681,19 @@ export function registerTodoTools(): Effect.Effect<void, Error, ToolRegistry> {
 
     yield* registerTool(createManageTodosTool());
     yield* registerTool(createListTodosTool());
+  });
+}
+
+// Register memory tools (view_memory, manage_memory) — opt-in per agent via
+// AgentConfig.tools, like file_management/git, since memory persists durable
+// facts about a specific person/project rather than pure orchestration state.
+export function registerMemoryTools(): Effect.Effect<void, Error, ToolRegistry> {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const registerTool = registry.registerForCategory(MEMORY_CATEGORY);
+
+    yield* registerTool(createViewMemoryTool());
+    yield* registerTool(createManageMemoryTool());
   });
 }
 

--- a/src/core/constants/memory.ts
+++ b/src/core/constants/memory.ts
@@ -1,0 +1,20 @@
+/** Maximum nesting depth (path segments) allowed under an agent's memory root. */
+export const MAX_MEMORY_PATH_DEPTH = 4;
+
+/** Maximum length of a single path segment (file or directory name). */
+export const MAX_MEMORY_PATH_SEGMENT_LENGTH = 128;
+
+/** Maximum size of a single memory file, in bytes. */
+export const MAX_MEMORY_FILE_BYTES = 262_144;
+
+/** Maximum total size of an agent's entire memory directory, in bytes. */
+export const MAX_MEMORY_TOTAL_BYTES_PER_AGENT = 10_485_760;
+
+/** Maximum number of files an agent's memory directory may contain. */
+export const MAX_MEMORY_FILES_PER_AGENT = 500;
+
+/** Character budget for a single `view` call before content is truncated. */
+export const MEMORY_VIEW_TRUNCATE_CHARS = 20_000;
+
+/** Reject `view` on files with more lines than this. */
+export const MEMORY_VIEW_MAX_LINES = 999_999;

--- a/src/core/interfaces/memory-service.ts
+++ b/src/core/interfaces/memory-service.ts
@@ -1,0 +1,87 @@
+import { FileSystem } from "@effect/platform";
+import { Context, Effect } from "effect";
+
+export interface MemoryDirectoryEntry {
+  readonly name: string;
+  readonly kind: "file" | "directory";
+  readonly sizeBytes: number;
+}
+
+export type MemoryViewOutcome =
+  | {
+      readonly kind: "directory";
+      readonly path: string;
+      readonly entries: readonly MemoryDirectoryEntry[];
+    }
+  | {
+      readonly kind: "file";
+      readonly path: string;
+      readonly content: string;
+      readonly startLine: number;
+      readonly totalLines: number;
+      readonly truncated: boolean;
+    }
+  | { readonly kind: "not_found"; readonly message: string }
+  | { readonly kind: "too_large"; readonly message: string };
+
+/**
+ * Outcome of a mutating memory action (create/str_replace/insert/delete/rename).
+ *
+ * Expected failure modes — no match, multiple matches, out-of-range insert,
+ * path already exists — are modeled as `{ success: false, message }` VALUES,
+ * not Effect failures, mirroring how Anthropic's own memory tool reports
+ * these as `is_error`-flagged tool results rather than exceptions. The
+ * `Error` channel on `MemoryService` methods is reserved for genuinely
+ * unexpected conditions: lock-acquisition timeout, disk I/O errors, and
+ * guardrail violations (size/count/depth caps, path-safety rejections).
+ */
+export interface MemoryMutationOutcome {
+  readonly success: boolean;
+  readonly message: string;
+}
+
+/**
+ * Per-agent, file-backed memory the agent itself manages via tool calls
+ * (view/create/str_replace/insert/delete/rename), scoped by `agentId` so
+ * memory follows an agent across every surface that invokes it.
+ */
+export interface MemoryService {
+  readonly view: (
+    agentId: string,
+    virtualPath: string,
+    viewRange?: readonly [number, number],
+  ) => Effect.Effect<MemoryViewOutcome, Error, FileSystem.FileSystem>;
+
+  readonly create: (
+    agentId: string,
+    virtualPath: string,
+    fileText: string,
+  ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
+
+  readonly strReplace: (
+    agentId: string,
+    virtualPath: string,
+    oldStr: string,
+    newStr: string | undefined,
+  ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
+
+  readonly insert: (
+    agentId: string,
+    virtualPath: string,
+    insertLine: number,
+    insertText: string,
+  ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
+
+  readonly delete: (
+    agentId: string,
+    virtualPath: string,
+  ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
+
+  readonly rename: (
+    agentId: string,
+    oldVirtualPath: string,
+    newVirtualPath: string,
+  ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
+}
+
+export const MemoryServiceTag = Context.GenericTag<MemoryService>("MemoryService");

--- a/src/core/interfaces/tool-registry.ts
+++ b/src/core/interfaces/tool-registry.ts
@@ -15,6 +15,7 @@ import type { FileSystemContextService } from "./fs";
 import type { LLMService } from "./llm";
 import type { LoggerService } from "./logger";
 import type { MCPServerManager } from "./mcp-server";
+import type { MemoryService } from "./memory-service";
 import type { PresentationService } from "./presentation";
 import type { TerminalService } from "./terminal";
 
@@ -44,7 +45,8 @@ export type ToolRequirements =
   | MCPServerManager
   | TerminalService
   | SkillService
-  | PresentationService;
+  | PresentationService
+  | MemoryService;
 
 export interface Tool<R = never> {
   readonly name: string;

--- a/src/core/utils/file-lock.ts
+++ b/src/core/utils/file-lock.ts
@@ -1,0 +1,67 @@
+import { FileSystem } from "@effect/platform";
+import { Effect, Option } from "effect";
+import {
+  FILE_LOCK_MAX_RETRIES,
+  FILE_LOCK_RETRY_DELAY_MS,
+  FILE_LOCK_TIMEOUT_MS,
+} from "@/core/constants/agent";
+
+/**
+ * Directory-based mutex shared by any store that needs cross-process,
+ * concurrent-safe read-modify-write (conversation history, memory, ...).
+ *
+ * `fs.makeDirectory` is atomic (fails if the directory already exists), so it
+ * doubles as a lock primitive. A stale lock (owner crashed mid-write) is
+ * reclaimed once its mtime exceeds FILE_LOCK_TIMEOUT_MS.
+ */
+function acquireLock(lockPath: string): Effect.Effect<void, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    for (let attempt = 0; attempt < FILE_LOCK_MAX_RETRIES; attempt++) {
+      const acquired = yield* fs.makeDirectory(lockPath, { recursive: false }).pipe(
+        Effect.map(() => true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+      if (acquired) return;
+
+      const statResult = yield* fs.stat(lockPath).pipe(Effect.option);
+      const stat = Option.getOrNull(statResult);
+      const mtimeMs = Option.match(stat?.mtime ?? Option.none(), {
+        onNone: () => 0,
+        onSome: (d) => d.getTime(),
+      });
+      if (stat && Date.now() - mtimeMs > FILE_LOCK_TIMEOUT_MS) {
+        yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
+        continue;
+      }
+      yield* Effect.sleep(FILE_LOCK_RETRY_DELAY_MS);
+    }
+    return yield* Effect.fail(new Error(`Failed to acquire lock at ${lockPath} after retries`));
+  });
+}
+
+function releaseLock(lockPath: string): Effect.Effect<void, never, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
+
+/**
+ * Run `operation` while holding the directory-mutex at `lockPath`.
+ *
+ * Guardrail checks (size/count caps) that gate a write must run INSIDE
+ * `operation`, alongside the write itself — never as a separate acquire/use/
+ * release pair before this one, or a concurrent writer can slip in between
+ * the two lock acquisitions and the guardrail becomes advisory only.
+ */
+export function withLock<A, E, R>(
+  lockPath: string,
+  operation: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | Error, R | FileSystem.FileSystem> {
+  return Effect.acquireUseRelease(
+    acquireLock(lockPath),
+    () => operation,
+    () => releaseLock(lockPath),
+  );
+}

--- a/src/core/utils/runtime-detection.ts
+++ b/src/core/utils/runtime-detection.ts
@@ -104,6 +104,16 @@ export function getHistoryDirectory(): string {
 }
 
 /**
+ * Get the directory where Jazz stores per-agent memory (files the agent
+ * itself creates/edits via the memory tool). Scoped by agent id so memory
+ * follows an agent across every surface that invokes it (CLI, Telegram,
+ * Slack, ...), not by session or conversation.
+ */
+export function getMemoryDirectory(): string {
+  return path.join(getJazzHomeDirectory(), "memory");
+}
+
+/**
  * Get the jazz-ai package's root directory (where package.json lives).
  *
  * This is used to locate built-in assets (skills, templates, etc.) that ship

--- a/src/services/history/conversation-history-service.ts
+++ b/src/services/history/conversation-history-service.ts
@@ -1,13 +1,9 @@
 import * as path from "node:path";
 import { FileSystem } from "@effect/platform";
-import { Effect, Option } from "effect";
-import {
-  FILE_LOCK_MAX_RETRIES,
-  FILE_LOCK_RETRY_DELAY_MS,
-  FILE_LOCK_TIMEOUT_MS,
-  MAX_CONVERSATION_HISTORY_PER_AGENT,
-} from "@/core/constants/agent";
+import { Effect } from "effect";
+import { MAX_CONVERSATION_HISTORY_PER_AGENT } from "@/core/constants/agent";
 import type { ChatMessage } from "@/core/types/message";
+import { withLock } from "@/core/utils/file-lock";
 import { getHistoryDirectory } from "@/core/utils/runtime-detection";
 
 export interface ConversationRecord {
@@ -31,52 +27,6 @@ function getAgentHistoryPath(agentId: string, dir?: string): string {
 
 function getLockPath(agentId: string, dir?: string): string {
   return path.join(dir ?? getHistoryDirectory(), `${agentId}.lock`);
-}
-
-function acquireLock(lockPath: string): Effect.Effect<void, Error, FileSystem.FileSystem> {
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    for (let attempt = 0; attempt < FILE_LOCK_MAX_RETRIES; attempt++) {
-      const acquired = yield* fs.makeDirectory(lockPath, { recursive: false }).pipe(
-        Effect.map(() => true),
-        Effect.catchAll(() => Effect.succeed(false)),
-      );
-      if (acquired) return;
-
-      const statResult = yield* fs.stat(lockPath).pipe(Effect.option);
-      const stat = Option.getOrNull(statResult);
-      const mtimeMs = Option.match(stat?.mtime ?? Option.none(), {
-        onNone: () => 0,
-        onSome: (d) => d.getTime(),
-      });
-      if (stat && Date.now() - mtimeMs > FILE_LOCK_TIMEOUT_MS) {
-        yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
-        continue;
-      }
-      yield* Effect.sleep(FILE_LOCK_RETRY_DELAY_MS);
-    }
-    return yield* Effect.fail(new Error("Failed to acquire history lock after retries"));
-  });
-}
-
-function releaseLock(lockPath: string): Effect.Effect<void, never, FileSystem.FileSystem> {
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(lockPath, { recursive: true }).pipe(Effect.catchAll(() => Effect.void));
-  });
-}
-
-function withLock<A, E, R>(
-  agentId: string,
-  dir: string | undefined,
-  operation: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E | Error, R | FileSystem.FileSystem> {
-  const lockPath = getLockPath(agentId, dir);
-  return Effect.acquireUseRelease(
-    acquireLock(lockPath),
-    () => operation,
-    () => releaseLock(lockPath),
-  );
 }
 
 function readHistory(
@@ -149,8 +99,7 @@ export function saveConversation(
       .makeDirectory(historyDir, { recursive: true })
       .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
     yield* withLock(
-      record.agentId,
-      dir,
+      getLockPath(record.agentId, dir),
       Effect.gen(function* () {
         const history = yield* readHistory(record.agentId, dir);
         // Upsert by conversationId: saving an existing conversation replaces

--- a/src/services/memory-service.test.ts
+++ b/src/services/memory-service.test.ts
@@ -1,0 +1,256 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Effect } from "effect";
+import { MAX_MEMORY_FILE_BYTES, MAX_MEMORY_FILES_PER_AGENT } from "@/core/constants/memory";
+import { MemoryServiceImpl } from "./memory-service";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-memory-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function runEffect<A>(eff: Effect.Effect<A, unknown, NodeFileSystem.NodeFileSystem["Type"]>) {
+  return Effect.runPromise(eff.pipe(Effect.provide(NodeFileSystem.layer)));
+}
+
+function runEither<A>(eff: Effect.Effect<A, unknown, NodeFileSystem.NodeFileSystem["Type"]>) {
+  return runEffect(eff.pipe(Effect.either));
+}
+
+function makeService(): MemoryServiceImpl {
+  return new MemoryServiceImpl({ baseMemoryDirectory: tmpDir });
+}
+
+describe("view", () => {
+  test("returns an empty directory listing for a fresh agent", async () => {
+    const service = makeService();
+    const outcome = await runEffect(service.view("agent-1", ""));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries).toEqual([]);
+    }
+  });
+
+  test("lists a file after create", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "hello"));
+    const outcome = await runEffect(service.view("agent-1", ""));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries.map((e) => e.name)).toEqual(["notes.txt"]);
+    }
+  });
+
+  test("reads file content with line numbers via view_range", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "line1\nline2\nline3"));
+    const outcome = await runEffect(service.view("agent-1", "notes.txt", [2, 3]));
+    expect(outcome.kind).toBe("file");
+    if (outcome.kind === "file") {
+      expect(outcome.content).toBe("line2\nline3");
+      expect(outcome.startLine).toBe(2);
+      expect(outcome.totalLines).toBe(3);
+    }
+  });
+
+  test("returns not_found for a missing path", async () => {
+    const service = makeService();
+    const outcome = await runEffect(service.view("agent-1", "missing.txt"));
+    expect(outcome.kind).toBe("not_found");
+  });
+});
+
+describe("create", () => {
+  test("creates a file and its parent directories", async () => {
+    const service = makeService();
+    const outcome = await runEffect(service.create("agent-1", "people/alex.md", "likes coffee"));
+    expect(outcome.success).toBe(true);
+    const view = await runEffect(service.view("agent-1", "people/alex.md"));
+    expect(view.kind).toBe("file");
+    if (view.kind === "file") {
+      expect(view.content).toBe("likes coffee");
+    }
+  });
+
+  test("errors instead of overwriting an existing file", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "first"));
+    const outcome = await runEffect(service.create("agent-1", "notes.txt", "second"));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("already exists");
+    const view = await runEffect(service.view("agent-1", "notes.txt"));
+    expect(view.kind).toBe("file");
+    if (view.kind === "file") {
+      expect(view.content).toBe("first");
+    }
+  });
+
+  test("rejects a file exceeding the per-file byte cap", async () => {
+    const service = makeService();
+    const tooBig = "x".repeat(MAX_MEMORY_FILE_BYTES + 1);
+    const result = await runEither(service.create("agent-1", "big.txt", tooBig));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects once the per-agent file count cap is exceeded", async () => {
+    const service = makeService();
+    for (let i = 0; i < MAX_MEMORY_FILES_PER_AGENT; i++) {
+      await runEffect(service.create("agent-1", `file-${i}.txt`, "x"));
+    }
+    const result = await runEither(service.create("agent-1", "one-too-many.txt", "x"));
+    expect(result._tag).toBe("Left");
+  }, 30_000);
+});
+
+describe("str_replace", () => {
+  test("replaces a unique match", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "hello world"));
+    const outcome = await runEffect(service.strReplace("agent-1", "notes.txt", "world", "there"));
+    expect(outcome.success).toBe(true);
+    const view = await runEffect(service.view("agent-1", "notes.txt"));
+    if (view.kind === "file") expect(view.content).toBe("hello there");
+  });
+
+  test("deletes in place when new_str is omitted", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "hello world"));
+    await runEffect(service.strReplace("agent-1", "notes.txt", " world", undefined));
+    const view = await runEffect(service.view("agent-1", "notes.txt"));
+    if (view.kind === "file") expect(view.content).toBe("hello");
+  });
+
+  test("fails with no match", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "hello world"));
+    const outcome = await runEffect(service.strReplace("agent-1", "notes.txt", "goodbye", "hi"));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("did not appear verbatim");
+  });
+
+  test("fails with multiple matches and reports line numbers", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "dup\nother\ndup"));
+    const outcome = await runEffect(service.strReplace("agent-1", "notes.txt", "dup", "x"));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("lines: 1, 3");
+  });
+});
+
+describe("insert", () => {
+  test("inserts text at the given line", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "a\nb"));
+    await runEffect(service.insert("agent-1", "notes.txt", 1, "inserted"));
+    const view = await runEffect(service.view("agent-1", "notes.txt"));
+    if (view.kind === "file") expect(view.content).toBe("a\ninserted\nb");
+  });
+
+  test("rejects an out-of-range insert_line", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "a\nb"));
+    const outcome = await runEffect(service.insert("agent-1", "notes.txt", 99, "x"));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("Invalid `insert_line`");
+  });
+});
+
+describe("delete", () => {
+  test("deletes an existing file", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "notes.txt", "x"));
+    const outcome = await runEffect(service.delete("agent-1", "notes.txt"));
+    expect(outcome.success).toBe(true);
+    const view = await runEffect(service.view("agent-1", "notes.txt"));
+    expect(view.kind).toBe("not_found");
+  });
+
+  test("fails for a missing path", async () => {
+    const service = makeService();
+    const outcome = await runEffect(service.delete("agent-1", "missing.txt"));
+    expect(outcome.success).toBe(false);
+  });
+
+  test("refuses to delete the memory root", async () => {
+    const service = makeService();
+    const outcome = await runEffect(service.delete("agent-1", ""));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("cannot delete");
+  });
+});
+
+describe("rename", () => {
+  test("renames an existing file", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "old.txt", "x"));
+    const outcome = await runEffect(service.rename("agent-1", "old.txt", "new.txt"));
+    expect(outcome.success).toBe(true);
+    expect((await runEffect(service.view("agent-1", "old.txt"))).kind).toBe("not_found");
+    expect((await runEffect(service.view("agent-1", "new.txt"))).kind).toBe("file");
+  });
+
+  test("fails when the destination already exists", async () => {
+    const service = makeService();
+    await runEffect(service.create("agent-1", "a.txt", "a"));
+    await runEffect(service.create("agent-1", "b.txt", "b"));
+    const outcome = await runEffect(service.rename("agent-1", "a.txt", "b.txt"));
+    expect(outcome.success).toBe(false);
+    expect(outcome.message).toContain("already exists");
+  });
+});
+
+describe("path safety", () => {
+  test("rejects .. traversal", async () => {
+    const service = makeService();
+    const result = await runEither(service.create("agent-1", "../escape.txt", "x"));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects a null byte", async () => {
+    const service = makeService();
+    const result = await runEither(service.create("agent-1", "notes\0.txt", "x"));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects paths deeper than the max depth", async () => {
+    const service = makeService();
+    const result = await runEither(service.create("agent-1", "a/b/c/d/e.txt", "x"));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects a path segment longer than the max length", async () => {
+    const service = makeService();
+    const result = await runEither(service.create("agent-1", `${"x".repeat(200)}.txt`, "x"));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects an invalid agent id", async () => {
+    const service = makeService();
+    const result = await runEither(service.view("../not-an-agent", "notes.txt"));
+    expect(result._tag).toBe("Left");
+  });
+
+  test("rejects reading through a symlink that escapes the memory root", async () => {
+    const service = makeService();
+    const agentRoot = path.join(tmpDir, "agent-1");
+    fs.mkdirSync(agentRoot, { recursive: true });
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-memory-outside-"));
+    fs.writeFileSync(path.join(outsideDir, "secret.txt"), "top secret");
+    fs.symlinkSync(outsideDir, path.join(agentRoot, "link"));
+
+    try {
+      const result = await runEither(service.view("agent-1", "link/secret.txt"));
+      expect(result._tag).toBe("Left");
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -1,0 +1,647 @@
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import {
+  MAX_MEMORY_FILE_BYTES,
+  MAX_MEMORY_FILES_PER_AGENT,
+  MAX_MEMORY_PATH_DEPTH,
+  MAX_MEMORY_PATH_SEGMENT_LENGTH,
+  MAX_MEMORY_TOTAL_BYTES_PER_AGENT,
+  MEMORY_VIEW_MAX_LINES,
+  MEMORY_VIEW_TRUNCATE_CHARS,
+} from "@/core/constants/memory";
+import type {
+  MemoryDirectoryEntry,
+  MemoryMutationOutcome,
+  MemoryService,
+  MemoryViewOutcome,
+} from "@/core/interfaces/memory-service";
+import { MemoryServiceTag } from "@/core/interfaces/memory-service";
+import { withLock } from "@/core/utils/file-lock";
+import { getMemoryDirectory } from "@/core/utils/runtime-detection";
+
+/** Raised for path-safety and guardrail violations — genuinely unexpected conditions, not tool-result-shaped errors. */
+export class MemoryPathViolation extends Error {}
+
+const AGENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+function requireValidAgentId(agentId: string): Effect.Effect<void, MemoryPathViolation> {
+  return AGENT_ID_PATTERN.test(agentId)
+    ? Effect.void
+    : Effect.fail(new MemoryPathViolation(`Invalid agent id: "${agentId}".`));
+}
+
+function displayPath(virtualPath: string): string {
+  const trimmed = virtualPath.trim();
+  if (trimmed.length === 0 || trimmed === "/") return "/";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+/**
+ * Split an LLM-supplied virtual path into safe segments. Never treats a
+ * leading "/" as an OS-absolute escape — the whole string is relative to a
+ * fixed virtual root, matching Anthropic's own /memories convention rather
+ * than Node's absolute-path semantics.
+ */
+function splitVirtualPathIntoSegments(virtualPath: string): string[] {
+  if (virtualPath.includes("\0")) {
+    throw new MemoryPathViolation("Path contains a null byte.");
+  }
+
+  const normalized = virtualPath.normalize("NFC");
+  const withoutLeadingSlashes = normalized.replace(/^\/+/, "");
+
+  if (withoutLeadingSlashes.length === 0) return [];
+
+  if (withoutLeadingSlashes.includes("\\")) {
+    throw new MemoryPathViolation("Path must not contain backslashes.");
+  }
+
+  const segments = withoutLeadingSlashes.split("/");
+  if (segments.length > MAX_MEMORY_PATH_DEPTH) {
+    throw new MemoryPathViolation(
+      `Path depth ${segments.length} exceeds the maximum of ${MAX_MEMORY_PATH_DEPTH}.`,
+    );
+  }
+
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      throw new MemoryPathViolation('Path must not contain empty segments ("//").');
+    }
+    if (segment === "." || segment === "..") {
+      throw new MemoryPathViolation(`Path segment "${segment}" is not allowed.`);
+    }
+    if (segment.length > MAX_MEMORY_PATH_SEGMENT_LENGTH) {
+      throw new MemoryPathViolation(
+        `Path segment exceeds the maximum length of ${MAX_MEMORY_PATH_SEGMENT_LENGTH}.`,
+      );
+    }
+  }
+
+  return segments;
+}
+
+function parseVirtualPath(virtualPath: string): Effect.Effect<string[], MemoryPathViolation> {
+  return Effect.try({
+    try: () => splitVirtualPathIntoSegments(virtualPath),
+    catch: (error) =>
+      error instanceof MemoryPathViolation ? error : new MemoryPathViolation(String(error)),
+  });
+}
+
+/** True if `candidatePath` exists and is a symlink. Non-existent paths are not symlinks. */
+function isSymlink(candidatePath: string): Effect.Effect<boolean> {
+  return Effect.tryPromise({
+    try: () => nodeFs.lstat(candidatePath),
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((stat) => stat.isSymbolicLink()),
+    Effect.catchAll(() => Effect.succeed(false)),
+  );
+}
+
+/**
+ * The single choke point every memory action goes through before touching
+ * the filesystem. Bans symlinks outright — re-checked on every call (not
+ * cached), so a same-run "create a file, swap it for a symlink via another
+ * tool, then read/delete through it" race is closed rather than exploitable.
+ */
+function resolveMemoryPath(
+  memoryRoot: string,
+  virtualPath: string,
+): Effect.Effect<string, MemoryPathViolation> {
+  return Effect.gen(function* () {
+    const segments = yield* parseVirtualPath(virtualPath);
+
+    const candidate = segments.length === 0 ? memoryRoot : path.join(memoryRoot, ...segments);
+    const normalizedCandidate = path.normalize(candidate);
+    const rootWithSep = memoryRoot.endsWith(path.sep) ? memoryRoot : memoryRoot + path.sep;
+    if (normalizedCandidate !== memoryRoot && !normalizedCandidate.startsWith(rootWithSep)) {
+      return yield* Effect.fail(
+        new MemoryPathViolation("Resolved path escapes the agent's memory root."),
+      );
+    }
+
+    let walked = memoryRoot;
+    for (const segment of segments) {
+      walked = path.join(walked, segment);
+      const symlink = yield* isSymlink(walked);
+      if (symlink) {
+        return yield* Effect.fail(
+          new MemoryPathViolation(
+            `Path component "${segment}" is a symlink; symlinks are not allowed under the memory root.`,
+          ),
+        );
+      }
+    }
+
+    return normalizedCandidate;
+  });
+}
+
+interface MemoryTreeStats {
+  readonly totalBytes: number;
+  readonly fileCount: number;
+}
+
+function walkMemoryTree(
+  fs: FileSystem.FileSystem,
+  dir: string,
+): Effect.Effect<MemoryTreeStats, Error> {
+  return Effect.gen(function* () {
+    const names = yield* fs
+      .readDirectory(dir)
+      .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+
+    let totalBytes = 0;
+    let fileCount = 0;
+    for (const name of names) {
+      const entryPath = path.join(dir, name);
+      const info = yield* fs.stat(entryPath).pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (!info) continue;
+      if (info.type === "Directory") {
+        const nested = yield* walkMemoryTree(fs, entryPath);
+        totalBytes += nested.totalBytes;
+        fileCount += nested.fileCount;
+      } else if (info.type === "File") {
+        totalBytes += Number(info.size);
+        fileCount += 1;
+      }
+    }
+    return { totalBytes, fileCount };
+  });
+}
+
+function listDirectoryEntries(
+  fs: FileSystem.FileSystem,
+  dir: string,
+  depthRemaining: number,
+): Effect.Effect<MemoryDirectoryEntry[], Error> {
+  return Effect.gen(function* () {
+    const names = yield* fs
+      .readDirectory(dir)
+      .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+    const visible = names.filter((name) => !name.startsWith(".")).sort();
+
+    const entries: MemoryDirectoryEntry[] = [];
+    for (const name of visible) {
+      const entryPath = path.join(dir, name);
+      const info = yield* fs.stat(entryPath).pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (!info) continue;
+
+      if (info.type === "Directory") {
+        entries.push({ name: `${name}/`, kind: "directory", sizeBytes: 0 });
+        if (depthRemaining > 1) {
+          const nested = yield* listDirectoryEntries(fs, entryPath, depthRemaining - 1);
+          for (const child of nested) {
+            entries.push({ ...child, name: `${name}/${child.name}` });
+          }
+        }
+      } else if (info.type === "File") {
+        entries.push({ name, kind: "file", sizeBytes: Number(info.size) });
+      }
+    }
+    return entries;
+  });
+}
+
+function writeFileAtomic(
+  fs: FileSystem.FileSystem,
+  targetPath: string,
+  content: string,
+): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    const directory = path.dirname(targetPath);
+    const tmpPath = path.join(
+      directory,
+      `.memory-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+    );
+
+    yield* fs
+      .makeDirectory(directory, { recursive: true })
+      .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+    yield* fs
+      .writeFileString(tmpPath, content)
+      .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+    yield* fs.rename(tmpPath, targetPath).pipe(
+      Effect.tapError(() => fs.remove(tmpPath).pipe(Effect.catchAll(() => Effect.void))),
+      Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+    );
+  });
+}
+
+/** Byte offset of the start of each line, for O(log N) offset→line lookups (mirrors edit.ts's approval-preview technique). */
+function buildLineOffsets(content: string): number[] {
+  const lineOffsets: number[] = [0];
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === "\n") lineOffsets.push(i + 1);
+  }
+  return lineOffsets;
+}
+
+function offsetToLine(lineOffsets: readonly number[], offset: number): number {
+  let lo = 0;
+  let hi = lineOffsets.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if ((lineOffsets[mid] as number) <= offset) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo + 1;
+}
+
+function findAllOccurrenceLineNumbers(content: string, searchStr: string): number[] {
+  const lineOffsets = buildLineOffsets(content);
+  const lineNumbers: number[] = [];
+  let index = 0;
+  while ((index = content.indexOf(searchStr, index)) !== -1) {
+    lineNumbers.push(offsetToLine(lineOffsets, index));
+    index += Math.max(searchStr.length, 1);
+  }
+  return lineNumbers;
+}
+
+export interface MemoryServiceImplOptions {
+  /** Override for tests; defaults to ~/.jazz/memory (or $JAZZ_HOME/memory). */
+  readonly baseMemoryDirectory?: string;
+}
+
+export class MemoryServiceImpl implements MemoryService {
+  private readonly baseMemoryDirectory: string;
+
+  constructor(options?: MemoryServiceImplOptions) {
+    this.baseMemoryDirectory = options?.baseMemoryDirectory ?? getMemoryDirectory();
+  }
+
+  private memoryLockPath(agentId: string): string {
+    return path.join(this.baseMemoryDirectory, `${agentId}.lock`);
+  }
+
+  private ensureAgentRoot(
+    agentId: string,
+  ): Effect.Effect<string, MemoryPathViolation | Error, FileSystem.FileSystem> {
+    const baseMemoryDirectory = this.baseMemoryDirectory;
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId);
+      const fs = yield* FileSystem.FileSystem;
+      const rawRoot = path.join(baseMemoryDirectory, agentId);
+      yield* fs
+        .makeDirectory(rawRoot, { recursive: true })
+        .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+      return yield* Effect.tryPromise({
+        try: () => nodeFs.realpath(rawRoot),
+        catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+      });
+    });
+  }
+
+  private withValidatedAgentLock<A, E, R>(
+    agentId: string,
+    operation: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | MemoryPathViolation | Error, R | FileSystem.FileSystem> {
+    const lockPath = this.memoryLockPath(agentId);
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId);
+      return yield* withLock(lockPath, operation);
+    });
+  }
+
+  readonly view: MemoryService["view"] = (agentId, virtualPath, viewRange) =>
+    Effect.gen(
+      function* (this: MemoryServiceImpl) {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* this.ensureAgentRoot(agentId);
+        const target = yield* resolveMemoryPath(root, virtualPath);
+
+        const info = yield* fs.stat(target).pipe(Effect.catchAll(() => Effect.succeed(null)));
+        if (!info) {
+          return {
+            kind: "not_found",
+            message: `The path ${displayPath(virtualPath)} does not exist. Please provide a valid path.`,
+          } satisfies MemoryViewOutcome;
+        }
+
+        if (info.type === "Directory") {
+          const entries = yield* listDirectoryEntries(fs, target, 2);
+          return {
+            kind: "directory",
+            path: displayPath(virtualPath),
+            entries,
+          } satisfies MemoryViewOutcome;
+        }
+
+        const content = yield* fs
+          .readFileString(target)
+          .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
+        const lines = content.split("\n");
+        const totalLines = lines.length;
+
+        if (totalLines > MEMORY_VIEW_MAX_LINES) {
+          return {
+            kind: "too_large",
+            message: `File ${displayPath(virtualPath)} exceeds maximum line limit of ${MEMORY_VIEW_MAX_LINES.toLocaleString()} lines.`,
+          } satisfies MemoryViewOutcome;
+        }
+
+        const requestedStart = viewRange ? viewRange[0] : 1;
+        const requestedEnd = viewRange
+          ? viewRange[1] === -1
+            ? totalLines
+            : viewRange[1]
+          : totalLines;
+        const startLine = Math.max(1, Math.min(requestedStart, totalLines));
+        const endLine = Math.max(startLine, Math.min(requestedEnd, totalLines));
+
+        const selected = lines.slice(startLine - 1, endLine).join("\n");
+        const truncated = selected.length > MEMORY_VIEW_TRUNCATE_CHARS;
+        const displayContent = truncated ? selected.slice(0, MEMORY_VIEW_TRUNCATE_CHARS) : selected;
+
+        return {
+          kind: "file",
+          path: displayPath(virtualPath),
+          content: displayContent,
+          startLine,
+          totalLines,
+          truncated,
+        } satisfies MemoryViewOutcome;
+      }.bind(this),
+    );
+
+  readonly create: MemoryService["create"] = (agentId, virtualPath, fileText) =>
+    this.withValidatedAgentLock(
+      agentId,
+      Effect.gen(
+        function* (this: MemoryServiceImpl) {
+          const fs = yield* FileSystem.FileSystem;
+          const root = yield* this.ensureAgentRoot(agentId);
+          const target = yield* resolveMemoryPath(root, virtualPath);
+
+          const fileTextBytes = Buffer.byteLength(fileText, "utf-8");
+          if (fileTextBytes > MAX_MEMORY_FILE_BYTES) {
+            return yield* Effect.fail(
+              new MemoryPathViolation(
+                `File would be ${fileTextBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+              ),
+            );
+          }
+
+          const alreadyExists = yield* fs
+            .exists(target)
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (alreadyExists) {
+            return {
+              success: false,
+              message: `Error: File ${displayPath(virtualPath)} already exists`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const stats = yield* walkMemoryTree(fs, root);
+          if (stats.fileCount + 1 > MAX_MEMORY_FILES_PER_AGENT) {
+            return yield* Effect.fail(
+              new MemoryPathViolation(
+                `Creating this file would exceed the maximum of ${MAX_MEMORY_FILES_PER_AGENT} files in memory.`,
+              ),
+            );
+          }
+          if (stats.totalBytes + fileTextBytes > MAX_MEMORY_TOTAL_BYTES_PER_AGENT) {
+            return yield* Effect.fail(
+              new MemoryPathViolation(
+                `Creating this file would exceed the total memory budget of ${MAX_MEMORY_TOTAL_BYTES_PER_AGENT} bytes.`,
+              ),
+            );
+          }
+
+          yield* writeFileAtomic(fs, target, fileText);
+
+          return {
+            success: true,
+            message: `File created successfully at: ${displayPath(virtualPath)}`,
+          } satisfies MemoryMutationOutcome;
+        }.bind(this),
+      ),
+    );
+
+  readonly strReplace: MemoryService["strReplace"] = (agentId, virtualPath, oldStr, newStr) =>
+    this.withValidatedAgentLock(
+      agentId,
+      Effect.gen(
+        function* (this: MemoryServiceImpl) {
+          const fs = yield* FileSystem.FileSystem;
+          const root = yield* this.ensureAgentRoot(agentId);
+          const target = yield* resolveMemoryPath(root, virtualPath);
+
+          const info = yield* fs.stat(target).pipe(Effect.catchAll(() => Effect.succeed(null)));
+          if (!info || info.type === "Directory") {
+            return {
+              success: false,
+              message: `The path ${displayPath(virtualPath)} does not exist. Please provide a valid path.`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const content = yield* fs
+            .readFileString(target)
+            .pipe(
+              Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+            );
+
+          const occurrenceLines = findAllOccurrenceLineNumbers(content, oldStr);
+          if (occurrenceLines.length === 0) {
+            return {
+              success: false,
+              message: `No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${displayPath(virtualPath)}.`,
+            } satisfies MemoryMutationOutcome;
+          }
+          if (occurrenceLines.length > 1) {
+            return {
+              success: false,
+              message: `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines: ${occurrenceLines.join(", ")}. Please ensure it is unique`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const replacement = newStr ?? "";
+          const index = content.indexOf(oldStr);
+          const updatedContent =
+            content.slice(0, index) + replacement + content.slice(index + oldStr.length);
+
+          const updatedBytes = Buffer.byteLength(updatedContent, "utf-8");
+          if (updatedBytes > MAX_MEMORY_FILE_BYTES) {
+            return yield* Effect.fail(
+              new MemoryPathViolation(
+                `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+              ),
+            );
+          }
+
+          yield* writeFileAtomic(fs, target, updatedContent);
+
+          return {
+            success: true,
+            message: "The memory file has been edited.",
+          } satisfies MemoryMutationOutcome;
+        }.bind(this),
+      ),
+    );
+
+  readonly insert: MemoryService["insert"] = (agentId, virtualPath, insertLine, insertText) =>
+    this.withValidatedAgentLock(
+      agentId,
+      Effect.gen(
+        function* (this: MemoryServiceImpl) {
+          const fs = yield* FileSystem.FileSystem;
+          const root = yield* this.ensureAgentRoot(agentId);
+          const target = yield* resolveMemoryPath(root, virtualPath);
+
+          const info = yield* fs.stat(target).pipe(Effect.catchAll(() => Effect.succeed(null)));
+          if (!info || info.type === "Directory") {
+            return {
+              success: false,
+              message: `Error: The path ${displayPath(virtualPath)} does not exist`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const content = yield* fs
+            .readFileString(target)
+            .pipe(
+              Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+            );
+          const lines = content.split("\n");
+
+          if (insertLine < 0 || insertLine > lines.length) {
+            return {
+              success: false,
+              message: `Error: Invalid \`insert_line\` parameter: ${insertLine}. It should be within the range of lines of the file: [0, ${lines.length}]`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const updatedLines = [
+            ...lines.slice(0, insertLine),
+            ...insertText.split("\n"),
+            ...lines.slice(insertLine),
+          ];
+          const updatedContent = updatedLines.join("\n");
+
+          const updatedBytes = Buffer.byteLength(updatedContent, "utf-8");
+          if (updatedBytes > MAX_MEMORY_FILE_BYTES) {
+            return yield* Effect.fail(
+              new MemoryPathViolation(
+                `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+              ),
+            );
+          }
+
+          yield* writeFileAtomic(fs, target, updatedContent);
+
+          return {
+            success: true,
+            message: `The file ${displayPath(virtualPath)} has been edited.`,
+          } satisfies MemoryMutationOutcome;
+        }.bind(this),
+      ),
+    );
+
+  readonly delete: MemoryService["delete"] = (agentId, virtualPath) =>
+    this.withValidatedAgentLock(
+      agentId,
+      Effect.gen(
+        function* (this: MemoryServiceImpl) {
+          const fs = yield* FileSystem.FileSystem;
+          const root = yield* this.ensureAgentRoot(agentId);
+          const target = yield* resolveMemoryPath(root, virtualPath);
+
+          if (target === root) {
+            return {
+              success: false,
+              message: "Error: cannot delete your memory root",
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const exists = yield* fs
+            .exists(target)
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (!exists) {
+            return {
+              success: false,
+              message: `Error: The path ${displayPath(virtualPath)} does not exist`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          yield* fs
+            .remove(target, { recursive: true })
+            .pipe(
+              Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+            );
+
+          return {
+            success: true,
+            message: `Successfully deleted ${displayPath(virtualPath)}`,
+          } satisfies MemoryMutationOutcome;
+        }.bind(this),
+      ),
+    );
+
+  readonly rename: MemoryService["rename"] = (agentId, oldVirtualPath, newVirtualPath) =>
+    this.withValidatedAgentLock(
+      agentId,
+      Effect.gen(
+        function* (this: MemoryServiceImpl) {
+          const fs = yield* FileSystem.FileSystem;
+          const root = yield* this.ensureAgentRoot(agentId);
+          const source = yield* resolveMemoryPath(root, oldVirtualPath);
+          const destination = yield* resolveMemoryPath(root, newVirtualPath);
+
+          if (source === root || destination === root) {
+            return {
+              success: false,
+              message: "Error: cannot rename your memory root",
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const sourceExists = yield* fs
+            .exists(source)
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (!sourceExists) {
+            return {
+              success: false,
+              message: `Error: The path ${displayPath(oldVirtualPath)} does not exist`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          const destinationExists = yield* fs
+            .exists(destination)
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (destinationExists) {
+            return {
+              success: false,
+              message: `Error: The destination ${displayPath(newVirtualPath)} already exists`,
+            } satisfies MemoryMutationOutcome;
+          }
+
+          yield* fs
+            .makeDirectory(path.dirname(destination), { recursive: true })
+            .pipe(
+              Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+            );
+          yield* fs
+            .rename(source, destination)
+            .pipe(
+              Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))),
+            );
+
+          return {
+            success: true,
+            message: `Successfully renamed ${displayPath(oldVirtualPath)} to ${displayPath(newVirtualPath)}`,
+          } satisfies MemoryMutationOutcome;
+        }.bind(this),
+      ),
+    );
+}
+
+export function createMemoryServiceLayer(
+  options?: MemoryServiceImplOptions,
+): Layer.Layer<MemoryService> {
+  return Layer.succeed(MemoryServiceTag, new MemoryServiceImpl(options));
+}


### PR DESCRIPTION
## Summary

- Adds a native, file-backed memory tool (`view_memory` / `manage_memory`) so an agent can persist durable facts about the people or projects it talks to across separate sessions and surfaces (CLI, Telegram, Slack) — scoped by `Agent.id`, not by session or channel.
- Action surface (create/str_replace/insert/delete/rename) mirrors Anthropic's own memory tool. Files live under `~/.jazz/memory/<agentId>/`.
- All six actions go through one path-safety choke point (`resolveMemoryPath`): rejects `..`/null bytes/absolute-path tricks/depth overruns, and bans symlinks outright anywhere in the resolved chain, re-checked on every call (not cached).
- Mutating actions share one lock per agent (guardrail check + write inside the same lock acquisition), reusing a lock helper extracted out of `conversation-history-service.ts` into `core/utils/file-lock.ts`.
- Registered **opt-in** (`ALL_CATEGORIES`, like `file_management`/`git`) rather than always-on, so it doesn't silently contradict personas (e.g. `researcher`) that promise their tools can't write files.
- System-prompt guidance on when to read/write memory is injected only for agents that actually have `view_memory`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` — 1607 pass, 0 fail (43 new tests covering path-traversal/symlink rejection, all six memory actions' edge cases, and tool-layer formatting)
- [x] `bun run docs:lint`