### PR TITLE
fix(telegram): stop silently swallowing reminder parse failures

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -611,16 +611,27 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
   // be parsed, fall through to a normal answer (so "remind me what X is" works).
   if (looksLikeReminderRequest(text)) {
     const now = Date.now();
-    const reminder = await parseReminderNL(config, text, now, tzForChat(config.jazzHome, chatId));
-    if (reminder) {
-      addReminder(config.jazzHome, chatId, reminder.fireAt, reminder.text);
+    const result = await parseReminderNL(config, text, now, tzForChat(config.jazzHome, chatId));
+    if (result.kind === "scheduled") {
+      addReminder(config.jazzHome, chatId, result.fireAt, result.text);
       await sendReply(
         config,
         chatId,
-        reminderConfirmation(config, chatId, reminder.fireAt, now, reminder.text),
+        reminderConfirmation(config, chatId, result.fireAt, now, result.text),
       );
       return;
     }
+    if (result.kind === "error") {
+      console.error(`Reminder parse failed for chat ${chatId}: ${result.reason}`);
+      await sendReply(
+        config,
+        chatId,
+        "⚠️ I couldn't work out when to schedule that reminder. Try rephrasing the time, e.g. " +
+          '"remind me in 10 minutes to …" or "remind me tomorrow at 9am to …".',
+      );
+      return;
+    }
+    // result.kind === "ambiguous" — not actually a scheduling request, fall through to normal chat.
   }
 
   const runToken = newRunToken();
@@ -903,16 +914,28 @@ function looksLikeReminderRequest(text: string): boolean {
 }
 
 /**
+ * Result of trying to resolve a natural-language reminder request.
+ * "ambiguous" means the model determined the message isn't actually asking to
+ * schedule anything (e.g. "remind me what X is") — safe to fall through to a
+ * normal chat turn. "error" means it looked like a scheduling request but
+ * resolving it failed (subprocess error, bad JSON, unparseable/past date) —
+ * callers must surface this to the user rather than silently ignoring it.
+ */
+type ReminderParseResult =
+  | { kind: "scheduled"; fireAt: number; text: string }
+  | { kind: "ambiguous" }
+  | { kind: "error"; reason: string };
+
+/**
  * Use the model to turn a natural-language reminder ("next friday at 2pm for X",
  * "in 2 hours", "september 23rd birthday") into an absolute time + text.
- * Returns null when there's no clear future time.
  */
 async function parseReminderNL(
   config: BridgeConfig,
   request: string,
   now: number,
   tz: string,
-): Promise<{ fireAt: number; text: string } | null> {
+): Promise<ReminderParseResult> {
   ensureSuggestAgent(config);
   const localNow = formatWhen(now, tz);
   const prompt =
@@ -935,20 +958,37 @@ async function parseReminderNL(
     "--timeout",
     "60000",
   ]);
-  if (!envelope.ok) return null;
+  if (!envelope.ok) {
+    return { kind: "error", reason: `suggest agent failed: ${envelope.error}` };
+  }
 
   const match = /\{[\s\S]*\}/.exec(envelope.answer);
-  if (!match) return null;
+  if (!match) {
+    return { kind: "error", reason: `no JSON in suggest agent reply: ${envelope.answer}` };
+  }
   try {
     const parsed = JSON.parse(match[0]) as { when?: unknown; text?: unknown };
-    if (typeof parsed.when !== "string" || typeof parsed.text !== "string") return null;
+    if (parsed.when === null) return { kind: "ambiguous" };
+    if (typeof parsed.when !== "string" || typeof parsed.text !== "string") {
+      return { kind: "error", reason: `malformed reminder JSON: ${match[0]}` };
+    }
     const fireAt = Date.parse(parsed.when);
-    if (!Number.isFinite(fireAt) || fireAt <= now) return null;
+    if (!Number.isFinite(fireAt)) {
+      return { kind: "error", reason: `unparseable date "${parsed.when}"` };
+    }
+    if (fireAt <= now) {
+      return {
+        kind: "error",
+        reason: `resolved time ${parsed.when} is not in the future (now=${new Date(now).toISOString()})`,
+      };
+    }
     const text = parsed.text.trim();
-    if (text.length === 0) return null;
-    return { fireAt, text };
-  } catch {
-    return null;
+    if (text.length === 0) {
+      return { kind: "error", reason: "empty reminder text" };
+    }
+    return { kind: "scheduled", fireAt, text };
+  } catch (error) {
+    return { kind: "error", reason: `failed to parse reminder JSON: ${String(error)}` };
   }
 }
 
@@ -979,7 +1019,7 @@ async function handleRemind(config: BridgeConfig, chatId: number, args: string):
   // Structured parse failed — fall back to natural-language understanding.
   if (fireAt === null) {
     const nl = await parseReminderNL(config, args, now, tz);
-    if (nl) {
+    if (nl.kind === "scheduled") {
       addReminder(config.jazzHome, chatId, nl.fireAt, nl.text);
       await sendReply(
         config,
@@ -987,6 +1027,9 @@ async function handleRemind(config: BridgeConfig, chatId: number, args: string):
         reminderConfirmation(config, chatId, nl.fireAt, now, nl.text),
       );
       return;
+    }
+    if (nl.kind === "error") {
+      console.error(`Reminder parse failed for chat ${chatId}: ${nl.reason}`);
     }
     await sendReply(config, chatId, `I couldn't work out when to remind you.\n${usage}`);
     return;


### PR DESCRIPTION
## What this PR does
Stops the Telegram bot from silently dropping natural-language reminder requests when the time-parsing step fails, instead of falling through to a generic chat reply that doesn't know reminders exist.

## Why
`parseReminderNL` returned `null` for two very different cases: "this message isn't really asking for a reminder" (correct to fall through to normal chat) and "this is a reminder request but parsing the time failed" (subprocess error, malformed JSON, unparseable or past date). The caller couldn't distinguish them, so real failures silently fell through to a full agent turn with no reminder capability — producing confused replies like "I can't do timers in this headless session" for a plain "remind me in 1 minute to say hi to my friend". Confirmed live on the production bot via SSH: the deployed commit already includes the natural-language reminder feature, logs showed no error output for the failed request, and no error branch in the code ever logs — matching a silent-failure bug rather than a stale deployment.

## How to test
- `bun run typecheck` and `bun run lint` pass.
- In the Telegram bot (or by unit-testing `parseReminderNL` directly), send a clear reminder request with a resolvable time (e.g. "remind me in 10 minutes to stretch") and confirm it's scheduled and confirmed as before — no change to the happy path.
- Force a parse failure (e.g. stub the suggest-agent call to return malformed JSON, or a past/unparseable date) and confirm: the bot replies with an explicit "I couldn't work out when to schedule that reminder..." message instead of falling through to a full agent turn, and `console.error` logs the specific reason (subprocess failure / bad JSON / past date / empty text).
- Send a message that mentions "remind me" but isn't actually a scheduling request (e.g. "remind me what a caldera is") and confirm it still falls through to a normal chat answer, unchanged from before.
- Same check via the `/remind <when> <text>` slash-command fallback path (`handleRemind`), which shares `parseReminderNL`.
