### PR TITLE
chore(subagents): drop the duplicate persona blurb, split the AI SDK step cap

### DIFF
--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -85,9 +85,6 @@ function initializeAgentRun(
       : null;
     const toolProfile = resolvedPersona?.toolProfile;
 
-    // An explicit budget from the call site (--max-iterations, a workflow's
-    // metadata, a sub-agent spawn) wins; app config sets the default for
-    // everything else.
     const resolvedMaxIterations = Math.max(
       1,
       Math.floor(options.maxIterations ?? appConfig.maxIterations ?? DEFAULT_MAX_ITERATIONS),
@@ -170,12 +167,8 @@ function initializeAgentRun(
       combinedToolNames = combinedToolNames.filter((name) => name !== "manage_memory");
     }
 
-    // A sub-agent run inherits its parent's effective toolset as a ceiling, so
-    // a child spawned under a different persona cannot end up with a tool the
-    // parent lacked. Applied after personas and built-in categories resolve —
-    // earlier would let the child's persona re-add a category the parent denied
-    // — and before the registry filter, so dropped names never reach approval
-    // or the LLM tool list.
+    // Applied after personas resolve (earlier would let a child's persona re-add
+    // a category the parent denied) and before the registry filter.
     if (options.toolAllowlist) {
       const allowed = new Set(options.toolAllowlist);
       const withheld = combinedToolNames.filter((toolName) => !allowed.has(toolName));

--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -130,6 +130,44 @@ describe("spawn_subagent auto-approve inheritance", () => {
   });
 });
 
+describe("spawn_subagent persona handling", () => {
+  it("passes the persona through as config rather than restating it in the task", async () => {
+    let captured: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      captured = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const tool = getSpawnTool();
+      const testLayer = Layer.mergeAll(
+        Layer.succeed(LoggerServiceTag, mockLogger),
+        Layer.succeed(PresentationServiceTag, presentation),
+      );
+      await Effect.runPromise(
+        (
+          tool.execute(
+            { task: "trace the call sites", persona: "coder" },
+            { agentId: parentAgent.id, parentAgent },
+          ) as Effect.Effect<unknown, unknown, LoggerService | PresentationService>
+        ).pipe(Effect.provide(testLayer)),
+      );
+
+      // The persona reaches the child as config, so AgentPromptBuilder resolves
+      // the packaged persona.md into its system prompt.
+      expect(captured?.agent.config.persona).toBe("coder");
+      // The task itself must not carry a competing one-line persona blurb.
+      expect(captured?.userInput).not.toContain("specialist");
+      expect(captured?.userInput).toContain("trace the call sites");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("spawn_subagent tool ceiling", () => {
   it("caps the child at the parent's effective tools", async () => {
     let captured: Omit<AgentRunnerOptions, "internal"> | undefined;

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -90,11 +90,8 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
             };
           }
 
-          // Every level gets a fresh iteration budget rather than its parent's
-          // remainder, so nothing else bounds how much a nest of sub-agents can
-          // spend. Refuse rather than silently flatten: a parent told its
-          // delegation was declined can do the work itself, whereas one handed a
-          // child that quietly ran at the wrong depth cannot tell.
+          // Refuse rather than silently running the child at the wrong depth: a
+          // parent told its delegation was declined can do the work itself.
           const currentDepth = context.subagentDepth ?? 0;
           const maxDepth = context.maxSubagentDepth ?? DEFAULT_MAX_SUBAGENT_DEPTH;
           if (currentDepth >= maxDepth) {
@@ -139,16 +136,9 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
             updatedAt: new Date(),
           };
 
-          const personaHints: Record<string, string> = {
-            coder: "You are a coding specialist. Focus on reading, writing, and modifying code.",
-            researcher:
-              "You are a research specialist. Focus on gathering, synthesising, and summarising information.",
-          };
-          const personaHint = personaHints[args.persona ?? ""] ?? "";
-
           const wrappedTask = `[SUB-AGENT TASK]
 You are a sub-agent performing a delegated task for a parent agent. This is a ONE-SHOT task.
-${personaHint ? `\n${personaHint}\n` : ""}
+
 Rules:
 - Complete the task and produce a answer
 - Do NOT ask follow-up questions or wait for user input
@@ -177,10 +167,7 @@ ${args.task}`;
             conversationId: `subagent-conv-${++subagentCounter}-${Date.now()}`,
             maxIterations: context.maxSubagentIterations ?? DEFAULT_MAX_SUBAGENT_ITERATIONS,
             ephemeralRegionId: regionId,
-            // Cap the child at the parent's own effective tools. The child runs
-            // under a caller-chosen persona, and a persona resolves its own
-            // built-in categories — without this ceiling a narrowly-scoped
-            // parent could reach a tool it lacks by picking a broader persona.
+            // Cap the child at the parent's own effective tools.
             ...(context.parentToolNames ? { toolAllowlist: context.parentToolNames } : {}),
             subagentDepth: currentDepth + 1,
             ...(context.getAutoApprovePolicy

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -97,17 +97,11 @@ export interface AgentRunnerOptions {
    */
   readonly autoApprovedTools?: readonly string[];
   /**
-   * Hard ceiling on this run's toolset. When set, the agent's effective tools
-   * are intersected with this list after personas and built-in categories are
-   * resolved. Sub-agent runs inherit their parent's effective tools this way,
-   * so a child spawned under a different persona can never end up holding a
-   * tool the parent itself was not allowed to use.
+   * Hard ceiling on this run's toolset, intersected after personas and built-in
+   * categories resolve. Sub-agents inherit their parent's tools this way.
    */
   readonly toolAllowlist?: readonly string[];
-  /**
-   * How many sub-agent levels sit above this run. Omitted (0) for a top-level
-   * run; `spawn_subagent` passes its own depth plus one when starting a child.
-   */
+  /** How many sub-agent levels sit above this run. 0 at the top level. */
   readonly subagentDepth?: number;
   /**
    * Callback invoked when the user chooses "always approve" for a specific tool
@@ -231,11 +225,7 @@ export interface AgentRunContext {
   readonly model: string;
   readonly connectedMCPServers: readonly string[];
   readonly maxRetries?: number;
-  /**
-   * The run's iteration budget, already resolved from the call site's request,
-   * app config, and the built-in default. Executors use this rather than
-   * re-deriving it from options.
-   */
+  /** Iteration budget, already resolved from the call site, config, and default. */
   readonly maxIterations: number;
   readonly knownSkills: readonly {
     readonly name: string;

--- a/src/core/constants/agent.ts
+++ b/src/core/constants/agent.ts
@@ -1,18 +1,9 @@
-/**
- * Default maximum number of agent iteration steps per top-level run, when
- * neither `--max-iterations` nor `maxIterations` in app config is set.
- */
+/** Default iteration budget for a top-level run, when neither --max-iterations nor config sets one */
 export const DEFAULT_MAX_ITERATIONS = 100;
 
 /**
- * Default iteration budget for a sub-agent run, when `maxSubagentIterations`
- * is not set in app config.
- *
- * Deliberately far below a top-level run's. A sub-agent is given one scoped
- * task and answers in one shot; a child still working after 30 iterations has
- * usually misunderstood the brief rather than found more to do. Keeping it
- * separate also bounds a nest of sub-agents, since every level gets a fresh
- * budget rather than its parent's remainder.
+ * Default iteration budget for a sub-agent run. Far below a top-level run's:
+ * a sub-agent answers one scoped task, and every level gets a fresh budget.
  */
 export const DEFAULT_MAX_SUBAGENT_ITERATIONS = 30;
 
@@ -20,13 +11,8 @@ export const DEFAULT_MAX_SUBAGENT_ITERATIONS = 30;
 export const MAX_CONCURRENT_TOOLS = 10;
 
 /**
- * How many levels of sub-agent may nest below a top-level run, when
- * `maxSubagentDepth` is not set in app config.
- *
- * Each level gets a fresh iteration budget rather than its parent's remainder —
- * a child spawned on the parent's last iteration still needs a full budget to be
- * useful — so depth, not the parent's remaining budget, is what bounds total
- * spend. Three levels covers orchestrator → specialist → helper.
+ * How many levels of sub-agent may nest below a top-level run. Every level gets
+ * a fresh iteration budget, so depth is what bounds total delegated spend.
  */
 export const DEFAULT_MAX_SUBAGENT_DEPTH = 3;
 
@@ -63,6 +49,12 @@ export const DEFAULT_MAX_LLM_RETRIES = 10;
 
 /** AI SDK internal retries are disabled — Jazz retries via Effect.retry instead. */
 export const AI_SDK_MAX_RETRIES = 0;
+
+/**
+ * Backstop on the AI SDK's multi-step loop inside a single completion call.
+ * Not Jazz's agent loop — must not follow `maxIterations` from app config.
+ */
+export const AI_SDK_MAX_STEPS = 20;
 
 /** Maximum delay between LLM retry attempts in seconds (caps exponential backoff) */
 export const MAX_RETRY_DELAY_SECONDS = 30;

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -19,20 +19,11 @@ export interface AppConfig {
   readonly telemetry?: TelemetryConfig;
   /** Maximum number of retries for transient LLM API failures. Defaults to 3. */
   readonly maxRetries?: number;
-  /**
-   * How many levels of sub-agent may nest below a top-level run. Defaults to 3.
-   * Set 0 to stop agents delegating at all.
-   */
+  /** Sub-agent nesting levels allowed. Defaults to 3; 0 disables delegation. */
   readonly maxSubagentDepth?: number;
-  /**
-   * Iteration budget for a top-level run. Defaults to 100. An explicit
-   * `--max-iterations` on the command line still wins over this.
-   */
+  /** Iteration budget for a top-level run. Defaults to 100; --max-iterations wins. */
   readonly maxIterations?: number;
-  /**
-   * Iteration budget for a sub-agent run. Defaults to 30 — a sub-agent answers
-   * one scoped task, so it needs far less headroom than the run that spawned it.
-   */
+  /** Iteration budget for a sub-agent run. Defaults to 30. */
   readonly maxSubagentIterations?: number;
 }
 

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -186,35 +186,19 @@ export interface ToolExecutionContext {
    * Used by tools like spawn_subagent to inherit LLM configuration.
    */
   readonly parentAgent?: Agent;
-  /**
-   * Iteration budget to give a sub-agent spawned from this run, resolved from
-   * `maxSubagentIterations` in app config. A sub-agent gets its own budget
-   * rather than the parent's remainder — a child spawned on the parent's last
-   * iteration would be useless with one round — so this is a separate knob,
-   * defaulting well below a top-level run's.
-   */
+  /** Iteration budget for a sub-agent spawned here — its own, not the parent's remainder. */
   readonly maxSubagentIterations?: number;
   /**
-   * The parent's effective tool names for this run (after persona deny lists
-   * and any inherited allowlist). `spawn_subagent` passes this down as the
-   * child's allowlist so a child can never hold a tool its parent lacks —
-   * otherwise swapping the child's persona would be a way around the parent's
-   * toolset, which is Jazz's strongest safety control.
+   * The parent's effective tool names. `spawn_subagent` passes these down as
+   * the child's allowlist so a child can never hold a tool its parent lacks.
    */
   readonly parentToolNames?: readonly string[];
   /**
-   * How many sub-agent levels deep the run executing this tool already sits.
-   * 0 for a top-level run, 1 for its children, and so on. `spawn_subagent`
-   * increments it for the child and refuses past `maxSubagentDepth`, which is
-   * the only thing bounding total delegated spend: every level gets a fresh
-   * iteration budget rather than its parent's remainder.
+   * How many sub-agent levels sit above the run executing this tool. 0 at the
+   * top level; `spawn_subagent` increments it and refuses past the limit.
    */
   readonly subagentDepth?: number;
-  /**
-   * Nesting limit in force for this run, resolved from `maxSubagentDepth` in
-   * app config. Resolved by the runner rather than read in the tool so the
-   * whole tree obeys one value.
-   */
+  /** Nesting limit for this run, resolved once by the runner so a whole tree agrees. */
   readonly maxSubagentDepth?: number;
   /**
    * Callback to replace conversation messages with compacted versions.

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -46,7 +46,7 @@ import shortUUID from "short-uuid";
 import { minimax } from "vercel-minimax-ai-provider";
 import { createZhipu, zhipu } from "zhipu-ai-provider";
 import { z } from "zod";
-import { DEFAULT_MAX_ITERATIONS, AI_SDK_MAX_RETRIES } from "@/core/constants/agent";
+import { AI_SDK_MAX_RETRIES, AI_SDK_MAX_STEPS } from "@/core/constants/agent";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
@@ -1313,7 +1313,7 @@ class AISDKService implements LLMService {
           ...(tools ? { tools } : {}),
           ...(requestedToolChoice ? { toolChoice: requestedToolChoice } : {}),
           ...(providerOptions ? { providerOptions } : {}),
-          stopWhen: stepCountIs(DEFAULT_MAX_ITERATIONS),
+          stopWhen: stepCountIs(AI_SDK_MAX_STEPS),
         });
         void this.logger.debug(
           `[LLM Timing] generateText completed in ${Date.now() - generateTextStart}ms`,
@@ -1560,7 +1560,7 @@ class AISDKService implements LLMService {
                   ...(requestedToolChoice ? { toolChoice: requestedToolChoice } : {}),
                   ...(providerOptions ? { providerOptions } : {}),
                   abortSignal: abortController.signal,
-                  stopWhen: stepCountIs(DEFAULT_MAX_ITERATIONS),
+                  stopWhen: stepCountIs(AI_SDK_MAX_STEPS),
                 });
                 const result = streamTextResult;
 


### PR DESCRIPTION
Three cleanups flagged while reviewing the sub-agent work. Unrelated to each other, all small.

## 1. The sub-agent task no longer restates the persona

`spawn_subagent` prepended a hardcoded one-liner to every task:

```
You are a coding specialist. Focus on reading, writing, and modifying code.
```

That was redundant, and worse than redundant. The child runs with `config.persona` set, so `AgentPromptBuilder` resolves the packaged `personas/coder/persona.md` and makes its **full** system prompt the child's — several hundred words on reading code before changing it, fixing causes rather than symptoms, proving the change works. The blurb sat in the user message competing with the real thing, and would have drifted as those persona files changed.

Nothing replaces it: the persona already arrives through the proper channel.

## 2. The AI SDK's step cap gets its own constant, at 20

`ai-sdk-service.ts` used `DEFAULT_MAX_ITERATIONS` for `stopWhen: stepCountIs(...)`. That's the AI SDK's own multi-step tool loop **inside a single completion call** — not Jazz's agent loop, which is driven from `agent-loop.ts`. It mattered because #343 made the agent-loop number user-facing and configurable; this unrelated cap silently followed it from 80 to 100.

It's now `AI_SDK_MAX_STEPS`, and **20 rather than 100**. What that cap actually governs:

- Jazz registers its tools as `tool({ description, inputSchema })` with **no `execute`**, so the SDK cannot run them — it stops after emitting the tool call and Jazz executes it and drives the next iteration. For ordinary tools the cap never fires.
- It only binds for **provider-native** tools (`openai.tools.webSearch`, `anthropic.tools.webSearch_20250305`), which the provider executes server-side so the model can continue within one call. Anthropic's already self-caps at `maxUses: 5`.

Removing `stopWhen` was the other option and is wrong: the SDK's default is `stepCountIs(1)`, so dropping it would cap every call at one step and break provider-native web search.

So 20 is a genuine backstop for the one case that can loop, instead of a number inherited from an unrelated setting.

## 3. Comment trimming

The tool-ceiling (#336), depth-limit (#341) and iteration-budget (#343) changes added explanatory comments well past the density of the surrounding code, against the repo's "default to no comments" guidance. Trimmed to one or two lines each, keeping only the non-obvious *why* — e.g. why the tool intersection happens after personas resolve, and why a depth-limited spawn refuses instead of silently running at the wrong depth. Net 47 fewer comment lines; no behaviour change.

## How to verify

1. Delegate a code task with `persona: "coder"`. Expected: unchanged or better — the packaged persona was always what did that work.
2. Set `"maxIterations": 200` in config. Expected: the agent loop honours 200; the SDK's internal cap stays at 20.
3. Run a web search on a provider with native search. Expected: unchanged — 20 steps is far above the 5 Anthropic permits itself.

## Tests

`bun test`: 1808 pass / 0 fail across 121 files. Typecheck and lint clean.

One new test in `subagent-tools.test.ts` pinning both halves of the persona change: the persona reaches the child as `config.persona`, and the wrapped task no longer contains the blurb.