### PR TITLE
feat(security): keep API keys out of plaintext config

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -162,6 +162,30 @@ CMD ["jazz"]
 Also consider a dedicated OS user for running Jazz, and separate service accounts (a bot
 GitHub account, a separate mailbox) so a mistake cannot reach your primary identity.
 
+### Know where your API keys live
+
+Jazz resolves every secret in this order, and uses the first hit:
+
+1. **Environment variable** — `OPENAI_API_KEY`, `BRAVE_API_KEY`, `GOOGLE_CLIENT_SECRET`, and so
+   on. Nothing touches disk. Best for containers and CI.
+2. **OS keyring** — macOS Keychain, or libsecret (`secret-tool`) on Linux. Used automatically
+   when available. Keys already sitting in `~/.jazz/config.json` are moved here on next start.
+3. **`~/.jazz/config.json`** — the fallback when there is no keyring, e.g. a headless server with
+   no session D-Bus. Jazz creates the file mode `0600` and repairs looser modes on load, but the
+   keys are plaintext to anyone who can read that file (including `root`).
+
+On a shared host, prefer 1 or 2. Set `JAZZ_DISABLE_KEYRING=1` to force the file path.
+
+Secrets resolved from the environment or the keyring are never written back into the config
+file. To check what is on disk:
+
+```bash
+cat ~/.jazz/config.json && ls -l ~/.jazz/config.json
+```
+
+Note that `~/.jazz/history/` and `~/.jazz/logs/` are separate plaintext stores and are not
+covered by the keyring — treat them as sensitive in their own right.
+
 ---
 
 ## If something goes wrong

--- a/docs/integrations/providers.md
+++ b/docs/integrations/providers.md
@@ -5,6 +5,11 @@
 Jazz supports **18 providers** behind one interface. You need at least one configured. Set
 keys by running `jazz` → *Update configuration*, or by editing `~/.jazz/config.json`.
 
+> **Where keys are stored:** environment variable first, then your OS keyring (macOS Keychain
+> or libsecret), then `~/.jazz/config.json` as a fallback. Keys you set through the wizard go
+> to the keyring when one is available, and existing plaintext keys are migrated there on next
+> start. See [Security → Know where your API keys live](../../SECURITY.md#know-where-your-api-keys-live).
+
 Full provider list: [`src/core/constants/models.ts`](../../src/core/constants/models.ts).
 For how the provider abstraction works, see
 [Internals → Providers & models](../internals/providers-and-models.md).

--- a/docs/integrations/web-search.md
+++ b/docs/integrations/web-search.md
@@ -5,6 +5,11 @@
 `web_search` needs a configured provider; without one it errors. `web_fetch` and
 `http_request` need no key.
 
+Each provider's key can come from an environment variable instead of the config file —
+`BRAVE_API_KEY`, `EXA_API_KEY`, `LINKUP_API_KEY`, `PARALLEL_API_KEY`, `PERPLEXITY_API_KEY`,
+`TAVILY_API_KEY` — or from your OS keyring. See
+[Security → Know where your API keys live](../../SECURITY.md#know-where-your-api-keys-live).
+
 ---
 
 Enable your agents to search the web and get current information.

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -70,7 +70,28 @@ describe("AgentConfigService", () => {
     expect(mockFS.writeFileString).toHaveBeenCalledWith(
       configPath,
       expect.stringContaining("sk-test"),
+      { mode: 0o600 },
     );
+  });
+
+  it("writes the config file owner-only and repairs an existing mode", async () => {
+    const configPath = "/tmp/config-mode.json";
+    const service = new AgentConfigServiceImpl(initialConfig, {}, configPath, mockFS);
+
+    await Effect.runPromise(service.set("logging.level", "debug"));
+
+    const writeCalls = (mockFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+    expect(writeCalls[writeCalls.length - 1]?.[2]).toEqual({ mode: 0o600 });
+    expect(mockFS.chmod).toHaveBeenCalledWith(configPath, 0o600);
+  });
+
+  it("creates the config directory owner-only", async () => {
+    const service = new AgentConfigServiceImpl(initialConfig, {}, undefined, mockFS);
+
+    await Effect.runPromise(service.set("logging.level", "debug"));
+
+    const dirCalls = (mockFS.makeDirectory as ReturnType<typeof mock>).mock.calls;
+    expect(dirCalls[dirCalls.length - 1]?.[1]).toEqual({ recursive: true, mode: 0o700 });
   });
 
   it("should return default value for missing keys with getOrElse", async () => {
@@ -116,6 +137,89 @@ describe("createConfigLayer", () => {
       makeDirectory: mock(() => Effect.void),
     } as unknown as FileSystem;
   }
+
+  it("resolves secrets from the environment over the config file", async () => {
+    const globalPath = path.join(os.homedir(), ".jazz", "config.json");
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ llm: { openai: { api_key: "sk-from-file" } } })],
+    ]);
+
+    process.env["OPENAI_API_KEY"] = "sk-from-env";
+    process.env["BRAVE_API_KEY"] = "brave-from-env";
+    try {
+      const layer = createConfigLayer().pipe(
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+      );
+      const program = Effect.gen(function* () {
+        const config = yield* AgentConfigServiceTag;
+        return {
+          openai: yield* config.get<string>("llm.openai.api_key"),
+          brave: yield* config.get<string>("web_search.brave.api_key"),
+        };
+      }).pipe(Effect.provide(layer));
+
+      const result = await Effect.runPromise(program);
+      expect(result.openai).toBe("sk-from-env");
+      expect(result.brave).toBe("brave-from-env");
+    } finally {
+      delete process.env["OPENAI_API_KEY"];
+      delete process.env["BRAVE_API_KEY"];
+    }
+  });
+
+  it("never writes an env-supplied secret into the config file", async () => {
+    const globalPath = path.join(os.homedir(), ".jazz", "config.json");
+    const fileContents = new Map<string, string>([[globalPath, JSON.stringify({})]]);
+    const testFS = createTestFileSystem(fileContents);
+
+    process.env["OPENAI_API_KEY"] = "sk-from-env";
+    try {
+      const layer = createConfigLayer().pipe(
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, testFS)),
+      );
+      const program = Effect.gen(function* () {
+        const config = yield* AgentConfigServiceTag;
+        yield* config.set("logging.level", "debug");
+      }).pipe(Effect.provide(layer));
+
+      await Effect.runPromise(program);
+
+      const calls = (testFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+      const written = calls[calls.length - 1]?.[1] as string;
+      expect(written).not.toContain("sk-from-env");
+      expect(JSON.parse(written).llm?.openai).toBeUndefined();
+    } finally {
+      delete process.env["OPENAI_API_KEY"];
+    }
+  });
+
+  it("keeps a file-stored secret on disk even when an env var shadows it", async () => {
+    const globalPath = path.join(os.homedir(), ".jazz", "config.json");
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ llm: { openai: { api_key: "sk-from-file" } } })],
+    ]);
+    const testFS = createTestFileSystem(fileContents);
+
+    process.env["OPENAI_API_KEY"] = "sk-from-env";
+    try {
+      const layer = createConfigLayer().pipe(
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, testFS)),
+      );
+      const program = Effect.gen(function* () {
+        const config = yield* AgentConfigServiceTag;
+        yield* config.set("logging.level", "debug");
+      }).pipe(Effect.provide(layer));
+
+      await Effect.runPromise(program);
+
+      const calls = (testFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+      const written = JSON.parse(calls[calls.length - 1]?.[1] as string);
+      expect(written.llm.openai.api_key).toBe("sk-from-file");
+      expect(written.llm.openai.api_key).not.toBe("sk-from-env");
+    } finally {
+      delete process.env["OPENAI_API_KEY"];
+    }
+  });
 
   it("merges global and local config with local overrides winning", async () => {
     const homeDir = os.homedir();

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -18,6 +18,24 @@ import {
   getJazzHomeDirectory,
   getLocalJazzDirectory,
 } from "@/core/utils/paths";
+import {
+  detectKeyringBackend,
+  keyringDelete,
+  keyringGet,
+  keyringSet,
+  type KeyringBackend,
+} from "./secrets/keyring";
+import { SECRET_PATHS, envVarForSecretPath, isSecretPath } from "./secrets/registry";
+
+/**
+ * ~/.jazz/config.json can hold API keys, so it is created private to the user
+ * and repaired on load — a default umask would otherwise leave it world-readable.
+ */
+const CONFIG_FILE_MODE = 0o600;
+const CONFIG_DIR_MODE = 0o700;
+
+/** Where a resolved secret came from. Anything but "file" must never be persisted. */
+type SecretOrigin = "env" | "keyring";
 
 /**
  * Extract only override fields (enabled) from a server config.
@@ -31,15 +49,27 @@ function extractMcpOverride(entry: unknown): MCPServerOverride | undefined {
 }
 
 /**
- * Build jazz config for persistence: full config but mcpServers replaced by overrides only.
+ * Build jazz config for persistence: full config but mcpServers replaced by
+ * overrides only, and secrets held elsewhere (env or keyring) left out entirely
+ * so resolving a key at runtime never causes it to be written back to disk.
  */
 function buildJazzConfigForPersist(
   config: AppConfig,
   mcpOverrides: Record<string, MCPServerOverride>,
+  secretOrigins: ReadonlyMap<string, SecretOrigin>,
+  fileSecrets: ReadonlyMap<string, string>,
 ): Record<string, unknown> {
   const json = config as unknown as Record<string, unknown>;
-  const out = { ...json };
+  const out = structuredClone(json);
   out["mcpServers"] = Object.keys(mcpOverrides).length > 0 ? mcpOverrides : undefined;
+  for (const path of secretOrigins.keys()) {
+    deepDelete(out, path);
+  }
+  // Restore what the file itself owns, so an env var that merely shadows a
+  // stored key at runtime does not erase it from disk.
+  for (const [path, value] of fileSecrets) {
+    deepSet(out, path, value);
+  }
   return out;
 }
 
@@ -52,18 +82,27 @@ export class AgentConfigServiceImpl implements AgentConfigService {
   private configPath: string | undefined;
   private fs: FileSystem.FileSystem;
   private currentRevision: number;
+  private keyringBackend: KeyringBackend;
+  private secretOrigins: Map<string, SecretOrigin>;
+  private fileSecrets: Map<string, string>;
 
   constructor(
     initialConfig: AppConfig,
     mcpOverrides: Record<string, MCPServerOverride>,
     configPath: string | undefined,
     fs: FileSystem.FileSystem,
+    keyringBackend: KeyringBackend = "none",
+    secretOrigins: ReadonlyMap<string, SecretOrigin> = new Map(),
+    fileSecrets: ReadonlyMap<string, string> = new Map(),
   ) {
     this.currentConfig = initialConfig;
     this.mcpOverrides = mcpOverrides;
     this.configPath = configPath;
     this.fs = fs;
     this.currentRevision = 0;
+    this.keyringBackend = keyringBackend;
+    this.secretOrigins = new Map(secretOrigins);
+    this.fileSecrets = new Map(fileSecrets);
   }
 
   get<A>(key: string): Effect.Effect<A, never> {
@@ -156,23 +195,61 @@ export class AgentConfigServiceImpl implements AgentConfigService {
           deepSet(this.currentConfig as unknown as Record<string, unknown>, key, value);
         }
 
+        if (isSecretPath(key)) {
+          yield* this.storeSecret(key, value);
+        }
+
         // Persist to file
         const path = this.configPath ?? `${getJazzHomeDirectory()}/config.json`;
         if (!this.configPath) {
           this.configPath = path;
           const dir = path.substring(0, path.lastIndexOf("/"));
           yield* this.fs
-            .makeDirectory(dir, { recursive: true })
+            .makeDirectory(dir, { recursive: true, mode: CONFIG_DIR_MODE })
             .pipe(Effect.catchAll(() => Effect.void));
         }
 
-        const toWrite = buildJazzConfigForPersist(this.currentConfig, this.mcpOverrides);
-        yield* this.fs
-          .writeFileString(path, JSON.stringify(toWrite, null, 2))
-          .pipe(Effect.catchAll(() => Effect.void));
+        const toWrite = buildJazzConfigForPersist(
+          this.currentConfig,
+          this.mcpOverrides,
+          this.secretOrigins,
+          this.fileSecrets,
+        );
+        yield* writePrivateFile(this.fs, path, JSON.stringify(toWrite, null, 2));
         this.currentRevision += 1;
       }.bind(this),
     ).pipe(Effect.catchAll(() => Effect.void));
+  }
+
+  /**
+   * Route a secret to the keyring when one is usable, recording where it now
+   * lives so it is excluded from the config file on persist. Falls through to
+   * file storage (mode 0600) when there is no keyring.
+   */
+  private storeSecret(key: string, value: unknown): Effect.Effect<void, never> {
+    return Effect.gen(
+      function* (this: AgentConfigServiceImpl) {
+        const isBlank = typeof value !== "string" || value.trim() === "";
+        if (isBlank) {
+          yield* keyringDelete(this.keyringBackend, key);
+          this.secretOrigins.delete(key);
+          this.fileSecrets.delete(key);
+          return;
+        }
+
+        const stored = yield* keyringSet(this.keyringBackend, key, value);
+        if (stored) {
+          this.secretOrigins.set(key, "keyring");
+          this.fileSecrets.delete(key);
+          return;
+        }
+
+        // No usable keyring: the value stays in the config file, which
+        // writePrivateFile keeps at mode 0600.
+        this.secretOrigins.delete(key);
+        this.fileSecrets.set(key, value);
+      }.bind(this),
+    );
   }
 
   get revision(): Effect.Effect<number, never> {
@@ -244,7 +321,24 @@ export function createConfigLayer(
 
       const finalConfig = mergeAgentsMcpIntoConfig(mainConfig, agentsServers, mcpOverrides);
 
-      return new AgentConfigServiceImpl(finalConfig, mcpOverrides, loaded.configPath, fs);
+      const keyringBackend = yield* detectKeyringBackend();
+      const secrets = yield* resolveSecrets(
+        fs,
+        finalConfig,
+        loaded.configPath,
+        loaded.globalConfig,
+        keyringBackend,
+      );
+
+      return new AgentConfigServiceImpl(
+        secrets.config,
+        mcpOverrides,
+        loaded.configPath,
+        fs,
+        keyringBackend,
+        secrets.origins,
+        secrets.fileSecrets,
+      );
     }),
   );
 }
@@ -335,6 +429,166 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.maxRetries !== undefined && { maxRetries: override.maxRetries }),
     ...(override.telemetry && { telemetry: { ...(base.telemetry ?? {}), ...override.telemetry } }),
   };
+}
+
+/**
+ * Write a file that only the owning user can read, repairing the mode on files
+ * that already exist — `writeFileString`'s mode applies solely at creation.
+ */
+function writePrivateFile(
+  fs: FileSystem.FileSystem,
+  filePath: string,
+  content: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    yield* fs
+      .writeFileString(filePath, content, { mode: CONFIG_FILE_MODE })
+      .pipe(Effect.catchAll(() => Effect.void));
+    yield* chmodQuietly(fs, filePath, CONFIG_FILE_MODE);
+  });
+}
+
+/** chmod that tolerates both failures and FileSystem stubs without `chmod`. */
+function chmodQuietly(
+  fs: FileSystem.FileSystem,
+  filePath: string,
+  mode: number,
+): Effect.Effect<void, never> {
+  return Effect.suspend(() => fs.chmod(filePath, mode)).pipe(
+    Effect.catchAll(() => Effect.void),
+    Effect.catchAllDefect(() => Effect.void),
+  );
+}
+
+/**
+ * Every secret-bearing path present in a config, including providers Jazz does
+ * not ship support for, so nothing is left behind in plaintext.
+ */
+function collectSecretPaths(config: Partial<AppConfig>): string[] {
+  const record = config as unknown as Record<string, unknown>;
+  const paths: string[] = [];
+
+  for (const section of ["llm", "web_search"]) {
+    const providers = record[section];
+    if (!providers || typeof providers !== "object") continue;
+    for (const [provider, providerConfig] of Object.entries(providers)) {
+      if (!providerConfig || typeof providerConfig !== "object") continue;
+      if (typeof (providerConfig as Record<string, unknown>)["api_key"] !== "string") continue;
+      paths.push(`${section}.${provider}.api_key`);
+    }
+  }
+
+  for (const path of ["google.clientId", "google.clientSecret"]) {
+    if (typeof deepGet(record, path) === "string") paths.push(path);
+  }
+
+  return paths;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/**
+ * Resolve secrets in precedence order — environment, then keyring, then the
+ * config file — and move any plaintext left in the global config file into the
+ * keyring when one is available.
+ */
+function resolveSecrets(
+  fs: FileSystem.FileSystem,
+  config: AppConfig,
+  globalConfigPath: string | undefined,
+  globalFileConfig: Partial<AppConfig> | undefined,
+  backend: KeyringBackend,
+): Effect.Effect<
+  {
+    config: AppConfig;
+    origins: Map<string, SecretOrigin>;
+    fileSecrets: Map<string, string>;
+  },
+  never
+> {
+  return Effect.gen(function* () {
+    const resolved = structuredClone(config) as unknown as Record<string, unknown>;
+    const origins = new Map<string, SecretOrigin>();
+    const candidates = new Set([...SECRET_PATHS, ...collectSecretPaths(config)]);
+
+    for (const path of candidates) {
+      const envVar = envVarForSecretPath(path);
+      const envValue = envVar ? process.env[envVar] : undefined;
+      if (nonEmptyString(envValue)) {
+        deepSet(resolved, path, envValue);
+        origins.set(path, "env");
+      }
+    }
+
+    if (backend !== "none") {
+      const lookups = [...candidates].filter((path) => !origins.has(path));
+      const found = yield* Effect.all(
+        lookups.map((path) =>
+          keyringGet(backend, path).pipe(Effect.map((value) => [path, value] as const)),
+        ),
+        { concurrency: "unbounded" },
+      );
+      for (const [path, value] of found) {
+        if (!nonEmptyString(value)) continue;
+        deepSet(resolved, path, value);
+        origins.set(path, "keyring");
+      }
+    }
+
+    const fileRecord = (globalFileConfig ?? {}) as unknown as Record<string, unknown>;
+    const migrated = yield* migratePlaintextSecrets(backend, fileRecord, candidates);
+    for (const path of migrated) {
+      origins.set(path, "keyring");
+    }
+
+    // Secrets the file still legitimately owns. Kept verbatim so that a shadowing
+    // env var never causes the stored copy to be dropped on the next write.
+    const fileSecrets = new Map<string, string>();
+    for (const path of candidates) {
+      if (migrated.includes(path)) continue;
+      const fileValue = deepGet(fileRecord, path);
+      if (nonEmptyString(fileValue)) fileSecrets.set(path, fileValue);
+    }
+
+    if (migrated.length > 0 && globalConfigPath) {
+      const cleaned = structuredClone(fileRecord);
+      for (const path of migrated) {
+        deepDelete(cleaned, path);
+      }
+      yield* writePrivateFile(fs, globalConfigPath, JSON.stringify(cleaned, null, 2));
+    } else if (globalConfigPath) {
+      yield* chmodQuietly(fs, globalConfigPath, CONFIG_FILE_MODE);
+    }
+
+    return { config: resolved as unknown as AppConfig, origins, fileSecrets };
+  });
+}
+
+/**
+ * Move secrets still sitting in the global config file into the keyring.
+ * Returns the paths that moved, i.e. those now safe to drop from the file.
+ */
+function migratePlaintextSecrets(
+  backend: KeyringBackend,
+  fileRecord: Record<string, unknown>,
+  candidates: ReadonlySet<string>,
+): Effect.Effect<string[], never> {
+  return Effect.gen(function* () {
+    if (backend === "none") return [];
+
+    const migrated: string[] = [];
+    for (const path of candidates) {
+      const fileValue = deepGet(fileRecord, path);
+      if (!nonEmptyString(fileValue)) continue;
+
+      const stored = yield* keyringSet(backend, path, fileValue);
+      if (stored) migrated.push(path);
+    }
+
+    return migrated;
+  });
 }
 
 function expandHome(p: string): string {
@@ -721,6 +975,33 @@ function deepHas(obj: Record<string, unknown>, path: string): boolean {
  * Example: deepSet(obj, "storage.type", "file") sets obj.storage.type = "file"
  * If obj.storage doesn't exist, it will be created as an empty object first.
  */
+/**
+ * Removes the value at a dot notation path, then discards any parent objects
+ * the removal emptied — so dropping `llm.openai.api_key` does not leave an
+ * orphaned `llm.openai: {}` behind in the written config.
+ */
+function deepDelete(obj: Record<string, unknown>, path: string): void {
+  const parts = path.split(".").filter(Boolean);
+  if (parts.length === 0) return;
+
+  const chain: Record<string, unknown>[] = [obj];
+  let cur: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const next = cur[parts[i] as string];
+    if (!next || typeof next !== "object") return;
+    cur = next as Record<string, unknown>;
+    chain.push(cur);
+  }
+
+  delete cur[parts[parts.length - 1] as string];
+
+  for (let i = chain.length - 1; i > 0; i--) {
+    const node = chain[i] as Record<string, unknown>;
+    if (Object.keys(node).length > 0) break;
+    delete (chain[i - 1] as Record<string, unknown>)[parts[i - 1] as string];
+  }
+}
+
 function deepSet(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split(".").filter(Boolean);
   let cur: Record<string, unknown> = obj;

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -74,6 +74,7 @@ import {
 import { createDeferred } from "@/core/utils/promise";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
 import { sanitize } from "@/core/utils/string";
+import { LLM_PROVIDER_ENV_VARS } from "@/services/secrets/registry";
 import {
   createModelFetcher,
   fetchModelsDevModels,
@@ -473,24 +474,7 @@ function checkProviderNativeWebSearchSupport(
  * Environment variable names for each provider's API key.
  * Used as a fallback when no key is configured in the config file.
  */
-const PROVIDER_ENV_VARS: Record<string, string> = {
-  alibaba: "ALIBABA_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
-  cerebras: "CEREBRAS_API_KEY",
-  deepseek: "DEEPSEEK_API_KEY",
-  fireworks: "FIREWORKS_API_KEY",
-  google: "GOOGLE_GENERATIVE_AI_API_KEY",
-  groq: "GROQ_API_KEY",
-  llamacpp: "LLAMACPP_API_KEY",
-  minimax: "MINIMAX_API_KEY",
-  mistral: "MISTRAL_API_KEY",
-  moonshotai: "MOONSHOT_API_KEY",
-  openai: "OPENAI_API_KEY",
-  openrouter: "OPENROUTER_API_KEY",
-  togetherai: "TOGETHER_AI_API_KEY",
-  xai: "XAI_API_KEY",
-  zhipuai: "ZHIPU_API_KEY",
-};
+const PROVIDER_ENV_VARS = LLM_PROVIDER_ENV_VARS;
 
 function getConfiguredProviders(
   llmConfig?: LLMConfig,

--- a/src/services/secrets/keyring.test.ts
+++ b/src/services/secrets/keyring.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { detectKeyringBackend, keyringGet, keyringSet, keyringDelete } from "./keyring";
+
+const originalDisable = process.env["JAZZ_DISABLE_KEYRING"];
+
+afterEach(() => {
+  if (originalDisable === undefined) {
+    delete process.env["JAZZ_DISABLE_KEYRING"];
+  } else {
+    process.env["JAZZ_DISABLE_KEYRING"] = originalDisable;
+  }
+});
+
+describe("keyring opt-out", () => {
+  it("reports no backend when JAZZ_DISABLE_KEYRING is set", async () => {
+    process.env["JAZZ_DISABLE_KEYRING"] = "1";
+    expect(await Effect.runPromise(detectKeyringBackend())).toBe("none");
+  });
+
+  it("treats explicit falsy values as not opting out", async () => {
+    for (const value of ["0", "false", "", "  "]) {
+      process.env["JAZZ_DISABLE_KEYRING"] = value;
+      // Platform decides the result, but it must not short-circuit to "none"
+      // for the opt-out reason on a platform Jazz supports.
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      if (process.platform === "darwin") {
+        expect(backend).toBe("macos");
+      } else {
+        expect(["libsecret", "none"]).toContain(backend);
+      }
+    }
+  });
+});
+
+describe('the "none" backend', () => {
+  it("reads nothing, refuses writes, and ignores deletes", async () => {
+    expect(await Effect.runPromise(keyringGet("none", "llm.openai.api_key"))).toBeUndefined();
+    expect(await Effect.runPromise(keyringSet("none", "llm.openai.api_key", "sk-x"))).toBe(false);
+    await Effect.runPromise(keyringDelete("none", "llm.openai.api_key"));
+  });
+});

--- a/src/services/secrets/keyring.ts
+++ b/src/services/secrets/keyring.ts
@@ -1,0 +1,231 @@
+import { spawn } from "node:child_process";
+import { Effect } from "effect";
+import { KEYRING_SERVICE_NAME } from "./registry";
+
+/**
+ * OS keyring access via the platform's own CLI rather than a native module.
+ *
+ * Jazz ships a slim install, and every native keyring binding drags prebuilt
+ * binaries per platform behind it. `security` is always present on macOS and
+ * `secret-tool` is the standard libsecret client on Linux, so shelling out
+ * keeps the dependency footprint at zero.
+ */
+export type KeyringBackend = "macos" | "libsecret" | "none";
+
+const PROBE_ACCOUNT = "__jazz_probe__";
+const COMMAND_TIMEOUT_MS = 5_000;
+
+interface CommandResult {
+  readonly ok: boolean;
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** True when the binary itself is missing or the call never completed. */
+  readonly unavailable: boolean;
+}
+
+function runCommand(
+  command: string,
+  args: readonly string[],
+  stdin?: string,
+): Effect.Effect<CommandResult, never> {
+  return Effect.async<CommandResult, never>((resume) => {
+    let settled = false;
+    const finish = (result: CommandResult): void => {
+      if (settled) return;
+      settled = true;
+      resume(Effect.succeed(result));
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, [...args], { stdio: ["pipe", "pipe", "pipe"] });
+    } catch {
+      finish({ ok: false, code: null, stdout: "", stderr: "", unavailable: true });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({ ok: false, code: null, stdout: "", stderr: "", unavailable: true });
+    }, COMMAND_TIMEOUT_MS);
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", () => {
+      clearTimeout(timer);
+      finish({ ok: false, code: null, stdout: "", stderr: "", unavailable: true });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      finish({
+        ok: code === 0,
+        code,
+        stdout,
+        stderr,
+        unavailable: false,
+      });
+    });
+
+    if (stdin !== undefined) {
+      child.stdin?.end(stdin);
+    } else {
+      child.stdin?.end();
+    }
+
+    return Effect.sync(() => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+    });
+  });
+}
+
+function keyringDisabledByEnv(): boolean {
+  const raw = process.env["JAZZ_DISABLE_KEYRING"];
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false";
+}
+
+/**
+ * Determine which keyring backend is usable right now.
+ *
+ * On Linux this probes an actual lookup: `secret-tool` is frequently installed
+ * on machines with no session D-Bus (headless servers), where every call fails.
+ */
+export function detectKeyringBackend(): Effect.Effect<KeyringBackend, never> {
+  return Effect.gen(function* () {
+    if (keyringDisabledByEnv()) return "none" as const;
+
+    if (process.platform === "darwin") {
+      const probe = yield* runCommand("security", [
+        "find-generic-password",
+        "-s",
+        KEYRING_SERVICE_NAME,
+        "-a",
+        PROBE_ACCOUNT,
+      ]);
+      return probe.unavailable ? ("none" as const) : ("macos" as const);
+    }
+
+    if (process.platform === "linux") {
+      const probe = yield* runCommand("secret-tool", [
+        "lookup",
+        "service",
+        KEYRING_SERVICE_NAME,
+        "account",
+        PROBE_ACCOUNT,
+      ]);
+      if (probe.unavailable) return "none" as const;
+      // A clean "not found" exits non-zero with no diagnostics; a broken or
+      // absent secret service always explains itself on stderr.
+      return probe.stderr.trim() === "" ? ("libsecret" as const) : ("none" as const);
+    }
+
+    return "none" as const;
+  });
+}
+
+/** Read a secret. Returns undefined when absent or unreadable. */
+export function keyringGet(
+  backend: KeyringBackend,
+  account: string,
+): Effect.Effect<string | undefined, never> {
+  return Effect.gen(function* () {
+    if (backend === "none") return undefined;
+
+    const result =
+      backend === "macos"
+        ? yield* runCommand("security", [
+            "find-generic-password",
+            "-w",
+            "-s",
+            KEYRING_SERVICE_NAME,
+            "-a",
+            account,
+          ])
+        : yield* runCommand("secret-tool", [
+            "lookup",
+            "service",
+            KEYRING_SERVICE_NAME,
+            "account",
+            account,
+          ]);
+
+    if (!result.ok) return undefined;
+    const value = result.stdout.replace(/\n$/, "");
+    return value === "" ? undefined : value;
+  });
+}
+
+/** Store a secret. Returns false when the keyring refused the write. */
+export function keyringSet(
+  backend: KeyringBackend,
+  account: string,
+  secret: string,
+): Effect.Effect<boolean, never> {
+  return Effect.gen(function* () {
+    if (backend === "none") return false;
+
+    if (backend === "macos") {
+      // `security` has no stdin mode for writes, so the value is briefly visible
+      // in this process's argv. Accepted: macOS Keychain is a single-user
+      // desktop path, and the multi-user exposure this guards against is Linux.
+      const result = yield* runCommand("security", [
+        "add-generic-password",
+        "-U",
+        "-s",
+        KEYRING_SERVICE_NAME,
+        "-a",
+        account,
+        "-w",
+        secret,
+      ]);
+      return result.ok;
+    }
+
+    const result = yield* runCommand(
+      "secret-tool",
+      ["store", "--label", `jazz: ${account}`, "service", KEYRING_SERVICE_NAME, "account", account],
+      secret,
+    );
+    return result.ok;
+  });
+}
+
+/** Remove a secret. Missing entries are not an error. */
+export function keyringDelete(
+  backend: KeyringBackend,
+  account: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    if (backend === "none") return;
+
+    if (backend === "macos") {
+      yield* runCommand("security", [
+        "delete-generic-password",
+        "-s",
+        KEYRING_SERVICE_NAME,
+        "-a",
+        account,
+      ]);
+      return;
+    }
+
+    yield* runCommand("secret-tool", [
+      "clear",
+      "service",
+      KEYRING_SERVICE_NAME,
+      "account",
+      account,
+    ]);
+  });
+}

--- a/src/services/secrets/registry.test.ts
+++ b/src/services/secrets/registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { SECRET_ENV_VARS, envVarForSecretPath, isSecretPath } from "./registry";
+
+describe("secret registry", () => {
+  it("treats known LLM, web search, and Google secret paths as secrets", () => {
+    expect(isSecretPath("llm.openai.api_key")).toBe(true);
+    expect(isSecretPath("web_search.brave.api_key")).toBe(true);
+    expect(isSecretPath("google.clientSecret")).toBe(true);
+    expect(isSecretPath("google.clientId")).toBe(true);
+  });
+
+  it("treats unknown providers as secrets so new keys are never left in plaintext", () => {
+    expect(isSecretPath("llm.some_future_provider.api_key")).toBe(true);
+    expect(isSecretPath("web_search.some_future_provider.api_key")).toBe(true);
+  });
+
+  it("does not treat ordinary config paths as secrets", () => {
+    expect(isSecretPath("logging.level")).toBe(false);
+    expect(isSecretPath("web_search.provider")).toBe(false);
+    expect(isSecretPath("llm.openai.base_url")).toBe(false);
+    expect(isSecretPath("storage.path")).toBe(false);
+  });
+
+  it("maps secret paths to their environment variables", () => {
+    expect(envVarForSecretPath("llm.anthropic.api_key")).toBe("ANTHROPIC_API_KEY");
+    expect(envVarForSecretPath("llm.google.api_key")).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
+    expect(envVarForSecretPath("web_search.exa.api_key")).toBe("EXA_API_KEY");
+    expect(envVarForSecretPath("google.clientSecret")).toBe("GOOGLE_CLIENT_SECRET");
+    expect(envVarForSecretPath("logging.level")).toBeUndefined();
+  });
+
+  it("gives every registered secret path a distinct environment variable", () => {
+    const envVars = Object.values(SECRET_ENV_VARS);
+    expect(new Set(envVars).size).toBe(envVars.length);
+  });
+});

--- a/src/services/secrets/registry.ts
+++ b/src/services/secrets/registry.ts
@@ -1,0 +1,83 @@
+/**
+ * Single source of truth for which config paths hold secrets, and which
+ * environment variable supplies each one.
+ *
+ * Every secret in Jazz is reachable at a dot-notation config path. Centralising
+ * the list here means the config service can resolve, redact, and relocate
+ * secrets without each call site knowing it is handling one.
+ */
+
+/** Keychain/libsecret service name under which Jazz stores its secrets. */
+export const KEYRING_SERVICE_NAME = "jazz";
+
+/**
+ * Env var names for LLM provider API keys, keyed by provider name.
+ * Exported separately because the LLM service also resolves providers from a
+ * raw LLMConfig that never passed through the config service.
+ */
+export const LLM_PROVIDER_ENV_VARS: Record<string, string> = {
+  ai_gateway: "AI_GATEWAY_API_KEY",
+  alibaba: "ALIBABA_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
+  fireworks: "FIREWORKS_API_KEY",
+  google: "GOOGLE_GENERATIVE_AI_API_KEY",
+  groq: "GROQ_API_KEY",
+  llamacpp: "LLAMACPP_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  moonshotai: "MOONSHOT_API_KEY",
+  openai: "OPENAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  togetherai: "TOGETHER_AI_API_KEY",
+  xai: "XAI_API_KEY",
+  zhipuai: "ZHIPU_API_KEY",
+};
+
+const WEB_SEARCH_PROVIDER_ENV_VARS: Record<string, string> = {
+  brave: "BRAVE_API_KEY",
+  exa: "EXA_API_KEY",
+  linkup: "LINKUP_API_KEY",
+  parallel: "PARALLEL_API_KEY",
+  perplexity: "PERPLEXITY_API_KEY",
+  tavily: "TAVILY_API_KEY",
+};
+
+const STANDALONE_SECRET_ENV_VARS: Record<string, string> = {
+  "google.clientId": "GOOGLE_CLIENT_ID",
+  "google.clientSecret": "GOOGLE_CLIENT_SECRET",
+};
+
+function buildSecretEnvVars(): Record<string, string> {
+  const paths: Record<string, string> = { ...STANDALONE_SECRET_ENV_VARS };
+  for (const [provider, envVar] of Object.entries(LLM_PROVIDER_ENV_VARS)) {
+    paths[`llm.${provider}.api_key`] = envVar;
+  }
+  for (const [provider, envVar] of Object.entries(WEB_SEARCH_PROVIDER_ENV_VARS)) {
+    paths[`web_search.${provider}.api_key`] = envVar;
+  }
+  return paths;
+}
+
+/** Config path -> environment variable name, for every known secret. */
+export const SECRET_ENV_VARS: Record<string, string> = buildSecretEnvVars();
+
+/** Every config path Jazz treats as a secret. */
+export const SECRET_PATHS: readonly string[] = Object.keys(SECRET_ENV_VARS);
+
+/**
+ * Whether a config path holds a secret.
+ *
+ * Falls back to a shape match so provider keys Jazz does not yet know about are
+ * still protected rather than silently written to disk in plaintext.
+ */
+export function isSecretPath(path: string): boolean {
+  if (path in SECRET_ENV_VARS) return true;
+  return /^(llm|web_search)\.[^.]+\.api_key$/.test(path);
+}
+
+/** Environment variable that supplies a secret path, if one is defined. */
+export function envVarForSecretPath(path: string): string | undefined {
+  return SECRET_ENV_VARS[path];
+}

--- a/test-preload.ts
+++ b/test-preload.ts
@@ -16,3 +16,11 @@ process.env["JAZZ_UI_GLYPHS"] ??= "ascii";
  * (models-dev.test.ts) manage this env var explicitly per-test.
  */
 process.env["JAZZ_OFFLINE"] ??= "1";
+
+/**
+ * Keep the suite away from the developer's real OS keyring. Without this, any
+ * test that builds a config layer would probe — and, worse, migrate real
+ * plaintext keys into — the login keychain. Tests covering keyring behavior set
+ * this to "0" explicitly.
+ */
+process.env["JAZZ_DISABLE_KEYRING"] ??= "1";


### PR DESCRIPTION
## What changes

API keys set through the Jazz wizard were written to `~/.jazz/config.json` in plaintext at the default umask — mode `0644`, readable by every other user on the box. On a single-user laptop that's untidy; on the shared VPS the README pitches, it's an exposure. A typical config holds four LLM keys, three search keys, and a Google client secret.

Jazz now resolves each secret from the first source that has it:

1. **Environment variable.** Previously only LLM providers had these. Web search providers (`BRAVE_API_KEY`, `EXA_API_KEY`, `LINKUP_API_KEY`, `PARALLEL_API_KEY`, `PERPLEXITY_API_KEY`, `TAVILY_API_KEY`) and `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` now have them too. Nothing touches disk.
2. **OS keyring.** macOS Keychain, or libsecret on Linux. Used automatically when available; `JAZZ_DISABLE_KEYRING=1` opts out.
3. **The config file**, for hosts with no usable keyring — now created `0600`, with looser modes repaired on load.

Keys already sitting in plaintext are migrated into the keyring on next start and removed from the file, so existing installs get the benefit without the user doing anything.

## What a user notices

Nothing, unless they look. The wizard and `jazz config` work exactly as before. Afterwards `~/.jazz/config.json` no longer contains their keys and is no longer world-readable.

## Why the keyring shells out

`security` and `secret-tool` are invoked as subprocesses rather than pulling in a native binding. Every native keyring module ships prebuilt binaries per platform, which cuts directly against the slim-install work in 519ce90. This adds zero dependencies.

Two consequences worth knowing:

- On macOS, `security` has no stdin mode for writes, so a secret is briefly visible in Jazz's own `argv` during a write. Accepted deliberately: the multi-user exposure this PR exists to fix is the Linux case, and there `secret-tool` reads from stdin.
- On Linux, `secret-tool` is often installed on machines with no session D-Bus. Detection therefore probes a real lookup instead of just checking the binary exists, and falls back to the `0600` file when the secret service doesn't answer.

Windows has no supported keyring path and uses the file fallback.

## Design note: env vars never clobber the file

Stripping env-resolved secrets from the persisted config would silently delete a user's stored key whenever an env var happened to shadow it. Instead the service tracks each secret's origin and restores file-owned values verbatim on write — so shadowing is a read-time concern only, and disk state is never lost. There's a regression test for exactly this.

## Verification

- `bun test` — 1779 pass, 0 fail
- `bun run typecheck`, `bun run lint` — clean
- End-to-end on macOS against a temp `JAZZ_HOME` with a throwaway provider: file went `0644` → `0600`, the key moved out of the config into the Keychain, resolution still returned the right value, and emptied parent objects were pruned. Test Keychain entry removed afterwards.

The suite is pinned to `JAZZ_DISABLE_KEYRING=1` in `test-preload.ts` — without it, any test building a config layer would probe, and migrate real keys into, the developer's own login keychain.

## Not covered

- Keyring read/write against a live Keychain or libsecret isn't unit-tested; it needs a real secret service. Verified manually as above.
- `~/.jazz/history/` and `~/.jazz/logs/` remain plaintext and are out of scope here.
- `google.clientId` / `google.clientSecret` are declared in `AppConfig` and defaulted, but nothing in `src/` reads them. They're protected here rather than removed — worth a separate look at whether they should exist at all.
