### PR TITLE
fix(ui): render selected suggestion as a sent user message

### DIFF
--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -33,7 +33,12 @@ import {
   formatToolExecutionErrorEffect,
   formatToolsDetectedEffect,
 } from "./format-utils";
-import { formatMarkdown, formatMarkdownHybrid } from "./markdown-formatter";
+import {
+  formatMarkdown,
+  formatMarkdownHybrid,
+  wrapToWidth,
+  getTerminalWidth,
+} from "./markdown-formatter";
 import { isInsideOpenStructure } from "./markdown-split";
 import { AgentResponseCard } from "../ui/AgentResponseCard";
 import { getGlyphs } from "../ui/glyphs";
@@ -1395,10 +1400,9 @@ class InkPresentationService implements PresentationService {
       },
       resolve: (value: unknown) => {
         const response = String(value);
-        const rawMessage = `${chalk.dim("Your response:")} ${CHALK_THEME.success(response)}`;
         store.printOutput({
-          type: "log",
-          message: rawMessage,
+          type: "user",
+          message: wrapToWidth(response, getTerminalWidth() - 8),
           timestamp: new Date(),
         });
         store.setPrompt(null);


### PR DESCRIPTION
## What this PR does
When the user selects a follow-up option offered by the agent (e.g. via `ask_user_question` suggestion chips), the selection now renders as a proper sent-message bubble in the terminal transcript instead of silently disappearing.

## Why
The questionnaire's `resolve` handler in `ink-presentation-service.ts` printed the selected value as a plain, unstyled `type: "log"` line ("Your response: ...") rather than the `type: "user"` entry that typed messages use. That log line has no chat-bubble styling (no colored rail), so it read as an easy-to-miss status line — by the time the assistant's reply streamed in, there was no visible trace of what had been selected. This aligns the option-select path with the existing typed-message path (`terminal.ts`'s `printUserMessage`), which wraps the text and pushes a `type: "user"` entry.

## How to test
- Start an interactive session, trigger a tool call that uses `ask_user_question` with suggestions (e.g. ask the agent a question likely to prompt a clarifying follow-up), and select one of the suggestion chips — confirm it now appears as a styled user bubble, not a dim log line.
- Edge case: type a custom (non-suggested) response into the questionnaire prompt instead of selecting a chip — confirm it's also rendered as a user bubble, since both paths share the same `resolve` handler.
- `bun test src/cli/presentation/ink-presentation-service.test.ts` — 32 tests pass.
