### PR TITLE
feat(subagents): cap a sub-agent at its parent's effective tools

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -81,7 +81,8 @@ pressure, loop detection, and automatic context compaction. The full mechanism:
 | **Delegator** | includes `spawn_subagent` | Deep research, work that would blow one context window |
 
 The delegator pattern works today: `spawn_subagent` hands a task to a child agent with its own
-context window, which returns a summary rather than 100k tokens of raw sources. See
+context window, which returns a summary rather than 100k tokens of raw sources. A sub-agent runs
+as the same agent under a chosen persona, and never holds more tools than its parent. See
 [Sub-agents](../internals/subagents.md).
 
 ---

--- a/docs/internals/subagents.md
+++ b/docs/internals/subagents.md
@@ -54,6 +54,38 @@ spawn_subagent({
 | `name` | Short role label shown in the sub-agent panel, so parallel children are distinguishable. |
 | `persona` | `coder` for code and git work, `researcher` for investigation, `default` for general. |
 
+A sub-agent always runs as the parent agent itself — same provider, same model, same config —
+varying only the persona. Delegating to a *different* saved agent, or running the child on a
+different model, is deliberately not offered.
+
+---
+
+## The tool ceiling
+
+A child never holds a tool its parent lacks. `spawn_subagent` passes the parent's effective
+tool names down as the child's allowlist, and the child's own toolset is intersected with it
+after personas and built-in categories resolve.
+
+```mermaid
+flowchart LR
+    P["Parent<br/>read_file · grep · spawn_subagent"]
+    N["Persona 'coder'<br/>read_file · grep · <s>execute_command</s>"]
+    P -->|"persona: 'coder'"| C["Child<br/>read_file · grep · spawn_subagent"]
+    N -.->|"intersected"| C
+
+    classDef good fill:#4f9d9d,stroke:#2f6d6d,color:#ffffff
+    class C good
+```
+
+The parent chooses the child's persona, and a persona resolves its own built-in tool
+categories — so without the intersection, a read-only CI reviewer could reach
+`execute_command` by spawning a child under a broader persona. This is what keeps the claim in
+[Agents](../concepts/agents.md) true: that omitting a tool is the strongest safety control
+available. Withheld tools are logged at `info`.
+
+Because the ceiling lives in the runner rather than at the call site, it holds for any future
+caller of a nested run, not just `spawn_subagent`.
+
 Because the parent can issue several tool calls in one iteration, sub-agents run in parallel
 up to the concurrency cap — each with its own panel in the TUI.
 
@@ -83,7 +115,8 @@ sequenceDiagram
 | --- | --- | --- |
 | The `task` string | The child's final answer | The parent's message history |
 | The chosen persona | Its cost, into the parent's total | The parent's tool results |
-| The agent's provider/model and toolset | | The child's intermediate work |
+| The agent's provider/model | | The child's intermediate work |
+| The parent's toolset, as a ceiling | | Any tool the parent itself lacks |
 
 **Cost rolls up.** Each child reports spend via `recordChildCost`, and the parent's
 `costUSD` is its own tokens plus all child cost. A run on a free local model that delegated
@@ -102,6 +135,7 @@ usual symptom is a confidently wrong answer to a question the child misunderstoo
 | Timeout | 30 min | A delegated task that hasn't finished in half an hour isn't going to |
 | Iterations | inherits the parent's budget | A child can't outlive the run that spawned it |
 | Nesting | children can delegate further | Bounded in practice by the parent's iteration budget |
+| Toolset | at most the parent's | A child must never be an escalation path |
 | Panel height | 12 lines | UI only |
 
 Budget pressure interacts deliberately with delegation: at 70% of its iteration budget the

--- a/src/core/agent/agent-runner.test.ts
+++ b/src/core/agent/agent-runner.test.ts
@@ -337,4 +337,41 @@ describe("AgentRunner", () => {
       expect(lastRequestedToolNames()).toContain("manage_memory");
     });
   });
+
+  describe("toolAllowlist", () => {
+    function lastRequestedToolNames(): string[] {
+      const lastCall = mockLlmService.createStreamingChatCompletion.mock.calls.at(-1);
+      const llmOptions = lastCall?.[1] as { tools?: { function: { name: string } }[] };
+      return (llmOptions.tools ?? []).map((tool) => tool.function.name);
+    }
+
+    it("withholds tools outside the inherited allowlist", async () => {
+      const options = {
+        ...defaultOptions,
+        agent: { ...mockAgent, config: { ...mockAgent.config, tools: ["tool1", "tool2"] } },
+        stream: true,
+        maxIterations: 1,
+        toolAllowlist: ["tool1"],
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      const requested = lastRequestedToolNames();
+      expect(requested).toContain("tool1");
+      expect(requested).not.toContain("tool2");
+    });
+
+    it("leaves the toolset untouched when no allowlist is inherited", async () => {
+      const options = {
+        ...defaultOptions,
+        agent: { ...mockAgent, config: { ...mockAgent.config, tools: ["tool1", "tool2"] } },
+        stream: true,
+        maxIterations: 1,
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      expect(lastRequestedToolNames()).toContain("tool2");
+    });
+  });
 });

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -157,6 +157,24 @@ function initializeAgentRun(
       combinedToolNames = combinedToolNames.filter((name) => name !== "manage_memory");
     }
 
+    // A sub-agent run inherits its parent's effective toolset as a ceiling, so
+    // a child spawned under a different persona cannot end up with a tool the
+    // parent lacked. Applied after personas and built-in categories resolve —
+    // earlier would let the child's persona re-add a category the parent denied
+    // — and before the registry filter, so dropped names never reach approval
+    // or the LLM tool list.
+    if (options.toolAllowlist) {
+      const allowed = new Set(options.toolAllowlist);
+      const withheld = combinedToolNames.filter((toolName) => !allowed.has(toolName));
+      combinedToolNames = combinedToolNames.filter((toolName) => allowed.has(toolName));
+      if (withheld.length > 0) {
+        yield* logger.info("Tools withheld by inherited allowlist", {
+          agentId: agent.id,
+          withheld,
+        });
+      }
+    }
+
     // Filter out any non-existent tools silently — tools may have been removed
     // or MCP servers may be unavailable. The agent can still operate with its
     // remaining tools.
@@ -237,6 +255,7 @@ function initializeAgentRun(
       // subsequent isAutoApproved checks within the same agent run.
       autoApprovedCommands,
       autoApprovedTools,
+      parentToolNames: expandedToolNames,
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       onAutoApproveCommand:
         options.onAutoApproveCommand ??

--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -129,6 +129,48 @@ describe("spawn_subagent auto-approve inheritance", () => {
   });
 });
 
+describe("spawn_subagent tool ceiling", () => {
+  it("caps the child at the parent's effective tools", async () => {
+    let captured: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      captured = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation, {
+        parentToolNames: ["read_file", "grep", "spawn_subagent"],
+      });
+
+      expect(captured?.toolAllowlist).toEqual(["read_file", "grep", "spawn_subagent"]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("sets no allowlist when the parent's toolset is unknown", async () => {
+    let captured: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      captured = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation);
+
+      expect(captured?.toolAllowlist).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("spawn_subagent presentation", () => {
   it("does not import the TUI from core", async () => {
     const source = await Bun.file(new URL("./subagent-tools.ts", import.meta.url)).text();

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -152,6 +152,11 @@ ${args.task}`;
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
             maxIterations: context.parentMaxIterations ?? DEFAULT_MAX_ITERATIONS,
             ephemeralRegionId: regionId,
+            // Cap the child at the parent's own effective tools. The child runs
+            // under a caller-chosen persona, and a persona resolves its own
+            // built-in categories — without this ceiling a narrowly-scoped
+            // parent could reach a tool it lacks by picking a broader persona.
+            ...(context.parentToolNames ? { toolAllowlist: context.parentToolNames } : {}),
             ...(context.getAutoApprovePolicy
               ? { autoApprovePolicy: context.getAutoApprovePolicy }
               : {}),

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -96,6 +96,14 @@ export interface AgentRunnerOptions {
    */
   readonly autoApprovedTools?: readonly string[];
   /**
+   * Hard ceiling on this run's toolset. When set, the agent's effective tools
+   * are intersected with this list after personas and built-in categories are
+   * resolved. Sub-agent runs inherit their parent's effective tools this way,
+   * so a child spawned under a different persona can never end up holding a
+   * tool the parent itself was not allowed to use.
+   */
+  readonly toolAllowlist?: readonly string[];
+  /**
    * Callback invoked when the user chooses "always approve" for a specific tool
    * from the approval prompt.
    */

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -192,6 +192,14 @@ export interface ToolExecutionContext {
    */
   readonly parentMaxIterations?: number;
   /**
+   * The parent's effective tool names for this run (after persona deny lists
+   * and any inherited allowlist). `spawn_subagent` passes this down as the
+   * child's allowlist so a child can never hold a tool its parent lacks —
+   * otherwise swapping the child's persona would be a way around the parent's
+   * toolset, which is Jazz's strongest safety control.
+   */
+  readonly parentToolNames?: readonly string[];
+  /**
    * Callback to replace conversation messages with compacted versions.
    * Used by summarize_context to actually update the executor's message array.
    */


### PR DESCRIPTION
Salvages the one piece of #328 that stands on its own. #328 stays closed — sub-agents keep spawning as the same agent, and nothing here lets a caller pick a different agent or a different model.

## What changes

A sub-agent can no longer end up with a tool its parent lacks.

`spawn_subagent` lets the parent choose the child's **persona**, and a persona resolves its own built-in tool categories. So a narrowly-scoped agent — say a CI reviewer with read-only tools — could reach `execute_command` by spawning a child under a broader persona. That was never intended, and it undercuts the claim in the docs that omitting a tool is Jazz's strongest safety control.

The parent's effective tool names now travel down as the child's allowlist, and the child's toolset is intersected with it.

**Before:** child's tools = its persona's categories, unbounded by the parent's.
**After:** child's tools = that set ∩ the parent's effective tools. Anything dropped is logged at `info` as `Tools withheld by inherited allowlist`.

## Why it's built this way

The intersection lives in the runner (`toolAllowlist` on `AgentRunnerOptions`), not at the `spawn_subagent` call site. Two reasons:

- It applies **after** persona deny-lists and built-in categories resolve — doing it earlier would let the child's persona re-add a category the parent had denied — and **before** the registry filter, so withheld names never reach approval or the LLM's tool list.
- Any future caller of a nested run inherits the invariant for free, rather than each call site having to remember it.

## How to verify

1. Configure an agent whose toolset omits `execute_command`, and ask it to delegate something shell-shaped to a `coder` sub-agent.
   Expected: the child cannot run shell commands, and the run log carries `Tools withheld by inherited allowlist`.
2. Delegate from an agent that *does* have `execute_command`.
   Expected: unchanged — the child gets it.

## Tests

`bun test`: 1770 pass / 0 fail across 118 files. Typecheck and lint clean.

Four new tests:
- `agent-runner.test.ts` — the allowlist filters the LLM tool list, and its absence changes nothing.
- `subagent-tools.test.ts` — `spawn_subagent` forwards `parentToolNames` as the child's `toolAllowlist`, and sets none when the parent's toolset is unknown (the path every existing embedded/test caller takes).

## Not included

The rest of #328 — delegating to a saved agent by name, per-task model choice, `list_models`, the `whenToUse` routing hint, and the prompt roster — is deliberately left out.