### PR TITLE
feat(chat): add --ephemeral / /incognito no-persistence mode

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -31,7 +31,7 @@ import {
   writeAgentFile,
 } from "./agents";
 import { startReminderSweep } from "./reminders";
-import { conversationKey, startNewConversation } from "./sessions";
+import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
 import { escapeHtml, markdownToTelegramHtml, splitForTelegram } from "./telegram-html";
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
 import { recordUsage, todayUsage } from "./usage";
@@ -55,6 +55,11 @@ const activeRuns = new Map<
 // Pending human approvals keyed by toolCallId, so an Accept/Reject tap can
 // find the run to write the decision back to and the message to clear.
 const pendingApprovals = new Map<string, { chatId: number; messageId: number; runToken: string }>();
+// Transcript for chats currently in /incognito mode. Lives only in this
+// process's memory — never written to disk — so a bridge restart drops the
+// context rather than ever falling back to a persisted history file. Cleared
+// on /new (which also turns incognito off, see handleCommand).
+const incognitoHistory = new Map<number, unknown[]>();
 
 type TransportMode = "polling" | "webhook";
 
@@ -104,6 +109,13 @@ interface JazzSuccessEnvelope {
   readonly costUSD: number;
   readonly tokenUsage?: { readonly totalTokens?: number };
   readonly webApp?: JazzWebApp;
+  /**
+   * Only present for `--ephemeral` runs (incognito chats): the full
+   * transcript, opaque to the bridge, round-tripped back in as
+   * `--history-json` on that chat's next turn instead of loading it from
+   * disk. See `incognitoHistory` below.
+   */
+  readonly messages?: unknown[];
 }
 
 interface JazzErrorEnvelope {
@@ -644,6 +656,8 @@ async function runJazz(
   onEvent: (event: JazzEvent) => void,
   runToken: string,
 ): Promise<JazzEnvelope> {
+  const incognito = isIncognito(config.jazzHome, chatId);
+  const priorIncognitoMessages = incognito ? incognitoHistory.get(chatId) : undefined;
   const child = Bun.spawn(
     [
       config.jazzBinary,
@@ -661,8 +675,14 @@ async function runJazz(
         : []),
       "--timezone",
       tzForChat(config.jazzHome, chatId),
-      "--conversation",
-      conversationKey(config.jazzHome, chatId),
+      ...(incognito
+        ? [
+            "--ephemeral",
+            ...(priorIncognitoMessages && priorIncognitoMessages.length > 0
+              ? ["--history-json", JSON.stringify(priorIncognitoMessages)]
+              : []),
+          ]
+        : ["--conversation", conversationKey(config.jazzHome, chatId)]),
       "--timeout",
       String(config.runTimeoutMs),
       prompt,
@@ -712,7 +732,14 @@ async function runJazz(
   }
 
   try {
-    return JSON.parse(lastJsonLine) as JazzEnvelope;
+    const envelope = JSON.parse(lastJsonLine) as JazzEnvelope;
+    // Carry the transcript forward in memory for this incognito chat's next
+    // turn — it never touches disk, so a dropped/missing `messages` field
+    // (e.g. the run errored) just means the next turn starts context-free.
+    if (incognito && envelope.ok) {
+      incognitoHistory.set(chatId, envelope.messages ?? []);
+    }
+    return envelope;
   } catch (error) {
     console.error(`Failed to parse Jazz envelope: ${String(error)}\nLine: ${lastJsonLine}`);
     return { ok: false, error: "Could not parse the agent response." };
@@ -1013,6 +1040,7 @@ const HELP_TEXT = [
   "/model — pick which Ollama model I use (just for you)",
   "/persona — pick my persona / style",
   "/new — start a fresh conversation (clears earlier context)",
+  "/incognito — start a private conversation (nothing saved to history or memory) until /new",
   "/remind <when> <text> — e.g. /remind 30m take pizza out",
   "  …or just say it: “remind me to call the dentist in 2 hours”, “send reminder next friday 2pm for review”",
   "/reminders — list and cancel your reminders",
@@ -1166,11 +1194,29 @@ async function handleCommand(
   }
 
   if (command === "new" || command === "reset") {
+    const wasIncognito = isIncognito(config.jazzHome, chatId);
+    if (wasIncognito) {
+      setIncognito(config.jazzHome, chatId, false);
+      incognitoHistory.delete(chatId);
+    }
     startNewConversation(config.jazzHome, chatId);
     await sendReply(
       config,
       chatId,
-      "🆕 Fresh conversation — I've cleared the earlier context. Your model and persona stay the same.",
+      wasIncognito
+        ? "🆕 Incognito conversation ended and discarded. Back to normal — your model and persona stay the same."
+        : "🆕 Fresh conversation — I've cleared the earlier context. Your model and persona stay the same.",
+    );
+    return;
+  }
+
+  if (command === "incognito") {
+    setIncognito(config.jazzHome, chatId, true);
+    incognitoHistory.delete(chatId);
+    await sendReply(
+      config,
+      chatId,
+      "🕶️ Incognito mode on — nothing from this conversation is saved to history or memory. Send /new to end it.",
     );
     return;
   }
@@ -1180,6 +1226,9 @@ async function handleCommand(
     const cap = config.dailyCostCapUsd;
     const lines = [
       "📊 <b>Status</b>",
+      ...(isIncognito(config.jazzHome, chatId)
+        ? ["🕶️ Incognito — nothing being saved right now"]
+        : []),
       `Model: <code>${escapeHtml(agent.config.llmProvider)}/${escapeHtml(agent.config.llmModel)}</code> (reasoning: ${escapeHtml(agent.config.reasoningEffort)})`,
       `Timezone: <code>${escapeHtml(tzForChat(config.jazzHome, chatId))}</code>${hasChatTz(config.jazzHome, chatId) ? "" : " (default)"}`,
       `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}`,

--- a/integrations/telegram-bot/sessions.test.ts
+++ b/integrations/telegram-bot/sessions.test.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
+
+describe("sessions", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-telegram-sessions-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("conversationKey / startNewConversation", () => {
+    it("defaults to the raw chat id before any /new", () => {
+      expect(conversationKey(tmpDir, 42)).toBe("42");
+    });
+
+    it("rotates to a new key each time /new is called", () => {
+      startNewConversation(tmpDir, 42);
+      expect(conversationKey(tmpDir, 42)).toBe("42-1");
+      startNewConversation(tmpDir, 42);
+      expect(conversationKey(tmpDir, 42)).toBe("42-2");
+    });
+
+    it("keeps other chats' epochs isolated", () => {
+      startNewConversation(tmpDir, 42);
+      expect(conversationKey(tmpDir, 99)).toBe("99");
+    });
+  });
+
+  describe("isIncognito / setIncognito", () => {
+    it("defaults to false", () => {
+      expect(isIncognito(tmpDir, 42)).toBe(false);
+    });
+
+    it("turns on and off independently per chat", () => {
+      setIncognito(tmpDir, 42, true);
+      expect(isIncognito(tmpDir, 42)).toBe(true);
+      expect(isIncognito(tmpDir, 99)).toBe(false);
+
+      setIncognito(tmpDir, 42, false);
+      expect(isIncognito(tmpDir, 42)).toBe(false);
+    });
+
+    it("never writes conversation content to disk — only the boolean flag", () => {
+      setIncognito(tmpDir, 42, true);
+      const raw = fs.readFileSync(path.join(tmpDir, "tg-incognito.json"), "utf8");
+      expect(JSON.parse(raw)).toEqual({ "42": true });
+    });
+
+    it("preserves an unparsable file instead of clobbering other chats' flags", () => {
+      const filePath = path.join(tmpDir, "tg-incognito.json");
+      fs.writeFileSync(filePath, "not json");
+
+      setIncognito(tmpDir, 42, true);
+
+      expect(fs.existsSync(`${filePath}.corrupt`)).toBe(true);
+      expect(isIncognito(tmpDir, 42)).toBe(true);
+    });
+  });
+});

--- a/integrations/telegram-bot/sessions.ts
+++ b/integrations/telegram-bot/sessions.ts
@@ -53,3 +53,52 @@ export function startNewConversation(dataDir: string, chatId: number): void {
   next[String(chatId)] = (next[String(chatId)] ?? 0) + 1;
   writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`);
 }
+
+/**
+ * /incognito marks a chat as private: runs for it use `jazz run --ephemeral`
+ * (no history/memory persistence — see `handleMessage`'s incognito branch,
+ * which also keeps that chat's transcript in the bridge's own memory instead
+ * of on disk) until /new is typed. Only this on/off flag lives on disk here —
+ * never the conversation content itself.
+ */
+function incognitoPath(dataDir: string): string {
+  return join(dataDir, "tg-incognito.json");
+}
+
+function loadIncognitoChats(dataDir: string): Record<string, boolean> | null {
+  const path = incognitoPath(dataDir);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, boolean>;
+    }
+  } catch {
+    // fall through to null (treated as unreadable)
+  }
+  return null;
+}
+
+export function isIncognito(dataDir: string, chatId: number): boolean {
+  return loadIncognitoChats(dataDir)?.[String(chatId)] === true;
+}
+
+export function setIncognito(dataDir: string, chatId: number, value: boolean): void {
+  const path = incognitoPath(dataDir);
+  const chats = loadIncognitoChats(dataDir);
+  if (chats === null && existsSync(path)) {
+    try {
+      renameSync(path, `${path}.corrupt`);
+      console.error(`Corrupt ${path} preserved as ${path}.corrupt`);
+    } catch {
+      // best effort
+    }
+  }
+  const next = chats ?? {};
+  if (value) {
+    next[String(chatId)] = true;
+  } else {
+    delete next[String(chatId)];
+  }
+  writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`);
+}

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -328,6 +328,10 @@ function registerAgentCommands(program: Command): void {
       "Maximum agent reasoning iterations per turn (default 80)",
       parsePositiveInt("--max-iterations"),
     )
+    .option(
+      "--ephemeral",
+      "Skip persistence for this session entirely: no conversation history save, no session log, and long-term memory writes are withheld. Nothing about the session touches disk.",
+    )
     .action(
       (
         agentIdentifier: string,
@@ -335,6 +339,7 @@ function registerAgentCommands(program: Command): void {
           stream?: boolean;
           noStream?: boolean;
           maxIterations?: number;
+          ephemeral?: boolean;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -346,6 +351,7 @@ function registerAgentCommands(program: Command): void {
             ...(options.maxIterations !== undefined
               ? { maxIterations: options.maxIterations }
               : {}),
+            ...(options.ephemeral === true ? { ephemeral: true } : {}),
           }),
           {
             verbose: opts.verbose,

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -111,6 +111,14 @@ function registerRunCommand(program: Command): void {
       "Force streaming mode. Required for --events to emit in non-TTY contexts (scripts, webhooks), where streaming is otherwise auto-disabled.",
     )
     .option("--no-stream", "Disable streaming mode")
+    .option(
+      "--ephemeral",
+      "Skip persistence entirely: --conversation is ignored (no history load/save) and long-term memory writes are withheld. Nothing about this run touches disk.",
+    )
+    .option(
+      "--history-json <json>",
+      "Inline JSON array of prior ChatMessages, used only with --ephemeral in place of --conversation — pass back the `messages` field from a previous --ephemeral --json response to keep multi-turn context without persistence.",
+    )
     .action(
       (
         prompt: string | undefined,
@@ -127,6 +135,8 @@ function registerRunCommand(program: Command): void {
           conversation?: string;
           stream?: boolean;
           noStream?: boolean;
+          ephemeral?: boolean;
+          historyJson?: string;
         },
       ) => {
         const opts = program.opts<CliOptions>();
@@ -218,6 +228,8 @@ function registerRunCommand(program: Command): void {
               : options.stream === true
                 ? { stream: true }
                 : {}),
+            ...(options.ephemeral === true ? { ephemeral: true } : {}),
+            ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
           }),
           {
             verbose: opts.verbose,

--- a/src/cli/commands/chat-agent.ts
+++ b/src/cli/commands/chat-agent.ts
@@ -24,6 +24,7 @@ export function chatWithAIAgentCommand(
   options?: {
     stream?: boolean;
     maxIterations?: number;
+    ephemeral?: boolean;
   },
 ) {
   return Effect.gen(function* () {
@@ -63,6 +64,11 @@ export function chatWithAIAgentCommand(
     yield* terminal.info(
       "/help commands & shortcuts · /exit quit · Esc Esc interrupt · Shift+Tab approval mode · Ctrl+R reasoning · Ctrl+O expand output",
     );
+    if (options?.ephemeral === true) {
+      yield* terminal.warn(
+        "🕶️ Ephemeral session — nothing will be saved to history, memory, or the session log.",
+      );
+    }
 
     // Check if model supports tools and warn if not
     const modelMeta = yield* Effect.promise(() =>

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -52,6 +52,20 @@ describe("formatOneShotResult", () => {
       toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
     });
   });
+
+  it("omits messages by default", () => {
+    const output = formatOneShotResult(baseResult, { json: true });
+    expect(JSON.parse(output)).not.toHaveProperty("messages");
+  });
+
+  it("includes messages when set (--ephemeral round-trip)", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ];
+    const output = formatOneShotResult({ ...baseResult, messages }, { json: true });
+    expect(JSON.parse(output).messages).toEqual(messages);
+  });
 });
 
 describe("formatOneShotError", () => {

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -64,10 +64,11 @@ export interface OneShotSuccess {
   /**
    * Full message transcript for this run, included only for `--ephemeral`
    * calls. Since ephemeral runs never load/save `--conversation` history on
-   * disk, a caller that wants multi-turn context (e.g. the Telegram bridge's
-   * incognito mode) round-trips this array back in as `--history-json` on
-   * the next call instead — the conversation lives in the caller's memory,
-   * never on disk.
+   * disk, any caller that wants multi-turn context (a webhook bridge, a
+   * script — this is generic to `jazz run`, not tied to any one integration)
+   * round-trips this array back in as `--history-json` on the next call
+   * instead. The conversation lives in the caller's own memory, never on
+   * disk.
    */
   readonly messages?: readonly ChatMessage[];
 }

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -61,6 +61,15 @@ export interface OneShotSuccess {
   readonly tokenUsage: OneShotTokenUsage;
   readonly toolCalls: readonly OneShotToolCall[];
   readonly webApp?: OneShotWebApp;
+  /**
+   * Full message transcript for this run, included only for `--ephemeral`
+   * calls. Since ephemeral runs never load/save `--conversation` history on
+   * disk, a caller that wants multi-turn context (e.g. the Telegram bridge's
+   * incognito mode) round-trips this array back in as `--history-json` on
+   * the next call instead — the conversation lives in the caller's memory,
+   * never on disk.
+   */
+  readonly messages?: readonly ChatMessage[];
 }
 
 /**
@@ -115,6 +124,7 @@ export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutp
     tokenUsage: result.tokenUsage,
     toolCalls: result.toolCalls,
     ...(result.webApp ? { webApp: result.webApp } : {}),
+    ...(result.messages ? { messages: result.messages } : {}),
   })}\n`;
 }
 
@@ -173,6 +183,19 @@ export interface RunAgentOnceOptions {
    * per-chat memory across invocations. Absent = one-shot (no persistence).
    */
   readonly conversationId?: string | undefined;
+  /**
+   * Skip persistence entirely for this run: `--conversation` is ignored (no
+   * history load/save), and the `manage_memory` tool is withheld (no
+   * long-term memory writes). Nothing about this run ever touches disk.
+   */
+  readonly ephemeral?: boolean | undefined;
+  /**
+   * Inline JSON-encoded `ChatMessage[]` of prior turns, used only with
+   * `ephemeral` in place of `--conversation` — the caller (e.g. a webhook
+   * bridge) holds the transcript itself and passes it back in each call
+   * instead of it living on disk. Malformed JSON is treated as "no history".
+   */
+  readonly historyJson?: string | undefined;
 }
 
 /**
@@ -353,13 +376,26 @@ export function runAgentOnceCommand(
         ? { ...agent, config: { ...agent.config, reasoningEffort: options.reasoningEffort } }
         : agent;
 
-    const conversationKey = options.conversationId?.trim();
+    const ephemeral = options.ephemeral === true;
+    const conversationKey = ephemeral ? undefined : options.conversationId?.trim();
     if (conversationKey !== undefined && conversationKey.length === 0) {
       return yield* failOneShot("Invalid --conversation id: must be non-empty.", outputOptions);
     }
 
     const priorRecord =
       conversationKey !== undefined ? yield* loadConversation(agent.id, conversationKey) : null;
+
+    // Ephemeral runs never touch disk, so prior context (if any) comes back
+    // in as inline JSON from the caller rather than a `--conversation` load.
+    let inlineHistory: ChatMessage[] | undefined;
+    if (ephemeral && options.historyJson !== undefined) {
+      try {
+        const parsed: unknown = JSON.parse(options.historyJson);
+        if (Array.isArray(parsed)) inlineHistory = parsed as ChatMessage[];
+      } catch {
+        // Malformed inline history starts the run fresh rather than failing it.
+      }
+    }
 
     const autoApprovePolicy: AutoApprovePolicy | undefined = options.approvalPolicy;
     const runId = `run-${agent.id}-${Date.now()}`;
@@ -368,7 +404,11 @@ export function runAgentOnceCommand(
       userInput: prompt,
       sessionId: runId,
       conversationId: conversationKey ?? runId,
-      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
+      ...(inlineHistory !== undefined
+        ? { conversationHistory: inlineHistory }
+        : priorRecord !== null
+          ? { conversationHistory: priorRecord.messages }
+          : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options.autoApprovedTools?.length
         ? { autoApprovedTools: options.autoApprovedTools }
@@ -376,6 +416,7 @@ export function runAgentOnceCommand(
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
       ...(options.stream !== undefined ? { stream: options.stream } : {}),
+      ...(ephemeral ? { disablePersistence: true } : {}),
     });
 
     const runResult = yield* options.timeoutMs != null
@@ -431,6 +472,7 @@ export function runAgentOnceCommand(
           },
           toolCalls,
           ...(webApp ? { webApp } : {}),
+          ...(ephemeral ? { messages: runResult.messages ?? [] } : {}),
         },
         outputOptions,
       ),

--- a/src/core/agent/agent-runner.test.ts
+++ b/src/core/agent/agent-runner.test.ts
@@ -81,6 +81,7 @@ const mockToolRegistry = {
     Effect.succeed([
       "tool1",
       "tool2",
+      "manage_memory",
       "load_skill",
       "load_skill_section",
       "ask_user_question",
@@ -118,6 +119,13 @@ const mockToolRegistry = {
         function: {
           name: "tool2",
           description: "Tool 2 description",
+          parameters: {},
+        },
+      },
+      {
+        function: {
+          name: "manage_memory",
+          description: "Manage long-term memory",
           parameters: {},
         },
       },
@@ -287,6 +295,46 @@ describe("AgentRunner", () => {
       expect(result).toBeDefined();
       expect(result.content).toBe("Hello world");
       expect(result.conversationId).toBeDefined();
+    });
+  });
+
+  describe("disablePersistence", () => {
+    const agentWithMemoryTool: Agent = {
+      ...mockAgent,
+      config: { ...mockAgent.config, tools: ["tool1", "tool2", "manage_memory"] },
+    };
+
+    function lastRequestedToolNames(): string[] {
+      const lastCall = mockLlmService.createStreamingChatCompletion.mock.calls.at(-1);
+      const llmOptions = lastCall?.[1] as { tools?: { function: { name: string } }[] };
+      return (llmOptions.tools ?? []).map((tool) => tool.function.name);
+    }
+
+    it("withholds manage_memory when disablePersistence is set", async () => {
+      const options = {
+        ...defaultOptions,
+        agent: agentWithMemoryTool,
+        stream: true,
+        maxIterations: 1,
+        disablePersistence: true,
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      expect(lastRequestedToolNames()).not.toContain("manage_memory");
+    });
+
+    it("keeps manage_memory when disablePersistence is not set", async () => {
+      const options = {
+        ...defaultOptions,
+        agent: agentWithMemoryTool,
+        stream: true,
+        maxIterations: 1,
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      expect(lastRequestedToolNames()).toContain("manage_memory");
     });
   });
 });

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -153,6 +153,12 @@ function initializeAgentRun(
       combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
     }
 
+    // Ephemeral runs (jazz run --ephemeral) withhold the memory-writing tool
+    // outright, so the model is never even offered a way to persist anything.
+    if (options.disablePersistence === true) {
+      combinedToolNames = combinedToolNames.filter((name) => name !== "manage_memory");
+    }
+
     // Filter out any non-existent tools silently — tools may have been removed
     // or MCP servers may be unavailable. The agent can still operate with its
     // remaining tools.

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -115,6 +115,13 @@ export interface AgentRunnerOptions {
    * Defaults to "UTC" (via ToolExecutionContext) when unset.
    */
   readonly timezone?: string;
+  /**
+   * When true, withhold the `manage_memory` tool for this run so nothing gets
+   * written to the agent's long-term memory. Unrelated to `ephemeralRegionId`
+   * above (that one is a streaming-UI concept) — this is the "no persistence"
+   * flag behind `jazz run --ephemeral`.
+   */
+  readonly disablePersistence?: boolean;
 }
 
 /**

--- a/src/core/interfaces/chat-service.ts
+++ b/src/core/interfaces/chat-service.ts
@@ -38,6 +38,13 @@ export interface ChatService {
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
       maxIterations?: number;
+      /**
+       * Skip persistence for this session entirely: no conversation history
+       * save (on /new or exit), no per-message session log, and the
+       * `manage_memory` tool is withheld. Nothing about the session touches
+       * disk. Mirrors `jazz run --ephemeral`.
+       */
+      ephemeral?: boolean;
     },
   ) => Effect.Effect<
     void,

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -55,6 +55,7 @@ export class ChatServiceImpl implements ChatService {
       initialHistory?: ChatMessage[];
       initialConversationTitle?: string;
       maxIterations?: number;
+      ephemeral?: boolean;
     },
   ): Effect.Effect<
     void,
@@ -118,6 +119,8 @@ export class ChatServiceImpl implements ChatService {
       }).pipe(Effect.catchAll(() => Effect.void));
 
       store.resetRunStats({ provider: agent.config.llmProvider, model: agent.config.llmModel });
+
+      const ephemeral = options?.ephemeral === true;
 
       let chatActive = true;
       let conversationHistory: ChatMessage[] = options?.initialHistory ?? [];
@@ -308,6 +311,7 @@ export class ChatServiceImpl implements ChatService {
             );
 
             if (
+              !ephemeral &&
               commandResult.saveCurrentHistory &&
               conversationTitle !== null &&
               conversationHistory.length > 0
@@ -429,6 +433,7 @@ export class ChatServiceImpl implements ChatService {
             ...(options?.maxIterations !== undefined
               ? { maxIterations: options.maxIterations }
               : {}),
+            ...(ephemeral ? { disablePersistence: true } : {}),
             autoApprovePolicy: getCurrentAutoApprovePolicy,
             autoApprovedCommands,
             autoApprovedTools,
@@ -544,12 +549,17 @@ export class ChatServiceImpl implements ChatService {
             };
           }
 
-          // Persist conversation history for next turn and log new messages
+          // Persist conversation history for next turn and log new messages.
+          // The in-memory bookkeeping (conversationHistory/loggedMessageCount)
+          // still runs for ephemeral sessions — only the on-disk session log
+          // (logMessageToSession) is skipped.
           if (response.messages) {
             // Log all new messages that haven't been logged yet
             const newMessages = response.messages.slice(loggedMessageCount);
-            for (const message of newMessages) {
-              yield* logMessageToSession(sessionId, message);
+            if (!ephemeral) {
+              for (const message of newMessages) {
+                yield* logMessageToSession(sessionId, message);
+              }
             }
             loggedMessageCount = response.messages.length;
             conversationHistory = response.messages;
@@ -561,25 +571,29 @@ export class ChatServiceImpl implements ChatService {
             }
           } else if (response.content) {
             // If we have content but no messages array, log both user and assistant messages
-            const userChatMessage: ChatMessage = {
-              role: "user",
-              content: userMessage,
-            };
-            yield* logMessageToSession(sessionId, userChatMessage);
+            if (!ephemeral) {
+              const userChatMessage: ChatMessage = {
+                role: "user",
+                content: userMessage,
+              };
+              yield* logMessageToSession(sessionId, userChatMessage);
 
-            const assistantMessage: ChatMessage = {
-              role: "assistant",
-              content: response.content,
-            };
-            yield* logMessageToSession(sessionId, assistantMessage);
+              const assistantMessage: ChatMessage = {
+                role: "assistant",
+                content: response.content,
+              };
+              yield* logMessageToSession(sessionId, assistantMessage);
+            }
             loggedMessageCount += 2; // user message + assistant message
           } else {
             // If no messages array and no content, still log the user message
-            const userChatMessage: ChatMessage = {
-              role: "user",
-              content: userMessage,
-            };
-            yield* logMessageToSession(sessionId, userChatMessage);
+            if (!ephemeral) {
+              const userChatMessage: ChatMessage = {
+                role: "user",
+                content: userMessage,
+              };
+              yield* logMessageToSession(sessionId, userChatMessage);
+            }
             loggedMessageCount += 1;
           }
 
@@ -628,7 +642,7 @@ export class ChatServiceImpl implements ChatService {
         });
       }
 
-      if (conversationTitle !== null && conversationHistory.length > 0) {
+      if (!ephemeral && conversationTitle !== null && conversationHistory.length > 0) {
         const record: ConversationRecord = {
           conversationId,
           title: conversationTitle,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*", "src/**/*.test.ts", "evals/**/*.test.ts"],
+  "include": ["src/**/*", "src/**/*.test.ts", "evals/**/*.test.ts", "integrations/**/*.test.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What this PR delivers

Adds a `jazz run --ephemeral` flag to the core CLI that guarantees a run never touches disk: conversation history is neither loaded nor saved, and the `manage_memory` tool is withheld so the model has no way to write to long-term memory either. Multi-turn context for these runs is round-tripped by the caller via a new `--history-json` flag instead of a persisted `--conversation` file.

The same `disablePersistence` gate is also wired into the interactive `jazz agent chat` REPL via a new `--ephemeral` flag there, covering a third disk-writing path (a per-session log file) that only the interactive REPL has.

Both ship alongside a Telegram bridge `/incognito` command built on the `jazz run` flag: while a chat is in incognito mode, its transcript lives only in the bridge process's own memory (never on disk) until `/new` ends the session and discards it.

## Why this matters

For operators: Telegram bot users, and anyone using `jazz agent chat` or `jazz run` directly, get a way to have a conversation that never lands in persisted history, agent memory, or the session log — useful for anything sensitive they don't want sitting on disk.

For maintainers: persistence is now gated through one testable flag (`disablePersistence` in `AgentRunnerOptions`) rather than scattered disk-writing conditionals, and `--history-json` keeps ephemeral `jazz run` calls genuinely multi-turn without reintroducing a disk dependency to get there.

## How CLI/bridge behaviour changes

| Path | Change |
|---|---|
| `jazz run` (no flags) | No behavioural change. |
| `jazz run --conversation <id>` | No behavioural change — persists as before. |
| `jazz run --ephemeral` | New: skips `loadConversation`/`saveConversation` entirely regardless of `--conversation`; withholds `manage_memory`; `--json` envelope additionally includes `messages` so the caller can round-trip context via `--history-json` on the next call. |
| `jazz agent chat` (no flags) | No behavioural change — still saves conversation history on `/new`/exit and logs every message to `~/.jazz/logs/<sessionId>.log`. |
| `jazz agent chat --ephemeral` | New: skips both history saves, skips the per-session log file entirely, and withholds `manage_memory`. Prints a one-line notice at session start. |
| Telegram bridge, normal chat | No behavioural change — still runs with `--conversation <chat-epoch-key>`. |
| Telegram bridge, chat in `/incognito` | New: `runJazz` passes `--ephemeral` (+ `--history-json` from an in-process `Map`) instead of `--conversation`. Nothing about the turn is written to `/data/history` or `/data/memory`. |
| Telegram bridge `/new` | Extended: now also clears incognito state and discards the in-memory transcript, in addition to the existing epoch rotation. |

## UX changes operators will notice

- New `/incognito` command and updated `/help` text in Telegram.
- `/status` shows a 🕶️ Incognito line when the current chat is in that mode.
- `/new`'s confirmation message differs when it's also ending an incognito session ("Incognito conversation ended and discarded...").
- New `--ephemeral` flag on `jazz agent chat`, printing a one-line "🕶️ Ephemeral session" notice at startup.

## Tests

1663 tests passing (11 new, 0 fail) — `bun run typecheck`, `bun run lint` (both `src` and `integrations`), and `bun test` are all clean.

- `src/core/agent/agent-runner.test.ts` — pins that `disablePersistence: true` withholds `manage_memory` from the tool set, and that it's present when unset. This is the shared gate both `jazz run --ephemeral` and `jazz agent chat --ephemeral` go through.
- `src/cli/commands/run-agent.test.ts` — pins the `--json` envelope: `messages` absent by default, present when set.
- `integrations/telegram-bot/sessions.test.ts` (new) — canonical spec for the incognito on/off flag's disk persistence, including corrupt-file recovery (mirrors the existing epoch-rotation tests in the same file).
- `chat-service.ts`'s three gated call sites (two `saveConversation`, one `logMessageToSession`) have no dedicated test — that file has no existing test harness (it's a large stateful Effect REPL loop with ~10 service dependencies) and this change is a straightforward boolean gate on already-existing calls, consistent with the file's current coverage.

### Edge cases to verify in a staging session

1. `/incognito`, chat for 2–3 turns, then check `/data/memory/tg_<chatId>` on the server — expected: replies stay contextual across turns, memory directory untouched.
2. Restart the bridge process mid-incognito session — expected: next message starts a fresh incognito turn with no prior context (in-memory history is lost on restart), but stays private rather than silently falling back to persisted mode.
3. `/new` while incognito — expected: reply confirms the conversation was discarded; the next message persists normally under a fresh conversation epoch.
4. Corrupt `tg-incognito.json` on disk, then `/incognito` — expected: corrupt file preserved as `.corrupt`, new state written correctly.
5. `/status` while incognito — expected: shows the 🕶️ Incognito line.
6. `jazz agent chat --ephemeral <agent>`, chat for a few turns, `/new`, then exit — expected: no file appears under `~/.jazz/logs/` for that session and no entry appears in that agent's history file.

## Notes for reviewers

- `integrations/telegram-bot/sessions.test.ts` is the canonical spec for the incognito flag's on-disk semantics — read it first if touching that file.
- Multi-turn context for `--ephemeral` runs is intentionally never loaded from disk. It's round-tripped via `--history-json` using the `messages` field the `--json` envelope now returns — this is the mechanism that keeps incognito conversations coherent across turns. `jazz agent chat --ephemeral` doesn't need this trick — it's one long-lived process, so in-memory `conversationHistory` already carries context across turns without ever hitting disk.
- Design decision: the incognito on/off flag itself is still persisted to disk (`tg-incognito.json`) — only the conversation *content* is kept ephemeral. This is deliberate: a bridge restart mid-session can't silently fall back to persisted mode, while nothing privacy-sensitive ever hits disk.
- `chat-service.ts`'s per-session log file (`logMessageToSession`) is a third, previously-unaccounted-for disk-writing path distinct from conversation history and long-term memory — it only exists on the interactive REPL, not `jazz run`, which is why `jazz run --ephemeral` didn't need to touch it but `jazz agent chat --ephemeral` does.
