### PR TITLE
fix(telegram): echo follow-up button choice as a sent message

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -451,10 +451,10 @@ function webAppKeyboard(url: string, title: string): Record<string, unknown> {
 function followupKeyboard(): Record<string, unknown> {
   return {
     inline_keyboard: [
-      [
-        { text: "🔍 Go deeper", callback_data: "f:deeper" },
-        { text: "✂️ Shorter", callback_data: "f:shorter" },
-      ],
+      Object.entries(FOLLOWUP_OPTIONS).map(([key, option]) => ({
+        text: option.label,
+        callback_data: `f:${key}`,
+      })),
     ],
   };
 }
@@ -867,11 +867,17 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
   }
 }
 
-const FOLLOWUP_PROMPTS: Record<string, string> = {
-  deeper:
-    "Go deeper on your previous answer: add more detail, concrete specifics, and any important nuances or caveats.",
-  shorter:
-    "Give a much shorter version of your previous answer — 2-3 sentences, just the essentials.",
+const FOLLOWUP_OPTIONS: Record<string, { label: string; prompt: string }> = {
+  deeper: {
+    label: "🔍 Go deeper",
+    prompt:
+      "Go deeper on your previous answer: add more detail, concrete specifics, and any important nuances or caveats.",
+  },
+  shorter: {
+    label: "✂️ Shorter",
+    prompt:
+      "Give a much shorter version of your previous answer — 2-3 sentences, just the essentials.",
+  },
 };
 
 // --- Dynamic contextual CTAs ----------------------------------------------
@@ -1321,6 +1327,7 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
       message_id: messageId,
       reply_markup: { inline_keyboard: [] },
     });
+    await sendReply(config, chatId, escapeHtml(item.label));
     void handleMessage(config, chatId, item.prompt).catch((error) =>
       console.error(`Suggestion follow-up failed for chat ${chatId}: ${String(error)}`),
     );
@@ -1389,19 +1396,20 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
   }
 
   if (kind === "f") {
-    const prompt = FOLLOWUP_PROMPTS[indexRaw ?? ""];
+    const option = FOLLOWUP_OPTIONS[indexRaw ?? ""];
     await callTelegram(config, "answerCallbackQuery", {
       callback_query_id: callback.id,
-      ...(prompt ? {} : { text: "Unknown action" }),
+      ...(option ? {} : { text: "Unknown action" }),
     });
-    if (!prompt) return;
+    if (!option) return;
     // Drop the follow-up buttons so they can't be tapped twice.
     await callTelegram(config, "editMessageReplyMarkup", {
       chat_id: chatId,
       message_id: messageId,
       reply_markup: { inline_keyboard: [] },
     });
-    void handleMessage(config, chatId, prompt).catch((error) =>
+    await sendReply(config, chatId, option.label);
+    void handleMessage(config, chatId, option.prompt).catch((error) =>
       console.error(`Follow-up failed for chat ${chatId}: ${String(error)}`),
     );
     return;


### PR DESCRIPTION
## What this PR does
Tapping a follow-up button in the Telegram bot (the static "🔍 Go deeper" / "✂️ Shorter" pair, or a dynamic contextual suggestion) now posts a message echoing the choice, so it appears in the chat like a sent message before the bot's answer follows.

## Why
Telegram never renders a button tap (`callback_query`) as a chat message on its own — only messages a user actually types get that treatment automatically. `handleCallback`'s `f:` and `s:` branches cleared the button row and fed the associated prompt straight into `handleMessage(...)` to generate the next answer, but never called `sendReply` for the tap itself. So the visible sequence was: buttons vanish → "🤔 Working…" → final answer, with no trace of what was picked. This also incidentally deduplicated the button label strings: `followupKeyboard()` previously hardcoded "🔍 Go deeper"/"✂️ Shorter" separately from the matching `FOLLOWUP_PROMPTS` map — both are now a single `FOLLOWUP_OPTIONS` map of `{ label, prompt }`.

## How to test
- In a Telegram chat with the bot, ask a question, wait for the answer with its "Go deeper"/"Shorter" buttons, and tap one — confirm a message with that button's label now appears before the bot's "Working…"/answer messages.
- Do the same for a dynamic contextual suggestion (when `JAZZ_TELEGRAM_DYNAMIC_CTA` upgrades the keyboard) — confirm the suggestion's own label is echoed, and that special characters in an LLM-generated label render correctly (HTML-escaped, not broken by Telegram's `parse_mode: HTML`).
