### PR TITLE
feat(subagents): bound sub-agent nesting depth

### DIFF
--- a/docs/internals/subagents.md
+++ b/docs/internals/subagents.md
@@ -86,6 +86,42 @@ available. Withheld tools are logged at `info`.
 Because the ceiling lives in the runner rather than at the call site, it holds for any future
 caller of a nested run, not just `spawn_subagent`.
 
+---
+
+## Nesting depth
+
+A child gets a **fresh** iteration budget, not its parent's remainder — a sub-agent spawned on
+the parent's last iteration would be useless with one round to work in, and the point of
+delegation is a clean context with room to use it.
+
+That is deliberate, and it means the parent's remaining budget bounds nothing. Depth does. Each
+run carries how many levels sit above it, and `spawn_subagent` refuses once the limit is
+reached:
+
+```
+Sub-agent nesting limit reached (depth 3 of 3). Do this task yourself instead of delegating it further.
+```
+
+It refuses rather than silently running the child at the wrong depth: a parent told its
+delegation was declined can do the work itself, whereas one handed a child that quietly ignored
+the limit cannot tell. Refusal is a normal tool error the parent can act on in its next
+iteration, and no sub-agent panel opens.
+
+The limit is `maxSubagentDepth` in `~/.jazz/config.json` (or `./.jazz/config.json`), defaulting
+to **3** — enough for orchestrator → specialist → helper:
+
+```json
+{
+  "maxSubagentDepth": 3
+}
+```
+
+Set it to `0` to stop agents delegating at all. The runner resolves the value once per run, so
+every level of a tree obeys the same number.
+
+Breadth is bounded separately: `MAX_CONCURRENT_TOOLS` (10) caps how many tool calls — sub-agents
+included — run at once within a single iteration.
+
 Because the parent can issue several tool calls in one iteration, sub-agents run in parallel
 up to the concurrency cap — each with its own panel in the TUI.
 
@@ -133,8 +169,8 @@ usual symptom is a confidently wrong answer to a question the child misunderstoo
 | Limit | Value | Why |
 | --- | --- | --- |
 | Timeout | 30 min | A delegated task that hasn't finished in half an hour isn't going to |
-| Iterations | inherits the parent's budget | A child can't outlive the run that spawned it |
-| Nesting | children can delegate further | Bounded in practice by the parent's iteration budget |
+| Iterations | a **fresh copy** of the parent's budget | A child spawned on the parent's last iteration would be useless with only the remainder |
+| Nesting | 3 levels, via `maxSubagentDepth` | Depth is what bounds total spend, since each level gets a fresh budget |
 | Toolset | at most the parent's | A child must never be an escalation path |
 | Panel height | 12 lines | UI only |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,6 +38,23 @@ See [MCP Servers](../integrations/index.md#mcp-servers) for format details.
 }
 ```
 
+### `maxSubagentDepth`
+
+How many levels of sub-agent may nest below a top-level run. Defaults to **3**.
+
+```json
+{
+  "maxSubagentDepth": 3
+}
+```
+
+Each level of delegation gets a *fresh* iteration budget rather than its parent's remainder — a
+child spawned on the parent's last iteration would be useless otherwise — so this depth, not the
+parent's remaining budget, is what bounds how much a nest of sub-agents can spend. Past the
+limit `spawn_subagent` returns an error telling the agent to do the work itself; it never
+silently runs the child anyway. Set `0` to stop agents delegating at all. See
+[Sub-agents](../internals/subagents.md#nesting-depth).
+
 ## Project Overrides: `./.jazz/config.json`
 
 Use for project-specific settings such as MCP enable/disable flags or logging level. Do not put agent storage paths here — agents always load from `~/.jazz`.

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -1,5 +1,5 @@
 import { Effect, Option } from "effect";
-import { DEFAULT_MAX_LLM_RETRIES } from "@/core/constants/agent";
+import { DEFAULT_MAX_LLM_RETRIES, DEFAULT_MAX_SUBAGENT_DEPTH } from "@/core/constants/agent";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
@@ -256,6 +256,11 @@ function initializeAgentRun(
       autoApprovedCommands,
       autoApprovedTools,
       parentToolNames: expandedToolNames,
+      subagentDepth: options.subagentDepth ?? 0,
+      maxSubagentDepth: Math.max(
+        0,
+        Math.floor(appConfig.maxSubagentDepth ?? DEFAULT_MAX_SUBAGENT_DEPTH),
+      ),
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       onAutoApproveCommand:
         options.onAutoApproveCommand ??

--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -171,6 +171,113 @@ describe("spawn_subagent tool ceiling", () => {
   });
 });
 
+describe("spawn_subagent nesting depth", () => {
+  function captureSpawn(): {
+    readonly captured: () => Omit<AgentRunnerOptions, "internal"> | undefined;
+    readonly spy: ReturnType<typeof spyOn>;
+  } {
+    let seen: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      seen = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+    return { captured: () => seen, spy };
+  }
+
+  it("starts a top-level run's child at depth 1", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation);
+
+      expect(captured()?.subagentDepth).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("increments the depth for each further level", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation, { subagentDepth: 2, maxSubagentDepth: 3 });
+
+      expect(captured()?.subagentDepth).toBe(3);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("refuses to spawn once the depth limit is reached", async () => {
+    const { spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const result = (await runSpawn(presentation, {
+        subagentDepth: 3,
+        maxSubagentDepth: 3,
+      })) as { success: boolean; error?: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("nesting limit");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("honours a configured limit other than the default", async () => {
+    const { spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const result = (await runSpawn(presentation, {
+        subagentDepth: 1,
+        maxSubagentDepth: 1,
+      })) as { success: boolean };
+
+      expect(result.success).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("lets a configured limit of 0 stop delegation outright", async () => {
+    const { spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const result = (await runSpawn(presentation, { maxSubagentDepth: 0 })) as {
+        success: boolean;
+      };
+
+      expect(result.success).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("opens no panel when the spawn is refused", async () => {
+    const { spy } = captureSpawn();
+
+    try {
+      const { presentation, calls } = createPresentationHarness();
+      await runSpawn(presentation, { subagentDepth: 3, maxSubagentDepth: 3 });
+
+      expect(calls.opens).toHaveLength(0);
+      expect(calls.collapses).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("spawn_subagent presentation", () => {
   it("does not import the TUI from core", async () => {
     const source = await Bun.file(new URL("./subagent-tools.ts", import.meta.url)).text();

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
-import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
+import { DEFAULT_MAX_ITERATIONS, DEFAULT_MAX_SUBAGENT_DEPTH } from "@/core/constants/agent";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { Tool, ToolRequirements } from "@/core/interfaces/tool-registry";
@@ -87,6 +87,28 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
             };
           }
 
+          // Every level gets a fresh iteration budget rather than its parent's
+          // remainder, so nothing else bounds how much a nest of sub-agents can
+          // spend. Refuse rather than silently flatten: a parent told its
+          // delegation was declined can do the work itself, whereas one handed a
+          // child that quietly ran at the wrong depth cannot tell.
+          const currentDepth = context.subagentDepth ?? 0;
+          const maxDepth = context.maxSubagentDepth ?? DEFAULT_MAX_SUBAGENT_DEPTH;
+          if (currentDepth >= maxDepth) {
+            yield* logger.info("Sub-agent spawn refused at depth limit", {
+              parentAgentId: parentAgent.id,
+              currentDepth,
+              maxDepth,
+            });
+            return {
+              success: false,
+              result: null,
+              error:
+                `Sub-agent nesting limit reached (depth ${currentDepth} of ${maxDepth}). ` +
+                `Do this task yourself instead of delegating it further.`,
+            };
+          }
+
           yield* logger.info("Spawning sub-agent", {
             task: args.task.substring(0, 200),
             persona: args.persona,
@@ -157,6 +179,7 @@ ${args.task}`;
             // built-in categories — without this ceiling a narrowly-scoped
             // parent could reach a tool it lacks by picking a broader persona.
             ...(context.parentToolNames ? { toolAllowlist: context.parentToolNames } : {}),
+            subagentDepth: currentDepth + 1,
             ...(context.getAutoApprovePolicy
               ? { autoApprovePolicy: context.getAutoApprovePolicy }
               : {}),

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -104,6 +104,11 @@ export interface AgentRunnerOptions {
    */
   readonly toolAllowlist?: readonly string[];
   /**
+   * How many sub-agent levels sit above this run. Omitted (0) for a top-level
+   * run; `spawn_subagent` passes its own depth plus one when starting a child.
+   */
+  readonly subagentDepth?: number;
+  /**
    * Callback invoked when the user chooses "always approve" for a specific tool
    * from the approval prompt.
    */

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -4,6 +4,17 @@ export const DEFAULT_MAX_ITERATIONS = 80;
 /** Maximum number of tools that can execute concurrently */
 export const MAX_CONCURRENT_TOOLS = 10;
 
+/**
+ * How many levels of sub-agent may nest below a top-level run, when
+ * `maxSubagentDepth` is not set in app config.
+ *
+ * Each level gets a fresh iteration budget rather than its parent's remainder —
+ * a child spawned on the parent's last iteration still needs a full budget to be
+ * useful — so depth, not the parent's remaining budget, is what bounds total
+ * spend. Three levels covers orchestrator → specialist → helper.
+ */
+export const DEFAULT_MAX_SUBAGENT_DEPTH = 3;
+
 /** Tool execution timeout in milliseconds (3 minutes) */
 export const TOOL_TIMEOUT_MS = 3 * 60 * 1000;
 

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -19,6 +19,11 @@ export interface AppConfig {
   readonly telemetry?: TelemetryConfig;
   /** Maximum number of retries for transient LLM API failures. Defaults to 3. */
   readonly maxRetries?: number;
+  /**
+   * How many levels of sub-agent may nest below a top-level run. Defaults to 3.
+   * Set 0 to stop agents delegating at all.
+   */
+  readonly maxSubagentDepth?: number;
 }
 
 export interface NotificationsConfig {

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -200,6 +200,20 @@ export interface ToolExecutionContext {
    */
   readonly parentToolNames?: readonly string[];
   /**
+   * How many sub-agent levels deep the run executing this tool already sits.
+   * 0 for a top-level run, 1 for its children, and so on. `spawn_subagent`
+   * increments it for the child and refuses past `maxSubagentDepth`, which is
+   * the only thing bounding total delegated spend: every level gets a fresh
+   * iteration budget rather than its parent's remainder.
+   */
+  readonly subagentDepth?: number;
+  /**
+   * Nesting limit in force for this run, resolved from `maxSubagentDepth` in
+   * app config. Resolved by the runner rather than read in the tool so the
+   * whole tree obeys one value.
+   */
+  readonly maxSubagentDepth?: number;
+  /**
    * Callback to replace conversation messages with compacted versions.
    * Used by summarize_context to actually update the executor's message array.
    */

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -343,4 +343,40 @@ describe("createConfigLayer", () => {
     expect(result.maxRetries).toBe(8);
     expect(result.telemetryEnabled).toBe(false);
   });
+
+  it("preserves maxSubagentDepth from a custom config file", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-subagent-depth-config.json");
+
+    const fileContents = new Map<string, string>([
+      [customConfigPath, JSON.stringify({ maxSubagentDepth: 1 })],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      return yield* config.get<number>("maxSubagentDepth");
+    }).pipe(Effect.provide(layer));
+
+    expect(await Effect.runPromise(program)).toBe(1);
+  });
+
+  it("leaves maxSubagentDepth unset when the config file omits it", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-subagent-depth-default.json");
+
+    const fileContents = new Map<string, string>([
+      [customConfigPath, JSON.stringify({ maxRetries: 3 })],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      return yield* config.get<number>("maxSubagentDepth");
+    }).pipe(Effect.provide(layer));
+
+    expect(await Effect.runPromise(program)).toBeUndefined();
+  });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -427,6 +427,9 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
       autoApprovedCommands: override.autoApprovedCommands,
     }),
     ...(override.maxRetries !== undefined && { maxRetries: override.maxRetries }),
+    ...(override.maxSubagentDepth !== undefined && {
+      maxSubagentDepth: override.maxSubagentDepth,
+    }),
     ...(override.telemetry && { telemetry: { ...(base.telemetry ?? {}), ...override.telemetry } }),
   };
 }


### PR DESCRIPTION
Stacked on #336 — review that one first. This PR's own diff is the second commit.

## The problem

A sub-agent gets a **fresh** iteration budget, not its parent's remainder. That's deliberate and correct: `DEFAULT_MAX_ITERATIONS` is 80, and a child spawned on the parent's 79th iteration would be useless with one round to work in. The point of delegation is a clean context with room to use it.

But it means the parent's remaining budget bounds nothing — and nesting was unlimited. Children can delegate further, with no depth counter anywhere, so a tree could run 80 iterations per level at any depth, fanning out up to `MAX_CONCURRENT_TOOLS` (10) at each one. Nothing but the 30-minute per-child timeout stood in the way.

[subagents.md](docs/internals/subagents.md) claimed otherwise on both counts — *"inherits the parent's budget / a child can't outlive the run that spawned it"* and *"nesting … bounded in practice by the parent's iteration budget"*. Neither was true. This PR makes the second one true and corrects the first.

## What changes

Each run carries how many sub-agent levels sit above it. `spawn_subagent` increments it for the child and refuses past the limit:

```
Sub-agent nesting limit reached (depth 3 of 3). Do this task yourself instead of delegating it further.
```

It refuses rather than silently running the child at the wrong depth. A parent told its delegation was declined can do the work itself; one handed a child that quietly ignored the limit cannot tell. It's a normal tool error the parent can act on next iteration, and no sub-agent panel opens.

## Configuring it

`maxSubagentDepth` in `~/.jazz/config.json` or `./.jazz/config.json`, defaulting to **3** — enough for orchestrator → specialist → helper:

```json
{
  "maxSubagentDepth": 3
}
```

`0` stops agents delegating at all. It follows `maxRetries` exactly: a top-level scalar on `AppConfig`, merged in `mergeConfig`, floored at 0. The runner resolves it once per run and puts it on the tool context, so every level of a tree obeys one value rather than each child re-reading config.

## How to verify

1. Ask an agent to delegate something that will itself delegate, three levels down.
   Expected: the fourth spawn is refused with the message above, and the third-level agent does the work itself.
2. Set `"maxSubagentDepth": 0` and ask any agent to delegate.
   Expected: refused immediately, no panel opens.
3. Leave it unset.
   Expected: 3 levels, as before for any realistic tree.

## Tests

`bun test`: 1778 pass / 0 fail across 118 files. Typecheck and lint clean.

Eight new tests:
- `subagent-tools.test.ts` — a top-level run's child starts at depth 1; depth increments per level; spawning is refused at the limit, at a custom limit, and at `0`; a refused spawn opens no panel.
- `config.test.ts` — `maxSubagentDepth` survives a custom config file, and stays unset when omitted.