### PR TITLE
feat(context): per-agent max context tokens, and stop trimming from pre-empting compaction

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -19,7 +19,7 @@ flowchart TB
     A --> P["<b>Persona</b><br/>tone and style<br/><i>default · coder · researcher</i>"]
     A --> T["<b>Toolset</b><br/>explicit list of tool names<br/><i>omission is a security control</i>"]
     A --> S["<b>Skills</b><br/>playbooks it may load"]
-    A --> X["<b>Extras</b><br/>reasoningEffort · summarizerModel<br/>customTools · envAllowlist"]
+    A --> X["<b>Extras</b><br/>reasoningEffort · summarizerModel<br/>maxContextTokens · customTools · envAllowlist"]
 
     classDef key fill:#4f9d9d,stroke:#2f6d6d,color:#ffffff
     class T key
@@ -42,6 +42,15 @@ An explicit list of tool names the agent may call, e.g. `read_file`, `grep`, `gi
 **This is the strongest safety control available:** an agent whose list omits
 `execute_command` cannot run shell commands, no matter what approval policy is set. Give each
 agent the fewest tools its job needs. See [Tools](./tools.md).
+
+### Context budget
+
+`maxContextTokens` caps how much conversation this agent may carry, in tokens, whatever the
+model would allow. It is optional: unset, the agent uses the model's own window. Set it to
+keep cost and latency predictable, or to stop a model degrading long before its advertised
+limit. The agent warns at 70% of the budget and auto-compacts at 80%, so a smaller ceiling
+means earlier, cheaper compaction rather than a hard failure. Edit it with `jazz agent edit`
+→ **Max Context Tokens**. See [Context management](../internals/context-management.md).
 
 ### Skills
 

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -244,6 +244,16 @@ Two thresholds share one budget, both defined in `context-window-manager.ts`:
 | Costs | nothing | an extra LLM call |
 | Effect | `context 74% full of 60,000 tokens — will auto-compact soon`, once per run | history is summarized |
 
+Both the user *and the agent* are told. Past 70% the request carries an ephemeral
+`[CONTEXT WARNING: …]` line telling the model to record what it needs and consolidate
+rather than gather more; past 90% a `[CONTEXT CRITICAL: …]` line telling it to write its
+output now. This mirrors the iteration-budget nudge in `buildBudgetPressureMessage`, and the
+two are merged into one appended message when both fire.
+
+The nudge is appended to the outgoing request only — never pushed into `currentMessages`.
+A persisted warning would cost tokens exactly when they are scarce, be re-sent every turn,
+and eventually be summarized into the very compaction it was warning about.
+
 The warning exists so that compaction is never a surprise: there is a window where you can
 still `/compact` on your own terms, narrow the task, or raise the ceiling before the
 summarizer decides what to keep. `ContextWindowManager` owns both decisions — `usage()`

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -42,11 +42,24 @@ flowchart TB
 
 | | Trimming | Compaction |
 | --- | --- | --- |
-| Runs | every iteration, after appending the assistant message | when tokens exceed 80% of the context budget (the model's window, or the agent's `maxContextTokens` ceiling when it is lower) |
+| Runs | after appending the assistant message, once tokens exceed **95%** of the context budget | when tokens exceed 80% of the context budget (the model's window, or the agent's `maxContextTokens` ceiling when it is lower) |
 | Costs | nothing | one LLM call |
 | Budget | a fixed working-set target (50k tokens by default) | the context window the provider will actually honour |
 | What's lost | old messages, entirely | detail — the gist survives as a summary |
 | Preserves | system message + last N complete turns | system message + a summary + recent messages |
+
+**Trimming sits above compaction, deliberately.** Its budget is 95% of the context budget,
+compaction's is 80%, so compaction always gets first refusal and trimming only fires when
+summarizing could not bring the run under budget — a single tool result too large to
+summarize around, for example. When it does fire you are told, because messages are being
+discarded without being summarized.
+
+This ordering used to be inverted. The trim budget was a flat 50,000 tokens regardless of
+the model, so on any window larger than ~62k (50k ÷ 0.8) trimming pre-empted compaction
+entirely: history was held at 50k by discarding the oldest turns, the 80% threshold was
+never reached, and the summarizer never ran. The run degraded into exactly the sliding
+window this design exists to avoid — and, because trimming rewrites the start of the
+message list, it also invalidated the provider's cacheable prefix on every single turn.
 
 Trimming keeps the working set tidy. Compaction is what saves a run that genuinely has more
 history than fits.

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -42,7 +42,7 @@ flowchart TB
 
 | | Trimming | Compaction |
 | --- | --- | --- |
-| Runs | every iteration, after appending the assistant message | when tokens exceed 80% of the model's window |
+| Runs | every iteration, after appending the assistant message | when tokens exceed 80% of the context budget (the model's window, or the agent's `maxContextTokens` ceiling when it is lower) |
 | Costs | nothing | one LLM call |
 | Budget | a fixed working-set target (50k tokens by default) | the context window the provider will actually honour |
 | What's lost | old messages, entirely | detail — the gist survives as a summary |
@@ -218,6 +218,36 @@ so a local model resolves to the 128k unknown-model placeholder rather than to a
 maximum. That placeholder is never treated as a ceiling — a pinned window above it is
 honoured, because the user pinned it and configured the server to serve it. Only a
 *genuinely known* maximum caps a runtime window.
+
+### The per-agent ceiling
+
+`config.maxContextTokens` caps the window for *any* provider. It is the answer to "this
+agent should never carry more than 60k tokens of history, even though the model would hold
+200k" — useful for keeping cost and latency predictable, for models whose quality sags long
+before their advertised limit, and for staying under a provider tier's real limit.
+
+The ceiling only ever lowers the window: `min(runtime window, maxContextTokens)`. Asking for
+more than the server will honour is ignored, because that is exactly the silent-truncation
+failure above. Everything downstream then follows the capped number — the warning, the
+compaction threshold, the summarizer's recent-message budget, and `/context`.
+
+Set it with `jazz agent edit` → **Max Context Tokens**; leave the prompt blank to remove the
+ceiling and go back to the model's own window.
+
+### Warn first, compact second
+
+Two thresholds share one budget, both defined in `context-window-manager.ts`:
+
+| | Warning | Compaction |
+| --- | --- | --- |
+| Fires at | 70% of the budget (`CONTEXT_WARN_THRESHOLD_RATIO`) | 80% (`CONTEXT_COMPACT_THRESHOLD_RATIO`) |
+| Costs | nothing | an extra LLM call |
+| Effect | `context 74% full of 60,000 tokens — will auto-compact soon`, once per run | history is summarized |
+
+The warning exists so that compaction is never a surprise: there is a window where you can
+still `/compact` on your own terms, narrow the task, or raise the ceiling before the
+summarizer decides what to keep. `ContextWindowManager` owns both decisions — `usage()`
+returns the current tokens, the budget, and both flags from a single count.
 
 ---
 

--- a/src/cli/commands/edit-agent.ts
+++ b/src/cli/commands/edit-agent.ts
@@ -59,6 +59,8 @@ interface AgentEditAnswers {
   llmApiKeyValue?: string;
   reasoningEffort?: "disable" | "low" | "medium" | "high";
   numCtx?: number;
+  /** New ceiling in tokens, or null to remove the ceiling. */
+  maxContextTokens?: number | null;
   tools?: string[];
   webSearchProvider?: WebSearchProviderName;
 }
@@ -190,6 +192,7 @@ export function editAgentCommand(
         ...(agent.config.llmProvider === "ollama"
           ? [{ name: "Context Window", value: "contextWindow" }]
           : []),
+        { name: "Max Context Tokens", value: "maxContextTokens" },
       ],
     });
 
@@ -487,10 +490,18 @@ export function editAgentCommand(
       ...(editAnswers.llmModel && { llmModel: editAnswers.llmModel }),
       ...(editAnswers.reasoningEffort && { reasoningEffort: editAnswers.reasoningEffort }),
       ...(typeof editAnswers.numCtx === "number" && { numCtx: editAnswers.numCtx }),
+      ...(typeof editAnswers.maxContextTokens === "number" && {
+        maxContextTokens: editAnswers.maxContextTokens,
+      }),
       ...(editAnswers.tools &&
         editAnswers.tools.length > 0 && { tools: Array.from(new Set(editAnswers.tools)) }),
       ...(editAnswers.webSearchProvider && { webSearchProvider: editAnswers.webSearchProvider }),
     };
+    if (editAnswers.maxContextTokens === null) {
+      const { maxContextTokens: _cleared, ...withoutCeiling } = updatedConfig;
+      void _cleared;
+      updatedConfig = withoutCeiling;
+    }
     if (editAnswers.llmApiKeyProvider) {
       updatedConfig = setAgentApiKeyOverride(
         updatedConfig,
@@ -907,6 +918,13 @@ async function promptForAgentUpdates(
     }
   }
 
+  if (fieldToUpdate === "maxContextTokens") {
+    const result = await Effect.runPromise(promptForMaxContextTokens(terminal, currentAgent));
+    if (result !== undefined) {
+      answers.maxContextTokens = result;
+    }
+  }
+
   return answers;
 }
 
@@ -929,6 +947,45 @@ function setAgentApiKeyOverride(
   }
 
   return { ...config, llmApiKeys: nextMap };
+}
+
+export const MIN_AGENT_MAX_CONTEXT_TOKENS = 1_000;
+
+/**
+ * Ask for the agent's context ceiling. Returns the new value, `null` to remove an
+ * existing ceiling, or `undefined` when the user cancelled and nothing should change.
+ */
+function promptForMaxContextTokens(
+  terminal: TerminalService,
+  currentAgent: Agent,
+): Effect.Effect<number | null | undefined, never> {
+  const current = currentAgent.config.maxContextTokens;
+  return terminal
+    .ask(
+      `Max context tokens for this agent? (blank = use the model's full window, min ${MIN_AGENT_MAX_CONTEXT_TOKENS.toLocaleString()})`,
+      {
+        ...(typeof current === "number" ? { defaultValue: String(current) } : {}),
+        cancellable: true,
+        validate: (input: string) => {
+          const trimmed = input.trim();
+          if (trimmed.length === 0) return true;
+          const parsed = Number(trimmed);
+          if (!Number.isInteger(parsed) || parsed < MIN_AGENT_MAX_CONTEXT_TOKENS) {
+            return `Enter a whole number of at least ${MIN_AGENT_MAX_CONTEXT_TOKENS.toLocaleString()}, or leave blank to remove the limit.`;
+          }
+          return true;
+        },
+      },
+    )
+    .pipe(
+      Effect.map((answer) => {
+        if (answer === undefined) return undefined;
+        const trimmed = answer.trim();
+        if (trimmed.length === 0) return null;
+        const parsed = Number(trimmed);
+        return Number.isInteger(parsed) && parsed >= MIN_AGENT_MAX_CONTEXT_TOKENS ? parsed : null;
+      }),
+    );
 }
 
 async function promptForReasoningEffort(

--- a/src/core/agent/context/context-window-manager.test.ts
+++ b/src/core/agent/context/context-window-manager.test.ts
@@ -241,3 +241,71 @@ describe("ContextWindowManager", () => {
     });
   });
 });
+
+describe("context budget thresholds", () => {
+  const fixedCounter = {
+    countMessage: () => 100,
+    countMessages: (messages: readonly ChatMessage[]) => messages.length * 100,
+  } as any;
+
+  function managerWithBudget(contextBudgetTokens: number): ContextWindowManager {
+    return new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens,
+      tokenCounter: fixedCounter,
+    });
+  }
+
+  it("derives warn and compact thresholds from the context budget, not the trim budget", () => {
+    const manager = managerWithBudget(10_000);
+
+    expect(manager.contextBudgetTokens).toBe(10_000);
+    expect(manager.warnThresholdTokens).toBe(7_000);
+    expect(manager.compactThresholdTokens).toBe(8_000);
+  });
+
+  it("falls back to the trim budget when no context budget is given", () => {
+    const manager = new ContextWindowManager({ maxTokens: 10_000, tokenCounter: fixedCounter });
+
+    expect(manager.contextBudgetTokens).toBe(10_000);
+    expect(manager.compactThresholdTokens).toBe(8_000);
+  });
+
+  it("warns before it compacts", () => {
+    const manager = managerWithBudget(10_000);
+    const below = Array.from({ length: 60 }, () => makeMessage("user", "x"));
+    const warning = Array.from({ length: 75 }, () => makeMessage("user", "x"));
+    const compacting = Array.from({ length: 85 }, () => makeMessage("user", "x"));
+
+    expect(manager.shouldWarn(below)).toBe(false);
+    expect(manager.shouldCompact(below)).toBe(false);
+    expect(manager.shouldWarn(warning)).toBe(true);
+    expect(manager.shouldCompact(warning)).toBe(false);
+    expect(manager.shouldWarn(compacting)).toBe(true);
+    expect(manager.shouldCompact(compacting)).toBe(true);
+  });
+
+  it("reports usage against the budget", () => {
+    const manager = managerWithBudget(10_000);
+    const usage = manager.usage(Array.from({ length: 75 }, () => makeMessage("user", "x")));
+
+    expect(usage.currentTokens).toBe(7_500);
+    expect(usage.budgetTokens).toBe(10_000);
+    expect(usage.ratio).toBeCloseTo(0.75, 5);
+    expect(usage.shouldWarn).toBe(true);
+    expect(usage.shouldCompact).toBe(false);
+  });
+
+  it("honours custom threshold ratios", () => {
+    const manager = new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens: 10_000,
+      warnThresholdRatio: 0.5,
+      compactThresholdRatio: 0.9,
+      tokenCounter: fixedCounter,
+    });
+
+    expect(manager.warnThresholdTokens).toBe(5_000);
+    expect(manager.compactThresholdTokens).toBe(9_000);
+  });
+});

--- a/src/core/agent/context/context-window-manager.ts
+++ b/src/core/agent/context/context-window-manager.ts
@@ -16,6 +16,17 @@ export const CONTEXT_WARN_THRESHOLD_RATIO = 0.7;
 /** Fraction of the context budget at which history is compacted automatically. */
 export const CONTEXT_COMPACT_THRESHOLD_RATIO = 0.8;
 
+/**
+ * Fraction of the context budget at which history is trimmed outright.
+ *
+ * Deliberately *above* the compaction threshold. Trimming discards messages without
+ * summarizing them, so it must never be the mechanism that normally runs — it is the
+ * floor for the cases compaction cannot fix, such as a single tool result too large
+ * to summarize around. A trim budget below the compaction threshold silently converts
+ * the whole design into a sliding window.
+ */
+export const CONTEXT_TRIM_THRESHOLD_RATIO = 0.95;
+
 export interface ContextWindowConfig {
   /** Maximum number of tokens to keep in history */
   readonly maxTokens: number;

--- a/src/core/agent/context/context-window-manager.ts
+++ b/src/core/agent/context/context-window-manager.ts
@@ -7,9 +7,33 @@ import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./toke
 /**
  * Configuration for context window management
  */
+/**
+ * Fraction of the context budget at which the user is told the window is filling up,
+ * while there is still room to act on it.
+ */
+export const CONTEXT_WARN_THRESHOLD_RATIO = 0.7;
+
+/** Fraction of the context budget at which history is compacted automatically. */
+export const CONTEXT_COMPACT_THRESHOLD_RATIO = 0.8;
+
 export interface ContextWindowConfig {
   /** Maximum number of tokens to keep in history */
   readonly maxTokens: number;
+
+  /**
+   * Total context the run may occupy — the effective model window, already lowered
+   * by the agent's own `maxContextTokens` ceiling. Warning and compaction are
+   * measured against this, not against `maxTokens`: `maxTokens` is the hard trim
+   * budget applied after every LLM turn, and it is deliberately far smaller.
+   * Defaults to `maxTokens` for callers that manage a single budget.
+   */
+  readonly contextBudgetTokens?: number;
+
+  /** Fraction of the budget that triggers a warning. Default {@link CONTEXT_WARN_THRESHOLD_RATIO}. */
+  readonly warnThresholdRatio?: number;
+
+  /** Fraction of the budget that triggers compaction. Default {@link CONTEXT_COMPACT_THRESHOLD_RATIO}. */
+  readonly compactThresholdRatio?: number;
 
   /**
    * Number of recent turns to always keep intact (never trim).
@@ -232,14 +256,63 @@ export class ContextWindowManager {
     return this.calculateTotalTokens(messages) > this.config.maxTokens;
   }
 
+  /** Total context this run may occupy, after the agent's own ceiling. */
+  get contextBudgetTokens(): number {
+    return this.config.contextBudgetTokens ?? this.config.maxTokens;
+  }
+
+  /** Token count above which the user is warned the window is filling up. */
+  get warnThresholdTokens(): number {
+    const ratio = this.config.warnThresholdRatio ?? CONTEXT_WARN_THRESHOLD_RATIO;
+    return Math.floor(this.contextBudgetTokens * ratio);
+  }
+
+  /** Token count above which history is compacted. */
+  get compactThresholdTokens(): number {
+    const ratio = this.config.compactThresholdRatio ?? CONTEXT_COMPACT_THRESHOLD_RATIO;
+    return Math.floor(this.contextBudgetTokens * ratio);
+  }
+
   /**
-   * Check if messages should be summarized (80% of token limit)
-   * This provides early warning before hitting the hard limit
+   * Where this conversation sits inside the budget, so callers can warn, compact,
+   * or report usage from one shared accounting.
+   */
+  usage(messages: ChatMessage[]): {
+    currentTokens: number;
+    budgetTokens: number;
+    ratio: number;
+    shouldWarn: boolean;
+    shouldCompact: boolean;
+  } {
+    const currentTokens = this.calculateTotalTokens(messages);
+    const budgetTokens = this.contextBudgetTokens;
+    return {
+      currentTokens,
+      budgetTokens,
+      ratio: budgetTokens > 0 ? currentTokens / budgetTokens : 0,
+      shouldWarn: currentTokens > this.warnThresholdTokens,
+      shouldCompact: currentTokens > this.compactThresholdTokens,
+    };
+  }
+
+  /** True once the conversation passes the warn threshold but before compaction. */
+  shouldWarn(messages: ChatMessage[]): boolean {
+    return this.calculateTotalTokens(messages) > this.warnThresholdTokens;
+  }
+
+  /** True once the conversation passes the compaction threshold. */
+  shouldCompact(messages: ChatMessage[]): boolean {
+    return this.calculateTotalTokens(messages) > this.compactThresholdTokens;
+  }
+
+  /**
+   * Check if messages should be summarized.
+   *
+   * @deprecated Use {@link shouldCompact}, which measures against the context
+   * budget rather than the trim budget.
    */
   shouldSummarize(messages: ChatMessage[]): boolean {
-    const currentTokens = this.calculateTotalTokens(messages);
-    const threshold = this.config.maxTokens * 0.8; // 80% threshold
-    return currentTokens > threshold;
+    return this.shouldCompact(messages);
   }
 
   /**

--- a/src/core/agent/context/effective-context-window.test.ts
+++ b/src/core/agent/context/effective-context-window.test.ts
@@ -143,3 +143,81 @@ describe("describeContextWindowShortfall", () => {
     expect(advice).toBeNull();
   });
 });
+
+describe("agent max context tokens", () => {
+  it("lowers a cloud window to the agent's ceiling", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "anthropic",
+      modelMaxTokens: 200000,
+      agentMaxTokens: 60000,
+    });
+
+    expect(effective.tokens).toBe(60000);
+    expect(effective.cappedByAgent).toBe(true);
+    expect(effective.agentMaxTokens).toBe(60000);
+    expect(effective.source).toBe("model-max");
+    expect(effective.modelMaxTokens).toBe(200000);
+  });
+
+  it("never raises the window above what the runtime will honour", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "ollama",
+      modelMaxTokens: 262144,
+      pinnedContextWindow: 32768,
+      agentMaxTokens: 131072,
+    });
+
+    expect(effective.tokens).toBe(32768);
+    expect(effective.cappedByAgent).toBe(false);
+    expect(effective.source).toBe("pinned");
+  });
+
+  it("ignores a non-positive ceiling", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "anthropic",
+      modelMaxTokens: 200000,
+      agentMaxTokens: 0,
+    });
+
+    expect(effective.tokens).toBe(200000);
+    expect(effective.cappedByAgent).toBe(false);
+    expect(effective.agentMaxTokens).toBeUndefined();
+  });
+
+  it("reports no cap when the agent ceiling is absent", () => {
+    const effective = resolveEffectiveContextWindow({
+      provider: "anthropic",
+      modelMaxTokens: 200000,
+    });
+
+    expect(effective.cappedByAgent).toBe(false);
+    expect(effective.agentMaxTokens).toBeUndefined();
+  });
+
+  it("still warns a local agent whose ceiling the server never promised", () => {
+    const advice = describeContextWindowShortfall(
+      "ollama",
+      resolveEffectiveContextWindow({
+        provider: "ollama",
+        modelMaxTokens: 262144,
+        agentMaxTokens: 32768,
+      }),
+    );
+
+    expect(advice).toContain("max context (32,768 tokens)");
+  });
+
+  it("stays quiet when a pinned window is capped further by the agent", () => {
+    const advice = describeContextWindowShortfall(
+      "ollama",
+      resolveEffectiveContextWindow({
+        provider: "ollama",
+        modelMaxTokens: 262144,
+        pinnedContextWindow: 131072,
+        agentMaxTokens: 32768,
+      }),
+    );
+
+    expect(advice).toBeNull();
+  });
+});

--- a/src/core/agent/context/effective-context-window.ts
+++ b/src/core/agent/context/effective-context-window.ts
@@ -18,9 +18,18 @@ export type ContextWindowSource = "pinned" | "server" | "model-max" | "fallback"
 export interface EffectiveContextWindow {
   /** Tokens the server will actually honour. Use this for compaction accounting. */
   readonly tokens: number;
+  /**
+   * Where `tokens` came from before the agent ceiling was applied. Kept as the
+   * runtime source so the local-server shortfall warning still reflects whether
+   * Jazz actually knows the server's window.
+   */
   readonly source: ContextWindowSource;
   /** What the catalog (or the local server) advertises, when anything does. */
   readonly modelMaxTokens?: number;
+  /** The agent's own ceiling, when one is configured. */
+  readonly agentMaxTokens?: number;
+  /** True when the agent ceiling — not the model or server — decided `tokens`. */
+  readonly cappedByAgent: boolean;
 }
 
 export interface EffectiveContextWindowInput {
@@ -35,6 +44,13 @@ export interface EffectiveContextWindowInput {
   readonly pinnedContextWindow?: number;
   /** Window the local server reported for the loaded model, when it is known. */
   readonly serverContextWindow?: number;
+  /**
+   * `config.maxContextTokens` — a per-agent ceiling that applies to every provider.
+   * It never raises the window, only lowers it: an agent may choose to run in less
+   * context than the model offers, but asking for more than the server will honour
+   * would put us back to silent truncation.
+   */
+  readonly agentMaxTokens?: number;
 }
 
 export function isLocalServerProvider(provider: string): boolean {
@@ -55,6 +71,33 @@ function positiveTokenCount(value: number | undefined): number | undefined {
 export function resolveEffectiveContextWindow(
   input: EffectiveContextWindowInput,
 ): EffectiveContextWindow {
+  return applyAgentCeiling(resolveRuntimeContextWindow(input), input.agentMaxTokens);
+}
+
+/**
+ * Lower the runtime window to the agent's own budget. A ceiling above the runtime
+ * window is ignored rather than honoured — it would hand back tokens the server
+ * never promised.
+ */
+function applyAgentCeiling(
+  runtime: Omit<EffectiveContextWindow, "cappedByAgent" | "agentMaxTokens">,
+  requestedAgentMaxTokens: number | undefined,
+): EffectiveContextWindow {
+  const agentMaxTokens = positiveTokenCount(requestedAgentMaxTokens);
+  if (agentMaxTokens === undefined) {
+    return { ...runtime, cappedByAgent: false };
+  }
+  return {
+    ...runtime,
+    tokens: Math.min(runtime.tokens, agentMaxTokens),
+    agentMaxTokens,
+    cappedByAgent: agentMaxTokens < runtime.tokens,
+  };
+}
+
+function resolveRuntimeContextWindow(
+  input: EffectiveContextWindowInput,
+): Omit<EffectiveContextWindow, "cappedByAgent" | "agentMaxTokens"> {
   const modelMaxTokens = positiveTokenCount(input.modelMaxTokens);
   const advertised: Pick<EffectiveContextWindow, "modelMaxTokens"> =
     modelMaxTokens !== undefined ? { modelMaxTokens } : {};
@@ -103,8 +146,9 @@ export function describeContextWindowShortfall(
   if (!isLocalServerProvider(provider)) return null;
   if (effective.source === "pinned" || effective.source === "server") return null;
 
-  const assumed =
-    effective.source === "model-max"
+  const assumed = effective.cappedByAgent
+    ? `this agent's max context (${effective.tokens.toLocaleString()} tokens)`
+    : effective.source === "model-max"
       ? `the model maximum (${effective.tokens.toLocaleString()} tokens)`
       : `a ${effective.tokens.toLocaleString()}-token estimate, since nothing reports this model's size`;
   return (

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -10,7 +10,10 @@ import type { Agent } from "@/core/types";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
-import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
+import {
+  CONTEXT_COMPACT_THRESHOLD_RATIO,
+  DEFAULT_CONTEXT_WINDOW_MANAGER,
+} from "./context-window-manager";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
 
 /** Build a token-counter hint from an agent's provider/model. */
@@ -219,7 +222,7 @@ export const Summarizer = {
       const maxTokens = modelContextWindow ?? DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
       const hint = modelHintFromAgent(agent);
       const currentTokens = DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint);
-      const threshold = maxTokens * 0.8; // 80% threshold
+      const threshold = maxTokens * CONTEXT_COMPACT_THRESHOLD_RATIO;
 
       // Check if summarization is needed
       if (currentTokens <= threshold) {
@@ -237,7 +240,7 @@ export const Summarizer = {
 
       yield* presentationService.presentWarning(
         agent.name,
-        "Context window ~80% full — auto-compacting conversation history...",
+        `Context window ~${Math.round(CONTEXT_COMPACT_THRESHOLD_RATIO * 100)}% full of ${maxTokens.toLocaleString()} tokens — auto-compacting conversation history...`,
       );
 
       yield* logger.info("Compacting history to preserve context...", {

--- a/src/core/agent/execution/agent-loop-observer.test.ts
+++ b/src/core/agent/execution/agent-loop-observer.test.ts
@@ -40,6 +40,12 @@ describe("makeDefaultObserver", () => {
     expect(calls[2]).toBe("warning:Agent:model returned an empty response");
   });
 
+  it("warns with the percentage and budget on context pressure", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(makeDefaultObserver(service).onContextPressure("Agent", 72, 128000));
+    expect(calls[0]).toContain("context 72% full of 128,000 tokens");
+  });
+
   it("maps onCompletion to presentCompletion", async () => {
     const { service, calls } = recordingPresentation();
     await Effect.runPromise(makeDefaultObserver(service).onCompletion("Agent"));

--- a/src/core/agent/execution/agent-loop-observer.ts
+++ b/src/core/agent/execution/agent-loop-observer.ts
@@ -13,6 +13,11 @@ export interface AgentLoopObserver {
   onEmptyResponse(agentName: string): Effect.Effect<void, never, never>;
   /** The agent runs on a local server whose real context window Jazz could not determine. */
   onContextWindowUnknown(agentName: string, advice: string): Effect.Effect<void, never, never>;
+  /**
+   * History was trimmed — messages discarded without being summarized. This is the
+   * backstop firing, which means compaction could not bring the run under budget.
+   */
+  onHistoryTrimmed(agentName: string, messagesRemoved: number): Effect.Effect<void, never, never>;
   /** The conversation passed the warn threshold; compaction has not run yet. */
   onContextPressure(
     agentName: string,
@@ -37,6 +42,11 @@ export function makeDefaultObserver(presentation: PresentationService): AgentLoo
     onEmptyResponse: (agentName) =>
       presentation.presentWarning(agentName, "model returned an empty response"),
     onContextWindowUnknown: (agentName, advice) => presentation.presentWarning(agentName, advice),
+    onHistoryTrimmed: (agentName, messagesRemoved) =>
+      presentation.presentWarning(
+        agentName,
+        `context still over budget after compacting — dropped ${messagesRemoved} older message(s) without summarizing them`,
+      ),
     onContextPressure: (agentName, percentUsed, budgetTokens) =>
       presentation.presentWarning(
         agentName,

--- a/src/core/agent/execution/agent-loop-observer.ts
+++ b/src/core/agent/execution/agent-loop-observer.ts
@@ -13,6 +13,12 @@ export interface AgentLoopObserver {
   onEmptyResponse(agentName: string): Effect.Effect<void, never, never>;
   /** The agent runs on a local server whose real context window Jazz could not determine. */
   onContextWindowUnknown(agentName: string, advice: string): Effect.Effect<void, never, never>;
+  /** The conversation passed the warn threshold; compaction has not run yet. */
+  onContextPressure(
+    agentName: string,
+    percentUsed: number,
+    budgetTokens: number,
+  ): Effect.Effect<void, never, never>;
   onCompletion(agentName: string): Effect.Effect<void, never, never>;
 }
 
@@ -31,6 +37,11 @@ export function makeDefaultObserver(presentation: PresentationService): AgentLoo
     onEmptyResponse: (agentName) =>
       presentation.presentWarning(agentName, "model returned an empty response"),
     onContextWindowUnknown: (agentName, advice) => presentation.presentWarning(agentName, advice),
+    onContextPressure: (agentName, percentUsed, budgetTokens) =>
+      presentation.presentWarning(
+        agentName,
+        `context ${percentUsed}% full of ${budgetTokens.toLocaleString()} tokens — will auto-compact soon`,
+      ),
     onCompletion: (agentName) => presentation.presentCompletion(agentName),
   };
 }

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -418,6 +418,91 @@ describe("executeAgentLoop", () => {
     expect(result.content).toBe("Hello world");
   });
 
+  it("does not trim a history that fits the model window", async () => {
+    // Regression: the trim budget was a flat 50k while compaction fired at 80% of the
+    // window, so on any model above ~62k trimming silently pre-empted compaction and
+    // the run degraded to a sliding window that dropped the earliest turns.
+    // Two iterations: trimming happens after the first LLM call, so only the second
+    // call can observe whether history survived.
+    const seenMessages: ConversationMessages[] = [];
+    let iteration = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: (messages) => {
+        seenMessages.push(messages);
+        iteration++;
+        if (iteration === 1) {
+          return Effect.succeed({
+            completion: {
+              id: "c1",
+              model: "gpt-4o",
+              content: "",
+              toolCalls: [
+                {
+                  id: "call_1",
+                  type: "function" as const,
+                  function: { name: "test_tool", arguments: "{}" },
+                },
+              ],
+            },
+            interrupted: false,
+          });
+        }
+        return Effect.succeed({
+          completion: { id: "c2", model: "gpt-4o", content: "Hello world" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock(() =>
+      Effect.succeed([
+        { toolCallId: "call_1", name: "test_tool", result: "output", success: true },
+      ]),
+    );
+
+    const messages: any[] = [{ role: "system", content: "system prompt" }];
+    for (let turn = 0; turn < 90; turn++) {
+      messages.push({ role: "user", content: `question ${turn} ` + "detail ".repeat(400) });
+      messages.push({ role: "assistant", content: `answer ${turn} ` + "finding ".repeat(400) });
+    }
+    // gpt-4o: a real 128k window, so the history below fits with room to spare.
+    const model = "gpt-4o";
+    const totalTokens = DEFAULT_TOKEN_COUNTER.countMessages(messages, {
+      provider: "openai",
+      modelId: model,
+    });
+    // Comfortably past the old 50k trim budget, well under 80% of the 128k window.
+    expect(totalTokens).toBeGreaterThan(50_000);
+    expect(totalTokens).toBeLessThan(128_000 * 0.8);
+
+    const options = makeOptions();
+    const agent = { ...options.agent, config: { ...options.agent.config, llmModel: model } } as any;
+
+    await Effect.runPromise(
+      executeAgentLoop(
+        { ...options, agent },
+        makeRunContext({ messages: messages as any, agent, model }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    // The second call is the one that sees post-trim history.
+    const sent = seenMessages[1] ?? [];
+    expect(sent.length).toBeGreaterThan(0);
+    // The earliest turn — the one carrying the task definition — must survive.
+    expect(sent.some((message) => message.content?.includes("question 0"))).toBe(true);
+  });
+
   it("should warn when iteration limit is reached", async () => {
     const warningCalls: string[] = [];
     const trackingPresentationService = {

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -12,6 +12,7 @@ import {
   type CompletionStrategy,
   type TrackedToolCall,
 } from "./agent-loop";
+import { buildContextPressureMessage } from "./agent-loop";
 import { makeDefaultObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { SkillServiceTag } from "../../../core/skills/skill-service";
@@ -344,6 +345,77 @@ describe("executeAgentLoop", () => {
     expect(pressureWarning).toBeDefined();
     expect(pressureWarning).toContain(`${maxContextTokens.toLocaleString()} tokens`);
     expect(warningCalls.some((msg) => msg.includes("auto-compacting"))).toBe(false);
+  });
+
+  it("tells the model to consolidate once context passes the warn threshold", () => {
+    expect(buildContextPressureMessage(6_000, 10_000)).toBeNull();
+    expect(buildContextPressureMessage(7_500, 10_000)?.content).toContain("CONTEXT WARNING");
+    expect(buildContextPressureMessage(7_500, 10_000)?.content).toContain("75%");
+    expect(buildContextPressureMessage(7_500, 10_000)?.content).toContain("10,000");
+  });
+
+  it("tells the model to stop gathering once context is critical", () => {
+    const message = buildContextPressureMessage(9_500, 10_000);
+    expect(message?.content).toContain("CONTEXT CRITICAL");
+    expect(message?.content).toContain("95%");
+    expect(message?.role).toBe("user");
+  });
+
+  it("returns no context nudge when there is no budget to measure against", () => {
+    expect(buildContextPressureMessage(500, 0)).toBeNull();
+  });
+
+  it("sends the context nudge to the model without persisting it in history", async () => {
+    const seenMessages: ConversationMessages[] = [];
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: (messages) => {
+        seenMessages.push(messages);
+        return Effect.succeed({
+          completion: { id: "c1", model: "gpt-4", content: "Hello world" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const messages = [
+      { role: "system" as const, content: "system prompt" },
+      {
+        role: "user" as const,
+        content: "the quick brown fox jumps over the lazy dog. ".repeat(200),
+      },
+    ];
+    const usedTokens = DEFAULT_TOKEN_COUNTER.countMessages(messages, {
+      provider: "openai",
+      modelId: "gpt-4",
+    });
+    const maxContextTokens = Math.ceil(usedTokens / 0.75);
+
+    const options = makeOptions();
+    const agentWithCeiling = {
+      ...options.agent,
+      config: { ...options.agent.config, maxContextTokens },
+    } as any;
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        { ...options, agent: agentWithCeiling },
+        makeRunContext({ messages: messages as any, agent: agentWithCeiling }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    const sent = seenMessages[0] ?? [];
+    const nudge = sent.find((message) => message.content?.includes("CONTEXT WARNING"));
+    expect(nudge).toBeDefined();
+    expect(nudge?.role).toBe("user");
+    expect(result.content).toBe("Hello world");
   });
 
   it("should warn when iteration limit is reached", async () => {

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -25,6 +25,7 @@ import { PresentationServiceTag } from "../../interfaces/presentation";
 import { TerminalServiceTag } from "../../interfaces/terminal";
 import { ToolRegistryTag } from "../../interfaces/tool-registry";
 import type { RecursiveRunner } from "../context/summarizer";
+import { DEFAULT_TOKEN_COUNTER } from "../context/token-counter";
 import type { AgentRunContext, AgentRunnerOptions, AgentResponse } from "../types";
 
 // Shared mocks
@@ -118,6 +119,8 @@ function recordingObserver() {
     onEmptyResponse: (name: string) => Effect.sync(() => void calls.push(`empty:${name}`)),
     onContextWindowUnknown: (name: string) =>
       Effect.sync(() => void calls.push(`context-window-unknown:${name}`)),
+    onContextPressure: (name: string, percentUsed: number) =>
+      Effect.sync(() => void calls.push(`context-pressure:${name}:${percentUsed}`)),
     onCompletion: (name: string) => Effect.sync(() => void calls.push(`completion:${name}`)),
   };
   return { observer, calls };
@@ -281,6 +284,66 @@ describe("executeAgentLoop", () => {
     expect(toolMessage?.name).toBe("test_tool");
 
     ToolExecutor.executeToolCalls = originalExecute;
+  });
+
+  it("warns against the agent's max context tokens before compacting", async () => {
+    const warningCalls: string[] = [];
+    const trackingPresentationService = {
+      ...mockPresentationService,
+      presentWarning: (_name: string, msg: string) => {
+        warningCalls.push(msg);
+        return Effect.void;
+      },
+    };
+    const trackingObserver = makeDefaultObserver(trackingPresentationService as any);
+
+    const strategy: CompletionStrategy = {
+      shouldShowThinking: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: { id: "c1", model: "gpt-4", content: "Hello world" },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const messages = [
+      { role: "system" as const, content: "system prompt" },
+      {
+        role: "user" as const,
+        content: "the quick brown fox jumps over the lazy dog. ".repeat(200),
+      },
+    ];
+    const usedTokens = DEFAULT_TOKEN_COUNTER.countMessages(messages, {
+      provider: "openai",
+      modelId: "gpt-4",
+    });
+    // Sit at 75% of the ceiling: past the warn threshold, short of compaction.
+    const maxContextTokens = Math.ceil(usedTokens / 0.75);
+
+    const options = makeOptions();
+    const agentWithCeiling = {
+      ...options.agent,
+      config: { ...options.agent.config, maxContextTokens },
+    } as any;
+
+    await Effect.runPromise(
+      executeAgentLoop(
+        { ...options, agent: agentWithCeiling },
+        makeRunContext({ messages: messages as any, agent: agentWithCeiling }),
+        displayConfig,
+        strategy,
+        trackingObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    const pressureWarning = warningCalls.find((msg) => msg.includes("context "));
+    expect(pressureWarning).toBeDefined();
+    expect(pressureWarning).toContain(`${maxContextTokens.toLocaleString()} tokens`);
+    expect(warningCalls.some((msg) => msg.includes("auto-compacting"))).toBe(false);
   });
 
   it("should warn when iteration limit is reached", async () => {

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -70,6 +70,7 @@ interface LoopState {
   response: AgentResponse;
   recentToolCalls: TrackedToolCall[];
   iterationsUsed: number;
+  contextPressureWarned: boolean;
 }
 
 interface LoopDeps {
@@ -468,6 +469,24 @@ function runIteration(
       yield* observer.onThinking(agent.name, iterationIndex === 0);
     }
 
+    const contextUsage = runContextWindowManager.usage(state.currentMessages);
+    if (contextUsage.shouldWarn && !contextUsage.shouldCompact && !state.contextPressureWarned) {
+      state.contextPressureWarned = true;
+      yield* logger.info("Context window filling up", {
+        agentId: agent.id,
+        conversationId: actualConversationId,
+        currentTokens: contextUsage.currentTokens,
+        budgetTokens: contextUsage.budgetTokens,
+      });
+      if (!options.internal) {
+        yield* observer.onContextPressure(
+          agent.name,
+          Math.round(contextUsage.ratio * 100),
+          contextUsage.budgetTokens,
+        );
+      }
+    }
+
     state.currentMessages = yield* Summarizer.compactIfNeeded(
       state.currentMessages,
       agent,
@@ -684,6 +703,9 @@ export function executeAgentLoop(
           ...(typeof agent.config.numCtx === "number" && {
             pinnedContextWindow: agent.config.numCtx,
           }),
+          ...(typeof agent.config.maxContextTokens === "number" && {
+            agentMaxTokens: agent.config.maxContextTokens,
+          }),
         });
         const contextWindowMaxTokens = effectiveContextWindow.tokens;
 
@@ -692,6 +714,7 @@ export function executeAgentLoop(
           DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().protectedRecentTurns;
         const runContextWindowManager = new ContextWindowManager({
           maxTokens: trimBudgetTokens,
+          contextBudgetTokens: contextWindowMaxTokens,
           ...(protectedRecentTurns !== undefined && { protectedRecentTurns }),
           modelHint: { provider, modelId: model },
         });
@@ -702,6 +725,8 @@ export function executeAgentLoop(
           contextWindow: contextWindowMaxTokens,
           modelMaxTokens: effectiveContextWindow.modelMaxTokens,
           contextWindowSource: effectiveContextWindow.source,
+          agentMaxTokens: effectiveContextWindow.agentMaxTokens,
+          cappedByAgent: effectiveContextWindow.cappedByAgent,
         });
 
         const shortfall = describeContextWindowShortfall(provider, effectiveContextWindow);
@@ -717,6 +742,7 @@ export function executeAgentLoop(
           },
           recentToolCalls: [],
           iterationsUsed: 0,
+          contextPressureWarned: false,
         };
         let finished = false;
         let interrupted = false;

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -15,6 +15,8 @@ import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import {
+  CONTEXT_COMPACT_THRESHOLD_RATIO,
+  CONTEXT_WARN_THRESHOLD_RATIO,
   ContextWindowManager,
   DEFAULT_CONTEXT_WINDOW_MANAGER,
 } from "../context/context-window-manager";
@@ -55,6 +57,40 @@ export function buildBudgetPressureMessage(
     return {
       role: "user",
       content: `[BUDGET WARNING: Iteration ${iteration}/${maxIterations} (${Math.round(pct * 100)}%). Begin consolidating results. Stop spawning new research subagents. Move to consolidation and output phases.]`,
+    };
+  }
+  return null;
+}
+
+/** Share of the context budget past which the agent is told to stop gathering and write. */
+const CONTEXT_CRITICAL_RATIO = 0.9;
+
+/**
+ * Tell the model its context is running out, mirroring the iteration-budget nudge.
+ *
+ * Without this the agent only learns about compaction after the fact, by finding its
+ * history rewritten underneath it. Warned in advance it can consolidate what it has
+ * while the detail is still there to consolidate.
+ */
+export function buildContextPressureMessage(
+  currentTokens: number,
+  budgetTokens: number,
+): { role: "user"; content: string } | null {
+  if (budgetTokens <= 0) return null;
+  const ratio = currentTokens / budgetTokens;
+  const percent = Math.round(ratio * 100);
+  const budget = budgetTokens.toLocaleString();
+
+  if (ratio >= CONTEXT_CRITICAL_RATIO) {
+    return {
+      role: "user",
+      content: `[CONTEXT CRITICAL: ${percent}% of the ${budget}-token context budget used. Write your final output NOW from what you have already gathered. Do not open new files, run new searches, or spawn subagents — their results may not survive compaction.]`,
+    };
+  }
+  if (ratio >= CONTEXT_WARN_THRESHOLD_RATIO) {
+    return {
+      role: "user",
+      content: `[CONTEXT WARNING: ${percent}% of the ${budget}-token context budget used. Older history is summarized automatically at ${Math.round(CONTEXT_COMPACT_THRESHOLD_RATIO * 100)}%, and detail is lost when that happens. Record any findings you need to keep in your next message, and prefer consolidating over gathering more.]`,
     };
   }
   return null;
@@ -516,9 +552,21 @@ function runIteration(
       lastUserMessage: lastUserContent,
     });
 
+    // Both nudges are ephemeral: appended to this request only, never pushed into
+    // history. A persisted warning would cost tokens exactly when they are scarce,
+    // be re-sent every turn, and end up summarized into the compaction it warned about.
+    const postCompactionUsage = runContextWindowManager.usage(state.currentMessages);
+    const contextMsg = buildContextPressureMessage(
+      postCompactionUsage.currentTokens,
+      postCompactionUsage.budgetTokens,
+    );
     const budgetMsg = buildBudgetPressureMessage(iterationIndex + 1, maxIterations);
-    const messagesForLLM = budgetMsg
-      ? ([...state.currentMessages, budgetMsg] as typeof state.currentMessages)
+    const pressureContent = [contextMsg?.content, budgetMsg?.content].filter(Boolean).join("\n");
+    const messagesForLLM = pressureContent
+      ? ([
+          ...state.currentMessages,
+          { role: "user" as const, content: pressureContent },
+        ] as typeof state.currentMessages)
       : state.currentMessages;
 
     const result = yield* strategy.getCompletion(messagesForLLM, iterationIndex);

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -16,6 +16,7 @@ import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import {
   CONTEXT_COMPACT_THRESHOLD_RATIO,
+  CONTEXT_TRIM_THRESHOLD_RATIO,
   CONTEXT_WARN_THRESHOLD_RATIO,
   ContextWindowManager,
   DEFAULT_CONTEXT_WINDOW_MANAGER,
@@ -653,6 +654,9 @@ function runIteration(
       actualConversationId,
     );
     state.currentMessages = trimUpdate.messages;
+    if (trimUpdate.result !== undefined && !options.internal) {
+      yield* observer.onHistoryTrimmed(agent.name, trimUpdate.result.messagesRemoved);
+    }
 
     if (completion.toolCalls && completion.toolCalls.length > 0) {
       yield* handleToolPhase(state, completion.toolCalls, completion.content, iterationIndex, deps);
@@ -757,7 +761,12 @@ export function executeAgentLoop(
         });
         const contextWindowMaxTokens = effectiveContextWindow.tokens;
 
-        const trimBudgetTokens = DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
+        // Trim is the floor, not the routine path: it discards messages instead of
+        // summarizing them, so its budget sits above the compaction threshold. Keying
+        // it to a constant below the window (it was 50k) made trimming pre-empt
+        // compaction on every model with a window over ~62k — a sliding window in all
+        // but name, and one that rewrote the cacheable prefix on every turn.
+        const trimBudgetTokens = Math.floor(contextWindowMaxTokens * CONTEXT_TRIM_THRESHOLD_RATIO);
         const protectedRecentTurns =
           DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().protectedRecentTurns;
         const runContextWindowManager = new ContextWindowManager({

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -290,6 +290,9 @@ ${args.task}`;
             ...(typeof parentAgent.config.numCtx === "number" && {
               pinnedContextWindow: parentAgent.config.numCtx,
             }),
+            ...(typeof parentAgent.config.maxContextTokens === "number" && {
+              agentMaxTokens: parentAgent.config.maxContextTokens,
+            }),
           }).tokens;
 
           const { systemMessage, messagesToSummarize, sanitizedRecentMessages } =

--- a/src/core/types/agent.ts
+++ b/src/core/types/agent.ts
@@ -63,6 +63,13 @@ export interface AgentConfig {
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
   /** Ollama context window (`num_ctx`) in tokens, chosen at agent creation. */
   readonly numCtx?: number;
+  /**
+   * Per-agent ceiling on the conversation context, in tokens. Applies to every
+   * provider and caps whatever window the model or local server would otherwise
+   * offer, so the agent warns and compacts against this budget instead of the
+   * full window. Unset means "use the model's window".
+   */
+  readonly maxContextTokens?: number;
   readonly temperature?: number;
   readonly tools?: readonly string[];
   readonly webSearchProvider?: WebSearchProviderName;

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1816,6 +1816,9 @@ function handleContextCommand(
       ...(typeof agent.config.numCtx === "number" && {
         pinnedContextWindow: agent.config.numCtx,
       }),
+      ...(typeof agent.config.maxContextTokens === "number" && {
+        agentMaxTokens: agent.config.maxContextTokens,
+      }),
     });
     const contextWindow = effectiveContextWindow.tokens;
 
@@ -1854,8 +1857,9 @@ function handleContextCommand(
     // Display model info and total usage on first row
     const modelDisplay = `${provider}/${modelId}`;
     const modelMaxTokens = effectiveContextWindow.modelMaxTokens;
-    const runtimeWindowNote =
-      modelMaxTokens !== undefined && effectiveContextWindow.tokens < modelMaxTokens
+    const runtimeWindowNote = effectiveContextWindow.cappedByAgent
+      ? ` · agent max context${modelMaxTokens !== undefined ? `, model max ${formatTokenCount(modelMaxTokens)}` : ""}`
+      : modelMaxTokens !== undefined && effectiveContextWindow.tokens < modelMaxTokens
         ? ` · runtime window, model max ${formatTokenCount(modelMaxTokens)}`
         : "";
     const usageDisplay = `${formatTokenCount(adjustedUsage.totalUsed)}/${formatTokenCount(contextWindow)} tokens (${usagePercent}%)${runtimeWindowNote}`;


### PR DESCRIPTION
## What changes

Agents can now declare a **maximum context budget** — `maxContextTokens` — capping how much conversation they carry regardless of how large the model's window is. An agent on a 200k model can be told to work within 60k.

Two things follow from that budget:

- **A warning at 70%**, to both you and the agent.
  - You see it once per run: `context 74% full of 60,000 tokens — will auto-compact soon`.
  - The model gets an ephemeral `[CONTEXT WARNING: …]` line telling it to record what it needs and consolidate rather than gather more — escalating to `[CONTEXT CRITICAL: …]` at 90%, meaning write your output now.
- **Auto-compaction at 80%**, as before — but now measured against the agent's ceiling rather than the model's window.

The warning is the point of the change as much as the ceiling is. Compaction costs an extra LLM call and is lossy by nature; today it fires with no notice to anyone. For you, the gap between thresholds is room to `/compact` on your own terms, narrow the task, or raise the ceiling before the summarizer decides what to keep. For the agent it is the difference between consolidating findings while the detail is still in context, and discovering after the fact that its history was rewritten underneath it.

This mirrors the **iteration** budget, which already nudges the model at 70% and 90% via `buildBudgetPressureMessage` — the two budgets now behave consistently, and merge into a single appended message when both fire.

## Also in this PR: trimming no longer pre-empts compaction

While reviewing the accounting I found the documented design was not the one running. The trim budget was a flat **50,000 tokens** regardless of model, while compaction fires at **80% of the window**. On any window above ~62k (50k ÷ 0.8) trimming won every time:

```
history tokens:        69,198
trim budget:           50,000
compaction threshold:  160,000 (80% of 200,000)
trim fires?            true
compaction fires?      false
```

History was pinned at 50k by discarding the oldest turns, the compaction threshold was never reached, and the summarizer never ran. Every Claude/GPT/Gemini agent was running the sliding window the docs explicitly describe as the thing to avoid — losing the task definition and keeping the trivia. Rewriting the head of the message list also invalidated the provider's cacheable prefix on every turn once past 50k.

Trim is now the **floor**: 95% of the context budget, above compaction's 80%. Compaction gets first refusal; trimming only covers what summarizing cannot fix, such as a single tool result too large to summarize around. When it does fire the user is told, since messages are dropped unsummarized.

**This changes cost and latency.** Requests on large-window models can now grow to ~80% of the window before compacting, where they were previously capped at 50k. Quality should improve (the plan survives) and prompt caching should offset much of it (the prefix is now stable between compactions), but per-turn input cost on long conversations will rise. `maxContextTokens` from this same PR is the knob for anyone who wants the old ceiling back — set it to 60k and you get roughly the previous budget, with proper summarization instead of truncation.

## Why

Three situations where the model's advertised window is the wrong number to plan against:

- **Cost and latency.** A long run on a 200k window gets progressively slower and more expensive per turn. Capping the budget compacts earlier and keeps turns cheap.
- **Quality.** Plenty of models degrade well before their advertised limit. The ceiling lets you run one at the size it's actually good at.
- **Tier limits.** A provider tier's real per-request limit is often below the catalog number.

## How it behaves

The ceiling **only ever lowers** the window — `min(runtime window, maxContextTokens)`. A ceiling above what the server will honour is ignored rather than obeyed, because handing back tokens the server never promised is exactly the silent-truncation failure this accounting exists to prevent. For local providers it composes with the existing `numCtx` pinning rather than overriding it.

Everything downstream follows the capped number: the warning, the compaction threshold, the summarizer's recent-message budget, `/context` (which labels the cap), and `spawn_subagent`'s summarize path.

## Setting it

`jazz agent edit` → **Max Context Tokens**. Blank removes the ceiling and returns the agent to the model's window; minimum 1,000.

It can also be set directly in `~/.jazz/agents/<id>.json` under `config`, and survives later CLI edits:

```json
"config": { "maxContextTokens": 60000 }
```

Unset means "use the model's window", so existing agents are unaffected.

## Verifying

```bash
bun test && bun run typecheck && bun run lint
```

A regression test covers the trim/compaction ordering specifically, and it was verified to fail against the old flat budget before being committed.

New coverage: the ceiling lowers a cloud window but never raises a pinned local one, non-positive values are ignored, warn and compact thresholds derive from the budget rather than the trim budget, the loop warns before it compacts, the context nudge reaches the model without being persisted into history, and the local-server shortfall warning still fires for a ceiling the server never promised.

To see it end to end: set a small ceiling on an agent, run a conversation past 70% of it, and the warning arrives before the compaction notice.

## Notes for reviewers

- `ContextWindowConfig` gains `contextBudgetTokens` **alongside** the existing `maxTokens` rather than replacing it. They are genuinely different numbers: `maxTokens` is the hard ~50k trim budget applied after every LLM turn, the new one is the full effective window. Defaulting it to `maxTokens` keeps every existing caller's behaviour identical.
- `shouldSummarize` is kept as a deprecated alias of the new `shouldCompact`.
- The 70/80 ratios are exported constants shared with the summarizer, so the two decisions can't drift apart.
- The agent-facing nudge is **ephemeral** — appended to the outgoing request, never pushed into `currentMessages`. Persisting it would cost tokens exactly when they are scarce, re-send every turn, and end up summarized into the compaction it warned about.
- Worth a second opinion: an agent-visible warning can make a model bail out of useful work early, the same failure mode the iteration nudge occasionally causes. The wording deliberately says *consolidate*, not *stop*, until 90%.
- **Not validated at read time.** A hand-edited JSON value that is quoted, zero, or negative is silently ignored and the agent runs with the full window — no error. The CLI can't produce those, but a hand-edit can. Happy to add a read-time warning in the storage path if you want that closed here rather than in a follow-up.
- Not exposed in the `jazz agent create` wizard — that's a step machine with back-navigation, and an optional tuning knob seemed wrong as a mandatory creation step. Easy to add if you disagree.
