### PR TITLE
fix(llm): stop re-injecting reasoning parts for providers that can't round-trip them

### DIFF
--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -195,6 +195,8 @@ function buildToolConfig(
   };
 }
 
+const REASONING_ROUND_TRIP_PROVIDERS = new Set(["anthropic"]);
+
 export function toCoreMessages(
   messages: ReadonlyArray<{
     role: "system" | "user" | "assistant" | "tool";
@@ -279,7 +281,12 @@ export function toCoreMessages(
         | ToolCallPart
       > = [];
 
-      if (m.reasoning_parts && messageIndex > lastUserMessageIndex && normalizedProviderName) {
+      if (
+        m.reasoning_parts &&
+        messageIndex > lastUserMessageIndex &&
+        normalizedProviderName &&
+        REASONING_ROUND_TRIP_PROVIDERS.has(normalizedProviderName)
+      ) {
         for (const storedPart of m.reasoning_parts) {
           if (storedPart.provider.toLowerCase() !== normalizedProviderName) continue;
           contentParts.push({


### PR DESCRIPTION
## What & why
Stops re-sending stored reasoning/thinking content back to providers that can't accept it, which was spamming stderr with the same AI SDK warning on every turn of a multi-turn conversation with local models (Ollama, llamacpp). Reasoning is now only replayed as input for providers that actually require it to work correctly (currently Anthropic, for continuing a tool-use loop with extended thinking).

## How to verify
- Run a multi-turn conversation against an Ollama model that emits `<thinking>` content (e.g. qwen3), and confirm the `reasoning parts ... not supported for Ollama responses` warning no longer appears on stderr after the first turn.
- Run a multi-turn conversation with tool calls against an Anthropic model with extended thinking enabled and confirm the tool-use loop still continues correctly (reasoning still gets replayed there).
