### PR TITLE
fix(context): account against the window local servers actually honour

### DIFF
--- a/docs/integrations/providers.md
+++ b/docs/integrations/providers.md
@@ -171,6 +171,8 @@ All fields are optional. When `base_url` is omitted, Jazz uses `http://localhost
 
 **Context window**: When you create an Ollama agent, Jazz asks you to pick a context window from a list capped to the model's real maximum. Ollama otherwise caps the runtime context to a small default (~4096 tokens) and silently truncates long conversations regardless of the model's trained size. The choice is stored per agent (`numCtx`) and sent as `num_ctx` on every request; change it later with `jazz agent edit`.
 
+It is also what Jazz compacts against, since it is the window the server will honour — the model's advertised maximum is not. An agent with no `numCtx` warns at run start: Jazz has no way to read the server's `OLLAMA_CONTEXT_LENGTH`, so it falls back to the advertised maximum and would compact too late if the server runs a smaller window.
+
 **Keep-alive**: Set `keep_alive` (e.g. `"30m"`, or `"-1"` to keep the model resident indefinitely) to avoid model-reload latency between agent turns. When unset, Ollama's own default (5 minutes) applies.
 
 Running on a server without internet access? See the [Airgapped & Self-Hosted guide](../guide/airgapped.md) — set `JAZZ_OFFLINE=1` to disable all outbound requests Jazz makes on its own.

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -213,6 +213,12 @@ gives its `-c` value directly. An unpinned Ollama agent gets a warning at run st
 than a silent assumption, because Ollama exposes a loaded model's window on `/api/ps` but
 has no endpoint for the server default before anything is loaded.
 
+The catalog is no help here at all: models.dev carries no `ollama` or `llamacpp` provider,
+so a local model resolves to the 128k unknown-model placeholder rather than to a real
+maximum. That placeholder is never treated as a ceiling — a pinned window above it is
+honoured, because the user pinned it and configured the server to serve it. Only a
+*genuinely known* maximum caps a runtime window.
+
 ---
 
 ## Tool results are reformatted before storage

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -44,7 +44,7 @@ flowchart TB
 | --- | --- | --- |
 | Runs | every iteration, after appending the assistant message | when tokens exceed 80% of the model's window |
 | Costs | nothing | one LLM call |
-| Budget | a fixed working-set target (50k tokens by default) | the model's real context window, from the catalog |
+| Budget | a fixed working-set target (50k tokens by default) | the context window the provider will actually honour |
 | What's lost | old messages, entirely | detail — the gist survives as a summary |
 | Preserves | system message + last N complete turns | system message + a summary + recent messages |
 
@@ -197,6 +197,21 @@ a summary is lossy — a detail the agent needed might not survive. Mitigations:
 
 Window size comes from the model catalog (models.dev), falling back to 128k when unknown —
 so the threshold tracks the actual model rather than a guess.
+
+**Local providers are the exception, and getting this wrong is the worst failure mode there
+is.** A cloud provider honours the window its catalog advertises. Ollama does not: it loads
+the model with whatever `num_ctx` the request carries, or with the server's
+`OLLAMA_CONTEXT_LENGTH` default — `qwen3.6:27b` advertises 262144 tokens and is routinely
+served at 131072 or less. Accounting against the advertised number means Jazz compacts long
+after the server has started dropping the middle of the conversation, and the agent keeps
+answering from a context it no longer has.
+
+So for `ollama` and `llamacpp` the threshold is taken from the agent's pinned `numCtx` when
+it has one (that value overrides the server default for the request, so it *is* the runtime
+window), and from the window the local server reported otherwise — llama-server's `/props`
+gives its `-c` value directly. An unpinned Ollama agent gets a warning at run start rather
+than a silent assumption, because Ollama exposes a loaded model's window on `/api/ps` but
+has no endpoint for the server default before anything is loaded.
 
 ---
 

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -3,6 +3,7 @@ import { Effect, Layer, Option } from "effect";
 import { Box, Text } from "ink";
 import React from "react";
 import type { ActivityState } from "@/cli/ui/activity-state";
+import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
 import { DEFAULT_DISPLAY_CONFIG } from "@/core/agent/types";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import { NotificationServiceTag, type NotificationService } from "@/core/interfaces/notification";
@@ -470,7 +471,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         this.seenLength = 0;
         this.hasStreamedText = false;
         store.updateRunStats({ provider: event.provider, model: event.model });
-        this.resolveContextWindow(event.provider, event.model);
+        this.resolveContextWindow(event.provider, event.model, event.pinnedContextWindow);
       }
 
       if (this.displayConfig.showThinking) {
@@ -778,13 +779,27 @@ export class InkStreamingRenderer implements StreamingRenderer {
   }
 
   /**
-   * Resolve the model's context window and publish it to the footer so
-   * tokens-in-context renders as `12.3k/200k` instead of a bare count.
+   * Resolve the context window the request will actually get and publish it to the
+   * footer, so tokens-in-context renders as `12.3k/200k` instead of a bare count —
+   * and so the denominator matches the one compaction accounts against.
    */
-  private resolveContextWindow(provider: string, model: string): void {
+  private resolveContextWindow(
+    provider: string,
+    model: string,
+    pinnedContextWindow: number | undefined,
+  ): void {
+    const publish = (modelMaxTokens: number): void => {
+      const effective = resolveEffectiveContextWindow({
+        provider,
+        modelMaxTokens,
+        ...(pinnedContextWindow !== undefined && { pinnedContextWindow }),
+      });
+      store.updateRunStats({ maxContextTokens: effective.tokens });
+    };
+
     const cached = getModelsDevMetadataSync(model, provider);
     if (cached !== undefined) {
-      store.updateRunStats({ maxContextTokens: cached.contextWindow });
+      publish(cached.contextWindow);
       return;
     }
     void getModelsDevMetadata(model, provider)
@@ -795,7 +810,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         // model and must not overwrite the footer denominator.
         const stats = store.getRunStatsSnapshot();
         if (stats.model !== model || stats.provider !== provider) return;
-        store.updateRunStats({ maxContextTokens: meta.contextWindow });
+        publish(meta.contextWindow);
       })
       .catch(() => {
         /* context window unavailable — footer shows the bare count */

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -788,10 +788,10 @@ export class InkStreamingRenderer implements StreamingRenderer {
     model: string,
     pinnedContextWindow: number | undefined,
   ): void {
-    const publish = (modelMaxTokens: number): void => {
+    const publish = (modelMaxTokens: number | undefined): void => {
       const effective = resolveEffectiveContextWindow({
         provider,
-        modelMaxTokens,
+        ...(modelMaxTokens !== undefined && { modelMaxTokens }),
         ...(pinnedContextWindow !== undefined && { pinnedContextWindow }),
       });
       store.updateRunStats({ maxContextTokens: effective.tokens });
@@ -801,6 +801,11 @@ export class InkStreamingRenderer implements StreamingRenderer {
     if (cached !== undefined) {
       publish(cached.contextWindow);
       return;
+    }
+    // A pinned window stands on its own: the catalog has no local-provider entry
+    // to wait for, and the footer must not show the maximum the run is not getting.
+    if (pinnedContextWindow !== undefined) {
+      publish(undefined);
     }
     void getModelsDevMetadata(model, provider)
       .then((meta) => {

--- a/src/core/agent/context/effective-context-window.test.ts
+++ b/src/core/agent/context/effective-context-window.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import {
+  describeContextWindowShortfall,
+  resolveEffectiveContextWindow,
+} from "./effective-context-window";
+
+describe("resolveEffectiveContextWindow", () => {
+  it("accounts against the pinned num_ctx, not the model maximum", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      modelMaxTokens: 262144,
+      pinnedContextWindow: 131072,
+    });
+
+    expect(effective.tokens).toBe(131072);
+    expect(effective.source).toBe("pinned");
+    expect(effective.modelMaxTokens).toBe(262144);
+  });
+
+  it("accounts against the window the local server reported when none is pinned", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "llamacpp",
+      modelMaxTokens: 262144,
+      serverContextWindow: 32768,
+    });
+
+    expect(effective.tokens).toBe(32768);
+    expect(effective.source).toBe("server");
+  });
+
+  it("prefers the pinned window over the one the server currently reports", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      modelMaxTokens: 262144,
+      pinnedContextWindow: 65536,
+      serverContextWindow: 131072,
+    });
+
+    expect(effective.tokens).toBe(65536);
+  });
+
+  it("never grants more context than the weights support", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      modelMaxTokens: 40960,
+      pinnedContextWindow: 131072,
+    });
+
+    expect(effective.tokens).toBe(40960);
+  });
+
+  it("leaves cloud providers on their advertised window even if num_ctx leaked into the config", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "anthropic",
+      modelMaxTokens: 200000,
+      pinnedContextWindow: 8192,
+    });
+
+    expect(effective.tokens).toBe(200000);
+    expect(effective.source).toBe("model-max");
+  });
+
+  it("ignores a non-positive pinned window rather than starving the run", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      modelMaxTokens: 262144,
+      pinnedContextWindow: 0,
+    });
+
+    expect(effective.tokens).toBe(262144);
+    expect(effective.source).toBe("model-max");
+  });
+});
+
+describe("describeContextWindowShortfall", () => {
+  it("warns when a local agent has no pinned window", () => {
+    const advice = describeContextWindowShortfall(
+      "ollama",
+      resolveEffectiveContextWindow({ provider: "ollama", modelMaxTokens: 262144 }),
+    );
+
+    expect(advice).toContain("262,144");
+    expect(advice).toContain("jazz agent edit");
+  });
+
+  it("stays quiet once a window is pinned", () => {
+    const advice = describeContextWindowShortfall(
+      "ollama",
+      resolveEffectiveContextWindow({
+        provider: "ollama",
+        modelMaxTokens: 262144,
+        pinnedContextWindow: 131072,
+      }),
+    );
+
+    expect(advice).toBeNull();
+  });
+
+  it("stays quiet for cloud providers, whose advertised window is the real one", () => {
+    const advice = describeContextWindowShortfall(
+      "anthropic",
+      resolveEffectiveContextWindow({ provider: "anthropic", modelMaxTokens: 200000 }),
+    );
+
+    expect(advice).toBeNull();
+  });
+});

--- a/src/core/agent/context/effective-context-window.test.ts
+++ b/src/core/agent/context/effective-context-window.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 import {
   describeContextWindowShortfall,
   resolveEffectiveContextWindow,
@@ -60,6 +61,33 @@ describe("resolveEffectiveContextWindow", () => {
     expect(effective.source).toBe("model-max");
   });
 
+  it("trusts a pinned window larger than the placeholder when no maximum is known", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      pinnedContextWindow: 200000,
+    });
+
+    expect(effective.tokens).toBe(200000);
+    expect(effective.source).toBe("pinned");
+    expect(effective.modelMaxTokens).toBeUndefined();
+  });
+
+  it("trusts a server-reported window larger than the placeholder when no maximum is known", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "llamacpp",
+      serverContextWindow: 200000,
+    });
+
+    expect(effective.tokens).toBe(200000);
+  });
+
+  it("falls back to the default window when nothing is known at all", () => {
+    const effective = resolveEffectiveContextWindow({ provider: "ollama" });
+
+    expect(effective.tokens).toBe(DEFAULT_CONTEXT_WINDOW);
+    expect(effective.source).toBe("fallback");
+  });
+
   it("ignores a non-positive pinned window rather than starving the run", () => {
     const effective = resolveEffectiveContextWindow({
       provider: "ollama",
@@ -80,6 +108,16 @@ describe("describeContextWindowShortfall", () => {
     );
 
     expect(advice).toContain("262,144");
+    expect(advice).toContain("jazz agent edit");
+  });
+
+  it("says the window is a guess when nothing reports the model's size", () => {
+    const advice = describeContextWindowShortfall(
+      "ollama",
+      resolveEffectiveContextWindow({ provider: "ollama" }),
+    );
+
+    expect(advice).toContain("estimate");
     expect(advice).toContain("jazz agent edit");
   });
 

--- a/src/core/agent/context/effective-context-window.ts
+++ b/src/core/agent/context/effective-context-window.ts
@@ -1,4 +1,5 @@
 import { LOCAL_SERVER_PROVIDERS } from "@/core/constants/local-providers";
+import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 
 /**
  * Where a local model's advertised maximum and its runtime window diverge.
@@ -12,19 +13,24 @@ import { LOCAL_SERVER_PROVIDERS } from "@/core/constants/local-providers";
  * going, from a context it no longer has.
  */
 
-export type ContextWindowSource = "pinned" | "server" | "model-max";
+export type ContextWindowSource = "pinned" | "server" | "model-max" | "fallback";
 
 export interface EffectiveContextWindow {
   /** Tokens the server will actually honour. Use this for compaction accounting. */
   readonly tokens: number;
   readonly source: ContextWindowSource;
-  /** What the catalog (or the model file) advertises, for surfacing the shortfall. */
-  readonly modelMaxTokens: number;
+  /** What the catalog (or the local server) advertises, when anything does. */
+  readonly modelMaxTokens?: number;
 }
 
 export interface EffectiveContextWindowInput {
   readonly provider: string;
-  readonly modelMaxTokens: number;
+  /**
+   * The model's advertised maximum — omitted when nothing knows it. models.dev
+   * carries no `ollama` or `llamacpp` provider at all, so for local models this is
+   * usually absent, and an absent maximum must never be treated as a ceiling.
+   */
+  readonly modelMaxTokens?: number;
   /** `config.numCtx`, sent as `options.num_ctx`; overrides the server default per request. */
   readonly pinnedContextWindow?: number;
   /** Window the local server reported for the loaded model, when it is known. */
@@ -41,29 +47,44 @@ function positiveTokenCount(value: number | undefined): number | undefined {
 
 /**
  * Resolve the context window to account against. Cloud providers always get their
- * advertised window; local providers get the smaller runtime window whenever one
- * is known, since a pinned `num_ctx` above the model maximum still cannot buy more
- * context than the weights support.
+ * advertised window; local providers get the smaller runtime window whenever one is
+ * known. A runtime window is capped by the model maximum only when that maximum is
+ * genuinely known — capping a deliberate `num_ctx` against the unknown-model
+ * placeholder would understate the window the user configured the server to serve.
  */
 export function resolveEffectiveContextWindow(
   input: EffectiveContextWindowInput,
 ): EffectiveContextWindow {
-  const modelMaxTokens = input.modelMaxTokens;
+  const modelMaxTokens = positiveTokenCount(input.modelMaxTokens);
+  const advertised: Pick<EffectiveContextWindow, "modelMaxTokens"> =
+    modelMaxTokens !== undefined ? { modelMaxTokens } : {};
+
   if (!isLocalServerProvider(input.provider)) {
-    return { tokens: modelMaxTokens, source: "model-max", modelMaxTokens };
+    return {
+      tokens: modelMaxTokens ?? DEFAULT_CONTEXT_WINDOW,
+      source: modelMaxTokens !== undefined ? "model-max" : "fallback",
+      ...advertised,
+    };
   }
+
+  const capToModelMax = (tokens: number): number =>
+    modelMaxTokens !== undefined ? Math.min(tokens, modelMaxTokens) : tokens;
 
   const pinned = positiveTokenCount(input.pinnedContextWindow);
   if (pinned !== undefined) {
-    return { tokens: Math.min(pinned, modelMaxTokens), source: "pinned", modelMaxTokens };
+    return { tokens: capToModelMax(pinned), source: "pinned", ...advertised };
   }
 
   const server = positiveTokenCount(input.serverContextWindow);
   if (server !== undefined) {
-    return { tokens: Math.min(server, modelMaxTokens), source: "server", modelMaxTokens };
+    return { tokens: capToModelMax(server), source: "server", ...advertised };
   }
 
-  return { tokens: modelMaxTokens, source: "model-max", modelMaxTokens };
+  return {
+    tokens: modelMaxTokens ?? DEFAULT_CONTEXT_WINDOW,
+    source: modelMaxTokens !== undefined ? "model-max" : "fallback",
+    ...advertised,
+  };
 }
 
 /**
@@ -73,18 +94,22 @@ export function resolveEffectiveContextWindow(
  * loaded and only for whatever `num_ctx` the last caller asked for — there is no
  * endpoint for the server's configured default. So an unpinned local agent cannot
  * be told what it will get, and the honest move is to say so rather than to keep
- * quietly assuming the maximum.
+ * quietly assuming a number.
  */
 export function describeContextWindowShortfall(
   provider: string,
   effective: EffectiveContextWindow,
 ): string | null {
-  if (!isLocalServerProvider(provider) || effective.source !== "model-max") {
-    return null;
-  }
+  if (!isLocalServerProvider(provider)) return null;
+  if (effective.source === "pinned" || effective.source === "server") return null;
+
+  const assumed =
+    effective.source === "model-max"
+      ? `the model maximum (${effective.tokens.toLocaleString()} tokens)`
+      : `a ${effective.tokens.toLocaleString()}-token estimate, since nothing reports this model's size`;
   return (
-    `No context window is pinned for this ${provider} agent, so Jazz is compacting against the ` +
-    `model maximum (${effective.modelMaxTokens.toLocaleString()} tokens). If the server runs a ` +
-    `smaller window it will truncate the conversation instead. Pin one with \`jazz agent edit\` → Context Window.`
+    `No context window is pinned for this ${provider} agent, so Jazz is compacting against ` +
+    `${assumed}. If the server runs a smaller window it will truncate the conversation instead. ` +
+    "Pin one with `jazz agent edit` → Context Window."
   );
 }

--- a/src/core/agent/context/effective-context-window.ts
+++ b/src/core/agent/context/effective-context-window.ts
@@ -1,0 +1,90 @@
+import { LOCAL_SERVER_PROVIDERS } from "@/core/constants/local-providers";
+
+/**
+ * Where a local model's advertised maximum and its runtime window diverge.
+ *
+ * A cloud provider honours the window its catalog advertises, so the advertised
+ * number is the real one. A local server does not: Ollama loads a model with
+ * `num_ctx` (per request) or `OLLAMA_CONTEXT_LENGTH` (server default), both far
+ * below what the weights support, and llama-server is fixed at its `-c` value.
+ * Accounting against the advertised maximum makes Jazz compact too late and lets
+ * the server silently drop the middle of the conversation instead — the run keeps
+ * going, from a context it no longer has.
+ */
+
+export type ContextWindowSource = "pinned" | "server" | "model-max";
+
+export interface EffectiveContextWindow {
+  /** Tokens the server will actually honour. Use this for compaction accounting. */
+  readonly tokens: number;
+  readonly source: ContextWindowSource;
+  /** What the catalog (or the model file) advertises, for surfacing the shortfall. */
+  readonly modelMaxTokens: number;
+}
+
+export interface EffectiveContextWindowInput {
+  readonly provider: string;
+  readonly modelMaxTokens: number;
+  /** `config.numCtx`, sent as `options.num_ctx`; overrides the server default per request. */
+  readonly pinnedContextWindow?: number;
+  /** Window the local server reported for the loaded model, when it is known. */
+  readonly serverContextWindow?: number;
+}
+
+export function isLocalServerProvider(provider: string): boolean {
+  return provider in LOCAL_SERVER_PROVIDERS;
+}
+
+function positiveTokenCount(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Resolve the context window to account against. Cloud providers always get their
+ * advertised window; local providers get the smaller runtime window whenever one
+ * is known, since a pinned `num_ctx` above the model maximum still cannot buy more
+ * context than the weights support.
+ */
+export function resolveEffectiveContextWindow(
+  input: EffectiveContextWindowInput,
+): EffectiveContextWindow {
+  const modelMaxTokens = input.modelMaxTokens;
+  if (!isLocalServerProvider(input.provider)) {
+    return { tokens: modelMaxTokens, source: "model-max", modelMaxTokens };
+  }
+
+  const pinned = positiveTokenCount(input.pinnedContextWindow);
+  if (pinned !== undefined) {
+    return { tokens: Math.min(pinned, modelMaxTokens), source: "pinned", modelMaxTokens };
+  }
+
+  const server = positiveTokenCount(input.serverContextWindow);
+  if (server !== undefined) {
+    return { tokens: Math.min(server, modelMaxTokens), source: "server", modelMaxTokens };
+  }
+
+  return { tokens: modelMaxTokens, source: "model-max", modelMaxTokens };
+}
+
+/**
+ * Warn when a local agent is accounting against a window nobody promised.
+ *
+ * Ollama exposes a loaded model's real window on `/api/ps`, but only while it is
+ * loaded and only for whatever `num_ctx` the last caller asked for — there is no
+ * endpoint for the server's configured default. So an unpinned local agent cannot
+ * be told what it will get, and the honest move is to say so rather than to keep
+ * quietly assuming the maximum.
+ */
+export function describeContextWindowShortfall(
+  provider: string,
+  effective: EffectiveContextWindow,
+): string | null {
+  if (!isLocalServerProvider(provider) || effective.source !== "model-max") {
+    return null;
+  }
+  return (
+    `No context window is pinned for this ${provider} agent, so Jazz is compacting against the ` +
+    `model maximum (${effective.modelMaxTokens.toLocaleString()} tokens). If the server runs a ` +
+    `smaller window it will truncate the conversation instead. Pin one with \`jazz agent edit\` → Context Window.`
+  );
+}

--- a/src/core/agent/execution/agent-loop-observer.ts
+++ b/src/core/agent/execution/agent-loop-observer.ts
@@ -11,6 +11,8 @@ export interface AgentLoopObserver {
   onInterrupted(agentName: string): Effect.Effect<void, never, never>;
   onIterationLimit(agentName: string, maxIterations: number): Effect.Effect<void, never, never>;
   onEmptyResponse(agentName: string): Effect.Effect<void, never, never>;
+  /** The agent runs on a local server whose real context window Jazz could not determine. */
+  onContextWindowUnknown(agentName: string, advice: string): Effect.Effect<void, never, never>;
   onCompletion(agentName: string): Effect.Effect<void, never, never>;
 }
 
@@ -28,6 +30,7 @@ export function makeDefaultObserver(presentation: PresentationService): AgentLoo
       ),
     onEmptyResponse: (agentName) =>
       presentation.presentWarning(agentName, "model returned an empty response"),
+    onContextWindowUnknown: (agentName, advice) => presentation.presentWarning(agentName, advice),
     onCompletion: (agentName) => presentation.presentCompletion(agentName),
   };
 }

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { FileSystem } from "@effect/platform";
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
+import { clearModelsDevCache } from "@/core/utils/models-dev-client";
 import {
   buildBudgetPressureMessage,
   detectMeltdown,
@@ -112,6 +116,8 @@ function recordingObserver() {
     onIterationLimit: (name: string, max: number) =>
       Effect.sync(() => void calls.push(`limit:${name}:${max}`)),
     onEmptyResponse: (name: string) => Effect.sync(() => void calls.push(`empty:${name}`)),
+    onContextWindowUnknown: (name: string) =>
+      Effect.sync(() => void calls.push(`context-window-unknown:${name}`)),
     onCompletion: (name: string) => Effect.sync(() => void calls.push(`completion:${name}`)),
   };
   return { observer, calls };
@@ -761,5 +767,147 @@ describe("detectMeltdown", () => {
     );
     const meltdown = Array(10).fill(tc("web_search", { query: "stuck" })) as TrackedToolCall[];
     expect(detectMeltdown([...diverse, ...meltdown])).toBe(true);
+  });
+});
+
+// qwen3.6:27b advertises 262144 tokens, but the Ollama host that serves it runs a
+// smaller runtime window. Accounting against the advertised number defers compaction
+// past the point the server starts silently dropping the middle of the conversation.
+describe("executeAgentLoop context window accounting", () => {
+  const MODEL_MAX_TOKENS = 262144;
+  const PINNED_CONTEXT_WINDOW = 131072;
+
+  const modelsDevCatalog = {
+    ollama: {
+      models: {
+        "qwen3.6:27b": {
+          name: "Qwen3.6 27B",
+          limit: { context: MODEL_MAX_TOKENS },
+          tool_call: true,
+        },
+      },
+    },
+  };
+
+  const originalJazzHome = process.env["JAZZ_HOME"];
+
+  // The suite runs offline, so the catalog is served from the on-disk snapshot.
+  beforeEach(() => {
+    const jazzHome = mkdtempSync(join(tmpdir(), "jazz-agent-loop-test-"));
+    mkdirSync(join(jazzHome, "cache"), { recursive: true });
+    writeFileSync(join(jazzHome, "cache", "models-dev.json"), JSON.stringify(modelsDevCatalog));
+    process.env["JAZZ_HOME"] = jazzHome;
+    clearModelsDevCache();
+  });
+
+  afterEach(() => {
+    clearModelsDevCache();
+    if (originalJazzHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = originalJazzHome;
+  });
+
+  // ~500k characters ≈ 143k tokens at qwen's 3.5 chars/token: over 80% of the pinned
+  // 131072 window, comfortably under 80% of the advertised 262144 one.
+  function longHistory(): { role: "user" | "assistant"; content: string }[] {
+    return [
+      { role: "user" as const, content: "system" },
+      ...Array.from({ length: 40 }, (_, index) => ({
+        role: index % 2 === 0 ? ("assistant" as const) : ("user" as const),
+        content: `turn ${index} `.padEnd(12500, "x"),
+      })),
+    ];
+  }
+
+  function ollamaAgent(numCtx?: number): unknown {
+    return {
+      id: "agent-1",
+      name: "local-agent",
+      config: {
+        persona: "default",
+        llmModel: "qwen3.6:27b",
+        llmProvider: "ollama",
+        reasoningEffort: "medium",
+        ...(numCtx !== undefined && { numCtx }),
+      },
+    };
+  }
+
+  function runWithHistory(numCtx?: number): Promise<{ compactions: number }> {
+    let compactions = 0;
+    const countingRunRecursive: RecursiveRunner = () =>
+      Effect.sync(() => {
+        compactions++;
+        return { content: "summary of earlier turns", conversationId: "id" } as AgentResponse;
+      });
+
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: { id: "c1", model: "qwen3.6:27b", content: "done" },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    return Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ agent: ollamaAgent(numCtx) as AgentRunnerOptions["agent"] }),
+        makeRunContext({
+          provider: "ollama",
+          model: "qwen3.6:27b",
+          agent: ollamaAgent(numCtx) as AgentRunContext["agent"],
+          messages: longHistory() as AgentRunContext["messages"],
+        }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        countingRunRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    ).then(() => ({ compactions }));
+  }
+
+  it("compacts against the pinned num_ctx rather than the advertised model maximum", async () => {
+    const { compactions } = await runWithHistory(PINNED_CONTEXT_WINDOW);
+    expect(compactions).toBeGreaterThan(0);
+  });
+
+  it("does not compact a history that genuinely fits the window", async () => {
+    const { compactions } = await runWithHistory(MODEL_MAX_TOKENS);
+    expect(compactions).toBe(0);
+  });
+
+  it("tells the user when a local agent pins no window", async () => {
+    const { observer, calls } = recordingObserver();
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: { id: "c1", model: "qwen3.6:27b", content: "done" },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ agent: ollamaAgent() as AgentRunnerOptions["agent"] }),
+        makeRunContext({
+          provider: "ollama",
+          model: "qwen3.6:27b",
+          agent: ollamaAgent() as AgentRunContext["agent"],
+        }),
+        displayConfig,
+        strategy,
+        observer,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(calls).toContain("context-window-unknown:local-agent");
   });
 });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -790,20 +790,32 @@ describe("executeAgentLoop context window accounting", () => {
   };
 
   const originalJazzHome = process.env["JAZZ_HOME"];
+  const originalOffline = process.env["JAZZ_OFFLINE"];
 
-  // The suite runs offline, so the catalog is served from the on-disk snapshot.
+  // Offline is forced here rather than inherited: the client fetches models.dev first
+  // and only falls back to the snapshot when the fetch fails, so a runner with network
+  // would resolve the real catalog — which carries no ollama provider at all.
+  function seedCatalog(catalog: unknown): void {
+    const jazzHome = process.env["JAZZ_HOME"];
+    if (jazzHome === undefined) throw new Error("JAZZ_HOME is not set for this test");
+    writeFileSync(join(jazzHome, "cache", "models-dev.json"), JSON.stringify(catalog));
+    clearModelsDevCache();
+  }
+
   beforeEach(() => {
     const jazzHome = mkdtempSync(join(tmpdir(), "jazz-agent-loop-test-"));
     mkdirSync(join(jazzHome, "cache"), { recursive: true });
-    writeFileSync(join(jazzHome, "cache", "models-dev.json"), JSON.stringify(modelsDevCatalog));
     process.env["JAZZ_HOME"] = jazzHome;
-    clearModelsDevCache();
+    process.env["JAZZ_OFFLINE"] = "1";
+    seedCatalog(modelsDevCatalog);
   });
 
   afterEach(() => {
     clearModelsDevCache();
     if (originalJazzHome === undefined) delete process.env["JAZZ_HOME"];
     else process.env["JAZZ_HOME"] = originalJazzHome;
+    if (originalOffline === undefined) delete process.env["JAZZ_OFFLINE"];
+    else process.env["JAZZ_OFFLINE"] = originalOffline;
   });
 
   // ~500k characters ≈ 143k tokens at qwen's 3.5 chars/token: over 80% of the pinned
@@ -876,6 +888,16 @@ describe("executeAgentLoop context window accounting", () => {
 
   it("does not compact a history that genuinely fits the window", async () => {
     const { compactions } = await runWithHistory(MODEL_MAX_TOKENS);
+    expect(compactions).toBe(0);
+  });
+
+  // models.dev carries no ollama provider, so every ollama model resolves to the
+  // unknown-model placeholder (128k). Treating that as a ceiling would silently shrink
+  // a window the user pinned and the server was configured to serve.
+  it("honours a pinned window larger than the placeholder when nothing knows the model", async () => {
+    seedCatalog({});
+
+    const { compactions } = await runWithHistory(200000);
     expect(compactions).toBe(0);
   });
 

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -1,6 +1,5 @@
 import { Effect, Fiber, Option, Ref } from "effect";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
-import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
@@ -681,7 +680,7 @@ export function executeAgentLoop(
 
         const effectiveContextWindow = resolveEffectiveContextWindow({
           provider,
-          modelMaxTokens: modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+          ...(modelMetadata && { modelMaxTokens: modelMetadata.contextWindow }),
           ...(typeof agent.config.numCtx === "number" && {
             pinnedContextWindow: agent.config.numCtx,
           }),
@@ -703,7 +702,6 @@ export function executeAgentLoop(
           contextWindow: contextWindowMaxTokens,
           modelMaxTokens: effectiveContextWindow.modelMaxTokens,
           contextWindowSource: effectiveContextWindow.source,
-          source: modelMetadata ? "models.dev" : "default",
         });
 
         const shortfall = describeContextWindowShortfall(provider, effectiveContextWindow);

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -19,6 +19,10 @@ import {
   ContextWindowManager,
   DEFAULT_CONTEXT_WINDOW_MANAGER,
 } from "../context/context-window-manager";
+import {
+  describeContextWindowShortfall,
+  resolveEffectiveContextWindow,
+} from "../context/effective-context-window";
 import { Summarizer, type RecursiveRunner } from "../context/summarizer";
 import {
   beginIteration,
@@ -675,7 +679,14 @@ export function executeAgentLoop(
           catch: () => new Error("Failed to fetch model metadata"),
         }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
 
-        const contextWindowMaxTokens = modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+        const effectiveContextWindow = resolveEffectiveContextWindow({
+          provider,
+          modelMaxTokens: modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+          ...(typeof agent.config.numCtx === "number" && {
+            pinnedContextWindow: agent.config.numCtx,
+          }),
+        });
+        const contextWindowMaxTokens = effectiveContextWindow.tokens;
 
         const trimBudgetTokens = DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
         const protectedRecentTurns =
@@ -690,8 +701,15 @@ export function executeAgentLoop(
           model,
           provider,
           contextWindow: contextWindowMaxTokens,
+          modelMaxTokens: effectiveContextWindow.modelMaxTokens,
+          contextWindowSource: effectiveContextWindow.source,
           source: modelMetadata ? "models.dev" : "default",
         });
+
+        const shortfall = describeContextWindowShortfall(provider, effectiveContextWindow);
+        if (shortfall !== null && !options.internal) {
+          yield* observer.onContextWindowUnknown(agent.name, shortfall);
+        }
 
         const state: LoopState = {
           currentMessages: [messages[0], ...messages.slice(1)],

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -13,6 +13,7 @@ import type { ConversationMessages } from "@/core/types/message";
 import { getModelsDevMetadata } from "@/core/utils/models-dev-client";
 import { defineTool, makeZodValidator } from "./base-tool";
 import { AgentRunner } from "../agent-runner";
+import { resolveEffectiveContextWindow } from "../context/effective-context-window";
 import { Summarizer, type RecursiveRunner } from "../context/summarizer";
 
 const SUBAGENT_PANEL_LINES = 12;
@@ -296,7 +297,13 @@ ${args.task}`;
             catch: () => new Error("Failed to fetch model metadata"),
           }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
 
-          const contextWindowMaxTokens = modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+          const contextWindowMaxTokens = resolveEffectiveContextWindow({
+            provider: parentAgent.config.llmProvider,
+            modelMaxTokens: modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+            ...(typeof parentAgent.config.numCtx === "number" && {
+              pinnedContextWindow: parentAgent.config.numCtx,
+            }),
+          }).tokens;
 
           const { systemMessage, messagesToSummarize, sanitizedRecentMessages } =
             Summarizer.splitMessages(

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { getGlyphs } from "@/cli/ui/glyphs";
 import { store } from "@/cli/ui/store";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
-import { DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { Tool, ToolRequirements } from "@/core/interfaces/tool-registry";
@@ -299,7 +298,7 @@ ${args.task}`;
 
           const contextWindowMaxTokens = resolveEffectiveContextWindow({
             provider: parentAgent.config.llmProvider,
-            modelMaxTokens: modelMetadata?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+            ...(modelMetadata && { modelMaxTokens: modelMetadata.contextWindow }),
             ...(typeof parentAgent.config.numCtx === "number" && {
               pinnedContextWindow: parentAgent.config.numCtx,
             }),

--- a/src/core/types/streaming.ts
+++ b/src/core/types/streaming.ts
@@ -30,6 +30,12 @@ export type StreamEvent =
       provider: string;
       model: string;
       timestamp: number;
+      /**
+       * `num_ctx` sent to a local server for this request. It is the window the
+       * server will honour, so consumers showing context usage must prefer it
+       * over the model's advertised maximum.
+       */
+      pinnedContextWindow?: number;
     }
   | {
       type: "complete";

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -9,7 +9,7 @@ import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
-import { AVAILABLE_PROVIDERS, DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
+import { AVAILABLE_PROVIDERS } from "@/core/constants/models";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
@@ -1632,21 +1632,23 @@ const TOTAL_CELLS = GRID_SIZE * GRID_SIZE;
 const AUTOCOMPACT_BUFFER_PERCENT = 0.165;
 
 /**
- * Get context window size for a specific model from models.dev.
+ * Get the model's advertised context window from models.dev, or `undefined` when
+ * the catalog does not know the model — the catalog carries no local-provider
+ * entries, and a placeholder maximum must not be mistaken for a real one.
  * Pass provider when known so provider-scoped metadata is used
  * otherwise model-only lookup can return another provider's limits.
  */
 function getModelContextWindowEffect(
   modelId: string,
   providerId?: string,
-): Effect.Effect<number, never, never> {
+): Effect.Effect<number | undefined, never, never> {
   return Effect.tryPromise({
     try: async () => {
       const meta = await getModelsDevMetadata(modelId, providerId);
-      return meta?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+      return meta?.contextWindow;
     },
     catch: () => new Error("Failed to fetch model metadata"),
-  }).pipe(Effect.catchAll(() => Effect.succeed(DEFAULT_CONTEXT_WINDOW)));
+  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
 }
 
 /**
@@ -1807,9 +1809,10 @@ function handleContextCommand(
     // Get model information
     const provider = agent.config.llmProvider;
     const modelId = agent.config.llmModel;
+    const advertisedContextWindow = yield* getModelContextWindowEffect(modelId, provider);
     const effectiveContextWindow = resolveEffectiveContextWindow({
       provider,
-      modelMaxTokens: yield* getModelContextWindowEffect(modelId, provider),
+      ...(advertisedContextWindow !== undefined && { modelMaxTokens: advertisedContextWindow }),
       ...(typeof agent.config.numCtx === "number" && {
         pinnedContextWindow: agent.config.numCtx,
       }),
@@ -1850,9 +1853,10 @@ function handleContextCommand(
 
     // Display model info and total usage on first row
     const modelDisplay = `${provider}/${modelId}`;
+    const modelMaxTokens = effectiveContextWindow.modelMaxTokens;
     const runtimeWindowNote =
-      effectiveContextWindow.tokens < effectiveContextWindow.modelMaxTokens
-        ? ` · runtime window, model max ${formatTokenCount(effectiveContextWindow.modelMaxTokens)}`
+      modelMaxTokens !== undefined && effectiveContextWindow.tokens < modelMaxTokens
+        ? ` · runtime window, model max ${formatTokenCount(modelMaxTokens)}`
         : "";
     const usageDisplay = `${formatTokenCount(adjustedUsage.totalUsed)}/${formatTokenCount(contextWindow)} tokens (${usagePercent}%)${runtimeWindowNote}`;
 

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -6,6 +6,7 @@ import { getThemeVariant, setThemeVariant } from "@/cli/ui/theme";
 import * as fmt from "@/cli/utils/list-format";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import { AVAILABLE_PROVIDERS, DEFAULT_CONTEXT_WINDOW } from "@/core/constants/models";
@@ -1806,7 +1807,14 @@ function handleContextCommand(
     // Get model information
     const provider = agent.config.llmProvider;
     const modelId = agent.config.llmModel;
-    const contextWindow = yield* getModelContextWindowEffect(modelId, provider);
+    const effectiveContextWindow = resolveEffectiveContextWindow({
+      provider,
+      modelMaxTokens: yield* getModelContextWindowEffect(modelId, provider),
+      ...(typeof agent.config.numCtx === "number" && {
+        pinnedContextWindow: agent.config.numCtx,
+      }),
+    });
+    const contextWindow = effectiveContextWindow.tokens;
 
     // Get tool definitions for more accurate tool token estimation
     const toolDefinitions = yield* toolRegistry.getToolDefinitions();
@@ -1842,7 +1850,11 @@ function handleContextCommand(
 
     // Display model info and total usage on first row
     const modelDisplay = `${provider}/${modelId}`;
-    const usageDisplay = `${formatTokenCount(adjustedUsage.totalUsed)}/${formatTokenCount(contextWindow)} tokens (${usagePercent}%)`;
+    const runtimeWindowNote =
+      effectiveContextWindow.tokens < effectiveContextWindow.modelMaxTokens
+        ? ` · runtime window, model max ${formatTokenCount(effectiveContextWindow.modelMaxTokens)}`
+        : "";
+    const usageDisplay = `${formatTokenCount(adjustedUsage.totalUsed)}/${formatTokenCount(contextWindow)} tokens (${usagePercent}%)${runtimeWindowNote}`;
 
     yield* terminal.log(`   ${gridRows[0]}   ${modelDisplay} · ${usageDisplay}`);
     yield* terminal.log(`   ${gridRows[1]}`);

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -1587,6 +1587,8 @@ class AISDKService implements LLMService {
                     ),
                     startTime: Date.now(),
                     toolsDisabled,
+                    ...(typeof options.num_ctx === "number" &&
+                      options.num_ctx > 0 && { pinnedContextWindow: options.num_ctx }),
                     ...(providerNativeToolNames && { providerNativeToolNames }),
                     ...(reasoningParser ? { reasoningParser } : {}),
                     ...(prepared

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -29,6 +29,8 @@ function modelsDevEntry(
 
 let modelsDevProviderModels: readonly ModelsDevModelEntry[] = [];
 let modelsDevProviderError: Error | null = null;
+/** Catalog metadata every model resolves to, so tests can pit models.dev against a local server. */
+let modelsDevMetadata: ModelsDevMetadata | null = null;
 
 // Bun module mocks are process-global: snapshot the real exports so afterAll can
 // restore them for test files that run later in the same process.
@@ -39,7 +41,7 @@ const actualModelsDevClient = {
 // Mock models-dev-client
 mock.module("@/core/utils/models-dev-client", () => ({
   getModelsDevMap: mock(() => Promise.resolve(new Map())),
-  getMetadataFromMap: mock(() => null),
+  getMetadataFromMap: mock(() => modelsDevMetadata),
   getModelsDevProviderModels: mock(() => {
     if (modelsDevProviderError) return Promise.reject(modelsDevProviderError);
     return Promise.resolve(modelsDevProviderModels);
@@ -80,7 +82,7 @@ describe("ModelFetcher", () => {
   });
 
   beforeEach(() => {
-    // Reset global fetch mock if needed
+    modelsDevMetadata = null;
   });
 
   it("should fetch models from OpenRouter", async () => {
@@ -170,6 +172,58 @@ describe("ModelFetcher", () => {
     expect(result[0]!.id).toBe("llama3:latest");
     expect(result[0]!.contextWindow).toBe(4096);
     expect(result[0]!.supportsTemperature).toBe(true);
+  });
+
+  it("reports the window llama-server was started with, not the catalog maximum", async () => {
+    modelsDevMetadata = {
+      contextWindow: 262144,
+      supportsTools: true,
+      isReasoningModel: false,
+      supportsVision: false,
+      supportsPdf: false,
+      supportsTemperature: true,
+    };
+    const modelsResponse = { data: [{ id: "qwen3.6-27b" }] };
+    const propsResponse = {
+      default_generation_settings: { n_ctx: 131072 },
+      chat_template_caps: { supports_tools: true, supports_tool_calls: true },
+    };
+
+    global.fetch = mock((url: string) => {
+      if (url.endsWith("/v1/models"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(modelsResponse) });
+      if (url.endsWith("/props"))
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(propsResponse) });
+      return Promise.reject("Unknown URL");
+    }) as unknown as typeof fetch;
+
+    const result = await Effect.runPromise(
+      fetcher.fetchModels("llamacpp", "http://localhost:8080/v1", "/models"),
+    );
+
+    expect(result[0]!.contextWindow).toBe(131072);
+  });
+
+  it("reports the context length of the Ollama model on this host, not the catalog's", async () => {
+    modelsDevMetadata = {
+      contextWindow: 1000000,
+      supportsTools: true,
+      isReasoningModel: false,
+      supportsVision: false,
+      supportsPdf: false,
+      supportsTemperature: true,
+    };
+
+    mockOllamaFetch({
+      tags: { models: [{ name: "qwen3.6:27b" }] },
+      show: { model_info: { "qwen35.context_length": 262144 }, capabilities: ["tools"] },
+    });
+
+    const result = await Effect.runPromise(
+      fetcher.fetchModels("ollama", "http://localhost:11434/api", "/tags"),
+    );
+
+    expect(result[0]!.contextWindow).toBe(262144);
   });
 
   it("should fail gracefully on 404", async () => {

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -434,6 +434,9 @@ async function transformOllamaModels(
         return {
           ...base,
           supportsTools,
+          // `/api/show` describes the model file actually on this host, so it outranks
+          // the catalog's normalized bare-name match for the same reason tool support does.
+          ...(extras.contextWindow !== undefined ? { contextWindow: extras.contextWindow } : {}),
           ...(extras.template ? { chatTemplate: extras.template } : {}),
           ...(extras.capabilities ? { capabilities: extras.capabilities } : {}),
         };
@@ -481,7 +484,13 @@ async function transformLlamaCppModels(
       };
     }
     const base = resolveToModelInfo(entry, dev ? modelsDevMap : null);
-    return chatTemplate ? { ...base, chatTemplate } : base;
+    return {
+      ...base,
+      // `/props` reports the window llama-server was started with (`-c`), which is what
+      // it will honour — the catalog's advertised maximum is not.
+      ...(ctx !== undefined ? { contextWindow: ctx } : {}),
+      ...(chatTemplate ? { chatTemplate } : {}),
+    };
   });
 }
 

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -38,6 +38,8 @@ interface StreamProcessorConfig {
   readonly hasReasoningEnabled: boolean;
   readonly startTime: number;
   readonly toolsDisabled?: boolean;
+  /** Local-provider `num_ctx` for this request, when the agent pinned one. */
+  readonly pinnedContextWindow?: number;
   readonly providerNativeToolNames?: Set<string>;
   /** Estimated character count of tool definitions for telemetry. */
   readonly toolDefinitionChars?: number;
@@ -162,6 +164,9 @@ export class StreamProcessor {
       provider: this.config.providerName,
       model: this.config.modelName,
       timestamp: this.config.startTime,
+      ...(this.config.pinnedContextWindow !== undefined && {
+        pinnedContextWindow: this.config.pinnedContextWindow,
+      }),
     });
 
     // Start processing stream


### PR DESCRIPTION
## The failure mode

Jazz decides when to compact by comparing the conversation against the model's context window. That window came from the models.dev catalog — the model's advertised **maximum**. For a cloud provider that is the real number. For a local server it is not.

A concrete case from a real deployment:

| | tokens |
| --- | --- |
| `qwen3.6:27b` advertises (`/api/show`) | 262144 |
| Ollama host actually serves (`OLLAMA_CONTEXT_LENGTH`) | 131072 |
| Jazz compacted at (80% of the advertised max) | 209715 |
| Ollama started truncating at | 131072 |

Between 131072 and 209715 tokens the run looks perfectly healthy. Ollama silently drops the middle of the conversation, the agent keeps answering, and nothing in Jazz reports a problem — the plan and the early tool results are simply gone. Silent mid-context truncation is the worst outcome available here: an error would at least be actionable.

`config.numCtx` made this worse rather than better. Jazz already sends it as `options.num_ctx`, which overrides the server default for that request — so a pinned `numCtx` *is* the authoritative runtime window — but the two executors that send it were the only code that read it. The accounting never saw it.

## What changed

One rule, in `src/core/agent/context/effective-context-window.ts`:

1. Not a local provider → the advertised window, unchanged.
2. `numCtx` pinned → that value.
3. Otherwise, the window the local server reported.
4. Otherwise, the advertised maximum, **plus a warning**.

A runtime window from (2) or (3) is capped by the model maximum **only when that maximum is genuinely known** — see the next section, which is why the input carries an optional maximum rather than a pre-defaulted number.

Every consumer of the context window now goes through it: compaction in the agent loop, the `summarize_context` split budget, the `/context` command, and the TUI footer denominator — so the number the user sees is the number compaction acts on.

**No new `num_ctx` goes on the wire.** Sending one where Jazz previously sent none would change the server's loaded configuration and force a reload — 17GB on a host with `OLLAMA_MAX_LOADED_MODELS=1`. Only the accounting and the surfacing changed.

## The catalog knows nothing about local models

`https://models.dev/api.json` has **no `ollama` provider key at all**, and no `llamacpp` either (verified against the live endpoint). So `getModelsDevMetadata("qwen3.6:27b", "ollama")` returns `undefined` and the advertised maximum falls back to the 128k `DEFAULT_CONTEXT_WINDOW` placeholder — for essentially every local model.

The first revision of this branch clamped the pinned window to that value. Pinning 200000 on a model that genuinely supports it would have silently accounted against 128000: the same silent wrongness this PR exists to remove, arriving through the fix. "Known maximum" and "assumed placeholder" are now distinct at the type level (`modelMaxTokens?: number`) rather than distinguished by comparing against a sentinel, and only a known maximum caps anything.

This also means the unpinned warning has two forms — assuming a real maximum, versus assuming a placeholder because nothing reports the model's size.

## The unpinned case, and why it warns instead of guessing

Ollama's `/api/ps` does report a loaded model's real `context_length` (verified against 0.32.6 — the value is absent from the published API docs example but present in the response). It is not a reliable source for this decision:

- it only reports a model **while it is loaded**, and a cold start is the normal case at run start;
- when a model is loaded, the value reflects whatever `num_ctx` the last caller asked for, not the server's configured default;
- there is no endpoint that exposes `OLLAMA_CONTEXT_LENGTH` itself.

Rather than invent a number — 4096 is what `constants/ollama.ts` documents as Ollama's silent-truncation default, but modern Ollama defaults higher, and hard-coding either would wreck working setups — an unpinned local agent keeps the advertised maximum and says so at run start, pointing at `jazz agent edit` → Context Window. Optimism is at least no longer silent.

`llamacpp` is the easy case: `/props` `default_generation_settings.n_ctx` is llama-server's `-c` value, always available, no load required. The plumbing accepts it (`serverContextWindow`) and model listing now uses it.

## Second bug, same shape

`model-fetcher.ts` fetched the server's context length for both local providers and then **discarded it whenever models.dev had a matching entry** — so a llama.cpp server started with `-c 131072` could be listed at a catalog model's number, and the create/edit-agent context-window ladder was capped against a window the server would never honour.

Local server reports now outrank the catalog for both providers, for the same reason `resolveOllamaToolSupport` already documents: models.dev matches on a normalized bare name, which can miss an Ollama tag or collide with another provider's same-named model, while the server is describing the model actually loaded on this host.

## Tests

- `effective-context-window.test.ts` — the precedence rule: cloud providers unaffected, a known maximum caps a pin, an **unknown** maximum does not, and the fallback applies only when nothing at all is known.
- `agent-loop.test.ts` — the regressions end to end, with a history sized between 80% of 131072 and 80% of 262144:
  - with `numCtx: 131072` against a catalog advertising 262144, the loop compacts; with the full 262144 it does not;
  - with an **empty** catalog (production reality for ollama) and `numCtx: 200000`, it does not compact — the placeholder is not a ceiling.
  Both were confirmed red before their respective fixes and green after.
- `model-fetcher.test.ts` — llama.cpp `/props` and Ollama `/api/show` each beat a models.dev entry advertising more.

The loop tests force `JAZZ_OFFLINE` in their own `beforeEach` rather than inheriting it from the test preload. The client fetches models.dev **first** and only falls back to the seeded snapshot when the fetch fails, so a runner with network reached the real catalog, found no ollama models, and fell back to 128k — which is exactly how CI failed on the first revision. Reproduced locally with `JAZZ_OFFLINE=0`; the tests now pass under both settings.

## Alternatives rejected

- **Probe `/api/ps` at run start** — adds a request per run for a value that is absent on cold start and misleading when another client pinned a different `num_ctx`. The plumbing is in place (`serverContextWindow`) if Ollama later exposes the server default.
- **Assume Ollama's documented ~4096 default when unpinned** — conservative to the point of being wrong: it would compact constantly on hosts that really do serve 131072.
- **Send `num_ctx` derived from the model max when unpinned** — forces a model reload, which is exactly the cost this change was told not to introduce.

## Known follow-up

`model-fetcher` now resolves the real per-model maximum from `/api/show`, but the agent loop still asks models.dev directly and so runs with an unknown maximum for local models. Feeding the fetcher's `ModelInfo` into the loop would make the cap exact rather than merely safe; it needs the `LLMService` layer plumbed into the loop, which is a larger change than this fix.

## Verification

```
bun run typecheck          clean
bun run lint               clean
bun test                   1682 pass, 0 fail, 6 skip, 10 todo (104 files)
bun run docs:check-links   every relative link in 56 Markdown files resolves
```