### PR TITLE
feat(dist): install Jazz as a single binary via curl | bash

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,114 @@
+name: Release Binaries
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to build binaries for (e.g. v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.event.release.tag_name }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS binaries are built on macOS so they come out ad-hoc signed.
+          # An unsigned Mach-O binary is killed on sight by arm64 macOS, and
+          # cross-compiling from Linux produces exactly that.
+          - name: darwin-arm64
+            runner: macos-latest
+            targets: bun-darwin-arm64
+          - name: darwin-x64
+            runner: macos-latest
+            targets: bun-darwin-x64
+          - name: linux
+            runner: ubuntu-latest
+            targets: bun-linux-x64 bun-linux-arm64 bun-linux-x64-musl bun-linux-arm64-musl
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Compile binaries
+        run: |
+          for target in ${{ matrix.targets }}; do
+            bun run scripts/build.ts --compile --target "$target"
+          done
+
+      - name: Sign macOS binaries
+        if: runner.os == 'macOS'
+        run: |
+          for binary in binaries/*; do
+            codesign --force --sign - "$binary"
+            codesign --verify --verbose "$binary"
+          done
+
+      - name: Smoke test the native binary
+        if: matrix.name == 'darwin-arm64' || matrix.name == 'linux'
+        run: |
+          native="binaries/jazz-$(uname -s | tr '[:upper:]' '[:lower:]')-$([ "$(uname -m)" = "x86_64" ] && echo x64 || echo arm64)"
+          JAZZ_HOME="$(mktemp -d)" "$native" --version
+          JAZZ_HOME="$(mktemp -d)" "$native" persona list | grep -q "built-in"
+
+      - name: Compress binaries
+        run: gzip -9 binaries/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.name }}
+          path: binaries/*.gz
+          retention-days: 1
+
+  publish:
+    name: Attach binaries to the release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: binaries-*
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          sha256sum *.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp scripts/install.sh artifacts/install.sh
+          gh release upload "$TAG_NAME" artifacts/* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ bun.lockb
 # Build outputs
 dist/
 build/
+binaries/
+.build/
 .tsbuild/
 .tsbuildinfo
 .tsbuildinfo.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,28 @@ When adding features:
 - Use Effect's `Layer` for dependency injection in tests
 - Mock external dependencies (no real API calls)
 
+## Distributions
+
+Jazz ships two ways, from one codebase:
+
+| Command                 | Output                                       | Used by                     |
+| ----------------------- | -------------------------------------------- | --------------------------- |
+| `bun run build`         | `dist/main.js`, a bundle Node runs            | the `jazz-ai` npm package   |
+| `bun run build:binary`  | `binaries/jazz-<os>-<arch>` for this machine  | local testing               |
+| `bun run build:binaries`| every published target                        | `.github/workflows/release-binaries.yml` |
+
+The binary is self-contained, which changes two things a contributor can trip over:
+
+- **Built-in assets.** `personas/`, `skills/`, and `workflows/` are real directories the npm
+  package resolves via `getPackageRootDirectory()`. A binary has no package directory, so the
+  build embeds each file and Jazz unpacks them to `~/.jazz/runtime/<version>/` on first run.
+  Adding a new built-in asset directory means adding it to `ASSET_DIRECTORIES` in
+  `scripts/build.ts` — otherwise it works everywhere except in the binary.
+- **Reading your own package files at runtime.** Anything that resolves a path relative to the
+  installed package must go through `getPackageRootDirectory()`, which returns the unpacked
+  directory in a binary. Reading straight from `import.meta.dirname` lands inside Bun's
+  virtual filesystem, where `readFile` works but `readdir` and `copyFile` do not.
+
 ## Before Submitting PR
 
 - [ ] `bun run typecheck` passes

--- a/README.md
+++ b/README.md
@@ -23,9 +23,20 @@ connects through [MCP](https://modelcontextprotocol.io/).
 ## Get started
 
 ```bash
+curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash
+jazz
+```
+
+That installs a single self-contained binary into `~/.local/bin` — no Node, no npm, nothing
+else to install. Set `JAZZ_INSTALL_DIR` to put it somewhere else. If you would rather go
+through npm:
+
+```bash
 npm install -g jazz-ai
 jazz
 ```
+
+Either way, `jazz update` upgrades in place.
 
 Jazz walks you through provider setup on first run. It can cost nothing:
 [OpenRouter](https://openrouter.ai)'s [free models router](https://openrouter.ai/openrouter/free)

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -4,7 +4,24 @@
 
 ## 1. Install the CLI
 
-Jazz is available via npm, bun, pnpm, or yarn.
+The install script downloads a single self-contained binary for macOS or Linux. It needs no
+Node, npm, or any other runtime.
+
+```bash
+curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash
+```
+
+It installs to `~/.local/bin` by default, verifies the download against the release
+checksums, and tells you if that directory is not on your `PATH`. Override the location with
+`JAZZ_INSTALL_DIR`, or pin a version with `JAZZ_VERSION`:
+
+```bash
+JAZZ_INSTALL_DIR=/usr/local/bin JAZZ_VERSION=v0.13.12 \
+  curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash
+```
+
+Jazz is also on npm, which is the route to use on Windows or on a platform with no published
+binary:
 
 ```bash
 # npm
@@ -19,6 +36,9 @@ pnpm add -g jazz-ai
 # yarn
 yarn global add jazz-ai
 ```
+
+`jazz update` upgrades either kind of installation: a binary replaces itself from the GitHub
+release, and a package install goes back through the package manager that put it there.
 
 ## 2. Start talking to it
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   ],
   "scripts": {
     "build": "bun run scripts/build.ts",
+    "build:binary": "bun run scripts/build.ts --compile",
+    "build:binaries": "bun run scripts/build.ts --compile --all-targets",
     "typecheck": "bun run tsc --noEmit -p tsconfig.app.json && bun run tsc --noEmit -p tsconfig.build.json",
     "typecheck:evals": "tsc -p evals/tsconfig.json",
     "evals": "bun run evals/cli.ts",
@@ -62,7 +64,7 @@
     "docs:lint": "bunx markdownlint-cli2",
     "docs:lint:fix": "bunx markdownlint-cli2 --fix",
     "test:typecheck": "bunx tsc --project tsconfig.test.json",
-    "clean": "rm -rf dist .tsbuild .tsbuildinfo .tsbuildinfo.scripts",
+    "clean": "rm -rf dist binaries .build .tsbuild .tsbuildinfo .tsbuildinfo.scripts",
     "prebuild": "bun run clean",
     "prepublishOnly": "bun run build"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import manifest from "../package.json" with { type: "json" };
 
 type SpawnResult = {
@@ -95,7 +97,7 @@ function resolveExternals(): string[] {
   return [...EXTERNAL_PACKAGES, ...OPTIONAL_RUNTIME_IMPORTS];
 }
 
-function main(): void {
+function buildNpmBundle(): void {
   const banner = "#!/usr/bin/env node";
   const outfile = "dist/main.js";
 
@@ -129,4 +131,203 @@ function main(): void {
   if (tsc.exitCode !== 0) throw new Error(`TypeScript failed with exit code ${tsc.exitCode}`);
 }
 
-main();
+/**
+ * Directories shipped alongside the code, in the order they are embedded.
+ *
+ * `vendor/` holds the macOS `terminal-notifier` app bundles and is embedded
+ * only into macOS binaries; the others are platform-independent.
+ */
+const ASSET_DIRECTORIES = ["personas", "skills", "workflows"] as const;
+const DARWIN_ONLY_ASSET_DIRECTORIES = ["vendor"] as const;
+
+/**
+ * Release targets, mapped from Bun's target triple to the asset name the
+ * install script looks for. Windows is deliberately absent: Jazz's scheduler
+ * and notification paths have never been exercised there, and the install
+ * script is POSIX-only.
+ */
+const COMPILE_TARGETS: Readonly<Partial<Record<Bun.Build.CompileTarget, string>>> = {
+  "bun-darwin-arm64": "jazz-darwin-arm64",
+  "bun-darwin-x64": "jazz-darwin-x64",
+  "bun-linux-arm64": "jazz-linux-arm64",
+  "bun-linux-x64": "jazz-linux-x64",
+  "bun-linux-arm64-musl": "jazz-linux-arm64-musl",
+  "bun-linux-x64-musl": "jazz-linux-x64-musl",
+};
+
+const GENERATED_ASSETS_MODULE = ".build/embedded-assets.generated.ts";
+
+function isKnownCompileTarget(target: string): target is Bun.Build.CompileTarget {
+  return Object.hasOwn(COMPILE_TARGETS, target);
+}
+
+/**
+ * The module a standalone build swaps in for `src/core/assets/embedded-assets`,
+ * plus the packages that must be stubbed for the bundle to link at all.
+ *
+ * `react-devtools-core` is an uninstalled optional peer of ink, reachable only
+ * from `ink/build/devtools.js`, which ink itself imports behind a `DEV=true`
+ * check. Marking it external is not enough: the bundler hoists an external
+ * dependency of a dynamically imported module to the top of the bundle, so the
+ * binary fails on startup resolving a package it would never have used. The
+ * same applies to `@x402/core/http`, the pay-per-request branch of `linkup-sdk`
+ * that an API-key client never takes. Stubbing both keeps the dead branches
+ * dead instead of fatal.
+ */
+function createStandalonePlugins(generatedAssetsModule: string): import("bun").BunPlugin[] {
+  return [
+    {
+      name: "jazz-standalone-assets",
+      setup(build) {
+        build.onResolve({ filter: /^@\/core\/assets\/embedded-assets$/ }, () => ({
+          path: path.resolve(generatedAssetsModule),
+        }));
+      },
+    },
+    {
+      name: "jazz-stub-optional-imports",
+      setup(build) {
+        const stubbed = new RegExp(`^(${["react-devtools-core", "@x402/core/http"].join("|")})$`);
+        build.onResolve({ filter: stubbed }, (args) => ({
+          path: args.path,
+          namespace: "jazz-stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "jazz-stub" }, () => ({
+          contents: "export default {};",
+          loader: "js",
+        }));
+      },
+    },
+  ];
+}
+
+/**
+ * Writes the embedded-asset manifest for one target platform.
+ *
+ * Each asset becomes a `{ type: "file" }` import, which Bun copies into the
+ * binary and resolves at runtime to a path inside the virtual filesystem.
+ *
+ * @param targetPlatform - Platform the binary is built for.
+ * @returns Path to the generated module.
+ */
+function generateEmbeddedAssetsModule(targetPlatform: string): string {
+  const directories = [
+    ...ASSET_DIRECTORIES,
+    ...(targetPlatform === "darwin" ? DARWIN_ONLY_ASSET_DIRECTORIES : []),
+  ];
+
+  const assets: { relativePath: string; executable: boolean }[] = [];
+  for (const directory of directories) {
+    for (const entry of new Bun.Glob("**/*").scanSync({ cwd: directory, onlyFiles: true })) {
+      const relativePath = `${directory}/${entry.split(path.sep).join("/")}`;
+      const mode = fs.statSync(relativePath).mode;
+      assets.push({ relativePath, executable: (mode & 0o111) !== 0 });
+    }
+  }
+
+  assets.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+
+  if (assets.length === 0) {
+    throw new Error(
+      `No assets found in ${directories.join(", ")} — run the build from the repository root.`,
+    );
+  }
+
+  const imports = assets.map(
+    (asset, index) => `import asset${index} from "../${asset.relativePath}" with { type: "file" };`,
+  );
+  const entries = assets.map(
+    (asset, index) =>
+      `  { relativePath: ${JSON.stringify(asset.relativePath)}, sourcePath: asset${index}, executable: ${asset.executable} },`,
+  );
+
+  // The interface is repeated rather than imported: this module replaces
+  // src/core/assets/embedded-assets, so importing from there would resolve
+  // straight back to this file.
+  const contents = [
+    "// Generated by scripts/build.ts. Do not edit.",
+    "export interface EmbeddedAssetFile {",
+    "  readonly relativePath: string;",
+    "  readonly sourcePath: string;",
+    "  readonly executable: boolean;",
+    "}",
+    "",
+    ...imports,
+    "",
+    "export const EMBEDDED_ASSET_FILES: readonly EmbeddedAssetFile[] = [",
+    ...entries,
+    "];",
+    "",
+  ].join("\n");
+
+  fs.mkdirSync(path.dirname(GENERATED_ASSETS_MODULE), { recursive: true });
+  fs.writeFileSync(GENERATED_ASSETS_MODULE, contents);
+  return GENERATED_ASSETS_MODULE;
+}
+
+/**
+ * Compiles one self-contained binary, assets and all.
+ *
+ * @param compileTarget - A Bun target triple from {@link COMPILE_TARGETS}.
+ * @returns Path to the compiled binary.
+ */
+async function buildStandaloneBinary(compileTarget: string): Promise<string> {
+  if (!isKnownCompileTarget(compileTarget)) {
+    throw new Error(
+      `Unknown target "${compileTarget}". Known targets: ${Object.keys(COMPILE_TARGETS).join(", ")}`,
+    );
+  }
+
+  const outputName = COMPILE_TARGETS[compileTarget] as string;
+
+  const targetPlatform = compileTarget.split("-")[1] ?? "";
+  const generatedAssets = generateEmbeddedAssetsModule(targetPlatform);
+  const outfile = path.join("binaries", outputName);
+
+  // Matches the reasoning in buildNpmBundle: the bundler picks the JSX runtime
+  // from NODE_ENV at build time, and the dev runtime is unusable at runtime.
+  process.env["NODE_ENV"] = "production";
+
+  const result = await Bun.build({
+    entrypoints: ["src/entry.ts"],
+    target: "bun",
+    minify: true,
+    plugins: createStandalonePlugins(generatedAssets),
+    compile: { target: compileTarget, outfile },
+  });
+
+  if (!result.success) {
+    for (const message of result.logs) process.stderr.write(`${message.message}\n`);
+    throw new Error(`Compile failed for ${compileTarget}`);
+  }
+
+  const sizeInMegabytes = (fs.statSync(outfile).size / 1024 / 1024).toFixed(1);
+  process.stdout.write(`  ${outputName}  ${sizeInMegabytes} MB\n`);
+  return outfile;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (!args.includes("--compile")) {
+    buildNpmBundle();
+    return;
+  }
+
+  const explicitTargets = args
+    .flatMap((arg, index) => (arg === "--target" ? [args[index + 1]] : []))
+    .filter((target): target is string => target !== undefined);
+
+  const targets = args.includes("--all-targets")
+    ? Object.keys(COMPILE_TARGETS)
+    : explicitTargets.length > 0
+      ? explicitTargets
+      : [`bun-${process.platform}-${process.arch}`];
+
+  fs.mkdirSync("binaries", { recursive: true });
+  for (const target of targets) {
+    await buildStandaloneBinary(target);
+  }
+}
+
+await main();

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Jazz installer.
+#
+#   curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash
+#
+# Environment variables:
+#   JAZZ_INSTALL_DIR   Directory to install into (default: $HOME/.local/bin)
+#   JAZZ_VERSION       Version to install, e.g. v0.13.12 (default: latest)
+
+set -euo pipefail
+
+REPO="lvndry/jazz"
+INSTALL_DIR="${JAZZ_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${JAZZ_VERSION:-latest}"
+
+# Global so the EXIT trap can still see it once main() has returned and its
+# locals are gone.
+tmp=""
+trap 'rm -rf "$tmp"' EXIT
+
+RED=$'\033[31m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+BOLD=$'\033[1m'
+RESET=$'\033[0m'
+
+info() { printf '%s\n' "$1"; }
+success() { printf '%s%s%s\n' "$GREEN" "$1" "$RESET"; }
+warn() { printf '%s%s%s\n' "$YELLOW" "$1" "$RESET"; }
+fail() {
+  printf '%s%s%s\n' "$RED" "$1" "$RESET" >&2
+  exit 1
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fail "This installer needs '$1', which is not on your PATH."
+}
+
+# Picks the release asset for this machine.
+#
+# Bun's glibc binaries do not run on musl systems, so Alpine and friends get
+# their own asset; the loader in /lib is what distinguishes them.
+detect_asset() {
+  local os arch libc=""
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$arch" in
+    x86_64 | amd64) arch="x64" ;;
+    arm64 | aarch64) arch="arm64" ;;
+    *) fail "Unsupported architecture: $arch. Install from npm instead: npm install -g jazz-ai" ;;
+  esac
+
+  case "$os" in
+    Darwin) os="darwin" ;;
+    Linux)
+      os="linux"
+      if [ -f /lib/ld-musl-x86_64.so.1 ] || [ -f /lib/ld-musl-aarch64.so.1 ] || [ -f /etc/alpine-release ]; then
+        libc="-musl"
+      fi
+      ;;
+    *) fail "Unsupported operating system: $os. Install from npm instead: npm install -g jazz-ai" ;;
+  esac
+
+  printf 'jazz-%s-%s%s' "$os" "$arch" "$libc"
+}
+
+# Verifies a downloaded file against the release SHA256SUMS.
+#
+# An installer that pipes a remote file straight into a directory on PATH has to
+# check what it got, and a missing checksum is treated as failure rather than
+# skipped: a release without one is a broken release, not an unverifiable file.
+verify_checksum() {
+  local file="$1" name="$2" sums="$3" expected actual
+
+  expected="$(awk -v target="$name" '$2 == target || $2 == "*" target { print $1 }' "$sums" | head -n 1)"
+  [ -n "$expected" ] || fail "Release has no checksum for $name — refusing to install."
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  else
+    fail "This installer needs 'sha256sum' or 'shasum' to verify the download."
+  fi
+
+  [ "$expected" = "$actual" ] || fail "Checksum mismatch for $name — refusing to install."
+}
+
+main() {
+  require curl
+  require gzip
+  require uname
+
+  local asset base
+  asset="$(detect_asset)"
+
+  if [ "$VERSION" = "latest" ]; then
+    base="https://github.com/$REPO/releases/latest/download"
+  else
+    base="https://github.com/$REPO/releases/download/$VERSION"
+  fi
+
+  tmp="$(mktemp -d)"
+
+  info "Downloading ${BOLD}${asset}${RESET} (${VERSION})..."
+  curl -fsSL --retry 3 -o "$tmp/$asset.gz" "$base/$asset.gz" ||
+    fail "Could not download $base/$asset.gz"
+  curl -fsSL --retry 3 -o "$tmp/SHA256SUMS" "$base/SHA256SUMS" ||
+    fail "Could not download $base/SHA256SUMS"
+
+  verify_checksum "$tmp/$asset.gz" "$asset.gz" "$tmp/SHA256SUMS"
+
+  gzip -dc "$tmp/$asset.gz" >"$tmp/jazz" || fail "Could not decompress $asset.gz"
+  chmod 755 "$tmp/jazz"
+
+  mkdir -p "$INSTALL_DIR" || fail "Could not create $INSTALL_DIR"
+  # Move into place rather than writing over the target: rename is atomic, and
+  # it is the only way to replace a binary that is currently running.
+  mv -f "$tmp/jazz" "$INSTALL_DIR/jazz" ||
+    fail "Could not write to $INSTALL_DIR. Choose another directory with JAZZ_INSTALL_DIR."
+
+  success "Jazz installed to $INSTALL_DIR/jazz"
+
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+      warn "$INSTALL_DIR is not on your PATH. Add it with:"
+      info "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc   # or ~/.bashrc"
+      ;;
+  esac
+
+  info ""
+  info "Run ${BOLD}jazz${RESET} to get started."
+}
+
+main "$@"

--- a/src/cli/commands/update-binary.test.ts
+++ b/src/cli/commands/update-binary.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { findExpectedChecksum, resolveReleaseAssetName } from "./update-binary";
+
+describe("binary update", () => {
+  const originalPlatform = process.platform;
+  const originalArch = process.arch;
+
+  function pretendPlatform(platform: string, arch: string): void {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    Object.defineProperty(process, "arch", { value: arch, configurable: true });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+  });
+
+  describe("resolveReleaseAssetName", () => {
+    it("names the macOS assets", () => {
+      pretendPlatform("darwin", "arm64");
+      expect(resolveReleaseAssetName()).toBe("jazz-darwin-arm64");
+
+      pretendPlatform("darwin", "x64");
+      expect(resolveReleaseAssetName()).toBe("jazz-darwin-x64");
+    });
+
+    it("names the Linux assets", () => {
+      pretendPlatform("linux", "x64");
+      expect(resolveReleaseAssetName()).toMatch(/^jazz-linux-x64(-musl)?$/);
+
+      pretendPlatform("linux", "arm64");
+      expect(resolveReleaseAssetName()).toMatch(/^jazz-linux-arm64(-musl)?$/);
+    });
+
+    it("returns null on platforms Jazz publishes no binary for", () => {
+      pretendPlatform("win32", "x64");
+      expect(resolveReleaseAssetName()).toBeNull();
+
+      pretendPlatform("linux", "ppc64");
+      expect(resolveReleaseAssetName()).toBeNull();
+    });
+  });
+
+  describe("findExpectedChecksum", () => {
+    const checksums = [
+      "aaa1111111111111111111111111111111111111111111111111111111111111  jazz-darwin-arm64.gz",
+      "bbb2222222222222222222222222222222222222222222222222222222222222 *jazz-linux-x64.gz",
+      "",
+    ].join("\n");
+
+    it("finds a digest by asset name", () => {
+      expect(findExpectedChecksum(checksums, "jazz-darwin-arm64.gz")).toBe(
+        "aaa1111111111111111111111111111111111111111111111111111111111111",
+      );
+    });
+
+    it("matches names written in sha256sum's binary-mode form", () => {
+      expect(findExpectedChecksum(checksums, "jazz-linux-x64.gz")).toBe(
+        "bbb2222222222222222222222222222222222222222222222222222222222222",
+      );
+    });
+
+    it("returns null for an asset the release does not list", () => {
+      expect(findExpectedChecksum(checksums, "jazz-linux-arm64-musl.gz")).toBeNull();
+    });
+  });
+});

--- a/src/cli/commands/update-binary.ts
+++ b/src/cli/commands/update-binary.ts
@@ -1,0 +1,205 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import { Effect } from "effect";
+import { type TerminalService } from "@/core/interfaces/terminal";
+import { UpdateInstallError } from "@/core/types/errors";
+
+/**
+ * In-place updates for standalone binary installations.
+ *
+ * A binary install has no package manager behind it, so `jazz update` cannot
+ * shell out to one. Instead it does what the install script does — pick the
+ * asset matching this machine, verify it against the release checksums, and put
+ * it on disk — with the wrinkle that the file being replaced is the running
+ * program.
+ */
+
+const RELEASE_DOWNLOAD_BASE = "https://github.com/lvndry/jazz/releases/download";
+const CHECKSUM_FILE = "SHA256SUMS";
+
+/**
+ * Detects whether this Linux system uses musl rather than glibc.
+ *
+ * Bun's glibc binaries do not run on musl distributions such as Alpine, so the
+ * two need separate release assets and the loader on disk is what tells them
+ * apart.
+ */
+function isMuslLinux(): boolean {
+  return (
+    fs.existsSync("/lib/ld-musl-x86_64.so.1") ||
+    fs.existsSync("/lib/ld-musl-aarch64.so.1") ||
+    fs.existsSync("/etc/alpine-release")
+  );
+}
+
+/**
+ * Returns the release asset name matching the running platform.
+ *
+ * @returns The asset name, or `null` on a platform Jazz publishes no binary for.
+ */
+export function resolveReleaseAssetName(): string | null {
+  const architecture = process.arch === "arm64" ? "arm64" : process.arch === "x64" ? "x64" : null;
+  if (!architecture) {
+    return null;
+  }
+
+  if (process.platform === "darwin") {
+    return `jazz-darwin-${architecture}`;
+  }
+
+  if (process.platform === "linux") {
+    return `jazz-linux-${architecture}${isMuslLinux() ? "-musl" : ""}`;
+  }
+
+  return null;
+}
+
+function fetchRelease(
+  url: string,
+  description: string,
+): Effect.Effect<ArrayBuffer, UpdateInstallError> {
+  return Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(url, { redirect: "follow" }),
+      catch: (cause: unknown) =>
+        new UpdateInstallError({ message: `Failed to download ${description}`, cause }),
+    });
+
+    if (!response.ok) {
+      return yield* Effect.fail(
+        new UpdateInstallError({
+          message: `Downloading ${description} returned status ${response.status}`,
+        }),
+      );
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => response.arrayBuffer(),
+      catch: (cause: unknown) =>
+        new UpdateInstallError({ message: `Failed to read ${description}`, cause }),
+    });
+  });
+}
+
+/**
+ * Looks up an asset's expected digest in a `sha256sum`-format checksum file.
+ *
+ * `sha256sum` marks files it read in binary mode with a `*` before the name,
+ * so the marker is stripped before matching.
+ */
+export function findExpectedChecksum(checksumFile: string, assetName: string): string | null {
+  for (const line of checksumFile.split("\n")) {
+    const [digest, name] = line.trim().split(/\s+/);
+    if (digest && name && name.replace(/^\*/, "") === assetName) {
+      return digest;
+    }
+  }
+  return null;
+}
+
+/**
+ * Replaces the running binary with `replacement`.
+ *
+ * The new binary is written beside the old one and moved over it, because a
+ * rename within a directory is atomic and — unlike writing in place — is
+ * allowed while the old binary is executing: the running process keeps its open
+ * inode and the next launch gets the new file.
+ */
+function replaceRunningBinary(
+  executablePath: string,
+  replacement: Uint8Array,
+): Effect.Effect<void, UpdateInstallError> {
+  return Effect.try({
+    try: () => {
+      const stagingPath = path.join(
+        path.dirname(executablePath),
+        `.${path.basename(executablePath)}.update-${process.pid}`,
+      );
+      try {
+        fs.writeFileSync(stagingPath, replacement, { mode: 0o755 });
+        fs.renameSync(stagingPath, executablePath);
+      } catch (cause) {
+        fs.rmSync(stagingPath, { force: true });
+        throw cause;
+      }
+    },
+    catch: (cause: unknown) =>
+      new UpdateInstallError({
+        message:
+          `Could not replace ${executablePath}.\n` +
+          `Jazz needs write access to that directory. Re-run the installer, or\n` +
+          `install somewhere you own:\n` +
+          `  JAZZ_INSTALL_DIR="$HOME/.local/bin" \\\n` +
+          `    curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash`,
+        cause,
+      }),
+  });
+}
+
+/**
+ * Downloads the release binary for `version` and installs it over this one.
+ *
+ * @param version - Version to install, without a leading `v`.
+ * @param terminal - Terminal used to report progress.
+ */
+export function installBinaryUpdate(
+  version: string,
+  terminal: TerminalService,
+): Effect.Effect<void, UpdateInstallError> {
+  return Effect.gen(function* () {
+    const assetName = resolveReleaseAssetName();
+    if (!assetName) {
+      return yield* Effect.fail(
+        new UpdateInstallError({
+          message:
+            `Jazz does not publish a binary for ${process.platform}/${process.arch}.\n` +
+            `Install from npm instead: npm install -g jazz-ai@latest`,
+        }),
+      );
+    }
+
+    const releaseBase = `${RELEASE_DOWNLOAD_BASE}/v${version}`;
+    yield* terminal.log(`\n📦 Downloading ${assetName} ${version}...`);
+
+    const [archive, checksums] = yield* Effect.all(
+      [
+        fetchRelease(`${releaseBase}/${assetName}.gz`, assetName),
+        fetchRelease(`${releaseBase}/${CHECKSUM_FILE}`, CHECKSUM_FILE),
+      ],
+      { concurrency: 2 },
+    );
+
+    const archiveBytes = new Uint8Array(archive);
+    const expected = findExpectedChecksum(new TextDecoder().decode(checksums), `${assetName}.gz`);
+
+    if (!expected) {
+      return yield* Effect.fail(
+        new UpdateInstallError({
+          message: `Release ${version} has no checksum for ${assetName}.gz — refusing to install.`,
+        }),
+      );
+    }
+
+    const actual = createHash("sha256").update(archiveBytes).digest("hex");
+    if (actual !== expected) {
+      return yield* Effect.fail(
+        new UpdateInstallError({
+          message:
+            `Checksum mismatch for ${assetName}.gz — refusing to install.\n` +
+            `  expected ${expected}\n  actual   ${actual}`,
+        }),
+      );
+    }
+
+    const binary = yield* Effect.try({
+      try: () => gunzipSync(archiveBytes),
+      catch: (cause: unknown) =>
+        new UpdateInstallError({ message: `Failed to decompress ${assetName}.gz`, cause }),
+    });
+
+    yield* terminal.log(`📦 Installing to ${process.execPath}...`);
+    yield* replaceRunningBinary(process.execPath, binary);
+  });
+}

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -3,7 +3,12 @@ import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import { UpdateCheckError, UpdateInstallError } from "@/core/types/errors";
-import { detectPackageManagerFromPath, findExecutablePathViaShell } from "@/core/utils/runtime";
+import {
+  detectPackageManagerFromPath,
+  findExecutablePathViaShell,
+  isStandaloneBinary,
+} from "@/core/utils/runtime";
+import { installBinaryUpdate } from "./update-binary";
 import packageJson from "../../../package.json";
 
 /**
@@ -303,13 +308,21 @@ function detectPackageManager(): Effect.Effect<PackageManagerInfo, UpdateInstall
 }
 
 /**
- * Install the latest version using the detected package manager
+ * Install the latest version.
+ *
+ * Binary installations replace themselves from the GitHub release; package
+ * installations hand the job to whichever package manager put Jazz there.
  */
 function installUpdate(
   packageName: string,
+  latestVersion: string,
   terminal: TerminalService,
 ): Effect.Effect<void, UpdateInstallError> {
   return Effect.gen(function* () {
+    if (isStandaloneBinary()) {
+      return yield* installBinaryUpdate(latestVersion, terminal);
+    }
+
     const { spawn } = yield* Effect.promise(() => import("child_process"));
 
     // Detect which package manager to use
@@ -434,16 +447,18 @@ export function updateCommand(options?: {
     yield* terminal.log("");
 
     // Install the update
-    yield* installUpdate(packageJson.name, terminal).pipe(
+    yield* installUpdate(packageJson.name, versionInfo.latestVersion, terminal).pipe(
       Effect.catchAll((installError: UpdateInstallError) => {
         return Effect.gen(function* () {
           yield* logger.error("Failed to install update", { error: installError.message });
           yield* terminal.error("Failed to install update:");
           yield* terminal.log(`   ${installError.message}`);
-          yield* terminal.log("\n💡 You can manually update by running:");
-          yield* terminal.log(`   npm install -g ${packageJson.name}@latest`);
-          yield* terminal.log(`   bun add -g ${packageJson.name}@latest`);
-          yield* terminal.log(`   pnpm add -g ${packageJson.name}@latest`);
+          if (!isStandaloneBinary()) {
+            yield* terminal.log("\n💡 You can manually update by running:");
+            yield* terminal.log(`   npm install -g ${packageJson.name}@latest`);
+            yield* terminal.log(`   bun add -g ${packageJson.name}@latest`);
+            yield* terminal.log(`   pnpm add -g ${packageJson.name}@latest`);
+          }
         });
       }),
     );

--- a/src/core/assets/asset-extraction.test.ts
+++ b/src/core/assets/asset-extraction.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  extractAssetsInto,
+  extractEmbeddedAssets,
+  hasEmbeddedAssets,
+  pruneStaleAssetDirectories,
+} from "./asset-extraction";
+import { type EmbeddedAssetFile } from "./embedded-assets";
+
+describe("embedded asset extraction", () => {
+  const temporaryRoots: string[] = [];
+
+  function makeTemporaryDirectory(): string {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-assets-"));
+    temporaryRoots.push(directory);
+    return directory;
+  }
+
+  function makeAssets(sourceRoot: string): EmbeddedAssetFile[] {
+    fs.mkdirSync(path.join(sourceRoot, "skills", "journal"), { recursive: true });
+    fs.writeFileSync(path.join(sourceRoot, "skills", "journal", "SKILL.md"), "# journal");
+    fs.writeFileSync(path.join(sourceRoot, "notifier"), "#!/bin/sh\n");
+
+    return [
+      {
+        relativePath: "skills/journal/SKILL.md",
+        sourcePath: path.join(sourceRoot, "skills", "journal", "SKILL.md"),
+        executable: false,
+      },
+      {
+        relativePath: "vendor/terminal-notifier/notifier",
+        sourcePath: path.join(sourceRoot, "notifier"),
+        executable: true,
+      },
+    ];
+  }
+
+  afterEach(() => {
+    while (temporaryRoots.length > 0) {
+      fs.rmSync(temporaryRoots.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no embedded assets outside a standalone binary", () => {
+    expect(hasEmbeddedAssets()).toBe(false);
+    expect(extractEmbeddedAssets(path.join(makeTemporaryDirectory(), "0.0.0"))).toBeNull();
+  });
+
+  it("unpacks assets into their relative paths", () => {
+    const sourceRoot = makeTemporaryDirectory();
+    const destination = path.join(makeTemporaryDirectory(), "0.1.0");
+
+    expect(extractAssetsInto(makeAssets(sourceRoot), destination)).toBe(destination);
+    expect(fs.readFileSync(path.join(destination, "skills/journal/SKILL.md"), "utf-8")).toBe(
+      "# journal",
+    );
+  });
+
+  it("gives executable assets the executable bit", () => {
+    const sourceRoot = makeTemporaryDirectory();
+    const destination = path.join(makeTemporaryDirectory(), "0.1.0");
+
+    extractAssetsInto(makeAssets(sourceRoot), destination);
+
+    const notifier = fs.statSync(path.join(destination, "vendor/terminal-notifier/notifier"));
+    const document = fs.statSync(path.join(destination, "skills/journal/SKILL.md"));
+    expect(notifier.mode & 0o111).not.toBe(0);
+    expect(document.mode & 0o111).toBe(0);
+  });
+
+  it("leaves no staging directory behind", () => {
+    const sourceRoot = makeTemporaryDirectory();
+    const parent = makeTemporaryDirectory();
+
+    extractAssetsInto(makeAssets(sourceRoot), path.join(parent, "0.1.0"));
+
+    expect(fs.readdirSync(parent)).toEqual(["0.1.0"]);
+  });
+
+  it("skips extraction when the version directory already exists", () => {
+    const sourceRoot = makeTemporaryDirectory();
+    const destination = path.join(makeTemporaryDirectory(), "0.1.0");
+    const assets = makeAssets(sourceRoot);
+
+    extractAssetsInto(assets, destination);
+    const extractedFile = path.join(destination, "skills/journal/SKILL.md");
+    fs.writeFileSync(extractedFile, "edited");
+
+    expect(extractAssetsInto(assets, destination)).toBe(destination);
+    expect(fs.readFileSync(extractedFile, "utf-8")).toBe("edited");
+  });
+
+  it("returns null when an asset cannot be read", () => {
+    const destination = path.join(makeTemporaryDirectory(), "0.1.0");
+
+    const result = extractAssetsInto(
+      [{ relativePath: "skills/gone.md", sourcePath: "/nonexistent/gone.md", executable: false }],
+      destination,
+    );
+
+    expect(result).toBeNull();
+    expect(fs.existsSync(destination)).toBe(false);
+  });
+
+  it("prunes asset directories from other versions", () => {
+    const runtimeRoot = makeTemporaryDirectory();
+    fs.mkdirSync(path.join(runtimeRoot, "0.1.0"));
+    fs.mkdirSync(path.join(runtimeRoot, "0.2.0", "skills"), { recursive: true });
+
+    pruneStaleAssetDirectories(runtimeRoot, "0.2.0");
+
+    expect(fs.readdirSync(runtimeRoot)).toEqual(["0.2.0"]);
+  });
+
+  it("ignores a missing runtime directory when pruning", () => {
+    expect(() =>
+      pruneStaleAssetDirectories(path.join(makeTemporaryDirectory(), "absent"), "0.2.0"),
+    ).not.toThrow();
+  });
+});

--- a/src/core/assets/asset-extraction.ts
+++ b/src/core/assets/asset-extraction.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import path from "node:path";
+// Imported through the path alias, not relatively: the standalone build swaps
+// this module out by matching the alias in scripts/build.ts.
+import { EMBEDDED_ASSET_FILES, type EmbeddedAssetFile } from "@/core/assets/embedded-assets";
+
+/**
+ * Unpacks the assets embedded in a standalone binary onto the real filesystem.
+ *
+ * Embedded files are readable in place, but only one at a time and only by the
+ * exact path the bundler assigned them — there is no directory to list and no
+ * package root to resolve against. Every built-in persona, skill, and workflow
+ * loader expects a directory it can walk, and the bundled `terminal-notifier`
+ * has to be a real executable on disk before it can be spawned. So the binary
+ * unpacks its assets once per version and hands the loaders that directory.
+ */
+
+/**
+ * Reports whether the running build carries embedded assets.
+ *
+ * True only in a standalone binary; the npm package and development mode read
+ * the checked-in directories instead.
+ */
+export function hasEmbeddedAssets(): boolean {
+  return EMBEDDED_ASSET_FILES.length > 0;
+}
+
+/**
+ * Unpacks this build's embedded assets into `destinationRoot`, once.
+ *
+ * @param destinationRoot - Directory to unpack into.
+ * @returns The unpacked directory, or `null` when there is nothing to unpack or
+ *   extraction failed.
+ */
+export function extractEmbeddedAssets(destinationRoot: string): string | null {
+  if (!hasEmbeddedAssets()) {
+    return null;
+  }
+
+  return extractAssetsInto(EMBEDDED_ASSET_FILES, destinationRoot);
+}
+
+/**
+ * Unpacks `assets` into `destinationRoot`, once.
+ *
+ * Extraction goes to a sibling temporary directory and is moved into place with
+ * a single rename, so `destinationRoot` never exists in a half-written state
+ * and concurrent Jazz processes cannot read a partial copy. The directory is
+ * versioned by the caller, which is what makes "already exists" a safe skip.
+ *
+ * @param assets - Files to unpack.
+ * @param destinationRoot - Directory to unpack into.
+ * @returns The unpacked directory, or `null` when extraction failed.
+ */
+export function extractAssetsInto(
+  assets: readonly EmbeddedAssetFile[],
+  destinationRoot: string,
+): string | null {
+  if (fs.existsSync(destinationRoot)) {
+    return destinationRoot;
+  }
+
+  const stagingRoot = `${destinationRoot}.partial-${process.pid}`;
+
+  try {
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+    fs.mkdirSync(stagingRoot, { recursive: true });
+
+    for (const asset of assets) {
+      const stagedPath = path.join(stagingRoot, asset.relativePath);
+      fs.mkdirSync(path.dirname(stagedPath), { recursive: true });
+      // Read-then-write rather than copyFileSync: the embedded source lives in
+      // Bun's virtual filesystem, which serves reads but fails copyfile(2) with
+      // ENOENT.
+      fs.writeFileSync(stagedPath, fs.readFileSync(asset.sourcePath), {
+        mode: asset.executable ? 0o755 : 0o644,
+      });
+    }
+
+    fs.mkdirSync(path.dirname(destinationRoot), { recursive: true });
+    fs.renameSync(stagingRoot, destinationRoot);
+    return destinationRoot;
+  } catch {
+    // A concurrent Jazz process extracting the same version wins the rename,
+    // which leaves the assets in place and this process with nothing to do.
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+    return fs.existsSync(destinationRoot) ? destinationRoot : null;
+  }
+}
+
+/**
+ * Deletes unpacked asset directories left behind by other versions.
+ *
+ * A self-updating binary replaces itself in place, so without this every
+ * upgrade would leave its predecessor's assets on disk forever.
+ *
+ * @param runtimeRoot - Directory holding the per-version asset directories.
+ * @param currentVersionDirectory - Name of the directory to keep.
+ */
+export function pruneStaleAssetDirectories(
+  runtimeRoot: string,
+  currentVersionDirectory: string,
+): void {
+  try {
+    for (const entry of fs.readdirSync(runtimeRoot)) {
+      if (entry !== currentVersionDirectory) {
+        fs.rmSync(path.join(runtimeRoot, entry), { recursive: true, force: true });
+      }
+    }
+  } catch {
+    // Pruning is housekeeping; a failure here must not stop Jazz from starting.
+  }
+}

--- a/src/core/assets/embedded-assets.ts
+++ b/src/core/assets/embedded-assets.ts
@@ -1,0 +1,24 @@
+/**
+ * Manifest of the asset files embedded in a standalone binary.
+ *
+ * Jazz ships `personas/`, `skills/`, and `workflows/` as real directories, and
+ * every loader that reads them walks the filesystem. That works for the npm
+ * package, where `getPackageRootDirectory()` finds the package by walking up
+ * from `dist/main.js`. A standalone binary has no package directory at all, so
+ * `scripts/build.ts` generates a replacement for this module that imports each
+ * asset with `{ type: "file" }`, and points the bundler at the generated file.
+ *
+ * This checked-in version is the one the npm build and development mode use,
+ * and it is deliberately empty: both already have the real directories on disk.
+ */
+
+export interface EmbeddedAssetFile {
+  /** Path relative to the package root, e.g. `skills/journal/SKILL.md`. */
+  readonly relativePath: string;
+  /** Path the embedded copy is readable from at runtime. */
+  readonly sourcePath: string;
+  /** Whether the extracted copy needs the executable bit. */
+  readonly executable: boolean;
+}
+
+export const EMBEDDED_ASSET_FILES: readonly EmbeddedAssetFile[] = [];

--- a/src/core/utils/paths.ts
+++ b/src/core/utils/paths.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  extractEmbeddedAssets,
+  hasEmbeddedAssets,
+  pruneStaleAssetDirectories,
+} from "@/core/assets/asset-extraction";
+import packageJson from "../../../package.json";
 
 /**
  * Resolves Jazz's user, project, and package directories.
@@ -75,12 +81,44 @@ export function getMemoryDirectory(): string {
   return path.join(getJazzHomeDirectory(), "memory");
 }
 
+let embeddedAssetRoot: string | null | undefined;
+
+/**
+ * Returns the directory a standalone binary unpacks its built-in assets into.
+ *
+ * Resolved once per process: the unpack itself is a no-op after the first run,
+ * but `getPackageRootDirectory` is called often enough that the existence check
+ * is worth skipping.
+ *
+ * @returns The unpacked directory, or `null` outside a standalone binary.
+ */
+function getEmbeddedAssetRoot(): string | null {
+  if (embeddedAssetRoot !== undefined) {
+    return embeddedAssetRoot;
+  }
+
+  if (!hasEmbeddedAssets()) {
+    embeddedAssetRoot = null;
+    return embeddedAssetRoot;
+  }
+
+  const runtimeRoot = path.join(getJazzHomeDirectory(), "runtime");
+  embeddedAssetRoot = extractEmbeddedAssets(path.join(runtimeRoot, packageJson.version));
+  pruneStaleAssetDirectories(runtimeRoot, packageJson.version);
+  return embeddedAssetRoot;
+}
+
 /**
  * Finds the `jazz-ai` package root containing `package.json`.
  *
  * @returns The package root directory, or `null` when it cannot be found.
  */
 export function getPackageRootDirectory(): string | null {
+  const unpackedAssets = getEmbeddedAssetRoot();
+  if (unpackedAssets) {
+    return unpackedAssets;
+  }
+
   try {
     let currentDir = path.resolve(import.meta.dirname);
     const root = path.parse(currentDir).root;

--- a/src/core/utils/runtime.ts
+++ b/src/core/utils/runtime.ts
@@ -21,6 +21,18 @@ export function isOfflineMode(): boolean {
 }
 
 /**
+ * Checks whether Jazz is running as a standalone binary.
+ *
+ * The compiled binary serves its own modules out of a virtual filesystem
+ * rooted at `/$bunfs` (`B:\~BUN` on Windows), which is the one thing that
+ * distinguishes it from every install that has real files on disk.
+ */
+export function isStandaloneBinary(): boolean {
+  const moduleDirectory = import.meta.dirname ?? "";
+  return moduleDirectory.startsWith("/$bunfs") || moduleDirectory.startsWith("B:\\~BUN");
+}
+
+/**
  * Checks whether Jazz is running from a global package-manager installation.
  *
  * Jazz source directories are treated as development mode. Otherwise known
@@ -28,6 +40,10 @@ export function isOfflineMode(): boolean {
  * `node_modules` paths are treated as global installations.
  */
 export function isRunningFromGlobalInstall(): boolean {
+  if (isStandaloneBinary()) {
+    return true;
+  }
+
   const pathsToCheck = [
     process.argv[1] ? path.resolve(process.argv[1]) : null,
     import.meta.dirname,
@@ -153,6 +169,13 @@ export function detectPackageManagerFromPath(
  */
 export function getJazzSchedulerInvocation(): Effect.Effect<readonly string[], never> {
   return Effect.gen(function* () {
+    // A standalone binary is the whole installation, so it is its own most
+    // reliable invocation — and the only one a machine without a package
+    // manager can run.
+    if (isStandaloneBinary()) {
+      return [process.execPath];
+    }
+
     const fromShell = yield* findExecutablePathViaShell();
     if (fromShell) {
       return [fromShell];


### PR DESCRIPTION
## What & why

Jazz can now be installed with one command and no runtime:

```bash
curl -fsSL https://github.com/lvndry/jazz/releases/latest/download/install.sh | bash
```

Until now the only way in was `npm install -g jazz-ai`, which means anyone without Node — or
without a Node they want Jazz living in — had to set one up first. Each release now also ships
self-contained macOS and Linux binaries with checksums. The npm package is unchanged and stays
the route for Windows, and `jazz update` upgrades either kind of install in place.

The one new idea worth naming: a binary has no package directory, so the built-in personas,
skills, workflows, and `terminal-notifier` are embedded at build time and unpacked to
`~/.jazz/runtime/<version>/` on first run. Every existing loader keeps reading real directories,
so nothing downstream had to change.

## How to verify

- `bun run build:binary`, then run `binaries/jazz-darwin-arm64 persona list` with a fresh
  `JAZZ_HOME` — the built-in personas must appear, which is the check that embedded assets
  actually unpacked.
- `bun run build && node dist/main.js --version` — the npm bundle must be unaffected.
- Corrupt a byte in a downloaded `.gz` and re-run `install.sh` — it must refuse to install on
  checksum mismatch rather than writing a broken binary onto your `PATH`.
- Run `install.sh` with `JAZZ_INSTALL_DIR` pointing at a directory you cannot write — it should
  fail with a clear message and leave no temp directory behind.
- After the first release lands: `jazz update` on a binary install should replace the running
  binary and report the new version on next launch.

## Note before merging

`install.sh` is served from `releases/latest/download/`, so the README command only works once a
release built by this workflow exists. The first release after merge is what makes the docs true.
