### PR TITLE
feat(agent): make iteration budgets configurable, with a separate sub-agent knob

### DIFF
--- a/docs/internals/subagents.md
+++ b/docs/internals/subagents.md
@@ -90,13 +90,14 @@ caller of a nested run, not just `spawn_subagent`.
 
 ## Nesting depth
 
-A child gets a **fresh** iteration budget, not its parent's remainder — a sub-agent spawned on
-the parent's last iteration would be useless with one round to work in, and the point of
-delegation is a clean context with room to use it.
+A child gets its **own** iteration budget — `maxSubagentIterations`, default 30 — not its
+parent's remainder. A sub-agent spawned on the parent's last iteration would be useless with one
+round to work in, and the point of delegation is a clean context with room to use it. It is set
+well below a top-level run's 100 because a sub-agent answers one scoped task; a child still
+working after 30 iterations has usually misunderstood the brief rather than found more to do.
 
-That is deliberate, and it means the parent's remaining budget bounds nothing. Depth does. Each
-run carries how many levels sit above it, and `spawn_subagent` refuses once the limit is
-reached:
+That means the parent's remaining budget bounds nothing. Depth does. Each run carries how many
+levels sit above it, and `spawn_subagent` refuses once the limit is reached:
 
 ```
 Sub-agent nesting limit reached (depth 3 of 3). Do this task yourself instead of delegating it further.
@@ -169,7 +170,7 @@ usual symptom is a confidently wrong answer to a question the child misunderstoo
 | Limit | Value | Why |
 | --- | --- | --- |
 | Timeout | 30 min | A delegated task that hasn't finished in half an hour isn't going to |
-| Iterations | a **fresh copy** of the parent's budget | A child spawned on the parent's last iteration would be useless with only the remainder |
+| Iterations | 30, via `maxSubagentIterations` | Its own budget, not the parent's remainder — and far below a top-level run's 100 |
 | Nesting | 3 levels, via `maxSubagentDepth` | Depth is what bounds total spend, since each level gets a fresh budget |
 | Toolset | at most the parent's | A child must never be an escalation path |
 | Panel height | 12 lines | UI only |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,6 +38,32 @@ See [MCP Servers](../integrations/index.md#mcp-servers) for format details.
 }
 ```
 
+### `maxIterations` and `maxSubagentIterations`
+
+Iteration budgets — how many reasoning loops a run gets before it stops and asks whether to
+continue.
+
+```json
+{
+  "maxIterations": 100,
+  "maxSubagentIterations": 30
+}
+```
+
+| Key | Default | Applies to |
+| --- | --- | --- |
+| `maxIterations` | 100 | A top-level run |
+| `maxSubagentIterations` | 30 | Each sub-agent run |
+
+They are **separate knobs on purpose.** A sub-agent gets its own budget rather than the parent's
+remainder — a child spawned on the parent's last iteration would be useless with one round — so
+without a lower default, every level of delegation would be as expensive as the run that spawned
+it. A sub-agent answers one scoped task; a child still working after 30 iterations has usually
+misunderstood the brief rather than found more to do.
+
+An explicit `--max-iterations` on the command line, or a workflow's own `maxIterations`, still
+wins over `maxIterations` here. Both values are floored at 1.
+
 ### `maxSubagentDepth`
 
 How many levels of sub-agent may nest below a top-level run. Defaults to **3**.

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -1,5 +1,10 @@
 import { Effect, Option } from "effect";
-import { DEFAULT_MAX_LLM_RETRIES, DEFAULT_MAX_SUBAGENT_DEPTH } from "@/core/constants/agent";
+import {
+  DEFAULT_MAX_ITERATIONS,
+  DEFAULT_MAX_LLM_RETRIES,
+  DEFAULT_MAX_SUBAGENT_DEPTH,
+  DEFAULT_MAX_SUBAGENT_ITERATIONS,
+} from "@/core/constants/agent";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
@@ -80,13 +85,21 @@ function initializeAgentRun(
       : null;
     const toolProfile = resolvedPersona?.toolProfile;
 
+    // An explicit budget from the call site (--max-iterations, a workflow's
+    // metadata, a sub-agent spawn) wins; app config sets the default for
+    // everything else.
+    const resolvedMaxIterations = Math.max(
+      1,
+      Math.floor(options.maxIterations ?? appConfig.maxIterations ?? DEFAULT_MAX_ITERATIONS),
+    );
+
     const runMetrics = createAgentRunMetrics({
       agent,
       conversationId: actualConversationId,
       provider,
       model,
       reasoningEffort: agent.config.reasoningEffort ?? "disable",
-      maxIterations: options.maxIterations,
+      maxIterations: resolvedMaxIterations,
     });
 
     // Level 1: List all available skills (metadata only)
@@ -261,6 +274,10 @@ function initializeAgentRun(
         0,
         Math.floor(appConfig.maxSubagentDepth ?? DEFAULT_MAX_SUBAGENT_DEPTH),
       ),
+      maxSubagentIterations: Math.max(
+        1,
+        Math.floor(appConfig.maxSubagentIterations ?? DEFAULT_MAX_SUBAGENT_ITERATIONS),
+      ),
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       onAutoApproveCommand:
         options.onAutoApproveCommand ??
@@ -291,6 +308,7 @@ function initializeAgentRun(
       model,
       connectedMCPServers,
       maxRetries: Math.max(0, Math.floor(appConfig.maxRetries ?? DEFAULT_MAX_LLM_RETRIES)),
+      maxIterations: resolvedMaxIterations,
       knownSkills: relevantSkills,
     };
   });

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { FileSystem } from "@effect/platform";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
+import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
 import { clearModelsDevCache } from "@/core/utils/models-dev";
 import {
   buildBudgetPressureMessage,
@@ -180,6 +181,7 @@ function makeRunContext(overrides?: Partial<AgentRunContext>): AgentRunContext {
     expandedToolNames: [],
     connectedMCPServers: [],
     knownSkills: [],
+    maxIterations: DEFAULT_MAX_ITERATIONS,
     ...overrides,
   };
 }

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -1,5 +1,4 @@
 import { Effect, Fiber, Option, Ref } from "effect";
-import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
 import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
@@ -274,7 +273,6 @@ function handleToolPhase(
     displayConfig,
     strategy,
     runMetrics,
-    maxIterations,
     options,
     logger,
   } = deps;
@@ -323,7 +321,6 @@ function handleToolPhase(
       },
       conversationMessages: state.currentMessages,
       parentAgent: agent,
-      parentMaxIterations: maxIterations,
       compactConversation: (compacted: readonly ChatMessage[]) => {
         state.currentMessages = [
           state.currentMessages[0],
@@ -667,10 +664,17 @@ export function executeAgentLoop(
     // Use: main loop
     ({ logger, finalizeFiberRef }) =>
       Effect.gen(function* () {
-        const { agent, maxIterations: maxIter } = options;
-        const maxIterations = maxIter ?? DEFAULT_MAX_ITERATIONS;
-        const { actualConversationId, context, tools, messages, runMetrics, provider, model } =
-          runContext;
+        const { agent } = options;
+        const {
+          actualConversationId,
+          context,
+          tools,
+          messages,
+          runMetrics,
+          provider,
+          model,
+          maxIterations,
+        } = runContext;
 
         // Fetch model's actual context window from models.dev
         const modelMetadata = yield* Effect.tryPromise({

--- a/src/core/agent/execution/batch-executor.test.ts
+++ b/src/core/agent/execution/batch-executor.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from "effect";
 import { OneShotPresentationService } from "@/core/presentation/oneshot-presentation-service";
 import { SkillServiceTag } from "@/core/skills/skill-service";
 import { executeWithoutStreaming } from "./batch-executor";
+import { DEFAULT_MAX_ITERATIONS } from "../../constants/agent";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
 import type { LLMService } from "../../interfaces/llm";
@@ -130,6 +131,7 @@ function makeRunContext(): AgentRunContext {
     connectedMCPServers: [],
     knownSkills: [],
     maxRetries: 0,
+    maxIterations: DEFAULT_MAX_ITERATIONS,
   };
 }
 

--- a/src/core/agent/execution/streaming-executor.test.ts
+++ b/src/core/agent/execution/streaming-executor.test.ts
@@ -5,6 +5,7 @@ import { Stream } from "effect";
 import { executeWithStreaming } from "./streaming-executor";
 import { ToolExecutor } from "./tool-executor";
 import { SkillServiceTag } from "../../../core/skills/skill-service";
+import { DEFAULT_MAX_ITERATIONS } from "../../constants/agent";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
 import type { LLMService } from "../../interfaces/llm";
@@ -138,6 +139,7 @@ describe("executeWithStreaming", () => {
       expandedToolNames: [],
       connectedMCPServers: [],
       knownSkills: [],
+      maxIterations: DEFAULT_MAX_ITERATIONS,
     };
 
     const displayConfig = {
@@ -337,6 +339,7 @@ describe("executeWithStreaming", () => {
       expandedToolNames: [],
       connectedMCPServers: [],
       knownSkills: [],
+      maxIterations: DEFAULT_MAX_ITERATIONS,
     };
 
     const displayConfig = {
@@ -445,6 +448,7 @@ describe("executeWithStreaming", () => {
       expandedToolNames: [],
       connectedMCPServers: [],
       knownSkills: [],
+      maxIterations: DEFAULT_MAX_ITERATIONS,
     };
 
     const mockLLMService: LLMService = {

--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { Effect, Layer } from "effect";
+import { DEFAULT_MAX_ITERATIONS, DEFAULT_MAX_SUBAGENT_ITERATIONS } from "@/core/constants/agent";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
@@ -272,6 +273,49 @@ describe("spawn_subagent nesting depth", () => {
 
       expect(calls.opens).toHaveLength(0);
       expect(calls.collapses).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("spawn_subagent iteration budget", () => {
+  function captureSpawn(): {
+    readonly captured: () => Omit<AgentRunnerOptions, "internal"> | undefined;
+    readonly spy: ReturnType<typeof spyOn>;
+  } {
+    let seen: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      seen = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+    return { captured: () => seen, spy };
+  }
+
+  it("gives the child the configured sub-agent budget", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation, { maxSubagentIterations: 12 });
+
+      expect(captured()?.maxIterations).toBe(12);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("falls back to the sub-agent default when config sets nothing", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation);
+
+      expect(captured()?.maxIterations).toBe(DEFAULT_MAX_SUBAGENT_ITERATIONS);
+      expect(DEFAULT_MAX_SUBAGENT_ITERATIONS).toBeLessThan(DEFAULT_MAX_ITERATIONS);
     } finally {
       spy.mockRestore();
     }

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -1,6 +1,9 @@
 import { Effect } from "effect";
 import { z } from "zod";
-import { DEFAULT_MAX_ITERATIONS, DEFAULT_MAX_SUBAGENT_DEPTH } from "@/core/constants/agent";
+import {
+  DEFAULT_MAX_SUBAGENT_DEPTH,
+  DEFAULT_MAX_SUBAGENT_ITERATIONS,
+} from "@/core/constants/agent";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { Tool, ToolRequirements } from "@/core/interfaces/tool-registry";
@@ -172,7 +175,7 @@ ${args.task}`;
             userInput: wrappedTask,
             sessionId: context.sessionId ?? context.conversationId ?? `session-${Date.now()}`,
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
-            maxIterations: context.parentMaxIterations ?? DEFAULT_MAX_ITERATIONS,
+            maxIterations: context.maxSubagentIterations ?? DEFAULT_MAX_SUBAGENT_ITERATIONS,
             ephemeralRegionId: regionId,
             // Cap the child at the parent's own effective tools. The child runs
             // under a caller-chosen persona, and a persona resolves its own

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -55,7 +55,8 @@ export interface AgentRunnerOptions {
   /**
    * Maximum number of iterations (agent reasoning loops) allowed for this run.
    * Each iteration may involve tool calls and LLM responses.
-   * If not specified, defaults to `DEFAULT_MAX_ITERATIONS` (80).
+   * If not specified, falls back to `maxIterations` in app config and then to
+   * `DEFAULT_MAX_ITERATIONS`.
    */
   readonly maxIterations?: number;
   /**
@@ -230,6 +231,12 @@ export interface AgentRunContext {
   readonly model: string;
   readonly connectedMCPServers: readonly string[];
   readonly maxRetries?: number;
+  /**
+   * The run's iteration budget, already resolved from the call site's request,
+   * app config, and the built-in default. Executors use this rather than
+   * re-deriving it from options.
+   */
+  readonly maxIterations: number;
   readonly knownSkills: readonly {
     readonly name: string;
     readonly description: string;

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -1,5 +1,20 @@
-/** Default maximum number of agent iteration steps per run */
-export const DEFAULT_MAX_ITERATIONS = 80;
+/**
+ * Default maximum number of agent iteration steps per top-level run, when
+ * neither `--max-iterations` nor `maxIterations` in app config is set.
+ */
+export const DEFAULT_MAX_ITERATIONS = 100;
+
+/**
+ * Default iteration budget for a sub-agent run, when `maxSubagentIterations`
+ * is not set in app config.
+ *
+ * Deliberately far below a top-level run's. A sub-agent is given one scoped
+ * task and answers in one shot; a child still working after 30 iterations has
+ * usually misunderstood the brief rather than found more to do. Keeping it
+ * separate also bounds a nest of sub-agents, since every level gets a fresh
+ * budget rather than its parent's remainder.
+ */
+export const DEFAULT_MAX_SUBAGENT_ITERATIONS = 30;
 
 /** Maximum number of tools that can execute concurrently */
 export const MAX_CONCURRENT_TOOLS = 10;

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -24,6 +24,16 @@ export interface AppConfig {
    * Set 0 to stop agents delegating at all.
    */
   readonly maxSubagentDepth?: number;
+  /**
+   * Iteration budget for a top-level run. Defaults to 100. An explicit
+   * `--max-iterations` on the command line still wins over this.
+   */
+  readonly maxIterations?: number;
+  /**
+   * Iteration budget for a sub-agent run. Defaults to 30 — a sub-agent answers
+   * one scoped task, so it needs far less headroom than the run that spawned it.
+   */
+  readonly maxSubagentIterations?: number;
 }
 
 export interface NotificationsConfig {

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -187,10 +187,13 @@ export interface ToolExecutionContext {
    */
   readonly parentAgent?: Agent;
   /**
-   * The iteration budget of the parent agent.
-   * Subagents inherit this so they run with the same cap as their parent.
+   * Iteration budget to give a sub-agent spawned from this run, resolved from
+   * `maxSubagentIterations` in app config. A sub-agent gets its own budget
+   * rather than the parent's remainder — a child spawned on the parent's last
+   * iteration would be useless with one round — so this is a separate knob,
+   * defaulting well below a top-level run's.
    */
-  readonly parentMaxIterations?: number;
+  readonly maxSubagentIterations?: number;
   /**
    * The parent's effective tool names for this run (after persona deny lists
    * and any inherited allowlist). `spawn_subagent` passes this down as the

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -362,6 +362,28 @@ describe("createConfigLayer", () => {
     expect(await Effect.runPromise(program)).toBe(1);
   });
 
+  it("preserves both iteration budgets from a custom config file", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-iterations-config.json");
+
+    const fileContents = new Map<string, string>([
+      [customConfigPath, JSON.stringify({ maxIterations: 150, maxSubagentIterations: 12 })],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      const maxIterations = yield* config.get<number>("maxIterations");
+      const maxSubagentIterations = yield* config.get<number>("maxSubagentIterations");
+      return { maxIterations, maxSubagentIterations };
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.maxIterations).toBe(150);
+    expect(result.maxSubagentIterations).toBe(12);
+  });
+
   it("leaves maxSubagentDepth unset when the config file omits it", async () => {
     const customConfigPath = path.join(os.tmpdir(), "jazz-subagent-depth-default.json");
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -430,6 +430,10 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.maxSubagentDepth !== undefined && {
       maxSubagentDepth: override.maxSubagentDepth,
     }),
+    ...(override.maxIterations !== undefined && { maxIterations: override.maxIterations }),
+    ...(override.maxSubagentIterations !== undefined && {
+      maxSubagentIterations: override.maxSubagentIterations,
+    }),
     ...(override.telemetry && { telemetry: { ...(base.telemetry ?? {}), ...override.telemetry } }),
   };
 }


### PR DESCRIPTION
Stacked on #341 (which is stacked on #336). This PR's own diff is the third commit.

## What changes

`DEFAULT_MAX_ITERATIONS` was a hardcoded 80 that only an explicit `--max-iterations` could move, and sub-agents silently inherited it — so a delegated one-shot task got the same headroom as the run that spawned it.

Two config keys now set these independently, in `~/.jazz/config.json` or `./.jazz/config.json`:

```json
{
  "maxIterations": 100,
  "maxSubagentIterations": 30
}
```

| Key | Default | Applies to | Was |
| --- | --- | --- | --- |
| `maxIterations` | **100** | A top-level run | 80, hardcoded |
| `maxSubagentIterations` | **30** | Each sub-agent run | inherited the parent's 80 |

## Why two knobs and not one

A sub-agent gets its **own** budget rather than the parent's remainder — that's the conclusion from #341, and it's right: a child spawned on the parent's last iteration would be useless with one round to work in.

But that means without a lower default, every level of delegation is as expensive as the top-level run. A sub-agent answers one scoped task and returns a summary; a child still working after 30 iterations has usually misunderstood the brief rather than found more to do. Together with the depth limit from #341, this is what actually bounds a nest of sub-agents.

## Precedence

`--max-iterations` (or a workflow's own `maxIterations`) → `maxIterations` in config → the built-in default. Unchanged for anyone passing the flag. Both values are floored at 1.

The runner resolves this once and puts it on the run context, so executors read one already-resolved number instead of re-deriving it from options. That also fixes run metrics, which recorded `options.maxIterations` — `undefined` on any run that didn't pass the flag — and now record the budget actually in force.

## Removal

`parentMaxIterations` is gone from `ToolExecutionContext`. Children no longer inherit the parent's budget, and nothing else read it — it would have been a field with no readers.

## How to verify

1. Run an agent with no config and no flag. Expected: 100 iterations; the limit message reads `iteration limit reached (100)`.
2. Set `"maxIterations": 20` and run again. Expected: 20.
3. Pass `--max-iterations 5` with that config still in place. Expected: 5 — the flag wins.
4. Have an agent delegate. Expected: the child runs on 30, independent of the parent's budget.
5. Set `"maxSubagentIterations": 5` and delegate. Expected: the child gets 5.

## Tests

`bun test`: 1781 pass / 0 fail across 118 files. Typecheck and lint clean.

- `subagent-tools.test.ts` — the child gets the configured sub-agent budget, and falls back to the default (asserting it stays below the top-level default).
- `config.test.ts` — both keys survive a custom config file.
- `agent-loop.test.ts`, `streaming-executor.test.ts`, `batch-executor.test.ts` — fixtures updated for the now-required `maxIterations` on `AgentRunContext`.

## Note for reviewers

`ai-sdk-service.ts` also uses `DEFAULT_MAX_ITERATIONS`, for `stopWhen: stepCountIs(...)`. That is the AI SDK's internal multi-step cap within a single LLM call — a different loop from Jazz's agent loop — so I left it reading the constant rather than the config key. It does inherit the bump from 80 to 100. Worth a second opinion on whether it should share the constant at all.