### PR TITLE
fix(deps): drop puppeteer's bundled Chrome download from every install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
         "parallel-web": "^1.1.0",
         "pdf-parse": "^2.4.5",
         "plist": "^5.0.0",
-        "puppeteer": "^25.4.0",
+        "puppeteer-core": "^25.4.0",
         "react": "^19.2.7",
         "semver": "^7.8.4",
         "short-uuid": "^6.0.3",
@@ -691,8 +691,6 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
-
     "linkup-sdk": ["linkup-sdk@3.2.5", "", { "dependencies": { "axios": "^1.8.2", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@x402/core": "^2.6.0", "@x402/evm": "^2.6.0", "viem": "^2.0.0" }, "optionalPeers": ["@x402/core", "@x402/evm", "viem"] }, "sha512-nZKmEkFBOt1A5Q3jeAV+YsJlYesMZlrCY209fs1kv5IQ+VUwYe2C/oiPUPKDa5d0l99n0mNmqHLw7MQRq6Xo1w=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
@@ -808,8 +806,6 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "puppeteer": ["puppeteer@25.4.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "lilconfig": "^3.1.3", "puppeteer-core": "25.4.0", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw=="],
 
     "puppeteer-core": ["puppeteer-core@25.4.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "17.0.2", "devtools-protocol": "0.0.1653615", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.1" } }, "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA=="],
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -194,6 +194,7 @@ That keeps the tier low while letting the one command through. Matching is on a 
 - **`http_request` is `read-only`** by risk classification even though it can issue POSTs. It reaches whatever URL the agent targets; network policy belongs at the firewall, not the tier. Treat it accordingly on surfaces that accept untrusted input.
 - **Timeouts** — 3 minutes by default per tool. `ask_user_question` and `ask_file_picker` are `longRunning` and never time out, because waiting for a human is not a hang.
 - **Concurrency** — up to 10 tools execute in parallel per iteration.
+- **`create_web_app` needs a browser for `mode: "static"`** — it screenshots the page through `puppeteer-core`, which deliberately ships no bundled Chrome so that installing Jazz never downloads one. It uses `PUPPETEER_EXECUTABLE_PATH` if set, otherwise an installed Google Chrome; with neither it fails and says so. `mode: "interactive"` needs no browser. The tool is opt-in per agent via `tools`, so it is not in the table above.
 
 ---
 

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -4,14 +4,12 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-# System Chromium for the create_web_app tool (Puppeteer screenshots HTML the
-# agent writes). PUPPETEER_SKIP_DOWNLOAD avoids also fetching Puppeteer's own
-# bundled copy — it launches this one instead via PUPPETEER_EXECUTABLE_PATH.
+# System Chromium for the create_web_app tool (puppeteer-core screenshots HTML
+# the agent writes). puppeteer-core ships no browser, so this is the only one.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
-ENV PUPPETEER_SKIP_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Dependencies first so the install layer caches across source edits.
 COPY package.json bun.lock bunfig.toml ./

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -127,6 +127,7 @@ run Ollama; cloud users typically just keep the default.)
 | `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                  |
 | `PORT`                               | `8080`                                  | In-container health-check port.                                                                          |
 | `TELEGRAM_WEBAPP_BASE_URL`           | webhook URL's origin, else unset        | Public HTTPS origin used to serve `create_web_app`'s "interactive" pages as Telegram Web App buttons. Unset disables interactive mode (the static/image mode always works).                                    |
+| `PUPPETEER_EXECUTABLE_PATH`          | `/usr/bin/chromium`                     | Browser used to screenshot `create_web_app`'s "static" mode. The image installs Chromium and points here; Jazz ships no bundled browser. Interactive mode needs no browser.                                    |
 
 > **Model ↔ reasoning:** reasoning-capable models (`gpt-5.4`, qwen3, …) work with
 > `medium`/`high`; models without it (mistral-small, gemma, …) error unless

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "parallel-web": "^1.1.0",
     "pdf-parse": "^2.4.5",
     "plist": "^5.0.0",
-    "puppeteer": "^25.4.0",
+    "puppeteer-core": "^25.4.0",
     "react": "^19.2.7",
     "semver": "^7.8.4",
     "short-uuid": "^6.0.3",

--- a/src/core/agent/tools/web-app-tools.test.ts
+++ b/src/core/agent/tools/web-app-tools.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type { ToolExecutionContext } from "@/core/types/tools";
+import {
+  type BrowserExecutableLookup,
+  createWebAppTool,
+  MISSING_BROWSER_ERROR,
+  resolveBrowserExecutablePath,
+} from "./web-app-tools";
+
+const context: ToolExecutionContext = { agentId: "agent-1" };
+
+const MINIMAL_HTML = "<html><body>hi</body></html>";
+
+function lookupWithChannels(
+  installed: Readonly<Record<string, string>>,
+  configuredExecutablePath?: string,
+): BrowserExecutableLookup & { readonly probedChannels: string[] } {
+  const probedChannels: string[] = [];
+  return {
+    probedChannels,
+    configuredExecutablePath,
+    findSystemChrome: async (channel) => {
+      probedChannels.push(channel);
+      return installed[channel] ?? null;
+    },
+  };
+}
+
+function runTool(tool: ReturnType<typeof createWebAppTool>, args: Record<string, unknown>) {
+  return Effect.runPromise(tool.execute(args, context).pipe(Effect.provide(NodeFileSystem.layer)));
+}
+
+describe("resolveBrowserExecutablePath", () => {
+  test("prefers PUPPETEER_EXECUTABLE_PATH over any installed channel", async () => {
+    const lookup = lookupWithChannels({ chrome: "/system/chrome" }, "/usr/bin/chromium");
+
+    expect(await resolveBrowserExecutablePath(lookup)).toBe("/usr/bin/chromium");
+    expect(lookup.probedChannels).toEqual([]);
+  });
+
+  test("falls back through the release channels in order", async () => {
+    const lookup = lookupWithChannels({ "chrome-dev": "/system/chrome-dev" });
+
+    expect(await resolveBrowserExecutablePath(lookup)).toBe("/system/chrome-dev");
+    expect(lookup.probedChannels).toEqual(["chrome", "chrome-beta", "chrome-dev"]);
+  });
+
+  test("ignores a blank PUPPETEER_EXECUTABLE_PATH instead of launching an empty path", async () => {
+    const lookup = lookupWithChannels({ chrome: "/system/chrome" }, "   ");
+
+    expect(await resolveBrowserExecutablePath(lookup)).toBe("/system/chrome");
+  });
+
+  test("returns null when nothing is configured and no channel is installed", async () => {
+    expect(await resolveBrowserExecutablePath(lookupWithChannels({}))).toBeNull();
+  });
+});
+
+describe("create_web_app without a browser", () => {
+  const jazzHome = mkdtempSync(join(tmpdir(), "jazz-web-app-"));
+  let previousJazzHome: string | undefined;
+
+  beforeAll(() => {
+    previousJazzHome = process.env.JAZZ_HOME;
+    process.env.JAZZ_HOME = jazzHome;
+  });
+
+  afterAll(() => {
+    if (previousJazzHome === undefined) delete process.env.JAZZ_HOME;
+    else process.env.JAZZ_HOME = previousJazzHome;
+    rmSync(jazzHome, { recursive: true, force: true });
+  });
+
+  test("static mode fails with an actionable error, not a puppeteer crash", async () => {
+    const tool = createWebAppTool(() => lookupWithChannels({}));
+
+    const result = await runTool(tool, {
+      html: MINIMAL_HTML,
+      title: "Chart",
+      mode: "static",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(MISSING_BROWSER_ERROR);
+    expect(result.error).toContain("PUPPETEER_EXECUTABLE_PATH");
+    expect(result.error).toContain("Chromium");
+  });
+
+  test("interactive mode still succeeds and never looks for a browser", async () => {
+    const lookup = lookupWithChannels({});
+    const tool = createWebAppTool(() => lookup);
+
+    const result = await runTool(tool, {
+      html: MINIMAL_HTML,
+      title: "Dashboard",
+      mode: "interactive",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({ mode: "interactive", title: "Dashboard" });
+    expect(lookup.probedChannels).toEqual([]);
+  });
+});

--- a/src/core/agent/tools/web-app-tools.ts
+++ b/src/core/agent/tools/web-app-tools.ts
@@ -1,5 +1,6 @@
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
+import puppeteer, { type ChromeReleaseChannel } from "puppeteer-core";
 import shortuuid from "short-uuid";
 import { z } from "zod";
 import type { Tool } from "@/core/interfaces/tool-registry";
@@ -21,10 +22,68 @@ import { defineTool, makeZodValidator } from "./base-tool";
  * Surface-specific delivery (serving the interactive HTML over a public URL,
  * or posting the static image) is the caller's job — e.g. the Telegram
  * bridge reads this tool's structured result off `AgentResponse.toolResults`.
+ *
+ * "static" mode needs a Chrome/Chromium on the host. Jazz depends on
+ * `puppeteer-core`, which ships no browser, so that a global `npm i -g jazz-ai`
+ * never pays for a ~150MB Chrome download nobody asked for. "interactive" mode
+ * needs no browser at all.
  */
 
 function getWebAppsDirectory(): string {
   return `${getUserDataDirectory()}/webapps`;
+}
+
+/** Tried in order when `PUPPETEER_EXECUTABLE_PATH` is unset. */
+const CHROME_RELEASE_CHANNELS: readonly ChromeReleaseChannel[] = [
+  "chrome",
+  "chrome-beta",
+  "chrome-dev",
+  "chrome-canary",
+];
+
+export const MISSING_BROWSER_ERROR =
+  "create_web_app with mode 'static' needs a Chrome or Chromium install to screenshot the page, " +
+  "and none was found. Install Google Chrome or Chromium, or point PUPPETEER_EXECUTABLE_PATH at " +
+  "an existing browser binary. Retrying with mode 'interactive' needs no browser.";
+
+export interface BrowserExecutableLookup {
+  /** Value of `PUPPETEER_EXECUTABLE_PATH`, honoured verbatim and never probed. */
+  readonly configuredExecutablePath: string | undefined;
+  /** Resolves an installed Chrome for a release channel, or `null` if absent. */
+  readonly findSystemChrome: (channel: ChromeReleaseChannel) => Promise<string | null>;
+}
+
+/**
+ * An explicit `PUPPETEER_EXECUTABLE_PATH` wins outright — it is how containers
+ * and airgapped hosts point at a system Chromium that no release channel finds.
+ */
+export async function resolveBrowserExecutablePath(
+  lookup: BrowserExecutableLookup,
+): Promise<string | null> {
+  const configuredExecutablePath = lookup.configuredExecutablePath?.trim();
+  if (configuredExecutablePath !== undefined && configuredExecutablePath.length > 0) {
+    return configuredExecutablePath;
+  }
+
+  for (const channel of CHROME_RELEASE_CHANNELS) {
+    const systemChrome = await lookup.findSystemChrome(channel);
+    if (systemChrome !== null) return systemChrome;
+  }
+
+  return null;
+}
+
+export function createSystemBrowserLookup(): BrowserExecutableLookup {
+  return {
+    configuredExecutablePath: process.env["PUPPETEER_EXECUTABLE_PATH"],
+    findSystemChrome: async (channel) => {
+      try {
+        return await puppeteer.executablePath(channel);
+      } catch {
+        return null;
+      }
+    },
+  };
 }
 
 const createWebAppParameters = z
@@ -74,9 +133,11 @@ async function renderStaticScreenshot(
   pngPath: string,
   width: number,
   height: number,
+  executablePath: string,
 ): Promise<void> {
-  const { default: puppeteer } = await import("puppeteer");
   const browser = await puppeteer.launch({
+    browser: "chrome",
+    executablePath,
     headless: true,
     // --no-sandbox: Chromium's sandbox needs kernel privileges most
     // containers don't grant; harmless outside a container too.
@@ -92,7 +153,9 @@ async function renderStaticScreenshot(
   }
 }
 
-export function createWebAppTool(): Tool<FileSystem.FileSystem> {
+export function createWebAppTool(
+  browserLookup: () => BrowserExecutableLookup = createSystemBrowserLookup,
+): Tool<FileSystem.FileSystem> {
   return defineTool<FileSystem.FileSystem, CreateWebAppArgs>({
     name: "create_web_app",
     description:
@@ -132,8 +195,16 @@ export function createWebAppTool(): Tool<FileSystem.FileSystem> {
         const width = args.width ?? 800;
         const height = args.height ?? 600;
 
+        const executablePath = yield* Effect.tryPromise({
+          try: () => resolveBrowserExecutablePath(browserLookup()),
+          catch: () => new Error(MISSING_BROWSER_ERROR),
+        });
+        if (executablePath === null) {
+          return yield* Effect.fail(new Error(MISSING_BROWSER_ERROR));
+        }
+
         yield* Effect.tryPromise({
-          try: () => renderStaticScreenshot(htmlPath, pngPath, width, height),
+          try: () => renderStaticScreenshot(htmlPath, pngPath, width, height, executablePath),
           catch: (error) =>
             new Error(
               `Failed to render static web app: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## What breaks today

`jazz-ai` depends on `puppeteer`, whose `postinstall` (`node install.mjs`) downloads a ~150MB Chrome build. Jazz is a globally-installed CLI, so **every** `npm i -g jazz-ai` — every dev machine, CI image and container — pays for that download. When it fails, it fails the whole install. It took out a downstream project's Docker build:

```
npm error Error: ERROR: Failed to set up chrome v151.0.7922.71!
npm error Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
ERROR: failed to solve: process "/bin/sh -c npm install -g jazz-ai@latest" did not complete successfully: exit code: 1
```

**And nobody used the browser it downloaded.** `puppeteer` had exactly one call site: `renderStaticScreenshot` in `web-app-tools.ts`, behind `create_web_app` with `mode: "static"` — a tool that is opt-in per agent and whose only consumer is the Telegram bridge. That bridge's Dockerfile already installed a system Chromium and set `PUPPETEER_SKIP_DOWNLOAD=true` + `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium`. The bundled Chrome was pure dead weight, and the lazy `await import("puppeteer")` never helped because postinstall runs at *install* time regardless of whether the code path is reached.

## What changes

Swap to **`puppeteer-core`** — same API, ships no browser, no postinstall.

Registry proof of the mechanism:

| package | `scripts` |
| --- | --- |
| `puppeteer@25.4.0` | `… "postinstall": "node install.mjs"` |
| `puppeteer-core@25.4.0` | *(no `postinstall`)* |

`puppeteer-core` requires an explicit browser, so `launch()` now gets one from a small pure function:

1. **`PUPPETEER_EXECUTABLE_PATH`** if set — honoured verbatim, never probed. This is how containers and locked-down hosts point at a system Chromium that no release channel would find.
2. Otherwise **puppeteer-core's own `channel` lookup** (`chrome` → `chrome-beta` → `chrome-dev` → `chrome-canary`) via `puppeteer.executablePath(channel)`, which finds a normal desktop Google Chrome install. Confirmed against current puppeteer-core docs — `channel` still means "look for a regular Chrome installation at a known system location" — rather than hand-rolling a path list.
3. Otherwise **fail with an actionable message**, not a puppeteer stack trace and not a silent/empty screenshot:

> create_web_app with mode 'static' needs a Chrome or Chromium install to screenshot the page, and none was found. Install Google Chrome or Chromium, or point PUPPETEER_EXECUTABLE_PATH at an existing browser binary. Retrying with mode 'interactive' needs no browser.

`mode: "interactive"` needs no browser and never consults the lookup, so it keeps working on a host with nothing installed.

### Rejected: `optionalDependencies`

npm still *attempts* the download on every install and merely swallows the failure. That keeps the whole bandwidth cost and converts a clear install-time error into a confusing runtime one. Not an improvement.

## Behaviour changes for users

| | Before | After |
| --- | --- | --- |
| `npm i -g jazz-ai` | downloads ~150MB Chrome; hard-fails if the download fails | no browser download; install cannot fail this way |
| `create_web_app` `mode: "interactive"` | works | works, unchanged |
| `create_web_app` `mode: "static"`, Chrome installed | works (bundled Chrome) | works (your installed Chrome) |
| `create_web_app` `mode: "static"`, no browser | worked (bundled Chrome) | **fails with an actionable error** — this is the one real regression, and it's documented |
| Telegram bridge (Docker) | works via `PUPPETEER_EXECUTABLE_PATH` | unchanged — the image still installs Chromium and sets the same variable |

## Operator notes

- `PUPPETEER_SKIP_DOWNLOAD=true` is **removed** from `integrations/telegram-bot/Dockerfile`. It only ever gated the `puppeteer` wrapper's install script, which no longer exists in the tree — genuinely dead, not merely redundant. `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` stays and is now the sole mechanism.
- Hosts that want `mode: "static"` need a Chrome/Chromium. Documented in `docs/reference/tools.md` and the Telegram README's env table.

## Verification

Gates, all from a clean worktree off `origin/main`:

```
bun run typecheck        exit 0
bun run lint             clean
bun test                 1688 pass, 6 skip, 10 todo, 0 fail (1704 across 105 files)
bun run docs:check-links ✓ every relative link in 56 Markdown files resolves
```

**Install is actually lighter** — built the package and did a clean global install into a throwaway prefix with a fresh `PUPPETEER_CACHE_DIR`:

```
npm install -g --prefix <tmp> jazz-ai-0.13.11.tgz
→ added 342 packages in 12s, exit 0
→ PUPPETEER_CACHE_DIR: empty
→ no Chrome binary anywhere in the install tree (only puppeteer-core source files named *chrome*)
→ no `puppeteer` wrapper package in the tree
→ `jazz --version` → 0.13.11
```

**Still renders** — smoke-tested the real tool end to end against the system Chrome, via channel discovery with no `PUPPETEER_EXECUTABLE_PATH` set: `mode: "static"` produced a correct 800x600 PNG. Also verified an explicit `PUPPETEER_EXECUTABLE_PATH` is honoured, and that a bad one yields `Browser was not found at the configured executablePath (/nope/chrome)` rather than a crash.

**The tests are non-vacuous** — each was shown red before green by mutating the fix:

| mutation | test that caught it |
| --- | --- |
| drop the env-first precedence | `prefers PUPPETEER_EXECUTABLE_PATH over any installed channel` |
| remove the `null` guard in the handler | `static mode fails with an actionable error, not a puppeteer crash` |
| stop trimming the env value | `ignores a blank PUPPETEER_EXECUTABLE_PATH instead of launching an empty path` |

Each mutation failed exactly one test (5 pass / 1 fail); restoring the fix returned 6/6.

## Scope

The lockfile diff is deliberately minimal — only the `puppeteer` → `puppeteer-core` entries move. No unrelated dependency bumps.