### PR TITLE
refactor(llm): rename the google provider to gemini

### DIFF
--- a/docs/integrations/providers.md
+++ b/docs/integrations/providers.md
@@ -66,7 +66,7 @@ You can set or update your API keys in config by running `jazz` -> `update confi
 
 **Supported Models:** [`src/core/constants/models.ts`](../../src/core/constants/models.ts#L28-L32)
 
-## Google Gemini
+## Gemini
 
 **Capabilities**: Gemini Pro and Flash models with multimodal support
 
@@ -78,12 +78,16 @@ You can set or update your API keys in config by running `jazz` -> `update confi
 ```json
 {
   "llm": {
-    "google": {
+    "gemini": {
       "api_key": "AIza..."
     }
   }
 }
 ```
+
+> Previously named `google`. Existing configs and agents are rewritten to
+> `gemini` automatically the first time Jazz reads them. The environment
+> variable keeps its upstream name, `GOOGLE_GENERATIVE_AI_API_KEY`.
 
 **Supported Models:** [`src/core/constants/models.ts`](../../src/core/constants/models.ts#L33-L42)
 

--- a/src/core/agent/context/token-counter.test.ts
+++ b/src/core/agent/context/token-counter.test.ts
@@ -21,8 +21,8 @@ describe("inferFamily", () => {
     [{ provider: "openai", modelId: "o3-mini" }, "openai-o200k"],
     [{ provider: "anthropic", modelId: "claude-opus-4-6" }, "anthropic"],
     [{ provider: "openrouter", modelId: "anthropic/claude-3.5-sonnet" }, "anthropic"],
-    [{ provider: "google", modelId: "gemini-2.5-pro" }, "google"],
-    [{ provider: "openrouter", modelId: "google/gemini-2.5-flash" }, "google"],
+    [{ provider: "gemini", modelId: "gemini-2.5-pro" }, "gemini"],
+    [{ provider: "openrouter", modelId: "google/gemini-2.5-flash" }, "gemini"],
     [{ provider: "mistral", modelId: "mistral-large-latest" }, "mistral"],
     [{ provider: "mistral", modelId: "ministral-8b-latest" }, "mistral"],
     [{ provider: "groq", modelId: "llama-3.1-70b" }, "llama"],
@@ -93,7 +93,7 @@ describe("TokenCounter — non-OpenAI families use ratio fallback", () => {
 
   it("Google uses ~4.0 chars/token by default", () => {
     const counter = new TokenCounter();
-    const hint: ModelHint = { provider: "google", modelId: "gemini-2.5-pro" };
+    const hint: ModelHint = { provider: "gemini", modelId: "gemini-2.5-pro" };
     const text = "a".repeat(80);
 
     expect(counter.countText(text, hint)).toBe(Math.ceil(80 / 4.0));
@@ -251,15 +251,15 @@ describe("TokenCounter — calibration converges to authoritative truth", () => 
     expect(counter.getRatio(hint)).toBe(before);
   });
 
-  it("calibration is per-model (anthropic ratio doesn't affect google)", () => {
+  it("calibration is per-model (anthropic ratio doesn't affect gemini)", () => {
     const counter = new TokenCounter();
     const anthropicHint: ModelHint = { provider: "anthropic", modelId: "claude-opus-4-6" };
-    const googleHint: ModelHint = { provider: "google", modelId: "gemini-2.5-pro" };
+    const geminiHint: ModelHint = { provider: "gemini", modelId: "gemini-2.5-pro" };
 
     counter.calibrate(175, [userMsg("a".repeat(700))], anthropicHint);
 
     expect(counter.getRatio(anthropicHint)).toBeCloseTo(4.0, 2);
-    expect(counter.getRatio(googleHint)).toBe(4.0); // google default unchanged
+    expect(counter.getRatio(geminiHint)).toBe(4.0); // gemini default unchanged
   });
 
   it("calibration invalidates the message cache so new ratio takes effect", () => {

--- a/src/core/agent/context/token-counter.ts
+++ b/src/core/agent/context/token-counter.ts
@@ -33,7 +33,7 @@ export type ModelFamily =
   | "openai-o200k" // gpt-4o, gpt-4.1, gpt-5.x
   | "openai-cl100k" // gpt-3.5, gpt-4, gpt-4-turbo
   | "anthropic"
-  | "google"
+  | "gemini"
   | "mistral"
   | "llama" // most open-weight models, served via Groq/Cerebras/Fireworks/Together
   | "qwen"
@@ -61,7 +61,7 @@ const FAMILY_DEFAULT_RATIO: Record<ModelFamily, number> = {
   "openai-o200k": 4.0,
   "openai-cl100k": 4.0,
   anthropic: 3.5,
-  google: 4.0,
+  gemini: 4.0,
   mistral: 3.8,
   llama: 3.6,
   qwen: 3.5,
@@ -110,7 +110,7 @@ export function inferFamily(hint: ModelHint): ModelFamily {
     return "openai-cl100k";
   }
   if (provider === "anthropic" || id.includes("claude")) return "anthropic";
-  if (provider === "google" || id.includes("gemini")) return "google";
+  if (provider === "gemini" || id.includes("gemini")) return "gemini";
   if (
     provider === "mistral" ||
     id.includes("mistral") ||

--- a/src/core/constants/models.ts
+++ b/src/core/constants/models.ts
@@ -2,7 +2,7 @@
  * Provider registry.
  *
  * Model lists are NOT hardcoded. Every provider resolves its models at runtime:
- * - Catalog-backed providers (openai, anthropic, google, ...) list models from
+ * - Catalog-backed providers (openai, anthropic, gemini, ...) list models from
  *   https://models.dev/api.json (fetched lazily, cached in memory for 1 hour).
  * - Dynamic providers (openrouter, groq, ollama, ...) list models from their own
  *   API endpoints, with models.dev used for best-effort metadata enrichment.
@@ -26,7 +26,7 @@ export const DEFAULT_CONTEXT_WINDOW = 128_000;
 export const AVAILABLE_PROVIDERS = [
   "openai",
   "anthropic",
-  "google",
+  "gemini",
   "openrouter",
   "xai",
   "ai_gateway",

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -100,7 +100,7 @@ export interface LLMConfig {
   readonly cerebras?: LLMProviderConfig;
   readonly deepseek?: LLMProviderConfig;
   readonly fireworks?: LLMProviderConfig;
-  readonly google?: LLMProviderConfig;
+  readonly gemini?: LLMProviderConfig;
   readonly groq?: LLMProviderConfig;
   readonly llamacpp?: LlamaCppProviderConfig;
   readonly minimax?: LLMProviderConfig;

--- a/src/core/utils/provider-migration.test.ts
+++ b/src/core/utils/provider-migration.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import {
+  migrateAgentProviderName,
+  migrateConfigProviderName,
+  migrateKeyringProviderName,
+} from "./provider-migration";
+
+describe("migrateAgentProviderName", () => {
+  it("renames the provider, the summarizer prefix, and the api key entry", () => {
+    const { record, changed } = migrateAgentProviderName({
+      id: "agent-1",
+      config: {
+        llmProvider: "google",
+        llmModel: "gemini-2.5-pro",
+        summarizerModel: "google/gemini-2.5-flash",
+        llmApiKeys: { google: "AIza-key", openai: "sk-key" },
+      },
+    });
+
+    expect(changed).toBe(true);
+    const config = (record as { config: Record<string, unknown> }).config;
+    expect(config["llmProvider"]).toBe("gemini");
+    expect(config["summarizerModel"]).toBe("gemini/gemini-2.5-flash");
+    expect(config["llmApiKeys"]).toEqual({ openai: "sk-key", gemini: "AIza-key" });
+  });
+
+  it("leaves an already-migrated agent untouched", () => {
+    const input = { id: "a", config: { llmProvider: "gemini", llmModel: "gemini-2.5-pro" } };
+    const { record, changed } = migrateAgentProviderName(input);
+    expect(changed).toBe(false);
+    expect(record).toBe(input);
+  });
+
+  it("does not touch other providers or a summarizer on another provider", () => {
+    const { changed } = migrateAgentProviderName({
+      config: { llmProvider: "openai", summarizerModel: "anthropic/claude-haiku-4-5" },
+    });
+    expect(changed).toBe(false);
+  });
+
+  it("does not rewrite a model id that merely contains google", () => {
+    const { record, changed } = migrateAgentProviderName({
+      config: { llmProvider: "openrouter", llmModel: "google/gemini-2.5-flash" },
+    });
+    expect(changed).toBe(false);
+    expect((record as { config: Record<string, unknown> }).config["llmModel"]).toBe(
+      "google/gemini-2.5-flash",
+    );
+  });
+
+  it("keeps a key already stored under the new name", () => {
+    const { record } = migrateAgentProviderName({
+      config: { llmProvider: "google", llmApiKeys: { google: "old", gemini: "new" } },
+    });
+    expect((record as { config: Record<string, unknown> }).config["llmApiKeys"]).toEqual({
+      gemini: "new",
+    });
+  });
+
+  it("tolerates malformed records", () => {
+    expect(migrateAgentProviderName(null).changed).toBe(false);
+    expect(migrateAgentProviderName("nonsense").changed).toBe(false);
+    expect(migrateAgentProviderName({ id: "no-config" }).changed).toBe(false);
+  });
+});
+
+describe("migrateConfigProviderName", () => {
+  it("moves llm.google to llm.gemini", () => {
+    const record: Record<string, unknown> = {
+      llm: { google: { api_key: "AIza" }, openai: { api_key: "sk" } },
+    };
+    expect(migrateConfigProviderName(record)).toBe(true);
+    expect(record["llm"]).toEqual({ openai: { api_key: "sk" }, gemini: { api_key: "AIza" } });
+  });
+
+  it("keeps an existing llm.gemini entry", () => {
+    const record: Record<string, unknown> = {
+      llm: { google: { api_key: "old" }, gemini: { api_key: "new" } },
+    };
+    expect(migrateConfigProviderName(record)).toBe(true);
+    expect(record["llm"]).toEqual({ gemini: { api_key: "new" } });
+  });
+
+  it("reports no change when there is nothing to migrate", () => {
+    expect(migrateConfigProviderName({ llm: { openai: { api_key: "sk" } } })).toBe(false);
+    expect(migrateConfigProviderName({})).toBe(false);
+  });
+});
+
+describe("migrateKeyringProviderName", () => {
+  function fakeKeyring(initial: Record<string, string>) {
+    const store = { ...initial };
+    return {
+      store,
+      get: (_backend: string, account: string) => Effect.succeed(store[account]),
+      set: (_backend: string, account: string, secret: string) => {
+        store[account] = secret;
+        return Effect.succeed(true);
+      },
+      remove: (_backend: string, account: string) => {
+        delete store[account];
+        return Effect.void;
+      },
+    };
+  }
+
+  it("moves the entry to the new account name", async () => {
+    const keyring = fakeKeyring({ "llm.google.api_key": "AIza" });
+    const moved = await Effect.runPromise(
+      migrateKeyringProviderName("macos", keyring.get, keyring.set, keyring.remove),
+    );
+    expect(moved).toBe(true);
+    expect(keyring.store).toEqual({ "llm.gemini.api_key": "AIza" });
+  });
+
+  it("does not clobber a key already under the new name, but clears the old one", async () => {
+    const keyring = fakeKeyring({ "llm.google.api_key": "old", "llm.gemini.api_key": "new" });
+    await Effect.runPromise(
+      migrateKeyringProviderName("macos", keyring.get, keyring.set, keyring.remove),
+    );
+    expect(keyring.store).toEqual({ "llm.gemini.api_key": "new" });
+  });
+
+  it("is a no-op when there is no legacy entry", async () => {
+    const keyring = fakeKeyring({ "llm.openai.api_key": "sk" });
+    const moved = await Effect.runPromise(
+      migrateKeyringProviderName("macos", keyring.get, keyring.set, keyring.remove),
+    );
+    expect(moved).toBe(false);
+    expect(keyring.store).toEqual({ "llm.openai.api_key": "sk" });
+  });
+});

--- a/src/core/utils/provider-migration.ts
+++ b/src/core/utils/provider-migration.ts
@@ -1,0 +1,106 @@
+/**
+ * One-time migration of the `google` provider name to `gemini`.
+ *
+ * The provider was renamed to match the model family it actually serves. The
+ * name was persisted in agent files and in ~/.jazz/config.json, so stored data
+ * is rewritten in place the first time Jazz reads it rather than being kept
+ * working through a permanent alias.
+ *
+ * The AI SDK's own `google` keys (`providerOptions.google`, the
+ * `@ai-sdk/google` package, `GOOGLE_GENERATIVE_AI_API_KEY`) are upstream names
+ * and are deliberately untouched.
+ */
+
+import { Effect } from "effect";
+
+export const LEGACY_PROVIDER_NAME = "google";
+export const RENAMED_PROVIDER_NAME = "gemini";
+
+/**
+ * Rewrite the provider name wherever an agent record can carry it.
+ * Returns the migrated record and whether anything actually changed, so the
+ * caller can avoid rewriting files that are already current.
+ */
+export function migrateAgentProviderName(raw: unknown): { record: unknown; changed: boolean } {
+  if (!raw || typeof raw !== "object") return { record: raw, changed: false };
+
+  const record = raw as Record<string, unknown>;
+  const config = record["config"];
+  if (!config || typeof config !== "object") return { record: raw, changed: false };
+
+  const agentConfig = { ...(config as Record<string, unknown>) };
+  let changed = false;
+
+  if (agentConfig["llmProvider"] === LEGACY_PROVIDER_NAME) {
+    agentConfig["llmProvider"] = RENAMED_PROVIDER_NAME;
+    changed = true;
+  }
+
+  const summarizer = agentConfig["summarizerModel"];
+  if (typeof summarizer === "string" && summarizer.startsWith(`${LEGACY_PROVIDER_NAME}/`)) {
+    agentConfig["summarizerModel"] =
+      `${RENAMED_PROVIDER_NAME}/${summarizer.slice(LEGACY_PROVIDER_NAME.length + 1)}`;
+    changed = true;
+  }
+
+  const apiKeys = agentConfig["llmApiKeys"];
+  if (apiKeys && typeof apiKeys === "object" && LEGACY_PROVIDER_NAME in apiKeys) {
+    const { [LEGACY_PROVIDER_NAME]: legacyKey, ...rest } = apiKeys as Record<string, unknown>;
+    // A key already stored under the new name wins; the legacy one is dropped.
+    agentConfig["llmApiKeys"] =
+      RENAMED_PROVIDER_NAME in rest ? rest : { ...rest, [RENAMED_PROVIDER_NAME]: legacyKey };
+    changed = true;
+  }
+
+  if (!changed) return { record: raw, changed: false };
+  return { record: { ...record, config: agentConfig }, changed: true };
+}
+
+const LEGACY_KEYRING_ACCOUNT = `llm.${LEGACY_PROVIDER_NAME}.api_key`;
+const RENAMED_KEYRING_ACCOUNT = `llm.${RENAMED_PROVIDER_NAME}.api_key`;
+
+/**
+ * Move a keyring entry stored under the old provider name to the new one.
+ *
+ * Keyring accounts are named after the config path, so the rename orphans any
+ * key stored by an earlier version. The helpers are passed in rather than
+ * imported to keep this module free of service dependencies.
+ */
+export function migrateKeyringProviderName<Backend>(
+  backend: Backend,
+  get: (backend: Backend, account: string) => Effect.Effect<string | undefined, never>,
+  set: (backend: Backend, account: string, secret: string) => Effect.Effect<boolean, never>,
+  remove: (backend: Backend, account: string) => Effect.Effect<void, never>,
+): Effect.Effect<boolean, never> {
+  return Effect.gen(function* () {
+    const legacy = yield* get(backend, LEGACY_KEYRING_ACCOUNT);
+    if (legacy === undefined || legacy.trim() === "") return false;
+
+    // Never clobber a key already stored under the new name.
+    const existing = yield* get(backend, RENAMED_KEYRING_ACCOUNT);
+    if (existing === undefined || existing.trim() === "") {
+      const stored = yield* set(backend, RENAMED_KEYRING_ACCOUNT, legacy);
+      if (!stored) return false;
+    }
+
+    yield* remove(backend, LEGACY_KEYRING_ACCOUNT);
+    return true;
+  });
+}
+
+/**
+ * Rewrite `llm.google` to `llm.gemini` in a raw config file record.
+ * Returns whether anything changed.
+ */
+export function migrateConfigProviderName(fileRecord: Record<string, unknown>): boolean {
+  const llm = fileRecord["llm"];
+  if (!llm || typeof llm !== "object") return false;
+
+  const llmRecord = llm as Record<string, unknown>;
+  if (!(LEGACY_PROVIDER_NAME in llmRecord)) return false;
+
+  const { [LEGACY_PROVIDER_NAME]: legacyEntry, ...rest } = llmRecord;
+  fileRecord["llm"] =
+    RENAMED_PROVIDER_NAME in rest ? rest : { ...rest, [RENAMED_PROVIDER_NAME]: legacyEntry };
+  return true;
+}

--- a/src/core/utils/provider-model.ts
+++ b/src/core/utils/provider-model.ts
@@ -7,7 +7,7 @@ const PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   cerebras: "Cerebras",
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
-  google: "Google",
+  gemini: "Gemini",
   groq: "Groq",
   llamacpp: "llama.cpp",
   minimax: "MiniMax",

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -18,6 +18,10 @@ import {
   getLocalJazzDirectory,
 } from "@/core/utils/paths";
 import {
+  migrateConfigProviderName,
+  migrateKeyringProviderName,
+} from "@/core/utils/provider-migration";
+import {
   detectKeyringBackend,
   keyringDelete,
   keyringGet,
@@ -327,6 +331,7 @@ export function createConfigLayer(
         loaded.configPath,
         loaded.globalConfig,
         keyringBackend,
+        loaded.renamedProvider ?? false,
       );
 
       return new AgentConfigServiceImpl(
@@ -496,6 +501,7 @@ function resolveSecrets(
   globalConfigPath: string | undefined,
   globalFileConfig: Partial<AppConfig> | undefined,
   backend: KeyringBackend,
+  renamedProvider: boolean,
 ): Effect.Effect<
   {
     config: AppConfig;
@@ -505,6 +511,8 @@ function resolveSecrets(
   never
 > {
   return Effect.gen(function* () {
+    yield* migrateKeyringProviderName(backend, keyringGet, keyringSet, keyringDelete);
+
     const resolved = structuredClone(config) as unknown as Record<string, unknown>;
     const origins = new Map<string, SecretOrigin>();
     const candidates = new Set([...SECRET_PATHS, ...collectSecretPaths(config)]);
@@ -550,7 +558,7 @@ function resolveSecrets(
 
     const droppedLegacy = dropLegacyGoogleBlock(fileRecord);
 
-    if ((migrated.length > 0 || droppedLegacy) && globalConfigPath) {
+    if ((migrated.length > 0 || droppedLegacy || renamedProvider) && globalConfigPath) {
       const cleaned = structuredClone(fileRecord);
       for (const path of migrated) {
         deepDelete(cleaned, path);
@@ -636,7 +644,7 @@ function stripStorageOverride(config: Partial<AppConfig>): Partial<AppConfig> {
 function readOptionalConfigFile(
   fs: FileSystem.FileSystem,
   filePath: string,
-): Effect.Effect<Partial<AppConfig> | undefined, never> {
+): Effect.Effect<{ config: Partial<AppConfig>; renamedProvider: boolean } | undefined, never> {
   return Effect.gen(function* () {
     const exists = yield* fs.exists(filePath).pipe(Effect.catchAll(() => Effect.succeed(false)));
     if (!exists) return undefined;
@@ -652,7 +660,8 @@ function readOptionalConfigFile(
     const config = parsed.value;
     if (typeof config !== "object" || config === null) return undefined;
 
-    return config;
+    const renamedProvider = migrateConfigProviderName(config);
+    return { config, renamedProvider };
   });
 }
 
@@ -665,6 +674,7 @@ function loadConfigFile(
     fileConfig?: Partial<AppConfig>;
     globalConfig?: Partial<AppConfig>;
     localConfig?: Partial<AppConfig>;
+    renamedProvider?: boolean;
   },
   ConfigurationError | ConfigurationNotFoundError
 > {
@@ -732,8 +742,11 @@ function loadConfigFile(
         );
       }
 
+      const renamedProvider = migrateConfigProviderName(config);
+
       const localConfigPath = `${getLocalJazzDirectory()}/config.json`;
-      const localConfigRaw = yield* readOptionalConfigFile(fs, localConfigPath);
+      const localRead = yield* readOptionalConfigFile(fs, localConfigPath);
+      const localConfigRaw = localRead?.config;
       const localConfig = localConfigRaw ? stripStorageOverride(localConfigRaw) : undefined;
 
       const emptyBase = defaultConfig();
@@ -745,10 +758,12 @@ function loadConfigFile(
         fileConfig: Partial<AppConfig>;
         globalConfig?: Partial<AppConfig>;
         localConfig?: Partial<AppConfig>;
+        renamedProvider?: boolean;
       } = {
         configPath: expandedPath,
         fileConfig: merged,
         globalConfig: config,
+        renamedProvider,
       };
 
       if (localConfigRaw) {
@@ -764,8 +779,10 @@ function loadConfigFile(
       : `${getJazzHomeDirectory()}/config.json`;
     const localConfigPath = `${getLocalJazzDirectory()}/config.json`;
 
-    const globalConfig = yield* readOptionalConfigFile(fs, globalConfigPath);
-    const localConfigRaw = yield* readOptionalConfigFile(fs, localConfigPath);
+    const globalRead = yield* readOptionalConfigFile(fs, globalConfigPath);
+    const globalConfig = globalRead?.config;
+    const localRead = yield* readOptionalConfigFile(fs, localConfigPath);
+    const localConfigRaw = localRead?.config;
     const localConfig = localConfigRaw ? stripStorageOverride(localConfigRaw) : undefined;
 
     if (!globalConfig && !localConfig) {
@@ -781,9 +798,11 @@ function loadConfigFile(
       fileConfig: Partial<AppConfig>;
       globalConfig?: Partial<AppConfig>;
       localConfig?: Partial<AppConfig>;
+      renamedProvider?: boolean;
     } = {
       configPath: globalConfigPath,
       fileConfig: merged,
+      renamedProvider: globalRead?.renamedProvider ?? false,
     };
 
     if (globalConfig) {

--- a/src/services/llm/ai-sdk-service.test.ts
+++ b/src/services/llm/ai-sdk-service.test.ts
@@ -223,7 +223,7 @@ describe("AI SDK Service - Unit Tests", () => {
       const llmConfigProviders: ProviderName[] = [
         "openai",
         "anthropic",
-        "google",
+        "gemini",
         "mistral",
         "xai",
         "deepseek",
@@ -498,6 +498,16 @@ describe("AI SDK Service - Unit Tests", () => {
       const openaiModels = PROVIDER_MODELS.openai;
       if (openaiModels.type === "static") {
         expect(result.length).toBe(openaiModels.models.length);
+      }
+    });
+
+    it("looks gemini up in the models.dev catalog under its upstream id", () => {
+      // models.dev lists Gemini under "google". That id is theirs, so the
+      // provider rename must not reach the catalog lookup.
+      const geminiModels = PROVIDER_MODELS.gemini;
+      expect(geminiModels.type).toBe("models-dev");
+      if (geminiModels.type === "models-dev") {
+        expect(geminiModels.catalogId).toBe("google");
       }
     });
 

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -511,9 +511,9 @@ function getConfiguredProviders(
       providers.push({ name: "fireworks", apiKey: llmConfig.fireworks.api_key });
       addedProviders.add("fireworks");
     }
-    if (llmConfig.google?.api_key) {
-      providers.push({ name: "google", apiKey: llmConfig.google.api_key });
-      addedProviders.add("google");
+    if (llmConfig.gemini?.api_key) {
+      providers.push({ name: "gemini", apiKey: llmConfig.gemini.api_key });
+      addedProviders.add("gemini");
     }
     if (llmConfig.groq?.api_key) {
       providers.push({ name: "groq", apiKey: llmConfig.groq.api_key });
@@ -604,8 +604,8 @@ function selectModel(
       model = apiKey ? createAnthropic({ apiKey })(modelId) : anthropic(modelId);
       break;
     }
-    case "google": {
-      const apiKey = resolveApiKey("google");
+    case "gemini": {
+      const apiKey = resolveApiKey("gemini");
       model = apiKey ? createGoogleGenerativeAI({ apiKey })(modelId) : google(modelId);
       break;
     }
@@ -802,7 +802,7 @@ export function buildProviderOptions(
       }
       break;
     }
-    case "google": {
+    case "gemini": {
       const reasoningEffort = options.reasoning_effort;
       if (reasoningEffort && reasoningEffort !== "disable") {
         const geminiProReasoningEffort = options.model.includes("gemini-3")
@@ -1050,7 +1050,7 @@ class AISDKService implements LLMService {
     if (modelSource.type === "models-dev") {
       return Effect.tryPromise({
         try: async () => {
-          const resolved = await fetchModelsDevModels(providerName);
+          const resolved = await fetchModelsDevModels(modelSource.catalogId ?? providerName);
           this.modelInfoCache.set(providerName, resolved);
           return resolved;
         },

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -97,8 +97,8 @@ function isTextChatModel(entry: ModelsDevModelEntry): boolean {
  *
  * Throws when models.dev is unavailable.
  */
-export async function fetchModelsDevModels(providerName: ProviderName): Promise<ModelInfo[]> {
-  const entries = await getModelsDevProviderModels(providerName);
+export async function fetchModelsDevModels(catalogId: string): Promise<ModelInfo[]> {
+  const entries = await getModelsDevProviderModels(catalogId);
 
   const ids = new Set(entries.map((entry) => entry.id));
   const isSnapshotDuplicate = (id: string): boolean => {

--- a/src/services/llm/models.ts
+++ b/src/services/llm/models.ts
@@ -7,7 +7,16 @@ import type { LLMConfig } from "@/core/types/config";
  * Dynamic models are fetched from provider API endpoints.
  */
 export type ModelSource =
-  { type: "models-dev" } | { type: "dynamic"; endpointPath: string; defaultBaseUrl?: string };
+  | {
+      type: "models-dev";
+      /**
+       * Provider id to look up in the models.dev catalog, when it differs from
+       * Jazz's own provider name. models.dev lists Gemini under "google", and
+       * that id belongs to their API, not to us.
+       */
+      catalogId?: string;
+    }
+  | { type: "dynamic"; endpointPath: string; defaultBaseUrl?: string };
 
 export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/api";
 export const DEFAULT_LLAMACPP_BASE_URL = "http://localhost:8080/v1";
@@ -15,7 +24,7 @@ export const DEFAULT_LLAMACPP_BASE_URL = "http://localhost:8080/v1";
 export const PROVIDER_MODELS: Record<ProviderName, ModelSource> = {
   anthropic: { type: "models-dev" },
   openai: { type: "models-dev" },
-  google: { type: "models-dev" },
+  gemini: { type: "models-dev", catalogId: "google" },
   xai: { type: "models-dev" },
   openrouter: {
     type: "dynamic",

--- a/src/services/secrets/registry.test.ts
+++ b/src/services/secrets/registry.test.ts
@@ -21,7 +21,7 @@ describe("secret registry", () => {
 
   it("maps secret paths to their environment variables", () => {
     expect(envVarForSecretPath("llm.anthropic.api_key")).toBe("ANTHROPIC_API_KEY");
-    expect(envVarForSecretPath("llm.google.api_key")).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
+    expect(envVarForSecretPath("llm.gemini.api_key")).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
     expect(envVarForSecretPath("web_search.exa.api_key")).toBe("EXA_API_KEY");
     expect(envVarForSecretPath("logging.level")).toBeUndefined();
   });

--- a/src/services/secrets/registry.ts
+++ b/src/services/secrets/registry.ts
@@ -22,7 +22,7 @@ export const LLM_PROVIDER_ENV_VARS: Record<string, string> = {
   cerebras: "CEREBRAS_API_KEY",
   deepseek: "DEEPSEEK_API_KEY",
   fireworks: "FIREWORKS_API_KEY",
-  google: "GOOGLE_GENERATIVE_AI_API_KEY",
+  gemini: "GOOGLE_GENERATIVE_AI_API_KEY",
   groq: "GROQ_API_KEY",
   llamacpp: "LLAMACPP_API_KEY",
   minimax: "MINIMAX_API_KEY",

--- a/src/services/storage/file.ts
+++ b/src/services/storage/file.ts
@@ -5,6 +5,7 @@ import { StorageServiceTag, type StorageService } from "@/core/interfaces/storag
 import { AgentConfigurationError, StorageError, StorageNotFoundError } from "@/core/types/errors";
 import type { Agent, AgentConfig } from "@/core/types/index";
 import { parseJson } from "@/core/utils/json";
+import { migrateAgentProviderName } from "@/core/utils/provider-migration";
 
 /** On-disk agent JSON may omit timestamps (e.g. repo templates); defaults apply at read time. */
 function resolveAgentFileTimestamps(raw: {
@@ -107,13 +108,7 @@ export class FileStorageService implements StorageService {
           .readFileString(path)
           .pipe(Effect.mapError((error) => this.mapReadError(path, error)));
 
-        const rawData = yield* parseJson<
-          Omit<Agent, "createdAt" | "updatedAt" | "model"> & {
-            readonly model?: string;
-            readonly createdAt?: string;
-            readonly updatedAt?: string;
-          }
-        >(content).pipe(
+        const parsed = yield* parseJson<unknown>(content).pipe(
           Effect.mapError(
             (error) =>
               new StorageError({
@@ -123,6 +118,22 @@ export class FileStorageService implements StorageService {
               }),
           ),
         );
+
+        // Rewrite the legacy "google" provider name in place. Doing this on read
+        // rather than as a one-shot startup pass also repairs agent files that
+        // show up later, from a backup or a synced machine.
+        const migration = migrateAgentProviderName(parsed);
+        if (migration.changed) {
+          yield* this.writeJsonFile(path, migration.record).pipe(
+            Effect.catchAll(() => Effect.void),
+          );
+        }
+
+        const rawData = migration.record as Omit<Agent, "createdAt" | "updatedAt" | "model"> & {
+          readonly model?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
+        };
 
         let normalizedTools: readonly string[];
         try {


### PR DESCRIPTION
> **Stacked on #342.** Base is `chore/remove-dead-google-config`; review that one first. GitHub will retarget this to `main` automatically once #342 merges.

## What changes

The provider formerly called `google` is now `gemini`, after the model family it actually serves. This is the **hard cutover**: no alias is kept, and stored data is rewritten in place.

`llm.google` → `llm.gemini` in config, and `gemini` everywhere the provider name appears — `AVAILABLE_PROVIDERS`, the model-source table, the display name, the tokenizer family, and the provider switches in the AI SDK service.

## Migration, because the old name was persisted

Three places had `google` written to disk, and all three are migrated:

| Where | What moves |
|---|---|
| `~/.jazz/config.json` | `llm.google` → `llm.gemini` |
| Agent files | `llmProvider`, the `summarizerModel` prefix, and the `llmApiKeys` entry |
| OS keyring | the `llm.google.api_key` account is moved, not orphaned |

The keyring one matters and is easy to miss: #338 names keyring accounts after the config path, so renaming the path without moving the entry would strand the key in the Keychain with Jazz unable to find it.

Agent migration runs **on read** rather than as a one-shot startup pass. That way an agent file restored from a backup or arriving from a synced machine after the upgrade is repaired too — which is precisely the failure mode a hard cutover otherwise invites. Migrated files are rewritten immediately, so it happens once per file.

Where a value already exists under the new name, the new name wins and the legacy one is dropped rather than clobbering it.

## What is deliberately *not* renamed

These are upstream identifiers, not ours:

- **models.dev still lists Gemini under `google`.** `fetchModelsDevModels` would throw `Provider "gemini" was not found in the models.dev catalog`. Handled with a new `ModelSource.catalogId`, so the lookup keeps using `google`. There's a test pinning this.
- **`providerOptions.google` / `providerMetadata.google.thoughtSignature`** — AI SDK wire format.
- **`@ai-sdk/google`, `createGoogleGenerativeAI`** — the package.
- **`GOOGLE_GENERATIVE_AI_API_KEY`** — the env var keeps its upstream name; only the config key under it changed.

Also unchanged: OpenRouter model ids like `openrouter/google/gemini-2.5-flash` legitimately contain `google/`, and the migration does not touch `llmModel`. There's a test for that too.

## Verification

- `bun test` — 1807 pass, 0 fail (12 new migration tests)
- `bun run typecheck`, `bun run lint` — clean
- End-to-end against a temp `JAZZ_HOME` seeded with a legacy config and a legacy agent file:

```
config: llm.gemini.api_key resolved = true
config: file now = {"gemini":{"api_key":"AIza-legacy"}}
agent : in-memory provider = gemini | model = gemini/gemini-2.5-pro
agent : on-disk llmProvider = gemini
agent : on-disk summarizerModel = gemini/gemini-2.5-flash
agent : on-disk llmApiKeys = {"gemini":"AIza-agent"}
```

## Known gap

Reasoning parts stored in `~/.jazz/history/` carry a `provider` field that may still read `google`. Those will no longer match on replay and get dropped, degrading old transcripts rather than breaking them. Migrating history was out of scope for this PR — worth a follow-up if it turns out to matter.
