### PR TITLE
feat(telegram): let the agent generate interactive UI via create_web_app

### DIFF
--- a/.github/jazz/README.md
+++ b/.github/jazz/README.md
@@ -28,11 +28,11 @@ repo. This is the guide for doing that.
 
 ## Required secrets
 
-| Secret | Needed? | Purpose |
-|---|---|---|
-| `GITHUB_TOKEN` | automatic | Read PR context, post comments (no action needed) |
-| `OPENROUTER_API_KEY` | if using OpenRouter | Model access for the agents |
-| `OPENAI_API_KEY` | if using OpenAI | Model access for the agents |
+| Secret               | Needed?             | Purpose                                           |
+| -------------------- | ------------------- | ------------------------------------------------- |
+| `GITHUB_TOKEN`       | automatic           | Read PR context, post comments (no action needed) |
+| `OPENROUTER_API_KEY` | if using OpenRouter | Model access for the agents                       |
+| `OPENAI_API_KEY`     | if using OpenAI     | Model access for the agents                       |
 
 You only need the key that matches the provider in your agent configs.
 
@@ -59,10 +59,8 @@ SHAs into the `WORKFLOW.md` template (`__PR_BASE_SHA__`, `__PR_HEAD_SHA__`,
 Two files almost certainly need editing — the defaults are tuned for **this**
 (TypeScript / Bun / Effect-TS) repo:
 
-1. **`agents/*.json` — pick your model.** Both agents default to
-   `cohere/north-mini-code:free` via OpenRouter with `reasoningEffort: medium`.
-   Swap `model` / `llmModel` / `llmProvider` for whatever you want. A stronger
-   (paid) model gives noticeably better reviews on large diffs.
+1. **`agents/*.json` — pick your model.**.
+   Swap `model` / `llmModel` / `llmProvider` for whatever you want. A stronger model gives noticeably better reviews on large diffs.
 2. **`workflows/code-review/WORKFLOW.md` — match your codebase.** Its **"Runtime
    Model"** section describes Jazz's specifics (single-threaded JS, Effect-TS
    error channels, Bun). Replace it with your language, framework, and the risk
@@ -74,11 +72,11 @@ truncation-safety guidance) is project-agnostic and can be copied as-is.
 
 ## Commands
 
-| You do | What runs |
-|---|---|
-| Open a PR / mark ready | Automatic code review (inline comments) |
-| Comment `/jazz-review` | Re-run the code review |
-| Comment `/jazz <question>` | PR assistant answers your request |
+| You do                     | What runs                                             |
+| -------------------------- | ----------------------------------------------------- |
+| Open a PR / mark ready     | Automatic code review (inline comments)               |
+| Comment `/jazz-review`     | Re-run the code review                                |
+| Comment `/jazz <question>` | PR assistant answers your request                     |
 | Actions tab → Run workflow | Manual dispatch (choose `code-review` or `assistant`) |
 
 Note: `/jazz review` (space) is **not** `/jazz-review` (hyphen). The space form

--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "cohere/north-mini-code:free",
+  "model": "inclusionai/ling-3.0-flash:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "cohere/north-mini-code:free",
+    "llmModel": "inclusionai/ling-3.0-flash:free",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -2,11 +2,11 @@
   "id": "pr-assistant",
   "name": "pr-assistant",
   "description": "Pull request assistant agent for /jazz PR comments",
-  "model": "cohere/north-mini-code:free",
+  "model": "inclusionai/ling-3.0-flash:free",
   "config": {
     "persona": "coder",
     "llmProvider": "openrouter",
-    "llmModel": "cohere/north-mini-code:free",
+    "llmModel": "inclusionai/ling-3.0-flash:free",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "parallel-web": "^1.1.0",
         "pdf-parse": "^2.4.5",
         "plist": "^5.0.0",
+        "puppeteer": "^25.4.0",
         "react": "^19.2.7",
         "semver": "^7.8.4",
         "short-uuid": "^6.0.3",
@@ -246,6 +247,8 @@
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
 
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -398,6 +401,8 @@
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
+    "chromium-bidi": ["chromium-bidi@17.0.2", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg=="],
+
     "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
@@ -455,6 +460,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1653615", "", {}, "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA=="],
 
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
@@ -684,6 +691,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
     "linkup-sdk": ["linkup-sdk@3.2.5", "", { "dependencies": { "axios": "^1.8.2", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@x402/core": "^2.6.0", "@x402/evm": "^2.6.0", "viem": "^2.0.0" }, "optionalPeers": ["@x402/core", "@x402/evm", "viem"] }, "sha512-nZKmEkFBOt1A5Q3jeAV+YsJlYesMZlrCY209fs1kv5IQ+VUwYe2C/oiPUPKDa5d0l99n0mNmqHLw7MQRq6Xo1w=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
@@ -713,6 +722,10 @@
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -795,6 +808,10 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "puppeteer": ["puppeteer@25.4.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "lilconfig": "^3.1.3", "puppeteer-core": "25.4.0", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw=="],
+
+    "puppeteer-core": ["puppeteer-core@25.4.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.1" } }, "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
@@ -908,6 +925,8 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.61.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.61.1", "@typescript-eslint/parser": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw=="],
@@ -931,6 +950,8 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vercel-minimax-ai-provider": ["vercel-minimax-ai-provider@0.0.2", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.6", "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.4" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-h9QzLL7RBmOreqWfr2fcoFVNTJgusENJVagVm8vAi+DBfd+1t+sVJZ/hAhKrtuCKCrm33BlOSWVdJehQFju5jQ=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -976,6 +997,8 @@
 
     "@parcel/watcher/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "@puppeteer/browsers/yargs": ["yargs@18.1.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^8.2.1", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg=="],
+
     "@types/marked/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "@types/marked-terminal/@types/node": ["@types/node@24.10.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="],
@@ -985,6 +1008,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1014,6 +1039,8 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "puppeteer-core/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -1033,6 +1060,10 @@
     "zhipu-ai-provider/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.40", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@puppeteer/browsers/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "@types/marked-terminal/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1064,8 +1095,14 @@
 
     "zhipu-ai-provider/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
+    "@puppeteer/browsers/yargs/cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@puppeteer/browsers/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@puppeteer/browsers/yargs/cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
   }
 }

--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -17,6 +17,14 @@ TELEGRAM_MODE=polling
 # TELEGRAM_WEBHOOK_SECRET=   # openssl rand -hex 32
 # TELEGRAM_WEBHOOK_URL=      # https://<host>.<tailnet>.ts.net/telegram/webhook
 
+# Public HTTPS origin this bridge is reachable at, used for the agent's
+# create_web_app tool in "interactive" mode (opens a Telegram Web App button).
+# In webhook mode this defaults to TELEGRAM_WEBHOOK_URL's origin — only set it
+# separately if you're on polling mode, or serve web apps from a different
+# host than the webhook. Leave unset to disable interactive web apps (the
+# "static" chart/image mode still works either way).
+# TELEGRAM_WEBAPP_BASE_URL=  # https://<host>.<tailnet>.ts.net
+
 # --- Model ---
 # Provider + model the agent uses. Any provider Jazz supports works, e.g.:
 #   openai      + gpt-5.4                 (default)

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -4,6 +4,15 @@ FROM oven/bun:1
 
 WORKDIR /app
 
+# System Chromium for the create_web_app tool (Puppeteer screenshots HTML the
+# agent writes). PUPPETEER_SKIP_DOWNLOAD avoids also fetching Puppeteer's own
+# bundled copy — it launches this one instead via PUPPETEER_EXECUTABLE_PATH.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
 # Dependencies first so the install layer caches across source edits.
 COPY package.json bun.lock bunfig.toml ./
 RUN bun install --frozen-lockfile

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -21,6 +21,7 @@ Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --jso
 - 📡 **Live progress** — a status bubble updates in real time with the agent's thinking, tool calls, sub-agents (🤖), and tools awaiting approval (⛔); it closes with a `✅ Done · tools · tokens · $cost` summary, and the answer lands as a new message (so it notifies).
 - ⏰ **Reminders** — `/remind 30m …` or plain language ("remind me in 2 hours …"), scheduled by the agent itself via a native tool, resolved in your own timezone (`/tz`, or auto-set from a shared location) and delivered even across restarts.
 - 📍 **Location aware** — share a pin to get oriented, find nearby places, and set your timezone automatically.
+- 📊 **On-demand UI** — the agent can write a self-contained webpage (a chart, a form, a small interactive tool) via `create_web_app` and deliver it as either a chat image (no tap) or a tappable Telegram Web App button.
 - 💬 **Per-chat memory**, ✍️ **Markdown rendering** (with plain-text fallback), 🔒 **allowlist-gated**, 🐳 **one-command Docker deploy**.
 
 ## Requirements
@@ -125,6 +126,7 @@ run Ollama; cloud users typically just keep the default.)
 | `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                               |
 | `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                  |
 | `PORT`                               | `8080`                                  | In-container health-check port.                                                                          |
+| `TELEGRAM_WEBAPP_BASE_URL`           | webhook URL's origin, else unset        | Public HTTPS origin used to serve `create_web_app`'s "interactive" pages as Telegram Web App buttons. Unset disables interactive mode (the static/image mode always works).                                    |
 
 > **Model ↔ reasoning:** reasoning-capable models (`gpt-5.4`, qwen3, …) work with
 > `medium`/`high`; models without it (mistral-small, gemma, …) error unless

--- a/integrations/telegram-bot/agent.telegram.json
+++ b/integrations/telegram-bot/agent.telegram.json
@@ -46,7 +46,8 @@
       "http_request",
       "add_reminder",
       "list_reminders",
-      "cancel_reminder"
+      "cancel_reminder",
+      "create_web_app"
     ]
   },
   "createdAt": "2026-07-20T00:00:00.000Z",

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -80,6 +80,22 @@ interface BridgeConfig {
   readonly geocodeUrl: string;
   /** Generate contextual follow-up CTAs per answer (a second short LLM call). */
   readonly dynamicCta: boolean;
+  /**
+   * Public HTTPS origin this bridge's own HTTP server is reachable at, used to
+   * build Web App button URLs for `create_web_app`'s "interactive" mode (e.g.
+   * a Tailscale Funnel origin). Falls back to TELEGRAM_WEBHOOK_URL's origin in
+   * webhook mode. Undefined disables interactive web apps (static/image mode
+   * still works — it needs no public URL).
+   */
+  readonly webAppBaseUrl: string | undefined;
+}
+
+interface JazzWebApp {
+  readonly id: string;
+  readonly mode: "static" | "interactive";
+  readonly title: string;
+  readonly htmlPath: string;
+  readonly imagePath?: string;
 }
 
 interface JazzSuccessEnvelope {
@@ -87,6 +103,7 @@ interface JazzSuccessEnvelope {
   readonly answer: string;
   readonly costUSD: number;
   readonly tokenUsage?: { readonly totalTokens?: number };
+  readonly webApp?: JazzWebApp;
 }
 
 interface JazzErrorEnvelope {
@@ -123,12 +140,16 @@ function loadConfig(): BridgeConfig {
 
   const mode: TransportMode =
     process.env["TELEGRAM_MODE"]?.trim() === "webhook" ? "webhook" : "polling";
+  const webhookUrl = process.env["TELEGRAM_WEBHOOK_URL"]?.trim() || undefined;
+  const webAppBaseUrl =
+    process.env["TELEGRAM_WEBAPP_BASE_URL"]?.trim() ||
+    (mode === "webhook" && webhookUrl !== undefined ? new URL(webhookUrl).origin : undefined);
 
   return {
     botToken: requireEnv("TELEGRAM_BOT_TOKEN"),
     mode,
     webhookSecret: process.env["TELEGRAM_WEBHOOK_SECRET"]?.trim() || "",
-    webhookUrl: process.env["TELEGRAM_WEBHOOK_URL"]?.trim() || undefined,
+    webhookUrl,
     allowedChatIds,
     baseAgentId: process.env["JAZZ_TELEGRAM_AGENT"]?.trim() || "telegram",
     approvalPolicy: process.env["JAZZ_APPROVAL_POLICY"]?.trim() || "low-risk",
@@ -147,7 +168,12 @@ function loadConfig(): BridgeConfig {
     dynamicCta: !["0", "false", "off"].includes(
       process.env["JAZZ_TELEGRAM_DYNAMIC_CTA"]?.trim().toLowerCase() ?? "",
     ),
+    webAppBaseUrl,
   };
+}
+
+function webAppsDirectory(config: BridgeConfig): string {
+  return `${config.jazzHome}/webapps`;
 }
 
 async function callTelegram(
@@ -163,6 +189,29 @@ async function callTelegram(
   const body = (await response.json().catch(() => undefined)) as { ok?: boolean } | undefined;
   if (!response.ok || body?.ok !== true) {
     console.error(`Telegram ${method} failed: ${response.status} ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+/** Upload a local image file as a Telegram photo message (multipart, not JSON). */
+async function sendPhotoFile(
+  config: BridgeConfig,
+  chatId: number,
+  filePath: string,
+  caption?: string,
+): Promise<unknown> {
+  const form = new FormData();
+  form.append("chat_id", String(chatId));
+  form.append("photo", Bun.file(filePath), "chart.png");
+  if (caption) form.append("caption", caption);
+
+  const response = await fetch(`${TELEGRAM_API_BASE}/bot${config.botToken}/sendPhoto`, {
+    method: "POST",
+    body: form,
+  });
+  const body = (await response.json().catch(() => undefined)) as { ok?: boolean } | undefined;
+  if (!response.ok || body?.ok !== true) {
+    console.error(`Telegram sendPhoto failed: ${response.status} ${JSON.stringify(body)}`);
   }
   return body;
 }
@@ -381,6 +430,10 @@ function approvalKeyboard(toolCallId: string): Record<string, unknown> {
       ],
     ],
   };
+}
+
+function webAppKeyboard(url: string, title: string): Record<string, unknown> {
+  return { inline_keyboard: [[{ text: `📱 ${title}`, web_app: { url } }]] };
 }
 
 function followupKeyboard(): Record<string, unknown> {
@@ -666,6 +719,41 @@ async function runJazz(
   }
 }
 
+/**
+ * Deliver a `create_web_app` result: a static chart/diagram is uploaded
+ * directly as a photo (no tap needed); an interactive page needs a public URL
+ * to open in — falls back to a warning if TELEGRAM_WEBAPP_BASE_URL isn't set.
+ */
+async function deliverWebApp(
+  config: BridgeConfig,
+  chatId: number,
+  webApp: JazzWebApp,
+): Promise<void> {
+  if (webApp.mode === "static") {
+    if (webApp.imagePath === undefined) {
+      console.error(`create_web_app returned static mode with no imagePath (id=${webApp.id})`);
+      return;
+    }
+    await sendPhotoFile(config, chatId, webApp.imagePath, webApp.title);
+    return;
+  }
+
+  if (config.webAppBaseUrl === undefined) {
+    await sendReply(
+      config,
+      chatId,
+      "⚠️ Generated an interactive UI, but no public URL is configured for this bot " +
+        "(set <code>TELEGRAM_WEBAPP_BASE_URL</code>) — can't open it.",
+    );
+    return;
+  }
+
+  const url = `${config.webAppBaseUrl}/webapps/${webApp.id}`;
+  await sendReply(config, chatId, `Tap to open: <b>${escapeHtml(webApp.title)}</b>`, {
+    markup: webAppKeyboard(url, webApp.title),
+  });
+}
+
 async function handleMessage(config: BridgeConfig, chatId: number, text: string): Promise<void> {
   ensureChatAgent(config.jazzHome, chatId, config.baseAgentId);
 
@@ -733,6 +821,9 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       });
       if (config.dynamicCta && answerMessageId !== undefined) {
         void upgradeToDynamicCtas(config, chatId, answerMessageId, text, envelope.answer);
+      }
+      if (envelope.webApp) {
+        await deliverWebApp(config, chatId, envelope.webApp);
       }
     } else {
       await reporter?.finish("⚠️ <b>Failed</b>");
@@ -1397,6 +1488,17 @@ function startHealthServer(config: BridgeConfig): void {
 
       if (request.method === "GET" && url.pathname === "/health") {
         return new Response("ok", { status: 200 });
+      }
+
+      const webAppMatch =
+        request.method === "GET" ? /^\/webapps\/([A-Za-z0-9_-]+)$/.exec(url.pathname) : null;
+      if (webAppMatch) {
+        const id = webAppMatch[1];
+        const file = Bun.file(`${webAppsDirectory(config)}/${id}.html`);
+        if (!(await file.exists())) {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response(file, { headers: { "content-type": "text/html; charset=utf-8" } });
       }
 
       if (

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "parallel-web": "^1.1.0",
     "pdf-parse": "^2.4.5",
     "plist": "^5.0.0",
+    "puppeteer": "^25.4.0",
     "react": "^19.2.7",
     "semver": "^7.8.4",
     "short-uuid": "^6.0.3",

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -42,11 +42,54 @@ export interface OneShotToolCall {
   readonly arguments: string;
 }
 
+/**
+ * Structured result of a `create_web_app` tool call, surfaced alongside the
+ * text answer so callers (e.g. the Telegram bridge) can deliver it as an
+ * image or a Web App button without having to parse it out of `answer`.
+ */
+export interface OneShotWebApp {
+  readonly id: string;
+  readonly mode: "static" | "interactive";
+  readonly title: string;
+  readonly htmlPath: string;
+  readonly imagePath?: string;
+}
+
 export interface OneShotSuccess {
   readonly answer: string;
   readonly costUSD: number;
   readonly tokenUsage: OneShotTokenUsage;
   readonly toolCalls: readonly OneShotToolCall[];
+  readonly webApp?: OneShotWebApp;
+}
+
+/**
+ * Narrow `create_web_app`'s structured tool result (last call wins if invoked
+ * more than once in a turn) out of the agent run's `toolResults` map.
+ */
+export function extractWebAppResult(
+  toolResults: Record<string, unknown> | undefined,
+): OneShotWebApp | undefined {
+  const raw = toolResults?.["create_web_app"];
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const data = raw as Record<string, unknown>;
+  if (
+    typeof data["id"] !== "string" ||
+    (data["mode"] !== "static" && data["mode"] !== "interactive") ||
+    typeof data["title"] !== "string" ||
+    typeof data["htmlPath"] !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: data["id"],
+    mode: data["mode"],
+    title: data["title"],
+    htmlPath: data["htmlPath"],
+    ...(typeof data["imagePath"] === "string" ? { imagePath: data["imagePath"] } : {}),
+  };
 }
 
 export interface OneShotOutputOptions {
@@ -71,6 +114,7 @@ export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutp
     costUSD: result.costUSD,
     tokenUsage: result.tokenUsage,
     toolCalls: result.toolCalls,
+    ...(result.webApp ? { webApp: result.webApp } : {}),
   })}\n`;
 }
 
@@ -373,6 +417,7 @@ export function runAgentOnceCommand(
       name: toolCall.function?.name ?? "",
       arguments: toolCall.function?.arguments ?? "",
     }));
+    const webApp = extractWebAppResult(runResult.toolResults);
 
     yield* writeStdout(
       formatOneShotResult(
@@ -385,6 +430,7 @@ export function runAgentOnceCommand(
             totalTokens: promptTokens + completionTokens,
           },
           toolCalls,
+          ...(webApp ? { webApp } : {}),
         },
         outputOptions,
       ),

--- a/src/core/agent/tools/register-tools.ts
+++ b/src/core/agent/tools/register-tools.ts
@@ -28,6 +28,7 @@ import { createSkillTools } from "./skill-tools";
 import { createSubagentTools } from "./subagent-tools";
 import { createListTodosTool, createManageTodosTool } from "./todo-tools";
 import { userInteractionTools } from "./user-interaction-tools";
+import { createWebAppTool } from "./web-app-tools";
 import { createWebFetchTool } from "./web-fetch-tools";
 import { createWebSearchTool } from "./web-search-tools";
 
@@ -66,6 +67,7 @@ export function registerAllTools(): Effect.Effect<void, Error, MCPRegistrationDe
     yield* registerContextTools();
     yield* registerSubagentTools();
     yield* registerUserInteractionTools();
+    yield* registerWebAppTools();
     yield* registerMCPToolsLazy();
   });
 }
@@ -438,6 +440,7 @@ export const USER_INTERACTION_CATEGORY: ToolCategory = {
   id: "user_interaction",
   displayName: "User Interaction",
 };
+export const WEB_APP_CATEGORY: ToolCategory = { id: "web_app", displayName: "Web App" };
 
 /**
  * Get MCP server names as tool categories without connecting to servers
@@ -728,6 +731,18 @@ export function registerContextTools(): Effect.Effect<void, Error, ToolRegistry>
 
     yield* registerTool(createContextInfoTool());
     yield* registerTool(createGetTimeTool());
+  });
+}
+
+// Register web app tools (create_web_app) — opt-in per agent via
+// AgentConfig.tools, like memory/reminders, since generating and screenshotting
+// arbitrary HTML is a heavier capability than the always-on read-only tools.
+export function registerWebAppTools(): Effect.Effect<void, Error, ToolRegistry> {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const registerTool = registry.registerForCategory(WEB_APP_CATEGORY);
+
+    yield* registerTool(createWebAppTool());
   });
 }
 

--- a/src/core/agent/tools/web-app-tools.ts
+++ b/src/core/agent/tools/web-app-tools.ts
@@ -1,0 +1,168 @@
+import { FileSystem } from "@effect/platform";
+import { Effect } from "effect";
+import shortuuid from "short-uuid";
+import { z } from "zod";
+import type { Tool } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionResult } from "@/core/types/tools";
+import { getUserDataDirectory } from "@/core/utils/runtime-detection";
+import { defineTool, makeZodValidator } from "./base-tool";
+
+/**
+ * Lets the agent produce arbitrary interactive UI — not just charts, any
+ * self-contained webpage (a form, a dashboard, a small game, an explorable
+ * chart) — for surfaces that can render it as a Telegram Web App / Mini App.
+ *
+ * The agent writes the whole HTML document itself (inline CSS/JS, CDN
+ * scripts for libraries like Chart.js are fine since the page runs in a real
+ * WebView with network access). This tool only persists it and, for "static"
+ * mode, rasterizes it once via a headless browser so it can be delivered as a
+ * plain chat image with no tap required.
+ *
+ * Surface-specific delivery (serving the interactive HTML over a public URL,
+ * or posting the static image) is the caller's job — e.g. the Telegram
+ * bridge reads this tool's structured result off `AgentResponse.toolResults`.
+ */
+
+function getWebAppsDirectory(): string {
+  return `${getUserDataDirectory()}/webapps`;
+}
+
+const createWebAppParameters = z
+  .object({
+    html: z
+      .string()
+      .min(1)
+      .describe(
+        "A complete, self-contained HTML document (<!doctype html> optional, but include " +
+          "<html>/<head>/<body>). Inline all CSS/JS; CDN <script>/<link> tags are fine. Don't " +
+          "reference local files — the page must render correctly with nothing but this string.",
+      ),
+    title: z
+      .string()
+      .min(1)
+      .max(120)
+      .describe("Short title for this UI — used as the button label / display name."),
+    mode: z
+      .enum(["static", "interactive"])
+      .describe(
+        "'static': render once to a PNG image delivered directly in the chat, no tap needed — " +
+          "use for a quick chart, diagram, or anything that doesn't need input or motion. " +
+          "'interactive': the person taps a button to open the live page — use when it needs " +
+          "hover/zoom/filter, form input, or is a game/tool they interact with.",
+      ),
+    width: z
+      .number()
+      .int()
+      .min(200)
+      .max(2000)
+      .optional()
+      .describe("Viewport width in pixels for 'static' rendering (default: 800)."),
+    height: z
+      .number()
+      .int()
+      .min(200)
+      .max(2000)
+      .optional()
+      .describe("Viewport height in pixels for 'static' rendering (default: 600)."),
+  })
+  .strict();
+
+type CreateWebAppArgs = z.infer<typeof createWebAppParameters>;
+
+async function renderStaticScreenshot(
+  htmlPath: string,
+  pngPath: string,
+  width: number,
+  height: number,
+): Promise<void> {
+  const { default: puppeteer } = await import("puppeteer");
+  const browser = await puppeteer.launch({
+    headless: true,
+    // --no-sandbox: Chromium's sandbox needs kernel privileges most
+    // containers don't grant; harmless outside a container too.
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width, height });
+    await page.goto(`file://${htmlPath}`, { waitUntil: "networkidle0" });
+    await page.screenshot({ path: pngPath, fullPage: true });
+  } finally {
+    await browser.close();
+  }
+}
+
+export function createWebAppTool(): Tool<FileSystem.FileSystem> {
+  return defineTool<FileSystem.FileSystem, CreateWebAppArgs>({
+    name: "create_web_app",
+    description:
+      "Create an interactive UI — a chart, form, dashboard, small game, or any other webpage — " +
+      "for delivery back to the person as either a static image (mode: static) or a live, " +
+      "tappable page (mode: interactive). Use this whenever a plain text/markdown answer " +
+      "genuinely isn't the right medium for the request (e.g. 'show me a chart', 'make an " +
+      "interactive UI for X'). You write the full HTML yourself.",
+    tags: ["ui", "webapp"],
+    parameters: createWebAppParameters,
+    riskLevel: "low-risk",
+    hidden: false,
+    validate: makeZodValidator(createWebAppParameters),
+    handler: (args, _context) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dir = getWebAppsDirectory();
+        yield* fs.makeDirectory(dir, { recursive: true });
+
+        const id = shortuuid.generate();
+        const htmlPath = `${dir}/${id}.html`;
+        yield* fs.writeFileString(htmlPath, args.html);
+
+        if (args.mode === "interactive") {
+          return {
+            success: true,
+            result: {
+              id,
+              mode: "interactive",
+              title: args.title,
+              htmlPath,
+            },
+          } satisfies ToolExecutionResult;
+        }
+
+        const pngPath = `${dir}/${id}.png`;
+        const width = args.width ?? 800;
+        const height = args.height ?? 600;
+
+        yield* Effect.tryPromise({
+          try: () => renderStaticScreenshot(htmlPath, pngPath, width, height),
+          catch: (error) =>
+            new Error(
+              `Failed to render static web app: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        });
+
+        return {
+          success: true,
+          result: {
+            id,
+            mode: "static",
+            title: args.title,
+            htmlPath,
+            imagePath: pngPath,
+          },
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { mode: string; title: string };
+      return `Created ${data.mode} web app: ${data.title}`;
+    },
+  });
+}


### PR DESCRIPTION
## What this PR delivers

A new `create_web_app` agent tool: the agent writes a complete, self-contained
HTML page itself (a chart, a form, a small interactive tool — anything a
webpage can express, not a fixed set of chart types) and delivers it back as
either a static chat image or a live, tappable page. It replaces the earlier
idea of pre-installing a specific charting library — the agent isn't limited
to one visualization type, and libraries it needs (e.g. Chart.js) can be
pulled in per-request via CDN `<script>` tags since the page runs in a real
WebView with network access.

Ships alongside it: the Telegram bridge wiring to actually deliver either
mode (photo upload for static, a Web App button for interactive), and the
Docker/Puppeteer plumbing needed to rasterize HTML to PNG headlessly.

## Why this matters

For operators running the Telegram bridge: replies are no longer limited to
markdown text — "show me a chart of X" or "build me a small interactive
tool for Y" now produce an actual visual/interactive result instead of a
text description of one.

For maintainers: the capability is generic by design. Nothing in core ties
`create_web_app` to charts specifically, so future requests for other
interactive UI ("make me a form", "a mini game") are already covered without
further core changes — only surface-specific delivery code (like the
Telegram bridge's photo/button wiring here) needs to exist per integration.

## How agent/bridge behaviour changes

| Path | Change |
|---|---|
| CLI `jazz run --json` envelope | Adds an optional `webApp: {id, mode, title, htmlPath, imagePath?}` field when `create_web_app` was called during the run. Absent on every other run — existing consumers of the envelope are unaffected. |
| Telegram bridge — static mode | New: the agent's chart/diagram is uploaded via `sendPhoto` (multipart), landing inline in the chat with no tap required. |
| Telegram bridge — interactive mode | New: the reply gets a "📱 &lt;title&gt;" button that opens a Telegram Web App at `/webapps/:id`, served by the bridge's existing health-check HTTP server (`GET /health`) on a new route. |
| Telegram bridge — interactive mode, no public URL configured | Falls back to a plain-text warning ("no public URL configured … can't open it") instead of sending a dead button or failing silently. |
| Any other agent (CLI direct use, non-Telegram surfaces) | No behavioural change — `create_web_app` is opt-in per agent's `tools` list (added only to `agent.telegram.json` here), so existing agents don't gain it automatically. |

## UX changes operators will notice

- Telegram replies can now include an inline chart/diagram image, or a tappable button that opens a live page inside Telegram.
- To unlock the tappable/interactive mode, operators set the new `TELEGRAM_WEBAPP_BASE_URL` env var (see `.env.example`) to the bridge's public HTTPS origin; in `TELEGRAM_MODE=webhook` it defaults to the webhook URL's origin automatically. Static/image mode needs no configuration and works out of the box.
- The Docker image grows (system `chromium` package + Puppeteer's own headless Chromium download) and the `bun install` layer takes longer to build.

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| CLI JSON envelope (`--json`) | `{ok, answer, costUSD, tokenUsage, toolCalls}` | adds optional `webApp: {id, mode, title, htmlPath, imagePath?}` |
| Agent tool registry | — | new tool `create_web_app` (category `web_app`), opt-in per agent like `memory`/`reminders` |

## Tests

- Full suite: 1652 pass, 6 skip, 10 todo across 102 files (`bun test`) — nothing existing broke.
- No dedicated automated tests were added for `create_web_app` or the bridge wiring: `bridge.ts` has no existing test harness to extend (it isn't part of the `src/` tree Jest/bun:test covers), and the tool's core behaviour (spawning a real headless browser) is closer to an integration/manual check than a unit test. Verified instead via `bun run typecheck`, `bun run lint`, and a standalone `tsc --noEmit` pass over `integrations/telegram-bot/*.ts` with the same strictness flags as the main `tsconfig.json`.

### Edge cases to verify in a staging session

1. Ask the bot for a quick chart ("show me a bar chart of X") — expected: an image lands in the chat via `sendPhoto`, no button, no tap needed.
2. Ask for something explicitly interactive ("build me a small interactive tool for Y") — expected: a "📱 &lt;title&gt;" button appears; tapping it opens the page inside Telegram and it renders correctly.
3. Trigger an interactive request with `TELEGRAM_WEBAPP_BASE_URL` unset — expected: the fallback warning text, not a broken button or a silent no-op.
4. Feed the tool HTML that fails to render (e.g. a network-dependent CDN script that 404s) — expected: `create_web_app` returns `success: false` with an error message the agent can react to, not a crashed run.
5. Ask for two web apps in one turn — expected/known limitation: only the last one's result surfaces in the JSON envelope (`toolResults` is keyed by tool name, last-call-wins), so only the second is delivered to the chat.

## Notes for reviewers

- `create_web_app`'s structured result rides the existing `AgentResponse.toolResults` map (keyed by tool name) rather than new plumbing — see `extractWebAppResult` in [run-agent.ts](src/cli/commands/run-agent.ts). This was chosen over adding a dedicated context callback (the pattern `recordChildCost` uses) because the field already exists and needed no changes to the agent loop itself.
- Puppeteer is on Bun's default `trustedDependencies` list, so `bun install` already downloads its own Chromium locally. The Docker image instead installs the system `chromium` package and sets `PUPPETEER_SKIP_DOWNLOAD=true` / `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` to avoid bundling two copies of Chromium in the image.
- The new `/webapps/:id` route on the bridge's health server only accepts ids matching `[A-Za-z0-9_-]+` (short-uuid's own alphabet) before touching the filesystem — deliberate, to rule out path traversal.
