### PR TITLE
chore(config): remove the unused google client id/secret

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -166,7 +166,7 @@ GitHub account, a separate mailbox) so a mistake cannot reach your primary ident
 
 Jazz resolves every secret in this order, and uses the first hit:
 
-1. **Environment variable** — `OPENAI_API_KEY`, `BRAVE_API_KEY`, `GOOGLE_CLIENT_SECRET`, and so
+1. **Environment variable** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BRAVE_API_KEY`, and so
    on. Nothing touches disk. Best for containers and CI.
 2. **OS keyring** — macOS Keychain, or libsecret (`secret-tool`) on Linux. Used automatically
    when available. Keys already sitting in `~/.jazz/config.json` are moved here on next start.

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -8,7 +8,6 @@ import type { OutputConfig } from "./output";
 export interface AppConfig {
   readonly storage: StorageConfig;
   readonly logging: LoggingConfig;
-  readonly google?: GoogleConfig;
   readonly llm?: LLMConfig;
   readonly web_search?: WebSearchConfig;
   readonly output?: OutputConfig;
@@ -61,11 +60,6 @@ export type StorageConfig =
 export interface LoggingConfig {
   readonly level: "debug" | "info" | "warn" | "error";
   readonly format: "json" | "plain";
-}
-
-export interface GoogleConfig {
-  readonly clientId: string;
-  readonly clientSecret: string;
 }
 
 export interface LLMProviderConfig {

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -44,7 +44,6 @@ describe("AgentConfigService", () => {
   const initialConfig: AppConfig = {
     storage: { type: "file", path: "/tmp" },
     logging: { level: "info", format: "plain" },
-    google: { clientId: "", clientSecret: "" },
     llm: {},
     web_search: { provider: "parallel" },
   };
@@ -137,6 +136,48 @@ describe("createConfigLayer", () => {
       makeDirectory: mock(() => Effect.void),
     } as unknown as FileSystem;
   }
+
+  it("removes the legacy google client block from the config file", async () => {
+    const globalPath = path.join(os.homedir(), ".jazz", "config.json");
+    const fileContents = new Map<string, string>([
+      [
+        globalPath,
+        JSON.stringify({
+          logging: { level: "info" },
+          google: { clientId: "dead-id", clientSecret: "dead-secret" },
+        }),
+      ],
+    ]);
+    const testFS = createTestFileSystem(fileContents);
+
+    const layer = createConfigLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, testFS)),
+    );
+    await Effect.runPromise(Effect.provide(AgentConfigServiceTag, layer));
+
+    const calls = (testFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const written = calls[calls.length - 1]?.[1] as string;
+    expect(written).not.toContain("dead-secret");
+    expect(JSON.parse(written).google).toBeUndefined();
+    expect(JSON.parse(written).logging).toEqual({ level: "info" });
+  });
+
+  it("leaves a repurposed google block alone", async () => {
+    const globalPath = path.join(os.homedir(), ".jazz", "config.json");
+    const fileContents = new Map<string, string>([
+      [globalPath, JSON.stringify({ google: { somethingElse: "keep-me" } })],
+    ]);
+    const testFS = createTestFileSystem(fileContents);
+
+    const layer = createConfigLayer().pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, testFS)),
+    );
+    await Effect.runPromise(Effect.provide(AgentConfigServiceTag, layer));
+
+    const calls = (testFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBe(0);
+  });
 
   it("resolves secrets from the environment over the config file", async () => {
     const globalPath = path.join(os.homedir(), ".jazz", "config.json");

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -5,7 +5,6 @@ import type { MCPServerConfig } from "@/core/interfaces/mcp-server";
 import { ConfigurationError, ConfigurationNotFoundError } from "@/core/types/errors";
 import type {
   AppConfig,
-  GoogleConfig,
   LLMConfig,
   LoggingConfig,
   MCPServerOverride,
@@ -373,15 +372,10 @@ function defaultConfig(): AppConfig {
     format: "plain",
   };
 
-  const google: GoogleConfig = {
-    clientId: "",
-    clientSecret: "",
-  };
-
   const llm: LLMConfig = {};
   const web_search: WebSearchConfig = {};
 
-  return { storage, logging, google, llm, web_search };
+  return { storage, logging, llm, web_search };
 }
 
 function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig {
@@ -412,7 +406,6 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
         }),
       },
     }),
-    ...(override.google && { google: { ...base.google, ...override.google } }),
     ...(override.llm && { llm: { ...(base.llm ?? {}), ...override.llm } }),
     ...(override.web_search && {
       web_search: { ...(base.web_search ?? {}), ...override.web_search },
@@ -476,10 +469,6 @@ function collectSecretPaths(config: Partial<AppConfig>): string[] {
       if (typeof (providerConfig as Record<string, unknown>)["api_key"] !== "string") continue;
       paths.push(`${section}.${provider}.api_key`);
     }
-  }
-
-  for (const path of ["google.clientId", "google.clientSecret"]) {
-    if (typeof deepGet(record, path) === "string") paths.push(path);
   }
 
   return paths;
@@ -552,18 +541,51 @@ function resolveSecrets(
       if (nonEmptyString(fileValue)) fileSecrets.set(path, fileValue);
     }
 
-    if (migrated.length > 0 && globalConfigPath) {
+    const droppedLegacy = dropLegacyGoogleBlock(fileRecord);
+
+    if ((migrated.length > 0 || droppedLegacy) && globalConfigPath) {
       const cleaned = structuredClone(fileRecord);
       for (const path of migrated) {
         deepDelete(cleaned, path);
       }
+      if (droppedLegacy) delete cleaned["google"];
       yield* writePrivateFile(fs, globalConfigPath, JSON.stringify(cleaned, null, 2));
+      if (droppedLegacy) noticeLegacyGoogleRemoved(globalConfigPath);
     } else if (globalConfigPath) {
       yield* chmodQuietly(fs, globalConfigPath, CONFIG_FILE_MODE);
     }
 
     return { config: resolved as unknown as AppConfig, origins, fileSecrets };
   });
+}
+
+/**
+ * Detect the legacy top-level `google` block — an OAuth client id/secret pair
+ * that was scaffolded into the config shape but never read by anything.
+ *
+ * It is matched by shape rather than merely by key, so a `google` block that
+ * someone repurposed for something else is left alone.
+ */
+function dropLegacyGoogleBlock(fileRecord: Record<string, unknown>): boolean {
+  const block = fileRecord["google"];
+  if (!block || typeof block !== "object") return false;
+
+  const keys = Object.keys(block);
+  if (keys.length === 0) return true;
+  return keys.every((key) => key === "clientId" || key === "clientSecret");
+}
+
+/**
+ * Tell the user once, on the run that removes it. The credential is not moved
+ * anywhere — nothing ever read it — so silently deleting it would be the wrong
+ * kind of quiet.
+ */
+function noticeLegacyGoogleRemoved(configPath: string): void {
+  process.stderr.write(
+    `jazz: removed the unused "google" client id/secret block from ${configPath}.\n` +
+      `      Nothing in Jazz ever read it. If you still need those values, recover them\n` +
+      `      from your version control or backups before they age out.\n`,
+  );
 }
 
 /**

--- a/src/services/secrets/registry.test.ts
+++ b/src/services/secrets/registry.test.ts
@@ -5,8 +5,6 @@ describe("secret registry", () => {
   it("treats known LLM, web search, and Google secret paths as secrets", () => {
     expect(isSecretPath("llm.openai.api_key")).toBe(true);
     expect(isSecretPath("web_search.brave.api_key")).toBe(true);
-    expect(isSecretPath("google.clientSecret")).toBe(true);
-    expect(isSecretPath("google.clientId")).toBe(true);
   });
 
   it("treats unknown providers as secrets so new keys are never left in plaintext", () => {
@@ -25,7 +23,6 @@ describe("secret registry", () => {
     expect(envVarForSecretPath("llm.anthropic.api_key")).toBe("ANTHROPIC_API_KEY");
     expect(envVarForSecretPath("llm.google.api_key")).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
     expect(envVarForSecretPath("web_search.exa.api_key")).toBe("EXA_API_KEY");
-    expect(envVarForSecretPath("google.clientSecret")).toBe("GOOGLE_CLIENT_SECRET");
     expect(envVarForSecretPath("logging.level")).toBeUndefined();
   });
 

--- a/src/services/secrets/registry.ts
+++ b/src/services/secrets/registry.ts
@@ -44,13 +44,8 @@ const WEB_SEARCH_PROVIDER_ENV_VARS: Record<string, string> = {
   tavily: "TAVILY_API_KEY",
 };
 
-const STANDALONE_SECRET_ENV_VARS: Record<string, string> = {
-  "google.clientId": "GOOGLE_CLIENT_ID",
-  "google.clientSecret": "GOOGLE_CLIENT_SECRET",
-};
-
 function buildSecretEnvVars(): Record<string, string> {
-  const paths: Record<string, string> = { ...STANDALONE_SECRET_ENV_VARS };
+  const paths: Record<string, string> = {};
   for (const [provider, envVar] of Object.entries(LLM_PROVIDER_ENV_VARS)) {
     paths[`llm.${provider}.api_key`] = envVar;
   }


### PR DESCRIPTION
## What changes

`AppConfig` has carried a top-level `google` block — `clientId` and `clientSecret` — since `1a5a49f` scaffolded it from a `crush.config.json` shape. It survived the #68 refactor and **nothing has ever read it**: grepping the whole repo for `clientId`/`clientSecret` turns up only the type declaration and its own default, and there is no dynamic `config.get("google.…")` access either.

It is not harmless dead weight. Anyone who filled it in has a real OAuth client secret sitting in `~/.jazz/config.json`.

This removes the type, the default, the merge branch, and the secret-registry entries (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, added in #338).

## The part that needed care

Deleting the field alone would have been quietly destructive. Persistence serialises the in-memory config shape, so the first time a user changed *any* setting, their stored `google` block would disappear from disk with no trace and no message.

Rather than leave that to chance, the block is dropped explicitly on load and the user is told once:

```
jazz: removed the unused "google" client id/secret block from ~/.jazz/config.json.
      Nothing in Jazz ever read it. If you still need those values, recover them
      from your version control or backups before they age out.
```

The match is on **shape, not just the key name** — a `google` block containing anything other than `clientId`/`clientSecret` is left completely alone, on the assumption someone repurposed it. There's a test for that case.

## Not affected

`llm.google` — the Gemini provider API key — is a different thing entirely and is untouched. So is `GOOGLE_GENERATIVE_AI_API_KEY`.

## Verification

- `bun test` — 1794 pass, 0 fail (two new tests: the block is removed; a repurposed block is not)
- `bun run typecheck`, `bun run lint` — clean
