### PR TITLE
feat(telegram): add Explain simpler and Example follow-up options

### DIFF
--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -449,14 +449,16 @@ function webAppKeyboard(url: string, title: string): Record<string, unknown> {
 }
 
 function followupKeyboard(): Record<string, unknown> {
-  return {
-    inline_keyboard: [
-      Object.entries(FOLLOWUP_OPTIONS).map(([key, option]) => ({
-        text: option.label,
-        callback_data: `f:${key}`,
-      })),
-    ],
-  };
+  const buttons = Object.entries(FOLLOWUP_OPTIONS).map(([key, option]) => ({
+    text: option.label,
+    callback_data: `f:${key}`,
+  }));
+  // Two per row so the labels stay readable on a mobile-width keyboard.
+  const rows: Array<Array<{ text: string; callback_data: string }>> = [];
+  for (let index = 0; index < buttons.length; index += 2) {
+    rows.push(buttons.slice(index, index + 2));
+  }
+  return { inline_keyboard: rows };
 }
 
 // --- Live progress --------------------------------------------------------
@@ -877,6 +879,15 @@ const FOLLOWUP_OPTIONS: Record<string, { label: string; prompt: string }> = {
     label: "✂️ Shorter",
     prompt:
       "Give a much shorter version of your previous answer — 2-3 sentences, just the essentials.",
+  },
+  simpler: {
+    label: "🧑‍🏫 Explain simpler",
+    prompt:
+      "Explain your previous answer in simpler terms, as if to someone with no background in the topic — avoid jargon and use plain language.",
+  },
+  example: {
+    label: "💡 Example",
+    prompt: "Give a concrete, real-world example that illustrates your previous answer.",
   },
 };
 


### PR DESCRIPTION
## What this PR does
Adds two more static follow-up options to the Telegram bot's post-answer keyboard: "🧑‍🏫 Explain simpler" and "💡 Example", alongside the existing "🔍 Go deeper" and "✂️ Shorter". The keyboard now lays out two buttons per row instead of one wide row.

## Why
"Go deeper"/"Shorter" only covered length/depth of the same answer. "Explain simpler" (plain-language, jargon-free) and "Example" (concrete illustration) are generically useful follow-ups for any answer, independent of topic, and round out the default set without requiring the dynamic contextual-suggestion path to kick in.

## How to test
- Ask the bot any question, wait for the answer, and confirm the keyboard now shows four buttons across two rows.
- Tap "Explain simpler" — confirm the follow-up message and next answer read as a plain-language explanation of the previous answer, not just a shorter one.
- Tap "Example" — confirm the response is a concrete example illustrating the previous answer.
- Edge case: with more than 4 options (e.g. if more are added later), confirm the row-chunking logic in `followupKeyboard()` still pairs them two-per-row correctly, including an odd trailing button on its own row.
