### PR TITLE
feat(net): honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.67.0",
         "tz-lookup": "^6.1.25",
+        "undici": "^8.10.0",
         "vercel-minimax-ai-provider": "^0.0.2",
         "wrap-ansi": "^10.0.0",
         "zhipu-ai-provider": "^0.4.0",
@@ -931,7 +932,7 @@
 
     "tz-lookup": ["tz-lookup@6.1.25", "", {}, "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="],
 
-    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -984,6 +985,10 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@effect/platform-node/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1114,6 +1119,8 @@
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "ollama-ai-provider-v2/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,6 +61,12 @@ Override settings or provide API keys via `.env` or the process environment.
 | `JAZZ_OFFLINE` | `1`/`true`: make no outbound request of Jazz's own — skips the update check *and* the models.dev catalog fetch. See [Airgapped](../guide/airgapped.md) |
 | `JAZZ_DISABLE_UPDATE_CHECK` | `1`: skip only the npm version check |
 | `JAZZ_MODELS_DEV_URL` | Point the model catalog at an internal mirror of `https://models.dev/api.json` |
+| `HTTPS_PROXY` / `HTTP_PROXY` | Send every outbound request — provider APIs, web tools, remote MCP servers, the update check — through an HTTP proxy. Lowercase names work too, and `ALL_PROXY` covers both protocols |
+| `NO_PROXY` | Comma-separated hosts and domain suffixes to reach directly, bypassing the proxy |
+
+Only `http://` and `https://` proxies are supported; a SOCKS proxy is reported at
+startup rather than silently ignored. If the proxy terminates TLS with a private
+CA, point Node at that CA with `NODE_EXTRA_CA_CERTS=/path/to/ca.pem`.
 
 ### Providers
 

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.67.0",
     "tz-lookup": "^6.1.25",
+    "undici": "^8.10.0",
     "vercel-minimax-ai-provider": "^0.0.2",
     "wrap-ansi": "^10.0.0",
     "zhipu-ai-provider": "^0.4.0",

--- a/src/core/utils/proxy.test.ts
+++ b/src/core/utils/proxy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { findUnsupportedProxy, installProxyFromEnvironment, readProxySettings } from "./proxy";
+
+describe("readProxySettings", () => {
+  test("returns null when nothing is configured", () => {
+    expect(readProxySettings({})).toBeNull();
+  });
+
+  test("returns null when the variables are empty or whitespace", () => {
+    expect(readProxySettings({ HTTP_PROXY: "", HTTPS_PROXY: "   " })).toBeNull();
+  });
+
+  test("reads uppercase variables", () => {
+    expect(
+      readProxySettings({
+        HTTP_PROXY: "http://proxy.corp:3128",
+        HTTPS_PROXY: "http://secure.corp:3129",
+        NO_PROXY: "localhost,.corp",
+      }),
+    ).toEqual({
+      httpProxy: "http://proxy.corp:3128",
+      httpsProxy: "http://secure.corp:3129",
+      noProxy: "localhost,.corp",
+    });
+  });
+
+  test("prefers lowercase over uppercase", () => {
+    expect(
+      readProxySettings({
+        http_proxy: "http://lower:3128",
+        HTTP_PROXY: "http://upper:3128",
+      }),
+    ).toEqual({ httpProxy: "http://lower:3128" });
+  });
+
+  test("falls back to ALL_PROXY for the protocol that has no value of its own", () => {
+    expect(
+      readProxySettings({
+        ALL_PROXY: "http://all:3128",
+        HTTPS_PROXY: "http://secure:3129",
+      }),
+    ).toEqual({ httpProxy: "http://all:3128", httpsProxy: "http://secure:3129" });
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(readProxySettings({ HTTPS_PROXY: "  http://proxy.corp:3128  " })).toEqual({
+      httpsProxy: "http://proxy.corp:3128",
+    });
+  });
+});
+
+describe("findUnsupportedProxy", () => {
+  test("accepts http and https proxies", () => {
+    expect(
+      findUnsupportedProxy({
+        httpProxy: "http://proxy.corp:3128",
+        httpsProxy: "https://proxy.corp:3129",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects socks proxies", () => {
+    expect(findUnsupportedProxy({ httpProxy: "socks5://proxy.corp:1080" })).toContain("socks5://");
+  });
+
+  test("rejects host-only values, which are not URLs undici can dial", () => {
+    expect(findUnsupportedProxy({ httpsProxy: "proxy.corp:3128" })).toContain("not supported");
+  });
+
+  test("rejects unparseable values", () => {
+    expect(findUnsupportedProxy({ httpsProxy: "http://[" })).toContain("not a valid URL");
+  });
+});
+
+describe("installProxyFromEnvironment", () => {
+  test("does nothing when no proxy is configured", async () => {
+    expect(await installProxyFromEnvironment({})).toEqual({ status: "not-configured" });
+  });
+
+  test("reports unsupported proxies instead of installing them", async () => {
+    const result = await installProxyFromEnvironment({ ALL_PROXY: "socks5://proxy.corp:1080" });
+    expect(result.status).toBe("unsupported");
+  });
+
+  test("defers to the runtime under Bun", async () => {
+    const result = await installProxyFromEnvironment({ HTTPS_PROXY: "http://proxy.corp:3128" });
+    expect(result.status).toBe("runtime-native");
+    expect(result).toMatchObject({ settings: { httpsProxy: "http://proxy.corp:3128" } });
+  });
+});

--- a/src/core/utils/proxy.ts
+++ b/src/core/utils/proxy.ts
@@ -1,0 +1,153 @@
+/**
+ * HTTP(S) proxy support driven by the standard `HTTP_PROXY` / `HTTPS_PROXY` /
+ * `NO_PROXY` environment variables.
+ *
+ * Every outbound request Jazz makes — provider APIs, the model catalog, the
+ * update check, web fetch/search tools, remote MCP servers — goes through the
+ * global `fetch`. Node's `fetch` ignores the proxy environment variables
+ * entirely, so on a corporate network every one of those requests fails at
+ * connect time with no hint as to why. Installing an undici global dispatcher
+ * built from the same variables is what makes them take effect.
+ */
+
+export type ProxySettings = {
+  readonly httpProxy?: string;
+  readonly httpsProxy?: string;
+  readonly noProxy?: string;
+};
+
+export type ProxyInstallResult =
+  | { readonly status: "not-configured" }
+  | { readonly status: "runtime-native"; readonly settings: ProxySettings }
+  | { readonly status: "installed"; readonly settings: ProxySettings }
+  | { readonly status: "unsupported"; readonly settings: ProxySettings; readonly reason: string }
+  | { readonly status: "failed"; readonly settings: ProxySettings; readonly reason: string };
+
+type Environment = Record<string, string | undefined>;
+
+const SUPPORTED_PROXY_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
+ * Reads proxy configuration from the environment.
+ *
+ * Lowercase names win over uppercase ones, matching curl and undici. `ALL_PROXY`
+ * fills in for whichever of the two protocols was not given its own value.
+ *
+ * @returns The configured settings, or `null` when no proxy is configured.
+ */
+export function readProxySettings(env: Environment = process.env): ProxySettings | null {
+  const allProxy = firstNonEmpty(env["all_proxy"], env["ALL_PROXY"]);
+  const httpProxy = firstNonEmpty(env["http_proxy"], env["HTTP_PROXY"], allProxy);
+  const httpsProxy = firstNonEmpty(env["https_proxy"], env["HTTPS_PROXY"], allProxy);
+  const noProxy = firstNonEmpty(env["no_proxy"], env["NO_PROXY"]);
+
+  if (!httpProxy && !httpsProxy) {
+    return null;
+  }
+
+  return {
+    ...(httpProxy ? { httpProxy } : {}),
+    ...(httpsProxy ? { httpsProxy } : {}),
+    ...(noProxy ? { noProxy } : {}),
+  };
+}
+
+/**
+ * Reports the first proxy URL undici cannot dial, if any.
+ *
+ * SOCKS proxies are the common case here: `ALL_PROXY=socks5://…` is a perfectly
+ * ordinary thing to have exported, and undici has no SOCKS support, so it is
+ * worth saying so rather than failing later on every request.
+ *
+ * @returns A human-readable reason, or `null` when every URL is usable.
+ */
+export function findUnsupportedProxy(settings: ProxySettings): string | null {
+  for (const url of [settings.httpProxy, settings.httpsProxy]) {
+    if (!url) {
+      continue;
+    }
+
+    let protocol: string;
+    try {
+      protocol = new URL(url).protocol;
+    } catch {
+      return `"${url}" is not a valid URL`;
+    }
+
+    if (!SUPPORTED_PROXY_PROTOCOLS.has(protocol)) {
+      return `"${protocol}//" proxies are not supported — use an http:// or https:// proxy`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Routes global `fetch` through the proxy named in the environment.
+ *
+ * Call this before anything issues a request. Bun's `fetch` already honours the
+ * same variables natively, so there it only reports what the runtime is doing.
+ */
+export async function installProxyFromEnvironment(
+  env: Environment = process.env,
+): Promise<ProxyInstallResult> {
+  const settings = readProxySettings(env);
+  if (!settings) {
+    return { status: "not-configured" };
+  }
+
+  const unsupported = findUnsupportedProxy(settings);
+  if (unsupported) {
+    return { status: "unsupported", settings, reason: unsupported };
+  }
+
+  if (isBunRuntime()) {
+    return { status: "runtime-native", settings };
+  }
+
+  try {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    setGlobalDispatcher(new EnvHttpProxyAgent(settings));
+    return { status: "installed", settings };
+  } catch (error) {
+    return {
+      status: "failed",
+      settings,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Installs proxy support and writes a warning to stderr if it could not be done.
+ *
+ * Staying quiet on success keeps normal runs clean; staying quiet on failure is
+ * what produces the unexplained connection errors this module exists to avoid.
+ */
+export async function installProxyFromEnvironmentAndWarn(
+  env: Environment = process.env,
+): Promise<ProxyInstallResult> {
+  const result = await installProxyFromEnvironment(env);
+
+  if (result.status === "unsupported" || result.status === "failed") {
+    console.error(`Jazz: proxy environment variables are set but unusable — ${result.reason}.`);
+    console.error("Jazz: continuing with direct connections, which will fail behind a proxy.");
+  }
+
+  return result;
+}
+
+function isBunRuntime(): boolean {
+  return typeof process.versions["bun"] === "string";
+}
+
+function firstNonEmpty(...values: readonly (string | undefined)[]): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -10,7 +10,15 @@
 // from transitive dependencies on newer Node versions).
 process.noDeprecation = true;
 
-void import("./main").catch((error) => {
+void (async () => {
+  // Node's `fetch` ignores HTTP_PROXY/HTTPS_PROXY, so on a proxied network every
+  // outbound request Jazz makes fails until a dispatcher is installed for them.
+  // This has to happen before the CLI module tree loads and issues its first one.
+  const { installProxyFromEnvironmentAndWarn } = await import("./core/utils/proxy");
+  await installProxyFromEnvironmentAndWarn();
+
+  await import("./main");
+})().catch((error) => {
   console.error("Fatal error:", error);
   throw error;
 });


### PR DESCRIPTION
## What & why

Jazz now routes its network traffic through the proxy named in `HTTP_PROXY` /
`HTTPS_PROXY`, honouring `NO_PROXY` for exceptions. Anyone on a corporate
network could not use Jazz at all before this: Node's `fetch` ignores those
variables, so the first provider call, model-catalog fetch, or update check
died at connect time with nothing pointing at the proxy as the cause.

Under the hood this installs an undici `EnvHttpProxyAgent` as the global
dispatcher at startup, which is what makes `fetch` — and therefore every
provider, web tool, and remote MCP server — obey the variables. Bun already
honours them natively, so nothing is installed there.

## How to verify

- With `HTTPS_PROXY` unset, run `jazz` as usual — behaviour is unchanged.
- Point `HTTPS_PROXY` at a proxy you can watch and run any agent turn; the
  provider request should appear in the proxy log.
- Add the provider host to `NO_PROXY` and confirm that request goes direct
  while everything else still goes through the proxy.
- Set `ALL_PROXY=socks5://…` and confirm startup prints a warning that SOCKS
  is unsupported instead of failing silently later on every request.
- If your proxy terminates TLS with a private CA, `NODE_EXTRA_CA_CERTS` is
  needed too — noted in the configuration reference.
