### PR TITLE
fix(reminders): create the base reminders directory before acquiring a lock

### DIFF
--- a/src/services/reminder-service.test.ts
+++ b/src/services/reminder-service.test.ts
@@ -42,6 +42,20 @@ describe("add", () => {
     }
   });
 
+  test("succeeds on a fresh deployment where the base reminder directory does not exist yet", async () => {
+    // Regression: on a real fresh deploy (or an agent's first-ever reminder),
+    // ~/.jazz/reminders/ has never been created. The lock is a directory made
+    // with recursive:false, so if nothing creates the parent first, every
+    // makeDirectory attempt inside acquireLock fails with ENOENT and the whole
+    // call surfaces as a false "failed to acquire lock after retries" — tests
+    // using mkdtempSync never caught this because mkdtempSync always
+    // pre-creates the directory.
+    const freshDir = path.join(tmpDir, "not-created-yet");
+    const service = new ReminderServiceImpl({ baseReminderDirectory: freshDir });
+    const outcome = await runEffect(service.add("agent-1", "30m", "call the plumber", "UTC"));
+    expect(outcome.success).toBe(true);
+  });
+
   test("returns a clear failure message for an unparseable 'when', not a thrown error", async () => {
     const service = makeService();
     const outcome = await runEffect(

--- a/src/services/reminder-service.ts
+++ b/src/services/reminder-service.ts
@@ -100,8 +100,18 @@ export class ReminderServiceImpl implements ReminderService {
     operation: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E | ReminderGuardrailViolation | Error, R | FileSystem.FileSystem> {
     const lockPath = reminderLockPath(this.baseReminderDirectory, agentId);
+    const baseReminderDirectory = this.baseReminderDirectory;
     return Effect.gen(function* () {
       yield* requireValidAgentId(agentId);
+      const fs = yield* FileSystem.FileSystem;
+      // The lock is a directory created with recursive:false, so its parent
+      // (baseReminderDirectory) must already exist — on a fresh deployment or
+      // an agent's first-ever reminder it doesn't, and every makeDirectory
+      // attempt inside acquireLock fails with ENOENT until the retry budget
+      // is exhausted, surfacing as a false "failed to acquire lock" error.
+      yield* fs
+        .makeDirectory(baseReminderDirectory, { recursive: true })
+        .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));
       return yield* withLock(lockPath, operation);
     });
   }

--- a/src/services/reminder-service.ts
+++ b/src/services/reminder-service.ts
@@ -104,11 +104,6 @@ export class ReminderServiceImpl implements ReminderService {
     return Effect.gen(function* () {
       yield* requireValidAgentId(agentId);
       const fs = yield* FileSystem.FileSystem;
-      // The lock is a directory created with recursive:false, so its parent
-      // (baseReminderDirectory) must already exist — on a fresh deployment or
-      // an agent's first-ever reminder it doesn't, and every makeDirectory
-      // attempt inside acquireLock fails with ENOENT until the retry budget
-      // is exhausted, surfacing as a false "failed to acquire lock" error.
       yield* fs
         .makeDirectory(baseReminderDirectory, { recursive: true })
         .pipe(Effect.catchAll((e) => Effect.fail(e instanceof Error ? e : new Error(String(e)))));


### PR DESCRIPTION
## Summary

Found live on the deployed Telegram bridge: "remind me in 1 minute" called `add_reminder`, which failed with `Failed to acquire lock at /data/reminders/tg_879894259.lock after retries`, and the agent fell back to a todo with a confused excuse.

Root cause: the lock is a directory created with `recursive: false`, which requires its parent (`baseReminderDirectory`) to already exist. On a fresh deployment — or an agent's very first reminder — `~/.jazz/reminders/` has never been created, so every retry inside `acquireLock` fails with ENOENT and the whole call surfaces as a false "failed to acquire lock" error. `MemoryServiceImpl` already creates its root directory before use; `ReminderServiceImpl` never did.

Tests never caught this because every existing test uses `fs.mkdtempSync`, which always pre-creates the directory it hands back — the missing-parent-directory precondition this bug depends on was never actually exercised.

## Fix

`ReminderServiceImpl.withValidatedAgentLock` now creates `baseReminderDirectory` (recursive) before acquiring the per-agent lock, mirroring `MemoryServiceImpl.ensureAgentRoot`.

## Test plan

- [x] New regression test: `add` succeeds when `baseReminderDirectory` is a not-yet-created subdirectory (fails without the fix, passes with it).
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` — 1652 pass, 0 fail