### PR TITLE
fix(telegram): register bot commands so /incognito shows in the / menu

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -1033,6 +1033,24 @@ async function upgradeToDynamicCtas(
 
 // --- Commands & inline keyboards ------------------------------------------
 
+/**
+ * Registered with Telegram via `setMyCommands` so these show up in the
+ * client's "/" autocomplete menu — separate from, and kept in sync by hand
+ * with, the prose list in HELP_TEXT below. `command` must be lowercase
+ * letters/digits/underscores only (no slash, no arguments).
+ */
+const BOT_COMMANDS: { command: string; description: string }[] = [
+  { command: "model", description: "Pick which Ollama model I use (just for you)" },
+  { command: "persona", description: "Pick my persona / style" },
+  { command: "new", description: "Start a fresh conversation (clears earlier context)" },
+  { command: "incognito", description: "Start a private conversation (nothing saved) until /new" },
+  { command: "remind", description: "Set a reminder, e.g. /remind 30m take pizza out" },
+  { command: "reminders", description: "List and cancel your reminders" },
+  { command: "tz", description: "Set your timezone, e.g. /tz Europe/Paris" },
+  { command: "status", description: "Model, today's usage, uptime" },
+  { command: "help", description: "Show available commands" },
+];
+
 const HELP_TEXT = [
   "I'm your Jazz assistant. Just send a message and I'll answer.",
   "",
@@ -1630,6 +1648,9 @@ async function start(): Promise<void> {
   startReminderSweep(config.jazzHome, (reminderChatId, html) =>
     sendReply(config, reminderChatId, html),
   );
+  // Populates Telegram's "/" autocomplete menu. Cheap and idempotent, so it's
+  // just re-sent on every start rather than only when BOT_COMMANDS changes.
+  await callTelegram(config, "setMyCommands", { commands: BOT_COMMANDS });
   console.log(
     `Telegram → Jazz bridge started (mode="${config.mode}", per-chat agents, policy="${config.approvalPolicy}")`,
   );


### PR DESCRIPTION
## What this PR does
Registers the bridge's command list with Telegram via `setMyCommands` on startup, so the client's "/" autocomplete menu actually lists them (`/incognito` included).

## Why
Telegram's "/" popup is driven by `setMyCommands`/`getMyCommands`, not by the `/help` text reply. The bridge never called it — `getMyCommands` on the live bot returned `[]`. This wasn't specific to `/incognito`; no command has ever shown in the menu. `/help` itself was already correct and unaffected.

## How to test
- Restart the bridge, then call `getMyCommands` — expect the 9 commands (model, persona, new, incognito, remind, reminders, tz, status, help), not `[]`.
- In Telegram, type `/` in the chat — the autocomplete list should now show `/incognito` alongside the others.
- Edge case: a bot restart re-sends the same list (idempotent) rather than erroring or duplicating entries.