### PR TITLE
feat(telemetry): export runs to OpenTelemetry collectors and Langfuse

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -7,6 +7,7 @@ Learn how to use Jazz effectively.
 - [Quick Start](./quick-start.md): Install and run your first agent.
 - [Creating Agents](./creating-agents.md): Build custom agents tailored to your needs.
 - [Airgapped & Self-Hosted](./airgapped.md): Run Jazz fully offline with Ollama or llama.cpp.
+- [Observability](./observability.md): Send run telemetry to your own OpenTelemetry collector or Langfuse.
 
 ## End-to-End Use Cases
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,0 +1,135 @@
+# Observability
+
+Jazz records every run locally and can push the same events to an OpenTelemetry collector you
+already operate. This matters most for the "agent running on a server you own" case, where the
+local NDJSON file is not where you go to look.
+
+## What Jazz records
+
+Each run emits:
+
+| Event | When |
+| --- | --- |
+| `agent_run_started` / `agent_run_completed` | Once per run — a run emits exactly one terminal event |
+| `agent_run_failed` | Instead of `completed` when the run dies |
+| `llm_usage` | Per LLM request, with token usage and duration |
+| `llm_retry` | Per failed LLM attempt |
+| `tool_invocation` / `tool_error` | Per tool call, with duration |
+| `command_executed` | Per CLI command, with the command path only |
+
+They land in `~/.jazz/telemetry/events/YYYY-MM-DD.ndjson` and are pruned after
+`telemetry.retentionDays` (90 by default). This happens whether or not you export anywhere.
+
+## Exporting to a collector
+
+Point Jazz at any OTLP/HTTP endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+That is the whole setup — an endpoint alone turns export on. To try it end to end, run a
+collector that prints what it receives:
+
+```bash
+docker run --rm -p 4318:4318 otel/opentelemetry-collector
+```
+
+Then run any agent and watch the events arrive. To configure it persistently instead of by
+environment, use `telemetry.otlp` in `~/.jazz/config.json` — see
+[Configuration](../reference/configuration.md#telemetry).
+
+## Signals: traces and logs
+
+Jazz exports **traces** by default. Spans are what turn a run into a waterfall, and they are
+what LLM-observability backends accept — Langfuse ingests OTLP traces and not logs.
+
+Each run becomes one trace: the run is the root span, and every LLM request, retry, and tool
+call is a child span under it. Span timings are derived from each event's recorded duration, so
+a span is written when the operation *finishes*.
+
+Set `telemetry.otlp.signals` to also (or instead) export log records, for a collector routing
+into a log store:
+
+```json
+{ "telemetry": { "otlp": { "signals": ["traces", "logs"] } } }
+```
+
+**Known limitation:** trace grouping is derived from the run id rather than a span context
+threaded through the agent loop, so a subagent run gets its own trace instead of nesting under
+the parent run's span. Everything within a single run nests correctly.
+
+## Exporting to Langfuse
+
+Langfuse ingests OTLP traces directly, so it needs no separate integration — just its endpoint
+and a Basic auth header built from your key pair:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic $(printf '%s:%s' "$LANGFUSE_PUBLIC_KEY" "$LANGFUSE_SECRET_KEY" | base64)"
+```
+
+Self-hosted Langfuse works the same way with your own host in place of `cloud.langfuse.com`.
+Do not add `logs` to `signals` for Langfuse — it has no logs endpoint and the requests would
+just fail.
+
+Note that `OTEL_EXPORTER_OTLP_HEADERS` values are percent-decoded, per the OpenTelemetry spec.
+Base64 padding (`=`) survives fine, but if your header value contains a literal `%` you must
+encode it as `%25`.
+
+## Attributes
+
+Spans and log records carry the same attributes. Where the OpenTelemetry GenAI semantic
+conventions define one, Jazz uses it:
+
+| Attribute | Value |
+| --- | --- |
+| `gen_ai.system` | Provider (`anthropic`, `openai`, …) |
+| `gen_ai.request.model` / `gen_ai.response.model` | Model id |
+| `gen_ai.operation.name` | `chat` |
+| `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` | Token counts |
+
+Everything else is namespaced under `jazz.*` — `jazz.agent.id`, `jazz.conversation.id`,
+`jazz.run.id`, `jazz.toolName`, `jazz.durationMs`, and the cache and reasoning token counts that
+have no semconv equivalent, under `jazz.usage.*`.
+
+These attribute names are still moving upstream. Jazz pins the semconv version it targets in
+`src/services/telemetry/otlp-mapping.ts`; treat a rename upstream as a deliberate change.
+
+## Prompts and completions
+
+By default Jazz exports **no** user or model text. Content-bearing fields are dropped and every
+remaining string attribute is truncated to 256 characters, so a stack trace or a long tool name
+cannot smuggle content out.
+
+Turning this off is deliberate and config-only — there is no environment variable for it:
+
+```json
+{ "telemetry": { "otlp": { "captureContent": true } } }
+```
+
+Enabling it sends prompts, model output, and tool arguments to whatever endpoint you configured.
+Today no event Jazz emits carries content, so the flag changes nothing yet; it exists so that
+adding a content-bearing field later cannot leak it by default.
+
+## Failure behavior
+
+Telemetry is best-effort by construction and never fails or slows a run:
+
+- Sinks are written concurrently and independently — a dead collector does not stop the local
+  file, and vice versa.
+- Failed writes are retried on the next flush, but only when *every* sink failed, so a working
+  file sink plus a dead collector never duplicates rows on disk.
+- If the collector stays down, the buffer stops growing at ten times `bufferSize` and the oldest
+  events are dropped with a warning in the log.
+- HTTP failures retry three times with backoff. A `401` or other non-retryable status fails fast
+  rather than burning attempts.
+
+## Turning it all off
+
+```json
+{ "telemetry": { "enabled": false } }
+```
+
+This stops local recording as well as export. To keep local files but stop exporting, set
+`telemetry.otlp.enabled` to `false` — the endpoint stays configured.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -149,6 +149,86 @@ Other providers follow the same `<PROVIDER>_API_KEY` convention — see
 | `JAZZ_TERMINAL_NOTIFIER` / `TERMINAL_NOTIFIER` | Path to a `terminal-notifier` binary for desktop notifications |
 | `JAZZ_TERMINAL` | Terminal identity used for notification attribution |
 
+## `telemetry`
+
+Jazz records what each run did — agent runs, LLM requests and token usage, retries, tool
+invocations, and CLI commands — as NDJSON under `~/.jazz/telemetry/events/YYYY-MM-DD.ndjson`,
+pruned after `retentionDays`. Set `telemetry.otlp` to also push those events to an
+OpenTelemetry collector. See [Observability](../guide/observability.md) for a working
+collector and Langfuse setup.
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "retentionDays": 90,
+    "otlp": {
+      "endpoint": "http://localhost:4318",
+      "headers": { "authorization": "Basic <base64>" },
+      "serviceName": "jazz",
+      "captureContent": false
+    }
+  }
+}
+```
+
+| Field | Default | Effect |
+| --- | --- | --- |
+| `enabled` | `true` | Master switch. `false` records nothing, locally or remotely |
+| `storagePath` | `~/.jazz/telemetry` | Where the local NDJSON files live |
+| `bufferSize` | `100` | Events buffered in memory before a flush |
+| `flushIntervalMs` | `30000` | Periodic flush interval |
+| `retentionDays` | `90` | Local files older than this are deleted |
+| `otlp.enabled` | `true` when an endpoint is set | Explicit opt-out that keeps the endpoint configured |
+| `otlp.signals` | `["traces"]` | Signals to export: `traces`, `logs`, or both |
+| `otlp.endpoint` | — | Collector base URL; `/v1/traces` and `/v1/logs` are appended |
+| `otlp.tracesEndpoint` | — | Full traces URL including path, overriding `endpoint` |
+| `otlp.logsEndpoint` | — | Full logs URL including path, overriding `endpoint` |
+| `otlp.headers` | `{}` | Extra HTTP headers, typically auth |
+| `otlp.serviceName` | `jazz` | `service.name` on exported records |
+| `otlp.captureContent` | `false` | Include prompt, completion, and tool argument text |
+| `otlp.timeoutMs` | `10000` | Per-request timeout |
+
+### OTLP environment variables
+
+Every `otlp` field falls back to the standard `OTEL_*` variable, so a Jazz process inherits an
+already-configured collector without touching `config.json`. Precedence is config → environment
+→ default.
+
+| Variable | Effect |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector base URL. Setting this alone turns export on |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Full traces URL, used verbatim; wins over the base URL |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Full logs URL, used verbatim; wins over the base URL |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `key=value` pairs, comma-separated, values percent-encoded |
+| `OTEL_SERVICE_NAME` | `service.name` on exported records |
+
+There is no environment variable for `captureContent` — it can only be turned on in config, and
+never follows from configuring an endpoint.
+
+### What gets exported
+
+Events are sent over OTLP/HTTP with JSON encoding. By default they are exported as **traces**:
+one trace per agent run, with the run as the root span and each LLM request, retry, and tool
+call as a child span. Traces are what LLM-observability backends accept — Langfuse ingests OTLP
+traces and not logs — so this is the signal that works everywhere. Add `logs` to
+`otlp.signals` to also emit the same events as OTLP log records.
+
+Where the OpenTelemetry GenAI semantic conventions define an attribute, Jazz uses it
+(`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`); everything else is namespaced under `jazz.*`.
+
+**`captureContent` is the one setting that turns observability into data egress.** With it off
+(the default) Jazz drops content-bearing fields and truncates every remaining string attribute
+to 256 characters. Turning it on sends user prompts, model output, and tool arguments to
+whatever endpoint you configured. No event Jazz emits today carries content, so the flag is
+currently inert — it exists so that adding a content-bearing field later cannot leak it by
+default.
+
+Export never blocks a run. A collector that is slow, down, or rejecting is logged as a warning
+and the events are dropped once the buffer ceiling is reached; the local NDJSON file is
+unaffected.
+
 ## `autoApprovedCommands`
 
 A persisted allowlist for `execute_command`, set at the top level of `~/.jazz/config.json`:

--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -19,8 +19,10 @@ import { handleError, isUserCancellation } from "./core/presentation/error-handl
 import { QuietPresentationServiceLayer } from "./core/presentation/quiet-presentation-service";
 import { SkillsLive } from "./core/skills/skill-service";
 import type { JazzError } from "./core/types/errors";
+import { getCurrentCommandName } from "./core/utils/current-command";
 import { isOfflineMode } from "./core/utils/runtime";
 import { resolveStorageDirectory } from "./core/utils/storage";
+import { emitTelemetry } from "./core/utils/telemetry-emit";
 import { SchedulerServiceLayer } from "./core/workflows/scheduler-service";
 import { WorkflowsLive } from "./core/workflows/workflow-service";
 import { createAgentServiceLayer } from "./services/agent-service";
@@ -216,6 +218,36 @@ export function createAppLayer(config: AppLayerConfig = {}) {
  * @param effect - The Effect to run
  * @param config - Configuration options for the application layer
  */
+/**
+ * Record the outcome of the CLI command that just finished.
+ *
+ * Only the command path is recorded — arguments and option values are omitted
+ * because they routinely carry prompts and file paths.
+ */
+function emitCommandExecuted(
+  exit: Exit.Exit<void, unknown>,
+  durationMs: number,
+): Effect.Effect<void> {
+  const command = getCurrentCommandName();
+  if (command === undefined) return Effect.void;
+
+  const failure = Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none();
+  const errorMessage = Option.isSome(failure)
+    ? failure.value instanceof Error
+      ? failure.value.message
+      : String(failure.value)
+    : undefined;
+
+  return emitTelemetry((telemetry) =>
+    telemetry.recordCommandExecuted({
+      command,
+      durationMs,
+      success: Exit.isSuccess(exit),
+      ...(errorMessage !== undefined && { error: errorMessage }),
+    }),
+  );
+}
+
 export function runCliEffect<R, E extends JazzError | Error>(
   effect: Effect.Effect<void, E, R>,
   config: AppLayerConfig = {},
@@ -243,6 +275,7 @@ export function runCliEffect<R, E extends JazzError | Error>(
   });
 
   const program = Effect.gen(function* () {
+    const commandStartedAt = Date.now();
     const shouldSkipCatchUp =
       process.env["JAZZ_DISABLE_CATCH_UP"] === "1" || options.skipCatchUp === true;
 
@@ -323,6 +356,8 @@ export function runCliEffect<R, E extends JazzError | Error>(
         ),
       )
       .pipe(Effect.map((r) => r.exit));
+
+    yield* emitCommandExecuted(exit, Date.now() - commandStartedAt);
 
     // Register cleanup for MCP server connections and telemetry flush
     yield* Effect.addFinalizer(() =>

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -44,6 +44,7 @@ import {
   workflowHistoryCommand,
 } from "./commands/workflow";
 import { parsePositiveInt } from "./utils/option-parsers";
+import { setCurrentCommandName } from "../core/utils/current-command";
 
 /**
  * CLI Application setup and command registration
@@ -58,6 +59,17 @@ interface CliOptions {
   config?: string;
   output?: string;
   tui?: boolean;
+}
+
+/** Build the full command path (`agent list`) by walking up to the root program. */
+function commandPath(command: Command): string {
+  const segments: string[] = [];
+  let current: Command | null = command;
+  while (current && current.parent) {
+    segments.unshift(current.name());
+    current = current.parent;
+  }
+  return segments.length > 0 ? segments.join(" ") : command.name();
 }
 
 /**
@@ -729,7 +741,7 @@ export function createCLIApp(): Effect.Effect<Command, never> {
       );
 
     // Apply global options before any command runs
-    program.hook("preAction", (thisCommand) => {
+    program.hook("preAction", (thisCommand, actionCommand) => {
       const opts = thisCommand.optsWithGlobals();
       if (opts["tui"] === false) {
         process.env["JAZZ_NO_TUI"] = "1";
@@ -737,6 +749,7 @@ export function createCLIApp(): Effect.Effect<Command, never> {
       if (opts["output"]) {
         process.env["JAZZ_OUTPUT_MODE"] = opts["output"] as string;
       }
+      setCurrentCommandName(commandPath(actionCommand));
     });
 
     // Register all commands

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -34,7 +34,7 @@ import { type Agent } from "../types";
 import { agentPromptBuilder } from "./agent-prompt";
 import { Summarizer } from "./context/summarizer";
 import { executeWithStreaming, executeWithoutStreaming } from "./execution";
-import { createAgentRunMetrics } from "./metrics/agent-run-metrics";
+import { createAgentRunMetrics, emitAgentRunStarted } from "./metrics/agent-run-metrics";
 import { registerCustomToolsForAgent } from "./tools/custom-tools";
 import { registerMCPToolsForAgent } from "./tools/register-mcp-tools";
 import { registerSkillSystemTools } from "./tools/register-tools";
@@ -101,6 +101,8 @@ function initializeAgentRun(
       reasoningEffort: agent.config.reasoningEffort ?? "disable",
       maxIterations: resolvedMaxIterations,
     });
+
+    yield* emitAgentRunStarted(runMetrics);
 
     // Level 1: List all available skills (metadata only)
     const relevantSkills = yield* skillService.listSkills();

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber, Option, Ref } from "effect";
+import { Cause, Effect, Fiber, Option, Ref } from "effect";
 import { type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
@@ -26,6 +26,8 @@ import {
   beginIteration,
   calibrateTokenCounter,
   completeIteration,
+  emitAgentRunFailed,
+  emitLLMUsage,
   estimateTokens,
   finalizeAgentRun,
   recordLLMUsage,
@@ -499,7 +501,9 @@ function runIteration(
       ? ([...state.currentMessages, budgetMsg] as typeof state.currentMessages)
       : state.currentMessages;
 
+    const completionStartTime = Date.now();
     const result = yield* strategy.getCompletion(messagesForLLM, iterationIndex);
+    const completionDurationMs = Date.now() - completionStartTime;
 
     if (result.interrupted) {
       const completion = result.completion;
@@ -535,6 +539,7 @@ function runIteration(
 
     if (completion.usage) {
       recordLLMUsage(runMetrics, completion.usage);
+      yield* emitLLMUsage(runMetrics, completion.usage, completionDurationMs);
 
       calibrateTokenCounter({
         authoritativePromptTokens: completion.usage.promptTokens,
@@ -778,7 +783,19 @@ export function executeAgentLoop(
           maxIterations,
           finalizeFiberRef,
         );
-      }),
+      }).pipe(
+        // A run that dies here never reaches finalizeRun, so `agent_run_completed`
+        // is never emitted. Record the failure instead. Interrupts (Ctrl+C, double
+        // Esc) are not failures and are left unrecorded.
+        Effect.tapErrorCause((cause) =>
+          Cause.isInterruptedOnly(cause)
+            ? Effect.void
+            : emitAgentRunFailed(
+                runContext.runMetrics,
+                Cause.failureOption(cause).pipe(Option.getOrElse(() => Cause.pretty(cause))),
+              ),
+        ),
+      ),
     // Release: cleanup
     ({ logger, finalizeFiberRef }) =>
       Effect.gen(function* () {

--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -16,7 +16,7 @@ import type { DisplayConfig } from "@/core/types/output";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
 import { makeDefaultObserver } from "./agent-loop-observer";
 import type { RecursiveRunner } from "../context/summarizer";
-import { recordLLMRetry } from "../metrics/agent-run-metrics";
+import { emitLLMRetry, recordLLMRetry } from "../metrics/agent-run-metrics";
 import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../types";
 
 /**
@@ -101,14 +101,14 @@ export function executeWithoutStreaming(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
-              Effect.gen(function* () {
-                try {
-                  return yield* llmService.createChatCompletion(provider, llmOptions);
-                } catch (error) {
-                  recordLLMRetry(runMetrics, error);
-                  throw error;
-                }
-              }),
+              llmService.createChatCompletion(provider, llmOptions).pipe(
+                Effect.tapError((error) =>
+                  Effect.gen(function* () {
+                    recordLLMRetry(runMetrics, error);
+                    yield* emitLLMRetry(runMetrics, error);
+                  }),
+                ),
+              ),
             ),
             batchRetrySchedule,
           ).pipe(

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -24,7 +24,11 @@ import { isRetryableLLMError } from "@/core/utils/llm-error";
 import { executeAgentLoop, type CompletionStrategy } from "./agent-loop";
 import { makeDefaultObserver } from "./agent-loop-observer";
 import type { RecursiveRunner } from "../context/summarizer";
-import { recordFirstTokenLatency, recordLLMRetry } from "../metrics/agent-run-metrics";
+import {
+  emitLLMRetry,
+  recordFirstTokenLatency,
+  recordLLMRetry,
+} from "../metrics/agent-run-metrics";
 import type { AgentResponse, AgentRunContext, AgentRunnerOptions } from "../types";
 
 const DEFERRED_RESPONSE_TIMEOUT = Duration.seconds(15);
@@ -131,28 +135,28 @@ export function executeWithStreaming(
             withLongRunningLlmNotice(
               agent.name,
               showAgentStatus,
-              Effect.gen(function* () {
-                try {
-                  return yield* llmService.createStreamingChatCompletion(provider, llmOptions);
-                } catch (error) {
-                  recordLLMRetry(runMetrics, error);
-                  if (
-                    error instanceof LLMRequestError ||
-                    error instanceof LLMRateLimitError ||
-                    error instanceof LLMAuthenticationError
-                  ) {
-                    yield* logger.error("LLM request error", {
-                      provider,
-                      model: agent.config.llmModel,
-                      errorType: error._tag,
-                      message: error.message,
-                      agentId: agent.id,
-                      conversationId: actualConversationId,
-                    });
-                  }
-                  throw error;
-                }
-              }),
+              llmService.createStreamingChatCompletion(provider, llmOptions).pipe(
+                Effect.tapError((error) =>
+                  Effect.gen(function* () {
+                    recordLLMRetry(runMetrics, error);
+                    yield* emitLLMRetry(runMetrics, error);
+                    if (
+                      error instanceof LLMRequestError ||
+                      error instanceof LLMRateLimitError ||
+                      error instanceof LLMAuthenticationError
+                    ) {
+                      yield* logger.error("LLM request error", {
+                        provider,
+                        model: agent.config.llmModel,
+                        errorType: error._tag,
+                        message: error.message,
+                        agentId: agent.id,
+                        conversationId: actualConversationId,
+                      });
+                    }
+                  }),
+                ),
+              ),
             ),
             streamingRetrySchedule,
           ).pipe(
@@ -188,14 +192,14 @@ export function executeWithStreaming(
                     withLongRunningLlmNotice(
                       agent.name,
                       showAgentStatus,
-                      Effect.gen(function* () {
-                        try {
-                          return yield* llmService.createChatCompletion(provider, llmOptions);
-                        } catch (innerError) {
-                          recordLLMRetry(runMetrics, innerError);
-                          throw innerError;
-                        }
-                      }),
+                      llmService.createChatCompletion(provider, llmOptions).pipe(
+                        Effect.tapError((innerError) =>
+                          Effect.gen(function* () {
+                            recordLLMRetry(runMetrics, innerError);
+                            yield* emitLLMRetry(runMetrics, innerError);
+                          }),
+                        ),
+                      ),
                     ),
                     fallbackRetrySchedule,
                   ).pipe(

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -24,6 +24,7 @@ import {
 import { extractCommandApprovalKey } from "@/core/utils/shell";
 import { formatToolArguments } from "@/core/utils/tool-formatter";
 import {
+  emitToolInvocation,
   recordToolError,
   recordToolInvocation,
   type createAgentRunMetrics,
@@ -408,6 +409,13 @@ export class ToolExecutor {
         // approval is waiting.
         yield* presentationService.signalToolExecutionStarted();
 
+        yield* emitToolInvocation(runMetrics, {
+          toolName: finalToolName,
+          success: result.success,
+          durationMs: toolDuration,
+          ...(result.success ? {} : { error: result.error ?? "Tool execution failed" }),
+        });
+
         const finalResult = result.success
           ? result.result
           : { error: result.error ?? "Tool execution failed", result: result.result };
@@ -440,6 +448,12 @@ export class ToolExecutor {
         }
 
         recordToolError(runMetrics, name, error);
+        yield* emitToolInvocation(runMetrics, {
+          toolName: name,
+          success: false,
+          durationMs: toolDuration,
+          error,
+        });
         yield* logger.error("Tool execution failed", {
           agentId,
           conversationId,

--- a/src/core/agent/metrics/agent-run-metrics.ts
+++ b/src/core/agent/metrics/agent-run-metrics.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { Context, Effect } from "effect";
+import { Effect } from "effect";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type { TelemetryService, TokenUsage } from "@/core/interfaces/telemetry";
-import { TelemetryServiceTag } from "@/core/interfaces/telemetry";
 import { type Agent } from "@/core/types";
 import type { ChatMessage } from "@/core/types/message";
+import { emitTelemetry } from "@/core/utils/telemetry-emit";
 import { DEFAULT_TOKEN_COUNTER } from "../context/token-counter";
 
 export interface AgentRunMetricsContext {
@@ -471,31 +471,102 @@ function buildTelemetryPayload(
   };
 }
 
-/**
- * Emit telemetry for a completed agent run.
- *
- * Uses a raw context lookup via `Context.getOption` cast through `any`
- * so that `TelemetryService` is NOT added to the `R` type parameter –
- * callers are completely unaffected.
- *
- * Failures are silently swallowed (telemetry is best-effort).
- */
 function emitAgentRunTelemetry(
   metrics: AgentRunMetrics,
   totalTokens: number,
   durationMs: number,
   details: { readonly iterationsUsed: number; readonly finished: boolean },
 ): Effect.Effect<void> {
-  return Effect.flatMap(Effect.context<never>(), (ctx) => {
-    const maybeTelemetry = Context.getOption(ctx, TelemetryServiceTag);
+  const payload = buildTelemetryPayload(metrics, totalTokens, durationMs, details);
+  return emitTelemetry((telemetry) => telemetry.recordAgentRunCompleted(payload));
+}
 
-    if (maybeTelemetry._tag === "None") return Effect.void;
+/** Emit `agent_run_started` at the top of a run. Best-effort. */
+export function emitAgentRunStarted(metrics: AgentRunMetrics): Effect.Effect<void> {
+  return emitTelemetry((telemetry) =>
+    telemetry.recordAgentRunStarted({
+      runId: metrics.runId,
+      agentId: metrics.agentId,
+      agentName: metrics.agentName,
+      conversationId: metrics.conversationId,
+      ...(metrics.provider && { provider: metrics.provider }),
+      ...(metrics.model && { model: metrics.model }),
+    }),
+  );
+}
 
-    const telemetry = maybeTelemetry.value;
-    const payload = buildTelemetryPayload(metrics, totalTokens, durationMs, details);
+/**
+ * Emit `agent_run_failed` when the run dies before `finalizeAgentRun` is
+ * reached. A run emits either this or `agent_run_completed`, never both.
+ */
+export function emitAgentRunFailed(metrics: AgentRunMetrics, error: unknown): Effect.Effect<void> {
+  const durationMs = Date.now() - metrics.startedAt.getTime();
+  return emitTelemetry((telemetry) =>
+    telemetry.recordAgentRunFailed({
+      runId: metrics.runId,
+      agentId: metrics.agentId,
+      agentName: metrics.agentName,
+      conversationId: metrics.conversationId,
+      error: normalizeError(error),
+      durationMs,
+    }),
+  );
+}
 
-    return telemetry.recordAgentRunCompleted(payload).pipe(Effect.catchAll(() => Effect.void));
-  }).pipe(Effect.catchAll(() => Effect.void));
+/** Emit `llm_usage` for a single completion. Best-effort. */
+export function emitLLMUsage(
+  metrics: AgentRunMetrics,
+  usage: TokenUsage,
+  durationMs: number,
+): Effect.Effect<void> {
+  return emitTelemetry((telemetry) =>
+    telemetry.recordLLMUsage({
+      provider: metrics.provider ?? "unknown",
+      model: metrics.model ?? "unknown",
+      usage,
+      agentId: metrics.agentId,
+      sessionId: metrics.conversationId,
+      durationMs,
+      runId: metrics.runId,
+    }),
+  );
+}
+
+/** Emit `llm_retry`. Best-effort. Call after `recordLLMRetry` bumps the count. */
+export function emitLLMRetry(metrics: AgentRunMetrics, error: unknown): Effect.Effect<void> {
+  return emitTelemetry((telemetry) =>
+    telemetry.recordLLMRetry({
+      provider: metrics.provider ?? "unknown",
+      model: metrics.model ?? "unknown",
+      error: normalizeError(error),
+      attempt: metrics.llmRetryCount,
+      agentId: metrics.agentId,
+      runId: metrics.runId,
+    }),
+  );
+}
+
+/** Emit `tool_invocation` / `tool_error` for a single tool call. Best-effort. */
+export function emitToolInvocation(
+  metrics: AgentRunMetrics,
+  data: {
+    readonly toolName: string;
+    readonly success: boolean;
+    readonly durationMs: number;
+    readonly error?: unknown;
+  },
+): Effect.Effect<void> {
+  return emitTelemetry((telemetry) =>
+    telemetry.recordToolInvocation({
+      toolName: data.toolName,
+      success: data.success,
+      durationMs: data.durationMs,
+      ...(data.error !== undefined && { error: normalizeError(data.error) }),
+      agentId: metrics.agentId,
+      sessionId: metrics.conversationId,
+      runId: metrics.runId,
+    }),
+  );
 }
 
 function normalizeError(error: unknown): string {

--- a/src/core/interfaces/telemetry.ts
+++ b/src/core/interfaces/telemetry.ts
@@ -197,6 +197,8 @@ export interface TelemetryService {
     readonly agentId?: string;
     readonly sessionId?: string;
     readonly durationMs?: number;
+    /** Groups this request under its agent run when exported as a trace. */
+    readonly runId?: string;
   }) => Effect.Effect<void, TelemetryError>;
 
   /**
@@ -208,6 +210,8 @@ export interface TelemetryService {
     readonly error: string;
     readonly attempt: number;
     readonly agentId?: string;
+    /** Groups this retry under its agent run when exported as a trace. */
+    readonly runId?: string;
   }) => Effect.Effect<void, TelemetryError>;
 
   /**
@@ -220,6 +224,8 @@ export interface TelemetryService {
     readonly error?: string;
     readonly agentId?: string;
     readonly sessionId?: string;
+    /** Groups this tool call under its agent run when exported as a trace. */
+    readonly runId?: string;
   }) => Effect.Effect<void, TelemetryError>;
 
   /**

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -51,6 +51,54 @@ export interface TelemetryConfig {
   readonly flushIntervalMs?: number;
   /** Maximum number of days to retain telemetry data. Defaults to 90. */
   readonly retentionDays?: number;
+  /** Export events to an OpenTelemetry-compatible collector. Off unless an endpoint is set. */
+  readonly otlp?: OtlpTelemetryConfig;
+}
+
+/**
+ * OTLP/HTTP export settings.
+ *
+ * Every field falls back to the corresponding `OTEL_*` environment variable, so
+ * a Jazz process inherits an already-configured collector without touching
+ * config.json.
+ */
+export interface OtlpTelemetryConfig {
+  /**
+   * Explicit opt-out. Export is enabled by the presence of an endpoint; set
+   * this to false to keep the endpoint configured but stop sending.
+   */
+  readonly enabled?: boolean;
+  /**
+   * Signals to export. Defaults to `["traces"]`: spans are what turns a run
+   * into a waterfall, and what LLM-observability backends accept — Langfuse
+   * ingests OTLP traces and not logs.
+   */
+  readonly signals?: readonly ("traces" | "logs")[];
+  /** Collector base URL, e.g. `http://localhost:4318`. Env: OTEL_EXPORTER_OTLP_ENDPOINT. */
+  readonly endpoint?: string;
+  /**
+   * Full traces URL including path, overriding `endpoint`. Needed by backends
+   * that do not serve OTLP at `<base>/v1/traces`.
+   * Env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.
+   */
+  readonly tracesEndpoint?: string;
+  /**
+   * Full logs URL including path, overriding `endpoint`.
+   * Env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.
+   */
+  readonly logsEndpoint?: string;
+  /** Extra HTTP headers, typically auth. Env: OTEL_EXPORTER_OTLP_HEADERS. */
+  readonly headers?: Readonly<Record<string, string>>;
+  /** `service.name` on exported records. Defaults to "jazz". Env: OTEL_SERVICE_NAME. */
+  readonly serviceName?: string;
+  /**
+   * Include prompt, completion, and tool argument text in exported events.
+   * Defaults to false: enabling it sends user content to the configured
+   * endpoint.
+   */
+  readonly captureContent?: boolean;
+  /** Per-request timeout in milliseconds. Defaults to 10000. */
+  readonly timeoutMs?: number;
 }
 
 /**

--- a/src/core/utils/current-command.ts
+++ b/src/core/utils/current-command.ts
@@ -1,0 +1,17 @@
+let currentCommandName: string | undefined;
+
+/**
+ * Record which CLI command is executing, as a space-separated path
+ * (`agent list`, `workflow run`).
+ *
+ * Only the command path is stored — never positional arguments or option
+ * values, which routinely carry prompts, file paths, and other user content
+ * that must not end up in telemetry.
+ */
+export function setCurrentCommandName(name: string): void {
+  currentCommandName = name;
+}
+
+export function getCurrentCommandName(): string | undefined {
+  return currentCommandName;
+}

--- a/src/core/utils/telemetry-emit.test.ts
+++ b/src/core/utils/telemetry-emit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import type { TelemetryService } from "@/core/interfaces/telemetry";
+import { TelemetryServiceTag } from "@/core/interfaces/telemetry";
+import { TelemetryError } from "@/core/types/errors";
+import { emitTelemetry } from "./telemetry-emit";
+
+function stubTelemetry(overrides: Partial<TelemetryService>): TelemetryService {
+  const notCalled = () => Effect.void as Effect.Effect<never, TelemetryError>;
+  return {
+    recordAgentRunStarted: notCalled,
+    recordAgentRunCompleted: notCalled,
+    recordAgentRunFailed: notCalled,
+    recordLLMUsage: notCalled,
+    recordLLMRetry: notCalled,
+    recordToolInvocation: notCalled,
+    recordCommandExecuted: notCalled,
+    recordEvent: notCalled,
+    getEvents: notCalled,
+    getUsageSummary: notCalled,
+    flush: notCalled,
+    ...overrides,
+  } as TelemetryService;
+}
+
+describe("emitTelemetry", () => {
+  it("is a no-op when no telemetry service is provided", async () => {
+    // Test layers routinely omit telemetry; instrumenting a call site must not
+    // break them.
+    await Effect.runPromise(emitTelemetry(() => Effect.void));
+  });
+
+  it("calls the service when one is present", async () => {
+    let called = false;
+    const telemetry = stubTelemetry({
+      recordEvent: () =>
+        Effect.sync(() => {
+          called = true;
+        }),
+    });
+
+    await Effect.runPromise(
+      emitTelemetry((service) => service.recordEvent("custom", {})).pipe(
+        Effect.provide(Layer.succeed(TelemetryServiceTag, telemetry)),
+      ),
+    );
+
+    expect(called).toBe(true);
+  });
+
+  it("swallows telemetry failures rather than failing the caller", async () => {
+    const telemetry = stubTelemetry({
+      recordEvent: () =>
+        Effect.fail(new TelemetryError({ operation: "write", message: "disk full" })),
+    });
+
+    await Effect.runPromise(
+      emitTelemetry((service) => service.recordEvent("custom", {})).pipe(
+        Effect.provide(Layer.succeed(TelemetryServiceTag, telemetry)),
+      ),
+    );
+  });
+
+  it("swallows defects thrown by the service", async () => {
+    const telemetry = stubTelemetry({
+      recordEvent: () => {
+        throw new Error("boom");
+      },
+    });
+
+    await Effect.runPromise(
+      emitTelemetry((service) => service.recordEvent("custom", {})).pipe(
+        Effect.provide(Layer.succeed(TelemetryServiceTag, telemetry)),
+      ),
+    );
+  });
+});

--- a/src/core/utils/telemetry-emit.ts
+++ b/src/core/utils/telemetry-emit.ts
@@ -1,0 +1,27 @@
+import { Context, Effect } from "effect";
+import type { TelemetryService } from "@/core/interfaces/telemetry";
+import { TelemetryServiceTag } from "@/core/interfaces/telemetry";
+
+/**
+ * Emit a telemetry event without adding `TelemetryService` to the caller's `R`.
+ *
+ * The service is looked up through the ambient context rather than required as
+ * a dependency, so instrumenting a call site never changes its type signature
+ * and never breaks test layers that omit telemetry. Failures are swallowed:
+ * telemetry must never fail a run.
+ */
+export function emitTelemetry(
+  emit: (telemetry: TelemetryService) => Effect.Effect<void, unknown>,
+): Effect.Effect<void> {
+  return Effect.flatMap(Effect.context<never>(), (context) => {
+    const maybeTelemetry = Context.getOption(context, TelemetryServiceTag);
+    if (maybeTelemetry._tag === "None") return Effect.void;
+    // `Effect.suspend` brings a synchronous throw from `emit` itself into the
+    // effect as a defect, so `catchAllDefect` can absorb it along with any
+    // defect raised while running.
+    return Effect.suspend(() => emit(maybeTelemetry.value));
+  }).pipe(
+    Effect.catchAll(() => Effect.void),
+    Effect.catchAllDefect(() => Effect.void),
+  );
+}

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -442,4 +442,36 @@ describe("createConfigLayer", () => {
 
     expect(await Effect.runPromise(program)).toBeUndefined();
   });
+
+  it("merges the telemetry.otlp block without dropping sibling telemetry settings", async () => {
+    const customConfigPath = path.join(os.tmpdir(), "jazz-otlp-config.json");
+
+    const fileContents = new Map<string, string>([
+      [
+        customConfigPath,
+        JSON.stringify({
+          telemetry: {
+            retentionDays: 7,
+            otlp: { endpoint: "http://collector:4318", captureContent: true },
+          },
+        }),
+      ],
+    ]);
+
+    const layer = createConfigLayer(undefined, customConfigPath).pipe(
+      Layer.provide(Layer.succeed(FileSystem.FileSystem, createTestFileSystem(fileContents))),
+    );
+    const program = Effect.gen(function* () {
+      const config = yield* AgentConfigServiceTag;
+      const endpoint = yield* config.get<string>("telemetry.otlp.endpoint");
+      const captureContent = yield* config.get<boolean>("telemetry.otlp.captureContent");
+      const retentionDays = yield* config.get<number>("telemetry.retentionDays");
+      return { endpoint, captureContent, retentionDays };
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.endpoint).toBe("http://collector:4318");
+    expect(result.captureContent).toBe(true);
+    expect(result.retentionDays).toBe(7);
+  });
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -427,7 +427,15 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
     ...(override.maxSubagentIterations !== undefined && {
       maxSubagentIterations: override.maxSubagentIterations,
     }),
-    ...(override.telemetry && { telemetry: { ...(base.telemetry ?? {}), ...override.telemetry } }),
+    ...(override.telemetry && {
+      telemetry: {
+        ...(base.telemetry ?? {}),
+        ...override.telemetry,
+        ...(override.telemetry.otlp && {
+          otlp: { ...(base.telemetry?.otlp ?? {}), ...override.telemetry.otlp },
+        }),
+      },
+    }),
   };
 }
 

--- a/src/services/llm/ai-sdk-service.test.ts
+++ b/src/services/llm/ai-sdk-service.test.ts
@@ -70,8 +70,13 @@ mock.module("@/core/utils/models-dev", () => ({
     ]),
 }));
 
+// `global.fetch` is assigned directly below, which `mock.restore()` does not
+// undo. Snapshot it so later test files in the same process still see real fetch.
+const actualFetch = globalThis.fetch;
+
 afterAll(() => {
   mock.module("@/core/utils/models-dev", () => actualModelsDevModule);
+  globalThis.fetch = actualFetch;
 });
 
 describe("AI SDK Service - Unit Tests", () => {

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -48,8 +48,13 @@ mock.module("@/core/utils/models-dev", () => ({
   }),
 }));
 
+// `global.fetch` is assigned directly below, which `mock.restore()` does not
+// undo. Snapshot it so later test files in the same process still see real fetch.
+const actualFetch = globalThis.fetch;
+
 afterAll(() => {
   mock.module("@/core/utils/models-dev", () => actualModelsDevModule);
+  globalThis.fetch = actualFetch;
 });
 
 /**

--- a/src/services/telemetry/file-sink.ts
+++ b/src/services/telemetry/file-sink.ts
@@ -1,0 +1,103 @@
+import { appendFile, mkdir, readFile, readdir, unlink } from "node:fs/promises";
+import path from "node:path";
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+import type { TelemetryEventReader, TelemetrySink } from "./sink";
+
+const EVENTS_DIR = "events";
+
+/** Date partition for an event file name: YYYY-MM-DD. */
+export function datePartition(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Appends events as NDJSON under `<storagePath>/events/YYYY-MM-DD.ndjson`.
+ *
+ * This is Jazz's default sink and the only one that can be read back.
+ */
+export class FileTelemetrySink implements TelemetrySink, TelemetryEventReader {
+  readonly name = "file";
+  private directoryCreated = false;
+
+  constructor(
+    private readonly storagePath: string,
+    private readonly retentionDays: number,
+  ) {}
+
+  private get eventsDirectory(): string {
+    return path.join(this.storagePath, EVENTS_DIR);
+  }
+
+  async write(events: readonly TelemetryEvent[]): Promise<void> {
+    if (events.length === 0) return;
+
+    if (!this.directoryCreated) {
+      await mkdir(this.eventsDirectory, { recursive: true });
+      this.directoryCreated = true;
+    }
+
+    const byPartition = new Map<string, TelemetryEvent[]>();
+    for (const event of events) {
+      const partition = datePartition(new Date(event.timestamp));
+      const existing = byPartition.get(partition);
+      if (existing) {
+        existing.push(event);
+      } else {
+        byPartition.set(partition, [event]);
+      }
+    }
+
+    for (const [partition, partitionEvents] of byPartition) {
+      const filePath = path.join(this.eventsDirectory, `${partition}.ndjson`);
+      const lines = partitionEvents.map((event) => JSON.stringify(event)).join("\n") + "\n";
+      await appendFile(filePath, lines, { encoding: "utf8" });
+    }
+  }
+
+  async readAll(): Promise<TelemetryEvent[]> {
+    let files: string[];
+    try {
+      files = await readdir(this.eventsDirectory);
+    } catch {
+      return [];
+    }
+
+    const events: TelemetryEvent[] = [];
+    for (const file of files.filter((name) => name.endsWith(".ndjson")).sort()) {
+      const content = await readFile(path.join(this.eventsDirectory, file), { encoding: "utf8" });
+      for (const line of content.split("\n")) {
+        if (line.trim().length === 0) continue;
+        try {
+          events.push(JSON.parse(line) as TelemetryEvent);
+        } catch {
+          // Skip malformed lines rather than failing the whole query.
+        }
+      }
+    }
+    return events;
+  }
+
+  /** Delete event files older than the retention window. Returns the count removed. */
+  async prune(): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - this.retentionDays);
+    const cutoffPartition = datePartition(cutoff);
+
+    let files: string[];
+    try {
+      files = await readdir(this.eventsDirectory);
+    } catch {
+      return 0;
+    }
+
+    let pruned = 0;
+    for (const file of files) {
+      if (!file.endsWith(".ndjson")) continue;
+      if (file.replace(".ndjson", "") < cutoffPartition) {
+        await unlink(path.join(this.eventsDirectory, file));
+        pruned += 1;
+      }
+    }
+    return pruned;
+  }
+}

--- a/src/services/telemetry/otlp-config.test.ts
+++ b/src/services/telemetry/otlp-config.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import {
+  joinOtlpEndpoint,
+  parseOtlpHeaders,
+  redactHeaders,
+  resolveOtlpConfig,
+} from "./otlp-config";
+
+describe("parseOtlpHeaders", () => {
+  it("parses comma-separated key=value pairs", () => {
+    expect(parseOtlpHeaders("api-key=abc,x-tenant=acme")).toEqual({
+      "api-key": "abc",
+      "x-tenant": "acme",
+    });
+  });
+
+  it("percent-decodes values per the W3C Baggage format", () => {
+    expect(parseOtlpHeaders("authorization=Basic%20cHViOnNlYw%3D%3D")).toEqual({
+      authorization: "Basic cHViOnNlYw==",
+    });
+  });
+
+  it("keeps values containing '=' intact", () => {
+    expect(parseOtlpHeaders("authorization=Basic cHVi==")).toEqual({
+      authorization: "Basic cHVi==",
+    });
+  });
+
+  it("skips malformed pairs instead of throwing", () => {
+    expect(parseOtlpHeaders("novalue,=orphan,good=1")).toEqual({ good: "1" });
+  });
+});
+
+describe("joinOtlpEndpoint", () => {
+  it("appends the signal path", () => {
+    expect(joinOtlpEndpoint("http://localhost:4318", "/v1/logs")).toBe(
+      "http://localhost:4318/v1/logs",
+    );
+  });
+
+  it("tolerates trailing slashes", () => {
+    expect(joinOtlpEndpoint("http://localhost:4318///", "/v1/logs")).toBe(
+      "http://localhost:4318/v1/logs",
+    );
+  });
+});
+
+describe("resolveOtlpConfig", () => {
+  it("returns undefined when no endpoint is configured anywhere", () => {
+    expect(resolveOtlpConfig(undefined, {})).toBeUndefined();
+  });
+
+  it("enables export from the environment alone", () => {
+    const resolved = resolveOtlpConfig(undefined, {
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+    });
+
+    expect(resolved?.enabled).toBe(true);
+    expect(resolved?.tracesEndpoint).toBe("http://collector:4318/v1/traces");
+    expect(resolved?.logsEndpoint).toBe("http://collector:4318/v1/logs");
+  });
+
+  it("defaults to traces, the signal LLM-observability backends accept", () => {
+    const resolved = resolveOtlpConfig(undefined, {
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+    });
+
+    expect(resolved?.signals).toEqual(["traces"]);
+  });
+
+  it("honours an explicit signal selection", () => {
+    const resolved = resolveOtlpConfig(
+      { endpoint: "http://collector:4318", signals: ["traces", "logs"] },
+      {},
+    );
+
+    expect(resolved?.signals).toEqual(["traces", "logs"]);
+  });
+
+  it("drops a signal whose endpoint cannot be resolved rather than guessing one", () => {
+    const resolved = resolveOtlpConfig(
+      {
+        tracesEndpoint: "https://langfuse.example/api/public/otel/v1/traces",
+        signals: ["traces", "logs"],
+      },
+      {},
+    );
+
+    expect(resolved?.signals).toEqual(["traces"]);
+  });
+
+  it("never enables content capture from the environment", () => {
+    const resolved = resolveOtlpConfig(undefined, {
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+    });
+
+    expect(resolved?.captureContent).toBe(false);
+  });
+
+  it("prefers explicit config over the environment", () => {
+    const resolved = resolveOtlpConfig(
+      { endpoint: "http://configured:4318", serviceName: "jazz-prod" },
+      { OTEL_EXPORTER_OTLP_ENDPOINT: "http://env:4318", OTEL_SERVICE_NAME: "from-env" },
+    );
+
+    expect(resolved?.logsEndpoint).toBe("http://configured:4318/v1/logs");
+    expect(resolved?.serviceName).toBe("jazz-prod");
+  });
+
+  it("prefers the signal-specific endpoint and uses it verbatim", () => {
+    const resolved = resolveOtlpConfig(undefined, {
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://cloud.langfuse.com/api/public/otel/v1/traces",
+    });
+
+    expect(resolved?.tracesEndpoint).toBe("https://cloud.langfuse.com/api/public/otel/v1/traces");
+    // The base URL still resolves the other signal.
+    expect(resolved?.logsEndpoint).toBe("http://collector:4318/v1/logs");
+  });
+
+  it("honours an explicit opt-out while keeping the endpoint", () => {
+    const resolved = resolveOtlpConfig(
+      { enabled: false },
+      { OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318" },
+    );
+
+    expect(resolved?.enabled).toBe(false);
+    expect(resolved?.tracesEndpoint).toBe("http://collector:4318/v1/traces");
+  });
+
+  it("reads headers from the environment", () => {
+    const resolved = resolveOtlpConfig(undefined, {
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318",
+      OTEL_EXPORTER_OTLP_HEADERS: "authorization=Bearer%20token",
+    });
+
+    expect(resolved?.headers).toEqual({ authorization: "Bearer token" });
+  });
+});
+
+describe("redactHeaders", () => {
+  it("masks credential-bearing headers", () => {
+    expect(
+      redactHeaders({
+        authorization: "Basic secret",
+        "x-api-key": "abc",
+        "x-tenant": "acme",
+      }),
+    ).toEqual({
+      authorization: "<redacted>",
+      "x-api-key": "<redacted>",
+      "x-tenant": "acme",
+    });
+  });
+});

--- a/src/services/telemetry/otlp-config.ts
+++ b/src/services/telemetry/otlp-config.ts
@@ -1,0 +1,115 @@
+import type { OtlpTelemetryConfig } from "@/core/types/config";
+
+export type OtlpSignal = "traces" | "logs";
+
+export interface ResolvedOtlpConfig {
+  readonly enabled: boolean;
+  /** Signals to export. Traces are what LLM-observability backends accept. */
+  readonly signals: readonly OtlpSignal[];
+  /** Full URL to POST spans to, including the `/v1/traces` path. */
+  readonly tracesEndpoint: string;
+  /** Full URL to POST log records to, including the `/v1/logs` path. */
+  readonly logsEndpoint: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly serviceName: string;
+  readonly captureContent: boolean;
+  readonly timeoutMs: number;
+}
+
+const DEFAULT_SERVICE_NAME = "jazz";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_SIGNALS: readonly OtlpSignal[] = ["traces"];
+
+/**
+ * Decode an `OTEL_EXPORTER_OTLP_HEADERS` value.
+ *
+ * The spec formats it as W3C Baggage: comma-separated `key=value` pairs with
+ * percent-encoded values.
+ */
+export function parseOtlpHeaders(raw: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const pair of raw.split(",")) {
+    const separatorIndex = pair.indexOf("=");
+    if (separatorIndex <= 0) continue;
+    const key = pair.slice(0, separatorIndex).trim();
+    const value = pair.slice(separatorIndex + 1).trim();
+    if (key.length === 0) continue;
+    try {
+      headers[key] = decodeURIComponent(value);
+    } catch {
+      headers[key] = value;
+    }
+  }
+  return headers;
+}
+
+/** Join an OTLP base endpoint with a signal path, tolerating a trailing slash. */
+export function joinOtlpEndpoint(base: string, signalPath: string): string {
+  return `${base.replace(/\/+$/, "")}${signalPath}`;
+}
+
+/**
+ * Resolve OTLP export settings from config and environment.
+ *
+ * Precedence is explicit config > environment > default, matching how the rest
+ * of Jazz resolves settings. Setting only `OTEL_EXPORTER_OTLP_ENDPOINT` is
+ * enough to turn export on — that is the ergonomic operators expect from an
+ * OTEL-aware process — but it never turns on `captureContent`, which has to be
+ * asked for deliberately.
+ */
+export function resolveOtlpConfig(
+  config: OtlpTelemetryConfig | undefined,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): ResolvedOtlpConfig | undefined {
+  const baseEndpoint = config?.endpoint ?? env["OTEL_EXPORTER_OTLP_ENDPOINT"];
+
+  const tracesEndpoint =
+    config?.tracesEndpoint ??
+    env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] ??
+    (baseEndpoint ? joinOtlpEndpoint(baseEndpoint, "/v1/traces") : undefined);
+
+  const logsEndpoint =
+    config?.logsEndpoint ??
+    env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] ??
+    (baseEndpoint ? joinOtlpEndpoint(baseEndpoint, "/v1/logs") : undefined);
+
+  if (tracesEndpoint === undefined && logsEndpoint === undefined) return undefined;
+
+  // A signal whose endpoint could not be resolved is dropped rather than
+  // pointed at a guessed URL.
+  const requestedSignals = config?.signals ?? DEFAULT_SIGNALS;
+  const signals = requestedSignals.filter((signal) =>
+    signal === "traces" ? tracesEndpoint !== undefined : logsEndpoint !== undefined,
+  );
+
+  // An endpoint alone enables export; `enabled: false` is an explicit opt-out.
+  const enabled = config?.enabled ?? true;
+
+  const envHeaders = env["OTEL_EXPORTER_OTLP_HEADERS"];
+  const headers = config?.headers ?? (envHeaders ? parseOtlpHeaders(envHeaders) : {});
+
+  return {
+    enabled,
+    signals,
+    tracesEndpoint: tracesEndpoint ?? "",
+    logsEndpoint: logsEndpoint ?? "",
+    headers,
+    serviceName: config?.serviceName ?? env["OTEL_SERVICE_NAME"] ?? DEFAULT_SERVICE_NAME,
+    captureContent: config?.captureContent ?? false,
+    timeoutMs: config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Header names that must never be echoed into logs or written to disk.
+ */
+const SENSITIVE_HEADER_PATTERN = /authorization|api[-_]?key|token|secret|cookie/i;
+
+/** Redact credential-bearing header values for logging. */
+export function redactHeaders(headers: Readonly<Record<string, string>>): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    redacted[key] = SENSITIVE_HEADER_PATTERN.test(key) ? "<redacted>" : value;
+  }
+  return redacted;
+}

--- a/src/services/telemetry/otlp-e2e.test.ts
+++ b/src/services/telemetry/otlp-e2e.test.ts
@@ -1,0 +1,162 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { FileTelemetrySink } from "./file-sink";
+import { resolveOtlpConfig } from "./otlp-config";
+import { OtlpTelemetrySink } from "./otlp-sink";
+import { TelemetryServiceImpl } from "./telemetry-service";
+
+interface CapturedSpan {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string;
+  readonly name: string;
+}
+
+/**
+ * Drives a whole run's worth of events through the service and a real HTTP
+ * endpoint, asserting the collector receives one connected trace.
+ */
+describe("OTLP export end to end", () => {
+  it("delivers a run as a single connected trace", async () => {
+    const receivedSpans: CapturedSpan[] = [];
+    const receivedPaths: string[] = [];
+
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        receivedPaths.push(new URL(request.url).pathname);
+        const payload = (await request.json()) as {
+          resourceSpans: { scopeSpans: { spans: CapturedSpan[] }[] }[];
+        };
+        for (const resourceSpan of payload.resourceSpans) {
+          for (const scopeSpan of resourceSpan.scopeSpans) {
+            receivedSpans.push(...scopeSpan.spans);
+          }
+        }
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    try {
+      const otlpConfig = resolveOtlpConfig(undefined, {
+        OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${server.port}`,
+      });
+      expect(otlpConfig).toBeDefined();
+
+      const service = new TelemetryServiceImpl({
+        enabled: true,
+        bufferSize: 100,
+        flushIntervalMs: 0,
+        sinks: [new OtlpTelemetrySink(otlpConfig!, "1.2.3")],
+      });
+
+      const runId = "run-e2e";
+      const shared = { agentId: "agent-1", sessionId: "conv-1", runId };
+
+      await Effect.runPromise(
+        service.recordAgentRunStarted({
+          runId,
+          agentId: "agent-1",
+          agentName: "researcher",
+          conversationId: "conv-1",
+        }),
+      );
+      await Effect.runPromise(
+        service.recordLLMUsage({
+          provider: "anthropic",
+          model: "claude-opus-5",
+          usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+          durationMs: 2000,
+          ...shared,
+        }),
+      );
+      await Effect.runPromise(
+        service.recordToolInvocation({
+          toolName: "web_search",
+          success: true,
+          durationMs: 500,
+          ...shared,
+        }),
+      );
+      await Effect.runPromise(
+        service.recordAgentRunCompleted({
+          runId,
+          agentId: "agent-1",
+          agentName: "researcher",
+          conversationId: "conv-1",
+          provider: "anthropic",
+          model: "claude-opus-5",
+          durationMs: 5000,
+          iterationsUsed: 2,
+          finished: true,
+          usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+          toolCalls: 1,
+          toolErrors: 0,
+        }),
+      );
+
+      await Effect.runPromise(service.flush());
+
+      expect(receivedPaths).toEqual(["/v1/traces"]);
+
+      // agent_run_started contributes no span; the other three do.
+      expect(receivedSpans).toHaveLength(3);
+
+      const traceIds = new Set(receivedSpans.map((span) => span.traceId));
+      expect(traceIds.size).toBe(1);
+
+      const root = receivedSpans.find((span) => span.parentSpanId === undefined);
+      expect(root?.name).toBe("agent researcher");
+
+      const children = receivedSpans.filter((span) => span.parentSpanId !== undefined);
+      expect(children.map((span) => span.name).sort()).toEqual([
+        "chat claude-opus-5",
+        "tool web_search",
+      ]);
+      expect(children.every((span) => span.parentSpanId === root?.spanId)).toBe(true);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("keeps writing locally when the collector is unreachable", async () => {
+    const storagePath = await mkdtemp(path.join(tmpdir(), "jazz-otlp-e2e-"));
+
+    const otlpConfig = resolveOtlpConfig({ endpoint: "http://127.0.0.1:1" }, {});
+    const fileSink = new FileTelemetrySink(storagePath, 90);
+
+    const service = new TelemetryServiceImpl({
+      enabled: true,
+      bufferSize: 100,
+      flushIntervalMs: 0,
+      sinks: [new OtlpTelemetrySink(otlpConfig!, "1.2.3"), fileSink],
+    });
+
+    await Effect.runPromise(
+      service.recordAgentRunCompleted({
+        runId: "run-1",
+        agentId: "agent-1",
+        agentName: "researcher",
+        conversationId: "conv-1",
+        durationMs: 100,
+        iterationsUsed: 1,
+        finished: true,
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        toolCalls: 0,
+        toolErrors: 0,
+      }),
+    );
+
+    // Resolves despite the dead collector — export never fails a run.
+    await Effect.runPromise(service.flush());
+
+    const stored = await fileSink.readAll();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.type).toBe("agent_run_completed");
+
+    await rm(storagePath, { recursive: true, force: true });
+  }, 20_000);
+});

--- a/src/services/telemetry/otlp-mapping.test.ts
+++ b/src/services/telemetry/otlp-mapping.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "bun:test";
+import type { TelemetryEvent, TelemetryEventType } from "@/core/interfaces/telemetry";
+import { buildLogsPayload, eventToAttributes, toLogRecord } from "./otlp-mapping";
+import type { OtlpKeyValue } from "./otlp-mapping";
+
+function makeEvent(
+  type: TelemetryEventType,
+  data: Record<string, unknown>,
+  overrides: Partial<TelemetryEvent> = {},
+): TelemetryEvent {
+  return {
+    id: "event-1",
+    type,
+    timestamp: "2026-08-15T12:00:00.000Z",
+    data,
+    ...overrides,
+  };
+}
+
+function attributeMap(attributes: readonly OtlpKeyValue[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const attribute of attributes) {
+    result[attribute.key] = Object.values(attribute.value)[0];
+  }
+  return result;
+}
+
+describe("eventToAttributes", () => {
+  it("maps provider, model and token usage onto GenAI semantic conventions", () => {
+    const event = makeEvent(
+      "llm_usage",
+      {
+        provider: "anthropic",
+        model: "claude-opus-5",
+        usage: { promptTokens: 120, completionTokens: 45, totalTokens: 165 },
+        durationMs: 2300,
+      },
+      { agentId: "agent-1", sessionId: "conv-1" },
+    );
+
+    const attributes = attributeMap(eventToAttributes(event, false));
+
+    expect(attributes["gen_ai.system"]).toBe("anthropic");
+    expect(attributes["gen_ai.request.model"]).toBe("claude-opus-5");
+    expect(attributes["gen_ai.response.model"]).toBe("claude-opus-5");
+    expect(attributes["gen_ai.operation.name"]).toBe("chat");
+    expect(attributes["gen_ai.usage.input_tokens"]).toBe("120");
+    expect(attributes["gen_ai.usage.output_tokens"]).toBe("45");
+  });
+
+  it("encodes integers as strings per proto3 JSON", () => {
+    const event = makeEvent("llm_usage", {
+      usage: { promptTokens: 7, completionTokens: 8, totalTokens: 15 },
+    });
+
+    const attributes = eventToAttributes(event, false);
+    const inputTokens = attributes.find((a) => a.key === "gen_ai.usage.input_tokens");
+
+    expect(inputTokens?.value).toEqual({ intValue: "7" });
+  });
+
+  it("keeps non-semconv fields under the jazz namespace", () => {
+    const event = makeEvent(
+      "agent_run_completed",
+      {
+        runId: "run-1",
+        agentName: "researcher",
+        durationMs: 5000,
+        finished: true,
+        usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3, cacheReadTokens: 99 },
+      },
+      { agentId: "agent-1", sessionId: "conv-1" },
+    );
+
+    const attributes = attributeMap(eventToAttributes(event, false));
+
+    expect(attributes["jazz.event.type"]).toBe("agent_run_completed");
+    expect(attributes["jazz.agent.id"]).toBe("agent-1");
+    expect(attributes["jazz.conversation.id"]).toBe("conv-1");
+    expect(attributes["jazz.runId"]).toBe("run-1");
+    expect(attributes["jazz.finished"]).toBe(true);
+    expect(attributes["jazz.usage.cacheReadTokens"]).toBe("99");
+  });
+
+  it("does not duplicate provider and model under the jazz namespace", () => {
+    const event = makeEvent("llm_usage", { provider: "openai", model: "gpt-5" });
+    const attributes = attributeMap(eventToAttributes(event, false));
+
+    expect(attributes["jazz.provider"]).toBeUndefined();
+    expect(attributes["jazz.model"]).toBeUndefined();
+  });
+
+  it("drops content-bearing keys when capture is off", () => {
+    const event = makeEvent("tool_invocation", {
+      toolName: "web_search",
+      arguments: { query: "private thing" },
+      result: "a long secret result",
+    });
+
+    const attributes = attributeMap(eventToAttributes(event, false));
+
+    expect(attributes["jazz.toolName"]).toBe("web_search");
+    expect(Object.keys(attributes).some((key) => key.startsWith("jazz.arguments"))).toBe(false);
+    expect(attributes["jazz.result"]).toBeUndefined();
+  });
+
+  it("includes content-bearing keys when capture is on", () => {
+    const event = makeEvent("tool_invocation", {
+      toolName: "web_search",
+      result: "a result",
+    });
+
+    const attributes = attributeMap(eventToAttributes(event, true));
+
+    expect(attributes["jazz.result"]).toBe("a result");
+  });
+
+  it("truncates long strings hard when capture is off", () => {
+    const event = makeEvent("agent_run_failed", { error: "x".repeat(5000) });
+
+    const withoutContent = attributeMap(eventToAttributes(event, false));
+    const withContent = attributeMap(eventToAttributes(event, true));
+
+    expect(String(withoutContent["jazz.error"]).length).toBe(256);
+    expect(String(withContent["jazz.error"]).length).toBe(5000);
+  });
+
+  it("summarises arrays by length rather than emitting their contents", () => {
+    const event = makeEvent("command_executed", {
+      command: "run",
+      args: ["--prompt", "something private"],
+    });
+
+    const attributes = attributeMap(eventToAttributes(event, false));
+
+    expect(attributes["jazz.args.count"]).toBe("2");
+    expect(JSON.stringify(attributes)).not.toContain("something private");
+  });
+});
+
+describe("toLogRecord", () => {
+  it("converts the timestamp to unix nanoseconds", () => {
+    const record = toLogRecord(makeEvent("llm_usage", {}), false);
+
+    expect(record.timeUnixNano).toBe(String(Date.parse("2026-08-15T12:00:00.000Z") * 1_000_000));
+  });
+
+  it("raises severity for failures and retries", () => {
+    expect(toLogRecord(makeEvent("tool_error", {}), false).severityText).toBe("ERROR");
+    expect(toLogRecord(makeEvent("agent_run_failed", {}), false).severityText).toBe("ERROR");
+    expect(toLogRecord(makeEvent("llm_retry", {}), false).severityText).toBe("WARN");
+    expect(toLogRecord(makeEvent("llm_usage", {}), false).severityText).toBe("INFO");
+  });
+
+  it("uses the event type as the record body", () => {
+    expect(toLogRecord(makeEvent("agent_run_started", {}), false).body).toEqual({
+      stringValue: "agent_run_started",
+    });
+  });
+});
+
+describe("buildLogsPayload", () => {
+  it("wraps records in the OTLP resource and scope envelope", () => {
+    const payload = buildLogsPayload([makeEvent("llm_usage", {})], {
+      serviceName: "jazz-prod",
+      serviceVersion: "1.2.3",
+      captureContent: false,
+    });
+
+    const resourceAttributes = attributeMap(payload.resourceLogs[0]!.resource.attributes);
+    expect(resourceAttributes["service.name"]).toBe("jazz-prod");
+    expect(resourceAttributes["service.version"]).toBe("1.2.3");
+    expect(payload.resourceLogs[0]!.scopeLogs[0]!.logRecords).toHaveLength(1);
+  });
+
+  it("is JSON-serialisable", () => {
+    const payload = buildLogsPayload([makeEvent("llm_usage", { model: "gpt-5" })], {
+      serviceName: "jazz",
+      serviceVersion: "1.0.0",
+      captureContent: false,
+    });
+
+    expect(() => JSON.stringify(payload)).not.toThrow();
+  });
+});

--- a/src/services/telemetry/otlp-mapping.ts
+++ b/src/services/telemetry/otlp-mapping.ts
@@ -1,0 +1,240 @@
+import type { TelemetryEvent, TelemetryEventType } from "@/core/interfaces/telemetry";
+
+/**
+ * Targeted version of the OpenTelemetry GenAI semantic conventions.
+ *
+ * These attribute names are still evolving upstream. Pin the version here so a
+ * rename upstream is a deliberate, visible change rather than silent drift.
+ */
+export const GENAI_SEMCONV_VERSION = "1.27.0";
+
+/** OTLP/JSON `AnyValue`. */
+export type OtlpAnyValue =
+  | { readonly stringValue: string }
+  | { readonly boolValue: boolean }
+  | { readonly intValue: string }
+  | { readonly doubleValue: number };
+
+export interface OtlpKeyValue {
+  readonly key: string;
+  readonly value: OtlpAnyValue;
+}
+
+export interface OtlpLogRecord {
+  readonly timeUnixNano: string;
+  readonly observedTimeUnixNano: string;
+  readonly severityNumber: number;
+  readonly severityText: string;
+  readonly body: { readonly stringValue: string };
+  readonly attributes: readonly OtlpKeyValue[];
+}
+
+export interface OtlpLogsPayload {
+  readonly resourceLogs: readonly {
+    readonly resource: { readonly attributes: readonly OtlpKeyValue[] };
+    readonly scopeLogs: readonly {
+      readonly scope: { readonly name: string; readonly version: string };
+      readonly logRecords: readonly OtlpLogRecord[];
+    }[];
+  }[];
+}
+
+/**
+ * Event data keys that carry user or model text. Dropped unless the operator
+ * explicitly opted into content capture.
+ *
+ * No event Jazz emits today populates any of these — the list exists so that
+ * adding a content-bearing field later cannot leak it by default.
+ */
+const CONTENT_KEYS = new Set([
+  "prompt",
+  "prompts",
+  "completion",
+  "content",
+  "messages",
+  "input",
+  "output",
+  "text",
+  "arguments",
+  "result",
+  "userMessage",
+  "lastUserMessage",
+]);
+
+const MAX_ATTRIBUTE_CHARS_REDACTED = 256;
+const MAX_ATTRIBUTE_CHARS_FULL = 8192;
+
+const SEVERITY_BY_EVENT_TYPE: Partial<Record<TelemetryEventType, [number, string]>> = {
+  agent_run_failed: [17, "ERROR"],
+  tool_error: [17, "ERROR"],
+  llm_retry: [13, "WARN"],
+};
+
+const DEFAULT_SEVERITY: [number, string] = [9, "INFO"];
+
+export function stringAttribute(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } };
+}
+
+/** int64 is encoded as a string in proto3 JSON. */
+export function intAttribute(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(Math.trunc(value)) } };
+}
+
+function attributeFromPrimitive(
+  key: string,
+  value: string | number | boolean,
+  maxChars: number,
+): OtlpKeyValue {
+  if (typeof value === "boolean") return { key, value: { boolValue: value } };
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? intAttribute(key, value)
+      : { key, value: { doubleValue: value } };
+  }
+  return stringAttribute(key, value.length > maxChars ? value.slice(0, maxChars) : value);
+}
+
+/**
+ * Flatten nested event data into dotted attribute keys, skipping keys that are
+ * consumed by the semantic-convention mapping and content keys when content
+ * capture is off.
+ */
+function flattenData(
+  data: Readonly<Record<string, unknown>>,
+  prefix: string,
+  skipTopLevelKeys: ReadonlySet<string>,
+  captureContent: boolean,
+  attributes: OtlpKeyValue[],
+  depth = 0,
+): void {
+  const maxChars = captureContent ? MAX_ATTRIBUTE_CHARS_FULL : MAX_ATTRIBUTE_CHARS_REDACTED;
+
+  for (const [key, value] of Object.entries(data)) {
+    if (depth === 0 && skipTopLevelKeys.has(key)) continue;
+    if (!captureContent && CONTENT_KEYS.has(key)) continue;
+    if (value === null || value === undefined) continue;
+
+    const attributeKey = `${prefix}${key}`;
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      attributes.push(attributeFromPrimitive(attributeKey, value, maxChars));
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      attributes.push(intAttribute(`${attributeKey}.count`, value.length));
+      continue;
+    }
+
+    if (typeof value === "object" && depth < 3) {
+      flattenData(
+        value as Record<string, unknown>,
+        `${attributeKey}.`,
+        skipTopLevelKeys,
+        captureContent,
+        attributes,
+        depth + 1,
+      );
+    }
+  }
+}
+
+/**
+ * Map a Jazz telemetry event onto GenAI semantic-convention attributes where
+ * one exists, and `jazz.*` attributes for everything else.
+ */
+export function eventToAttributes(event: TelemetryEvent, captureContent: boolean): OtlpKeyValue[] {
+  const attributes: OtlpKeyValue[] = [
+    stringAttribute("jazz.event.type", event.type),
+    stringAttribute("jazz.event.id", event.id),
+  ];
+
+  if (event.agentId) attributes.push(stringAttribute("jazz.agent.id", event.agentId));
+  if (event.sessionId) attributes.push(stringAttribute("jazz.conversation.id", event.sessionId));
+
+  const data = event.data;
+  const consumed = new Set<string>();
+
+  const provider = data["provider"];
+  if (typeof provider === "string") {
+    attributes.push(stringAttribute("gen_ai.system", provider));
+    consumed.add("provider");
+  }
+
+  const model = data["model"];
+  if (typeof model === "string") {
+    attributes.push(stringAttribute("gen_ai.request.model", model));
+    attributes.push(stringAttribute("gen_ai.response.model", model));
+    consumed.add("model");
+  }
+
+  if (event.type === "llm_usage" || event.type === "agent_run_completed") {
+    attributes.push(stringAttribute("gen_ai.operation.name", "chat"));
+  }
+
+  const usage = data["usage"];
+  if (usage && typeof usage === "object") {
+    const usageRecord = usage as Record<string, unknown>;
+    const promptTokens = usageRecord["promptTokens"];
+    const completionTokens = usageRecord["completionTokens"];
+    if (typeof promptTokens === "number") {
+      attributes.push(intAttribute("gen_ai.usage.input_tokens", promptTokens));
+    }
+    if (typeof completionTokens === "number") {
+      attributes.push(intAttribute("gen_ai.usage.output_tokens", completionTokens));
+    }
+    // The remaining usage fields (cache, reasoning, tool-token estimates) have
+    // no semconv equivalent and stay under jazz.usage.*.
+    flattenData(usageRecord, "jazz.usage.", new Set(), captureContent, attributes);
+    consumed.add("usage");
+  }
+
+  flattenData(data, "jazz.", consumed, captureContent, attributes);
+
+  return attributes;
+}
+
+export function toLogRecord(event: TelemetryEvent, captureContent: boolean): OtlpLogRecord {
+  const timeUnixNano = String(BigInt(new Date(event.timestamp).getTime()) * 1_000_000n);
+  const [severityNumber, severityText] = SEVERITY_BY_EVENT_TYPE[event.type] ?? DEFAULT_SEVERITY;
+
+  return {
+    timeUnixNano,
+    observedTimeUnixNano: timeUnixNano,
+    severityNumber,
+    severityText,
+    body: { stringValue: event.type },
+    attributes: eventToAttributes(event, captureContent),
+  };
+}
+
+export function buildLogsPayload(
+  events: readonly TelemetryEvent[],
+  options: {
+    readonly serviceName: string;
+    readonly serviceVersion: string;
+    readonly captureContent: boolean;
+  },
+): OtlpLogsPayload {
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            stringAttribute("service.name", options.serviceName),
+            stringAttribute("service.version", options.serviceVersion),
+            stringAttribute("telemetry.sdk.name", "jazz"),
+            stringAttribute("telemetry.sdk.language", "nodejs"),
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: { name: "jazz", version: options.serviceVersion },
+            logRecords: events.map((event) => toLogRecord(event, options.captureContent)),
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/src/services/telemetry/otlp-sink.test.ts
+++ b/src/services/telemetry/otlp-sink.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "bun:test";
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+import type { ResolvedOtlpConfig } from "./otlp-config";
+import { OtlpTelemetrySink } from "./otlp-sink";
+
+const EVENT: TelemetryEvent = {
+  id: "event-1",
+  type: "llm_usage",
+  timestamp: "2026-08-15T12:00:00.000Z",
+  data: { provider: "anthropic", model: "claude-opus-5" },
+};
+
+function makeConfig(overrides: Partial<ResolvedOtlpConfig> = {}): ResolvedOtlpConfig {
+  return {
+    enabled: true,
+    signals: ["logs"],
+    tracesEndpoint: "http://collector.test/v1/traces",
+    logsEndpoint: "http://collector.test/v1/logs",
+    headers: {},
+    serviceName: "jazz",
+    captureContent: false,
+    timeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+/** Records calls and replies with a queue of responses. */
+function stubFetch(responses: (Response | Error)[]) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    const next = responses.shift();
+    if (next === undefined) return new Response(null, { status: 200 });
+    if (next instanceof Error) throw next;
+    return next;
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, calls };
+}
+
+const noSleep = async () => {};
+
+describe("OtlpTelemetrySink", () => {
+  it("posts an OTLP payload to the configured logs endpoint", async () => {
+    const { impl, calls } = stubFetch([new Response(null, { status: 200 })]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await sink.write([EVENT]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://collector.test/v1/logs");
+    expect(calls[0]!.init.method).toBe("POST");
+
+    const body = JSON.parse(String(calls[0]!.init.body)) as {
+      resourceLogs: { scopeLogs: { logRecords: unknown[] }[] }[];
+    };
+    expect(body.resourceLogs[0]!.scopeLogs[0]!.logRecords).toHaveLength(1);
+  });
+
+  it("sends configured headers alongside the JSON content type", async () => {
+    const { impl, calls } = stubFetch([new Response(null, { status: 200 })]);
+    const sink = new OtlpTelemetrySink(
+      makeConfig({ headers: { authorization: "Basic abc" } }),
+      "1.2.3",
+      { fetch: impl, sleep: noSleep },
+    );
+
+    await sink.write([EVENT]);
+
+    expect(calls[0]!.init.headers).toMatchObject({
+      "content-type": "application/json",
+      authorization: "Basic abc",
+    });
+  });
+
+  it("does not call the endpoint for an empty batch", async () => {
+    const { impl, calls } = stubFetch([]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await sink.write([]);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("retries a 503 and succeeds on a later attempt", async () => {
+    const { impl, calls } = stubFetch([
+      new Response(null, { status: 503 }),
+      new Response(null, { status: 200 }),
+    ]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await sink.write([EVENT]);
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("retries network failures", async () => {
+    const { impl, calls } = stubFetch([
+      new Error("ECONNREFUSED"),
+      new Response(null, { status: 200 }),
+    ]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await sink.write([EVENT]);
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("gives up after the attempt ceiling and rejects", async () => {
+    const { impl, calls } = stubFetch([
+      new Response(null, { status: 500 }),
+      new Response(null, { status: 500 }),
+      new Response(null, { status: 500 }),
+    ]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await expect(sink.write([EVENT])).rejects.toThrow("500");
+    expect(calls).toHaveLength(3);
+  });
+
+  it("does not retry a 401, which retrying cannot fix", async () => {
+    const { impl, calls } = stubFetch([new Response(null, { status: 401 })]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await expect(sink.write([EVENT])).rejects.toThrow("401");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("retries a 429 despite it being a 4xx", async () => {
+    const { impl, calls } = stubFetch([
+      new Response(null, { status: 429 }),
+      new Response(null, { status: 200 }),
+    ]);
+    const sink = new OtlpTelemetrySink(makeConfig(), "1.2.3", { fetch: impl, sleep: noSleep });
+
+    await sink.write([EVENT]);
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("posts spans to the traces endpoint when traces are selected", async () => {
+    const { impl, calls } = stubFetch([new Response(null, { status: 200 })]);
+    const sink = new OtlpTelemetrySink(makeConfig({ signals: ["traces"] }), "1.2.3", {
+      fetch: impl,
+      sleep: noSleep,
+    });
+
+    await sink.write([EVENT]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://collector.test/v1/traces");
+
+    const body = JSON.parse(String(calls[0]!.init.body)) as {
+      resourceSpans: { scopeSpans: { spans: { name: string }[] }[] }[];
+    };
+    expect(body.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.name).toBe("chat claude-opus-5");
+  });
+
+  it("posts both signals when both are selected", async () => {
+    const { impl, calls } = stubFetch([
+      new Response(null, { status: 200 }),
+      new Response(null, { status: 200 }),
+    ]);
+    const sink = new OtlpTelemetrySink(makeConfig({ signals: ["traces", "logs"] }), "1.2.3", {
+      fetch: impl,
+      sleep: noSleep,
+    });
+
+    await sink.write([EVENT]);
+
+    expect(calls.map((call) => call.url).sort()).toEqual([
+      "http://collector.test/v1/logs",
+      "http://collector.test/v1/traces",
+    ]);
+  });
+
+  it("skips the traces request when no event maps to a span", async () => {
+    const { impl, calls } = stubFetch([new Response(null, { status: 200 })]);
+    const sink = new OtlpTelemetrySink(makeConfig({ signals: ["traces"] }), "1.2.3", {
+      fetch: impl,
+      sleep: noSleep,
+    });
+
+    await sink.write([{ ...EVENT, type: "agent_run_started" }]);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("delivers to a real HTTP endpoint end to end", async () => {
+    const received: unknown[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        received.push(await request.json());
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    try {
+      const sink = new OtlpTelemetrySink(
+        makeConfig({ logsEndpoint: `http://localhost:${server.port}/v1/logs` }),
+        "1.2.3",
+      );
+
+      await sink.write([EVENT]);
+
+      expect(received).toHaveLength(1);
+      const payload = received[0] as {
+        resourceLogs: {
+          scopeLogs: { logRecords: { body: { stringValue: string } }[] }[];
+        }[];
+      };
+      expect(payload.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.body.stringValue).toBe(
+        "llm_usage",
+      );
+    } finally {
+      await server.stop(true);
+    }
+  });
+});

--- a/src/services/telemetry/otlp-sink.ts
+++ b/src/services/telemetry/otlp-sink.ts
@@ -1,0 +1,116 @@
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+import type { ResolvedOtlpConfig } from "./otlp-config";
+import { buildLogsPayload } from "./otlp-mapping";
+import { buildTracesPayload, isSpanEvent } from "./otlp-trace-mapping";
+import type { TelemetrySink } from "./sink";
+
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 250;
+
+/** 4xx other than 408/429 means the request itself is wrong — retrying cannot help. */
+function isRetryableStatus(status: number): boolean {
+  if (status === 408 || status === 429) return true;
+  return status >= 500;
+}
+
+function backoffDelayMs(attempt: number): number {
+  return BASE_BACKOFF_MS * 2 ** (attempt - 1);
+}
+
+export interface OtlpSinkDependencies {
+  /** Injected for testing; defaults to global fetch. */
+  readonly fetch?: typeof globalThis.fetch;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Exports telemetry events to an OTLP/HTTP endpoint.
+ *
+ * Encodes OTLP/JSON by hand rather than pulling in the OpenTelemetry SDK: the
+ * payload is a well-specified JSON body, and Jazz's published install stays
+ * dependency-free.
+ *
+ * Traces are the default signal because they are what LLM-observability backends
+ * accept — Langfuse ingests OTLP traces and not logs — and what turns a run into
+ * a readable waterfall. Logs carry the same events unstructured, for collectors
+ * routing to a log store.
+ */
+export class OtlpTelemetrySink implements TelemetrySink {
+  readonly name = "otlp";
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(
+    private readonly config: ResolvedOtlpConfig,
+    private readonly serviceVersion: string,
+    dependencies: OtlpSinkDependencies = {},
+  ) {
+    this.fetchImpl = dependencies.fetch ?? globalThis.fetch.bind(globalThis);
+    this.sleep =
+      dependencies.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  async write(events: readonly TelemetryEvent[]): Promise<void> {
+    if (events.length === 0) return;
+
+    const payloadOptions = {
+      serviceName: this.config.serviceName,
+      serviceVersion: this.serviceVersion,
+      captureContent: this.config.captureContent,
+    };
+
+    const sends: Promise<void>[] = [];
+
+    if (this.config.signals.includes("traces") && events.some(isSpanEvent)) {
+      sends.push(this.post(this.config.tracesEndpoint, buildTracesPayload(events, payloadOptions)));
+    }
+
+    if (this.config.signals.includes("logs")) {
+      sends.push(this.post(this.config.logsEndpoint, buildLogsPayload(events, payloadOptions)));
+    }
+
+    if (sends.length === 0) return;
+
+    // Both signals carry the same batch; one endpoint failing should not hide
+    // the other's outcome, so report only after all have settled.
+    const results = await Promise.allSettled(sends);
+    const failure = results.find((result) => result.status === "rejected");
+    if (failure && failure.status === "rejected") {
+      throw failure.reason instanceof Error ? failure.reason : new Error(String(failure.reason));
+    }
+  }
+
+  private async post(endpoint: string, payload: unknown): Promise<void> {
+    const body = JSON.stringify(payload);
+    let lastError = new Error(`OTLP export to ${endpoint} failed`);
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      let retryable: boolean;
+
+      try {
+        const response = await this.fetchImpl(endpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...this.config.headers },
+          body,
+          signal: AbortSignal.timeout(this.config.timeoutMs),
+        });
+
+        if (response.ok) return;
+
+        lastError = new Error(
+          `OTLP endpoint ${endpoint} returned ${response.status} ${response.statusText}`,
+        );
+        retryable = isRetryableStatus(response.status);
+      } catch (error) {
+        // Network failures and timeouts are transient by nature.
+        lastError = error instanceof Error ? error : new Error(String(error));
+        retryable = true;
+      }
+
+      if (!retryable) break;
+      if (attempt < MAX_ATTEMPTS) await this.sleep(backoffDelayMs(attempt));
+    }
+
+    throw lastError;
+  }
+}

--- a/src/services/telemetry/otlp-trace-mapping.test.ts
+++ b/src/services/telemetry/otlp-trace-mapping.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+import type { TelemetryEvent, TelemetryEventType } from "@/core/interfaces/telemetry";
+import {
+  buildTracesPayload,
+  isSpanEvent,
+  rootSpanIdForRun,
+  toSpan,
+  traceIdForRun,
+} from "./otlp-trace-mapping";
+
+function makeEvent(
+  type: TelemetryEventType,
+  data: Record<string, unknown>,
+  overrides: Partial<TelemetryEvent> = {},
+): TelemetryEvent {
+  return {
+    id: `event-${type}`,
+    type,
+    timestamp: "2026-08-15T12:00:30.000Z",
+    data,
+    ...overrides,
+  };
+}
+
+describe("trace and span ids", () => {
+  it("derives ids of the byte lengths OTLP requires", () => {
+    expect(traceIdForRun("run-1")).toHaveLength(32);
+    expect(rootSpanIdForRun("run-1")).toHaveLength(16);
+  });
+
+  it("is deterministic, so spans from separate batches join the same trace", () => {
+    expect(traceIdForRun("run-1")).toBe(traceIdForRun("run-1"));
+    expect(traceIdForRun("run-1")).not.toBe(traceIdForRun("run-2"));
+  });
+});
+
+describe("toSpan", () => {
+  it("makes the run's terminal event the root span", () => {
+    const span = toSpan(
+      makeEvent("agent_run_completed", {
+        runId: "run-1",
+        agentName: "researcher",
+        durationMs: 30_000,
+      }),
+      false,
+    );
+
+    expect(span.spanId).toBe(rootSpanIdForRun("run-1"));
+    expect(span.parentSpanId).toBeUndefined();
+    expect(span.name).toBe("agent researcher");
+  });
+
+  it("parents LLM and tool spans to the run's root span", () => {
+    const llmSpan = toSpan(
+      makeEvent("llm_usage", { runId: "run-1", model: "claude-opus-5", durationMs: 2000 }),
+      false,
+    );
+    const toolSpan = toSpan(
+      makeEvent("tool_invocation", { runId: "run-1", toolName: "web_search", durationMs: 500 }),
+      false,
+    );
+
+    expect(llmSpan.traceId).toBe(traceIdForRun("run-1"));
+    expect(toolSpan.traceId).toBe(traceIdForRun("run-1"));
+    expect(llmSpan.parentSpanId).toBe(rootSpanIdForRun("run-1"));
+    expect(toolSpan.parentSpanId).toBe(rootSpanIdForRun("run-1"));
+    expect(llmSpan.spanId).not.toBe(toolSpan.spanId);
+  });
+
+  it("derives the span start by subtracting duration from the event time", () => {
+    const span = toSpan(makeEvent("llm_usage", { runId: "run-1", durationMs: 2000 }), false);
+
+    const endMs = Date.parse("2026-08-15T12:00:30.000Z");
+    expect(span.endTimeUnixNano).toBe(String(endMs * 1_000_000));
+    expect(span.startTimeUnixNano).toBe(String((endMs - 2000) * 1_000_000));
+  });
+
+  it("produces a zero-length span when no duration was recorded", () => {
+    const span = toSpan(makeEvent("llm_retry", { runId: "run-1" }), false);
+
+    expect(span.startTimeUnixNano).toBe(span.endTimeUnixNano);
+  });
+
+  it("marks failures with error status and message", () => {
+    const runSpan = toSpan(
+      makeEvent("agent_run_failed", { runId: "run-1", error: "provider unreachable" }),
+      false,
+    );
+    const toolSpan = toSpan(
+      makeEvent("tool_error", { runId: "run-1", toolName: "shell", error: "exit 1" }),
+      false,
+    );
+
+    expect(runSpan.status).toEqual({ code: 2, message: "provider unreachable" });
+    expect(toolSpan.status).toEqual({ code: 2, message: "exit 1" });
+  });
+
+  it("leaves successful spans with unset status", () => {
+    const span = toSpan(makeEvent("tool_invocation", { runId: "run-1" }), false);
+    expect(span.status.code).toBe(0);
+  });
+
+  it("names LLM spans after the model, per GenAI semconv", () => {
+    expect(toSpan(makeEvent("llm_usage", { model: "gpt-5" }), false).name).toBe("chat gpt-5");
+  });
+
+  it("falls back to the conversation when an event carries no run id", () => {
+    const span = toSpan(makeEvent("tool_invocation", {}, { sessionId: "conv-9" }), false);
+    expect(span.traceId).toBe(traceIdForRun("conv-9"));
+  });
+
+  it("makes an event with neither run nor conversation its own root span", () => {
+    const span = toSpan(makeEvent("command_executed", { command: "agent list" }), false);
+
+    expect(span.traceId).toHaveLength(32);
+    expect(span.name).toBe("jazz agent list");
+    // Parenting it to a run root that will never be emitted would orphan it.
+    expect(span.parentSpanId).toBeUndefined();
+  });
+
+  it("still parents a run-scoped command to its run", () => {
+    const span = toSpan(
+      makeEvent("command_executed", { command: "run", runId: "run-1", durationMs: 10 }),
+      false,
+    );
+
+    expect(span.parentSpanId).toBe(rootSpanIdForRun("run-1"));
+  });
+
+  it("carries the GenAI attributes from the log mapping", () => {
+    const span = toSpan(
+      makeEvent("llm_usage", {
+        runId: "run-1",
+        provider: "anthropic",
+        model: "claude-opus-5",
+        usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+      }),
+      false,
+    );
+
+    const keys = span.attributes.map((attribute) => attribute.key);
+    expect(keys).toContain("gen_ai.system");
+    expect(keys).toContain("gen_ai.usage.input_tokens");
+    expect(keys).toContain("jazz.run.id");
+  });
+});
+
+describe("isSpanEvent", () => {
+  it("excludes agent_run_started, whose span comes from the terminal event", () => {
+    expect(isSpanEvent(makeEvent("agent_run_started", {}))).toBe(false);
+    expect(isSpanEvent(makeEvent("agent_run_completed", {}))).toBe(true);
+  });
+});
+
+describe("buildTracesPayload", () => {
+  it("groups a whole run into one trace", () => {
+    const events = [
+      makeEvent("agent_run_started", { runId: "run-1" }, { id: "e0" }),
+      makeEvent("llm_usage", { runId: "run-1", durationMs: 1000 }, { id: "e1" }),
+      makeEvent("tool_invocation", { runId: "run-1", durationMs: 200 }, { id: "e2" }),
+      makeEvent("agent_run_completed", { runId: "run-1", durationMs: 5000 }, { id: "e3" }),
+    ];
+
+    const payload = buildTracesPayload(events, {
+      serviceName: "jazz",
+      serviceVersion: "1.0.0",
+      captureContent: false,
+    });
+
+    const spans = payload.resourceSpans[0]!.scopeSpans[0]!.spans;
+    // agent_run_started contributes no span of its own.
+    expect(spans).toHaveLength(3);
+    expect(new Set(spans.map((span) => span.traceId)).size).toBe(1);
+
+    const roots = spans.filter((span) => span.parentSpanId === undefined);
+    expect(roots).toHaveLength(1);
+  });
+
+  it("is JSON-serialisable", () => {
+    const payload = buildTracesPayload([makeEvent("llm_usage", { runId: "run-1" })], {
+      serviceName: "jazz",
+      serviceVersion: "1.0.0",
+      captureContent: false,
+    });
+
+    expect(() => JSON.stringify(payload)).not.toThrow();
+  });
+});

--- a/src/services/telemetry/otlp-trace-mapping.ts
+++ b/src/services/telemetry/otlp-trace-mapping.ts
@@ -1,0 +1,195 @@
+import { createHash } from "node:crypto";
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+import { eventToAttributes, stringAttribute, type OtlpKeyValue } from "./otlp-mapping";
+
+/** OTLP span kind. Everything Jazz emits is INTERNAL work inside one process. */
+const SPAN_KIND_INTERNAL = 1;
+
+const STATUS_UNSET = 0;
+const STATUS_ERROR = 2;
+
+export interface OtlpSpan {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string;
+  readonly name: string;
+  readonly kind: number;
+  readonly startTimeUnixNano: string;
+  readonly endTimeUnixNano: string;
+  readonly attributes: readonly OtlpKeyValue[];
+  readonly status: { readonly code: number; readonly message?: string };
+}
+
+export interface OtlpTracesPayload {
+  readonly resourceSpans: readonly {
+    readonly resource: { readonly attributes: readonly OtlpKeyValue[] };
+    readonly scopeSpans: readonly {
+      readonly scope: { readonly name: string; readonly version: string };
+      readonly spans: readonly OtlpSpan[];
+    }[];
+  }[];
+}
+
+/** Trace ids are 16 bytes of hex, span ids 8. Derive them deterministically. */
+function deriveId(seed: string, bytes: number): string {
+  return createHash("sha256")
+    .update(seed)
+    .digest("hex")
+    .slice(0, bytes * 2);
+}
+
+export function traceIdForRun(runId: string): string {
+  return deriveId(`jazz-trace:${runId}`, 16);
+}
+
+export function rootSpanIdForRun(runId: string): string {
+  return deriveId(`jazz-run:${runId}`, 8);
+}
+
+function spanIdForEvent(eventId: string): string {
+  return deriveId(`jazz-event:${eventId}`, 8);
+}
+
+/**
+ * The run an event belongs to.
+ *
+ * `runId` is what actually groups a trace. Falling back to the conversation and
+ * then the event's own id means an event recorded outside a run still produces a
+ * valid single-span trace rather than being dropped.
+ */
+function runIdOf(event: TelemetryEvent): { readonly id: string; readonly isRunScoped: boolean } {
+  const runId = event.data["runId"];
+  if (typeof runId === "string" && runId.length > 0) return { id: runId, isRunScoped: true };
+  if (event.sessionId) return { id: event.sessionId, isRunScoped: true };
+  // Nothing ties this event to a run — `jazz agent list` and other bare CLI
+  // commands land here. Give it its own trace rather than parenting it to a
+  // root span that will never be emitted.
+  return { id: event.id, isRunScoped: false };
+}
+
+function toNanos(milliseconds: number): string {
+  return String(BigInt(Math.trunc(milliseconds)) * 1_000_000n);
+}
+
+function durationOf(event: TelemetryEvent): number {
+  const durationMs = event.data["durationMs"];
+  return typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs > 0
+    ? durationMs
+    : 0;
+}
+
+function spanNameOf(event: TelemetryEvent): string {
+  const data = event.data;
+  switch (event.type) {
+    case "agent_run_completed":
+    case "agent_run_failed": {
+      const agentName = data["agentName"];
+      return typeof agentName === "string" ? `agent ${agentName}` : "agent run";
+    }
+    case "llm_usage": {
+      // GenAI semconv names a chat span "{operation} {model}".
+      const model = data["model"];
+      return typeof model === "string" ? `chat ${model}` : "chat";
+    }
+    case "llm_retry":
+      return "llm retry";
+    case "tool_invocation":
+    case "tool_error": {
+      const toolName = data["toolName"];
+      return typeof toolName === "string" ? `tool ${toolName}` : "tool";
+    }
+    case "command_executed": {
+      const command = data["command"];
+      return typeof command === "string" ? `jazz ${command}` : "command";
+    }
+    default:
+      return event.type;
+  }
+}
+
+function errorMessageOf(event: TelemetryEvent): string | undefined {
+  const error = event.data["error"];
+  return typeof error === "string" && error.length > 0 ? error : undefined;
+}
+
+const ERROR_EVENT_TYPES = new Set(["agent_run_failed", "tool_error"]);
+
+/**
+ * Event types that do not become spans.
+ *
+ * `agent_run_started` is deliberately excluded: the run's span is built entirely
+ * from the terminal event, which carries `durationMs`. Deriving both endpoints
+ * from one event keeps the mapping stateless — no correlation buffer waiting for
+ * a matching start, and nothing lost when a process exits mid-run.
+ */
+const NON_SPAN_EVENT_TYPES = new Set(["agent_run_started"]);
+
+export function isSpanEvent(event: TelemetryEvent): boolean {
+  return !NON_SPAN_EVENT_TYPES.has(event.type);
+}
+
+export function toSpan(event: TelemetryEvent, captureContent: boolean): OtlpSpan {
+  const { id: runId, isRunScoped } = runIdOf(event);
+  const traceId = traceIdForRun(runId);
+  const rootSpanId = rootSpanIdForRun(runId);
+
+  const isRunSpan = event.type === "agent_run_completed" || event.type === "agent_run_failed";
+  const isRoot = isRunSpan || !isRunScoped;
+  const spanId = isRunSpan ? rootSpanId : spanIdForEvent(event.id);
+
+  const endMs = new Date(event.timestamp).getTime();
+  const startMs = endMs - durationOf(event);
+
+  const errorMessage = errorMessageOf(event);
+  const isError = ERROR_EVENT_TYPES.has(event.type);
+
+  const attributes = [
+    ...eventToAttributes(event, captureContent),
+    stringAttribute("jazz.run.id", runId),
+  ];
+
+  return {
+    traceId,
+    spanId,
+    ...(isRoot ? {} : { parentSpanId: rootSpanId }),
+    name: spanNameOf(event),
+    kind: SPAN_KIND_INTERNAL,
+    startTimeUnixNano: toNanos(startMs),
+    endTimeUnixNano: toNanos(endMs),
+    attributes,
+    status: {
+      code: isError ? STATUS_ERROR : STATUS_UNSET,
+      ...(isError && errorMessage ? { message: errorMessage } : {}),
+    },
+  };
+}
+
+export function buildTracesPayload(
+  events: readonly TelemetryEvent[],
+  options: {
+    readonly serviceName: string;
+    readonly serviceVersion: string;
+    readonly captureContent: boolean;
+  },
+): OtlpTracesPayload {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            stringAttribute("service.name", options.serviceName),
+            stringAttribute("service.version", options.serviceVersion),
+            stringAttribute("telemetry.sdk.name", "jazz"),
+            stringAttribute("telemetry.sdk.language", "nodejs"),
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "jazz", version: options.serviceVersion },
+            spans: events.filter(isSpanEvent).map((event) => toSpan(event, options.captureContent)),
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/src/services/telemetry/sink.ts
+++ b/src/services/telemetry/sink.ts
@@ -1,0 +1,31 @@
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+
+/**
+ * A destination for telemetry events.
+ *
+ * Sinks are plain promise-based so they can be driven both from Effect code
+ * and from the service's timer-based flush, which runs outside any Effect
+ * context. A sink that rejects is logged and skipped — one broken destination
+ * must never stop the others or reach the agent loop.
+ */
+export interface TelemetrySink {
+  /** Stable identifier used in log messages. */
+  readonly name: string;
+  /** Persist or transmit a batch of events. */
+  readonly write: (events: readonly TelemetryEvent[]) => Promise<void>;
+  /** Release any resources held by the sink. */
+  readonly close?: () => Promise<void>;
+}
+
+/**
+ * A sink that can also read back what it stored, backing `getEvents` and
+ * `getUsageSummary`. Only the local file sink implements this — an OTLP
+ * collector is write-only from Jazz's point of view.
+ */
+export interface TelemetryEventReader {
+  readonly readAll: () => Promise<TelemetryEvent[]>;
+}
+
+export function isEventReader(sink: TelemetrySink): sink is TelemetrySink & TelemetryEventReader {
+  return typeof (sink as Partial<TelemetryEventReader>).readAll === "function";
+}

--- a/src/services/telemetry/telemetry-service.test.ts
+++ b/src/services/telemetry/telemetry-service.test.ts
@@ -1,0 +1,297 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { TelemetryEvent } from "@/core/interfaces/telemetry";
+import { FileTelemetrySink } from "./file-sink";
+import type { TelemetrySink } from "./sink";
+import { TelemetryServiceImpl } from "./telemetry-service";
+
+class RecordingSink implements TelemetrySink {
+  readonly written: TelemetryEvent[] = [];
+  constructor(readonly name: string) {}
+  async write(events: readonly TelemetryEvent[]): Promise<void> {
+    this.written.push(...events);
+  }
+}
+
+class FailingSink implements TelemetrySink {
+  attempts = 0;
+  constructor(readonly name: string) {}
+  async write(): Promise<void> {
+    this.attempts += 1;
+    throw new Error("sink is down");
+  }
+}
+
+function makeService(sinks: TelemetrySink[], overrides: { bufferSize?: number } = {}) {
+  return new TelemetryServiceImpl({
+    enabled: true,
+    bufferSize: overrides.bufferSize ?? 100,
+    flushIntervalMs: 0,
+    sinks,
+  });
+}
+
+const USAGE = { promptTokens: 10, completionTokens: 5, totalTokens: 15 };
+
+describe("TelemetryServiceImpl sink fan-out", () => {
+  it("writes every event to every sink", async () => {
+    const first = new RecordingSink("first");
+    const second = new RecordingSink("second");
+    const service = makeService([first, second]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+    await Effect.runPromise(service.flush());
+
+    expect(first.written).toHaveLength(1);
+    expect(second.written).toHaveLength(1);
+    expect(first.written[0]!.type).toBe("llm_usage");
+  });
+
+  it("keeps writing to healthy sinks when one fails", async () => {
+    const healthy = new RecordingSink("healthy");
+    const broken = new FailingSink("broken");
+    const service = makeService([broken, healthy]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+    await Effect.runPromise(service.flush());
+
+    expect(broken.attempts).toBe(1);
+    expect(healthy.written).toHaveLength(1);
+  });
+
+  it("does not surface a sink failure to the caller", async () => {
+    const service = makeService([new FailingSink("broken")]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+
+    // flush() resolving rather than rejecting is the contract callers rely on.
+    await Effect.runPromise(service.flush());
+  });
+
+  it("reports failing sinks by name", async () => {
+    const errors: string[] = [];
+    const service = new TelemetryServiceImpl({
+      enabled: true,
+      bufferSize: 100,
+      flushIntervalMs: 0,
+      sinks: [new FailingSink("broken")],
+      onSinkError: (sinkName) => errors.push(sinkName),
+    });
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+    await Effect.runPromise(service.flush());
+
+    expect(errors).toEqual(["broken"]);
+  });
+
+  it("re-enqueues events only when every sink failed", async () => {
+    const broken = new FailingSink("broken");
+    const service = makeService([broken]);
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+    await Effect.runPromise(service.flush());
+    await Effect.runPromise(service.flush());
+
+    // The same event is retried on the next flush rather than dropped.
+    expect(broken.attempts).toBe(2);
+  });
+
+  it("does not re-enqueue when at least one sink succeeded", async () => {
+    const healthy = new RecordingSink("healthy");
+    const broken = new FailingSink("broken");
+    const service = makeService([broken, healthy]);
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+    await Effect.runPromise(service.flush());
+    await Effect.runPromise(service.flush());
+
+    // Re-enqueueing would duplicate the row in the healthy sink.
+    expect(healthy.written).toHaveLength(1);
+  });
+
+  it("drops the oldest events once the buffer ceiling is hit", async () => {
+    const dropped: number[] = [];
+    const service = new TelemetryServiceImpl({
+      enabled: true,
+      bufferSize: 2,
+      flushIntervalMs: 0,
+      sinks: [new FailingSink("broken")],
+      onEventsDropped: (count) => dropped.push(count),
+    });
+
+    // bufferSize 2 × the 10× ceiling = 20 retained; 30 events overflows it.
+    for (let index = 0; index < 30; index++) {
+      await Effect.runPromise(service.recordEvent("custom", { index }));
+    }
+    await Effect.runPromise(service.flush());
+
+    expect(dropped.reduce((total, count) => total + count, 0)).toBeGreaterThan(0);
+  });
+
+  it("records nothing when disabled", async () => {
+    const sink = new RecordingSink("only");
+    const service = new TelemetryServiceImpl({
+      enabled: false,
+      bufferSize: 100,
+      flushIntervalMs: 0,
+      sinks: [sink],
+    });
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+    await Effect.runPromise(service.flush());
+
+    expect(sink.written).toHaveLength(0);
+  });
+});
+
+describe("TelemetryServiceImpl querying", () => {
+  let storagePath: string;
+
+  beforeEach(async () => {
+    storagePath = await mkdtemp(path.join(tmpdir(), "jazz-telemetry-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(storagePath, { recursive: true, force: true });
+  });
+
+  it("reads back events written to the file sink", async () => {
+    const service = makeService([new FileTelemetrySink(storagePath, 90)]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+    await Effect.runPromise(service.flush());
+
+    const events = await Effect.runPromise(service.getEvents());
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("llm_usage");
+  });
+
+  it("includes buffered events that have not been flushed yet", async () => {
+    const service = makeService([new FileTelemetrySink(storagePath, 90)]);
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+
+    const events = await Effect.runPromise(service.getEvents());
+    expect(events).toHaveLength(1);
+  });
+
+  it("returns only buffered events when no sink can be read back", async () => {
+    const service = makeService([new RecordingSink("write-only")]);
+
+    await Effect.runPromise(service.recordEvent("custom", {}));
+
+    const events = await Effect.runPromise(service.getEvents());
+    expect(events).toHaveLength(1);
+  });
+
+  it("filters by type and agent", async () => {
+    const service = makeService([new FileTelemetrySink(storagePath, 90)]);
+
+    await Effect.runPromise(
+      service.recordToolInvocation({ toolName: "web_search", success: true, agentId: "agent-1" }),
+    );
+    await Effect.runPromise(
+      service.recordToolInvocation({ toolName: "shell", success: false, agentId: "agent-2" }),
+    );
+    await Effect.runPromise(service.flush());
+
+    const toolErrors = await Effect.runPromise(service.getEvents({ types: ["tool_error"] }));
+    expect(toolErrors).toHaveLength(1);
+
+    const agentOne = await Effect.runPromise(service.getEvents({ agentId: "agent-1" }));
+    expect(agentOne).toHaveLength(1);
+    expect(agentOne[0]!.type).toBe("tool_invocation");
+  });
+});
+
+describe("TelemetryServiceImpl usage aggregation", () => {
+  it("counts tool calls once when both run and invocation events are present", async () => {
+    const service = makeService([new RecordingSink("memory")]);
+
+    await Effect.runPromise(
+      service.recordToolInvocation({ toolName: "web_search", success: true, agentId: "agent-1" }),
+    );
+    await Effect.runPromise(
+      service.recordToolInvocation({ toolName: "shell", success: false, agentId: "agent-1" }),
+    );
+    await Effect.runPromise(
+      service.recordAgentRunCompleted({
+        runId: "run-1",
+        agentId: "agent-1",
+        agentName: "researcher",
+        conversationId: "conv-1",
+        durationMs: 5000,
+        iterationsUsed: 2,
+        finished: true,
+        usage: USAGE,
+        toolCalls: 2,
+        toolErrors: 1,
+      }),
+    );
+
+    const summary = await Effect.runPromise(service.getUsageSummary());
+
+    expect(summary.totalToolCalls).toBe(2);
+    expect(summary.totalToolErrors).toBe(1);
+    expect(summary.totalAgentRuns).toBe(1);
+  });
+
+  it("counts wall-clock duration once, from the run rather than each request", async () => {
+    const service = makeService([new RecordingSink("memory")]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({
+        provider: "anthropic",
+        model: "claude-opus-5",
+        usage: USAGE,
+        durationMs: 2000,
+      }),
+    );
+    await Effect.runPromise(
+      service.recordAgentRunCompleted({
+        runId: "run-1",
+        agentId: "agent-1",
+        agentName: "researcher",
+        conversationId: "conv-1",
+        durationMs: 5000,
+        iterationsUsed: 1,
+        finished: true,
+        usage: USAGE,
+        toolCalls: 0,
+        toolErrors: 0,
+      }),
+    );
+
+    const summary = await Effect.runPromise(service.getUsageSummary());
+
+    expect(summary.totalDurationMs).toBe(5000);
+  });
+
+  it("breaks token usage down per model", async () => {
+    const service = makeService([new RecordingSink("memory")]);
+
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+    await Effect.runPromise(
+      service.recordLLMUsage({ provider: "anthropic", model: "claude-opus-5", usage: USAGE }),
+    );
+
+    const summary = await Effect.runPromise(service.getUsageSummary());
+
+    expect(summary.totalRequests).toBe(2);
+    expect(summary.totalTokens).toBe(30);
+    expect(summary.byModel["anthropic/claude-opus-5"]?.requests).toBe(2);
+  });
+});

--- a/src/services/telemetry/telemetry-service.ts
+++ b/src/services/telemetry/telemetry-service.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, readFile, readdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { Effect, Layer } from "effect";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
@@ -16,15 +15,28 @@ import type {
 } from "@/core/interfaces/telemetry";
 import { TelemetryServiceTag } from "@/core/interfaces/telemetry";
 import type { TelemetryConfig } from "@/core/types/config";
-import { TelemetryError, TelemetryWriteError } from "@/core/types/errors";
+import { TelemetryError } from "@/core/types/errors";
 import { getUserDataDirectory } from "@/core/utils/paths";
+import { FileTelemetrySink } from "./file-sink";
+import { redactHeaders, resolveOtlpConfig } from "./otlp-config";
+import { OtlpTelemetrySink } from "./otlp-sink";
+import { isEventReader, type TelemetrySink } from "./sink";
+import packageJson from "../../../package.json";
 
 // ── Constants ───────────────────────────────────────────────────────
 
 const DEFAULT_BUFFER_SIZE = 100;
 const DEFAULT_FLUSH_INTERVAL_MS = 30_000;
 const DEFAULT_RETENTION_DAYS = 90;
-const EVENTS_DIR = "events";
+
+/**
+ * Hard ceiling on retained-but-unflushed events, as a multiple of bufferSize.
+ *
+ * Failed writes are re-enqueued so a transient collector outage does not lose
+ * data, but an endpoint that is down for the whole run must not grow the buffer
+ * without bound. Past this point the oldest events are dropped.
+ */
+const MAX_BUFFER_MULTIPLIER = 10;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -34,13 +46,6 @@ const EVENTS_DIR = "events";
  */
 function resolveDefaultStoragePath(): string {
   return path.join(getUserDataDirectory(), "telemetry");
-}
-
-/**
- * Create a date string suitable for partitioning event files: YYYY-MM-DD.
- */
-function datePartition(date: Date): string {
-  return date.toISOString().slice(0, 10);
 }
 
 function emptyUsageSummary(): UsageSummary {
@@ -66,18 +71,36 @@ function emptyUsageSummary(): UsageSummary {
 
 // ── Implementation ──────────────────────────────────────────────────
 
+export interface TelemetryServiceOptions {
+  readonly enabled: boolean;
+  readonly bufferSize: number;
+  readonly flushIntervalMs: number;
+  /** Destinations events are fanned out to on every flush. */
+  readonly sinks: readonly TelemetrySink[];
+  /** Reports a sink failure. Wired to the logger by the layer. */
+  readonly onSinkError?: (sinkName: string, error: unknown) => void;
+  /** Reports events dropped because the buffer hit its ceiling. */
+  readonly onEventsDropped?: (count: number) => void;
+}
+
 export class TelemetryServiceImpl implements TelemetryService {
   private buffer: TelemetryEvent[] = [];
   private flushTimer: ReturnType<typeof setInterval> | null = null;
-  private dirCreated = false;
+  private readonly enabled: boolean;
+  private readonly bufferSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly sinks: readonly TelemetrySink[];
+  private readonly onSinkError: (sinkName: string, error: unknown) => void;
+  private readonly onEventsDropped: (count: number) => void;
 
-  constructor(
-    private readonly storagePath: string,
-    private readonly enabled: boolean,
-    private readonly bufferSize: number,
-    private readonly flushIntervalMs: number,
-    private readonly retentionDays: number,
-  ) {
+  constructor(options: TelemetryServiceOptions) {
+    this.enabled = options.enabled;
+    this.bufferSize = options.bufferSize;
+    this.flushIntervalMs = options.flushIntervalMs;
+    this.sinks = options.sinks;
+    this.onSinkError = options.onSinkError ?? (() => {});
+    this.onEventsDropped = options.onEventsDropped ?? (() => {});
+
     if (this.enabled && this.flushIntervalMs > 0) {
       this.flushTimer = setInterval(() => {
         void this.flushSync();
@@ -328,223 +351,83 @@ export class TelemetryServiceImpl implements TelemetryService {
   }
 
   private flushBuffer(): Effect.Effect<void, TelemetryError> {
-    return Effect.gen(
-      function* (this: TelemetryServiceImpl) {
-        if (this.buffer.length === 0) return;
-
-        const toFlush = [...this.buffer];
-        this.buffer = [];
-
-        yield* this.writeEvents(toFlush);
-      }.bind(this),
-    );
+    return Effect.promise(() => this.flushSync());
   }
 
   /**
-   * Synchronous flush (used by the interval timer outside of Effect context).
+   * Write the buffer out to every sink.
+   *
+   * Promise-based because the interval timer drives it from outside any Effect
+   * context. Sinks are written concurrently and independently: one failing
+   * destination never blocks another, and no failure is surfaced to the caller.
+   * Events are re-enqueued only when every sink failed, so a working file sink
+   * plus a dead collector does not duplicate rows on disk.
    */
   private async flushSync(): Promise<void> {
-    if (this.buffer.length === 0) return;
+    if (this.buffer.length === 0 || this.sinks.length === 0) return;
 
     const toFlush = [...this.buffer];
     this.buffer = [];
 
-    const eventsDir = path.join(this.storagePath, EVENTS_DIR);
+    const results = await Promise.allSettled(this.sinks.map((sink) => sink.write(toFlush)));
 
-    try {
-      if (!this.dirCreated) {
-        await mkdir(eventsDir, { recursive: true });
-        this.dirCreated = true;
+    let failures = 0;
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        failures += 1;
+        this.onSinkError(this.sinks[index]?.name ?? "unknown", result.reason);
       }
+    });
 
-      // Group by date partition
-      const grouped = new Map<string, TelemetryEvent[]>();
-      for (const event of toFlush) {
-        const partition = datePartition(new Date(event.timestamp));
-        const existing = grouped.get(partition);
-        if (existing) {
-          existing.push(event);
-        } else {
-          grouped.set(partition, [event]);
-        }
-      }
-
-      for (const [partition, events] of grouped) {
-        const filePath = path.join(eventsDir, `${partition}.ndjson`);
-        const lines = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
-        await appendFile(filePath, lines, { encoding: "utf8" });
-      }
-    } catch {
-      // Re-enqueue events that failed to flush (best-effort)
+    if (failures === this.sinks.length) {
       this.buffer.unshift(...toFlush);
+      this.enforceBufferCeiling();
     }
   }
 
-  private writeEvents(events: readonly TelemetryEvent[]): Effect.Effect<void, TelemetryError> {
-    return Effect.gen(
-      function* (this: TelemetryServiceImpl) {
-        const eventsDir = path.join(this.storagePath, EVENTS_DIR);
+  private enforceBufferCeiling(): void {
+    const ceiling = this.bufferSize * MAX_BUFFER_MULTIPLIER;
+    if (this.buffer.length <= ceiling) return;
 
-        yield* Effect.tryPromise({
-          try: async () => {
-            if (!this.dirCreated) {
-              await mkdir(eventsDir, { recursive: true });
-              this.dirCreated = true;
-            }
-          },
-          catch: (error) =>
-            new TelemetryWriteError({
-              path: eventsDir,
-              message: `Failed to create telemetry directory: ${String(error)}`,
-              cause: error,
-              suggestion: "Check file system permissions for the telemetry storage path.",
-            }),
-        }).pipe(
-          Effect.mapError(
-            (err) =>
-              new TelemetryError({
-                operation: "flush",
-                message: err.message,
-                cause: err,
-              }),
-          ),
-        );
-
-        // Group events by date partition for file organization
-        const grouped = new Map<string, TelemetryEvent[]>();
-        for (const event of events) {
-          const partition = datePartition(new Date(event.timestamp));
-          const existing = grouped.get(partition);
-          if (existing) {
-            existing.push(event);
-          } else {
-            grouped.set(partition, [event]);
-          }
-        }
-
-        for (const [partition, partitionEvents] of grouped) {
-          const filePath = path.join(eventsDir, `${partition}.ndjson`);
-          const lines = partitionEvents.map((e) => JSON.stringify(e)).join("\n") + "\n";
-
-          yield* Effect.tryPromise({
-            try: () => appendFile(filePath, lines, { encoding: "utf8" }),
-            catch: (error) =>
-              new TelemetryError({
-                operation: "write",
-                message: `Failed to write telemetry events to ${filePath}: ${String(error)}`,
-                cause: error,
-                suggestion: "Check file system permissions for the telemetry storage path.",
-              }),
-          });
-        }
-      }.bind(this),
-    );
+    const dropped = this.buffer.length - ceiling;
+    this.buffer = this.buffer.slice(dropped);
+    this.onEventsDropped(dropped);
   }
 
   private loadAllEvents(): Effect.Effect<TelemetryEvent[], TelemetryError> {
-    return Effect.gen(
-      function* (this: TelemetryServiceImpl) {
-        const eventsDir = path.join(this.storagePath, EVENTS_DIR);
+    const reader = this.sinks.find(isEventReader);
+    if (!reader) return Effect.succeed([...this.buffer]);
 
-        const files = yield* Effect.tryPromise({
-          try: async () => {
-            try {
-              return await readdir(eventsDir);
-            } catch {
-              return [];
-            }
-          },
-          catch: (error) =>
-            new TelemetryError({
-              operation: "read",
-              message: `Failed to list telemetry events directory: ${String(error)}`,
-              cause: error,
-            }),
-        });
-
-        const ndjsonFiles = files.filter((f) => f.endsWith(".ndjson")).sort();
-        const allEvents: TelemetryEvent[] = [];
-
-        // Also include buffered (not yet flushed) events
-        allEvents.push(...this.buffer);
-
-        for (const file of ndjsonFiles) {
-          const filePath = path.join(eventsDir, file);
-          const content = yield* Effect.tryPromise({
-            try: () => readFile(filePath, { encoding: "utf8" }),
-            catch: (error) =>
-              new TelemetryError({
-                operation: "read",
-                message: `Failed to read telemetry file ${filePath}: ${String(error)}`,
-                cause: error,
-              }),
-          });
-
-          const lines = content.split("\n").filter((line) => line.trim().length > 0);
-          for (const line of lines) {
-            try {
-              const event = JSON.parse(line) as TelemetryEvent;
-              allEvents.push(event);
-            } catch {
-              // Skip malformed lines
-            }
-          }
-        }
-
-        return allEvents;
-      }.bind(this),
-    );
+    return Effect.tryPromise({
+      try: async () => [...this.buffer, ...(await reader.readAll())],
+      catch: (error) =>
+        new TelemetryError({
+          operation: "read",
+          message: `Failed to read telemetry events: ${String(error)}`,
+          cause: error,
+        }),
+    });
   }
 
   /**
-   * Remove telemetry files older than retentionDays.
+   * Remove stored events older than the retention window.
+   * Only the file sink retains anything locally; other sinks are no-ops here.
    */
   pruneOldEvents(): Effect.Effect<number, TelemetryError> {
-    return Effect.gen(
-      function* (this: TelemetryServiceImpl) {
-        const eventsDir = path.join(this.storagePath, EVENTS_DIR);
-        const cutoff = new Date();
-        cutoff.setDate(cutoff.getDate() - this.retentionDays);
-        const cutoffPartition = datePartition(cutoff);
-
-        const files = yield* Effect.tryPromise({
-          try: async () => {
-            try {
-              return await readdir(eventsDir);
-            } catch {
-              return [];
-            }
-          },
-          catch: (error) =>
-            new TelemetryError({
-              operation: "prune",
-              message: `Failed to list telemetry directory for pruning: ${String(error)}`,
-              cause: error,
-            }),
-        });
-
-        let pruned = 0;
-        for (const file of files) {
-          if (!file.endsWith(".ndjson")) continue;
-          // File name format: YYYY-MM-DD.ndjson
-          const partition = file.replace(".ndjson", "");
-          if (partition < cutoffPartition) {
-            yield* Effect.tryPromise({
-              try: () => unlink(path.join(eventsDir, file)),
-              catch: (error) =>
-                new TelemetryError({
-                  operation: "prune",
-                  message: `Failed to delete old telemetry file ${file}: ${String(error)}`,
-                  cause: error,
-                }),
-            });
-            pruned += 1;
-          }
-        }
-
-        return pruned;
-      }.bind(this),
+    const fileSink = this.sinks.find(
+      (sink): sink is FileTelemetrySink => sink instanceof FileTelemetrySink,
     );
+    if (!fileSink) return Effect.succeed(0);
+
+    return Effect.tryPromise({
+      try: () => fileSink.prune(),
+      catch: (error) =>
+        new TelemetryError({
+          operation: "prune",
+          message: `Failed to prune telemetry events: ${String(error)}`,
+          cause: error,
+        }),
+    });
   }
 
   private aggregateUsage(events: readonly TelemetryEvent[]): UsageSummary {
@@ -627,22 +510,16 @@ export class TelemetryServiceImpl implements TelemetryService {
               };
             }
           }
-          if (data["durationMs"] != null) {
-            summary.totalDurationMs += Number(data["durationMs"]);
-          }
           break;
         }
 
         case "agent_run_completed": {
           summary.totalAgentRuns += 1;
+          // `totalDurationMs` tracks wall clock, so only run duration counts —
+          // per-request `llm_usage` durations are contained within it. Tool
+          // counters come from the per-invocation events for the same reason.
           if (data["durationMs"] != null) {
             summary.totalDurationMs += Number(data["durationMs"]);
-          }
-          if (data["toolCalls"] != null) {
-            summary.totalToolCalls += Number(data["toolCalls"]);
-          }
-          if (data["toolErrors"] != null) {
-            summary.totalToolErrors += Number(data["toolErrors"]);
           }
 
           // Accumulate per-agent usage
@@ -654,13 +531,6 @@ export class TelemetryServiceImpl implements TelemetryService {
                 : "unknown";
           const agentName = typeof data["agentName"] === "string" ? data["agentName"] : "unknown";
           const usage = data["usage"] as TokenUsage | undefined;
-
-          // Accumulate tool token usage from agent run
-          if (usage) {
-            summary.toolDefinitionTokens += usage.toolDefinitionTokens ?? 0;
-            summary.toolResultTokens += usage.toolResultTokens ?? 0;
-            summary.toolDefinitionsOffered += usage.toolDefinitionsOffered ?? 0;
-          }
 
           const existingAgent = summary.byAgent[agentId];
           if (existingAgent) {
@@ -753,21 +623,51 @@ export function createTelemetryServiceLayer(): Layer.Layer<
       const flushIntervalMs = telemetryConfig?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
       const retentionDays = telemetryConfig?.retentionDays ?? DEFAULT_RETENTION_DAYS;
 
+      const sinks: TelemetrySink[] = [new FileTelemetrySink(storagePath, retentionDays)];
+
+      const otlpConfig = resolveOtlpConfig(telemetryConfig?.otlp);
+      if (otlpConfig?.enabled === true) {
+        sinks.push(new OtlpTelemetrySink(otlpConfig, packageJson.version));
+      }
+
       yield* logger.debug("Telemetry service initialized", {
         enabled,
         storagePath,
         bufferSize,
         flushIntervalMs,
         retentionDays,
+        sinks: sinks.map((sink) => sink.name),
+        ...(otlpConfig && {
+          otlp: {
+            enabled: otlpConfig.enabled,
+            logsEndpoint: otlpConfig.logsEndpoint,
+            serviceName: otlpConfig.serviceName,
+            captureContent: otlpConfig.captureContent,
+            // Headers carry credentials and must never reach the log file.
+            headers: redactHeaders(otlpConfig.headers),
+          },
+        }),
       });
 
-      return new TelemetryServiceImpl(
-        storagePath,
+      return new TelemetryServiceImpl({
         enabled,
         bufferSize,
         flushIntervalMs,
-        retentionDays,
-      );
+        sinks,
+        onSinkError: (sinkName, error) => {
+          Effect.runFork(
+            logger.warn("Telemetry sink write failed", {
+              sink: sinkName,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          );
+        },
+        onEventsDropped: (count) => {
+          Effect.runFork(
+            logger.warn("Telemetry buffer full; dropped oldest events", { dropped: count }),
+          );
+        },
+      });
     }),
   );
 }


### PR DESCRIPTION
## What & why

Jazz wrote run metrics to `~/.jazz` and stopped there. If you run an agent on a server you own, that file is not where you go to look. This lets you point a run at an OpenTelemetry collector you already operate — set `OTEL_EXPORTER_OTLP_ENDPOINT` and runs start showing up, no config file needed.

Runs are exported as **traces**: one trace per run, with each LLM request and tool call as a child span. That is the signal LLM-observability backends accept, so Langfuse works through the same path with no separate integration. The exporter encodes OTLP/JSON by hand rather than pulling in the OpenTelemetry SDK, so the published install gains no dependencies.

Two things were needed to make this worth exporting at all, and both are in here:

- **Six of the seven telemetry record methods had no callers.** A whole run produced one row. LLM usage, retries, tool invocations, and CLI commands now actually get recorded — which makes the local NDJSON file useful too, whether or not you export anywhere.
- **`recordLLMRetry` never fired.** Its three call sites wrapped `yield*` in a `try/catch` inside `Effect.gen`, which does not catch Effect failures, so `llmRetryCount` has always been `0` and `lastError` was never set from a retry.

Prompt and completion text is **not** exported. Content-bearing fields are dropped and string attributes truncated. Turning that off is config-only (`telemetry.otlp.captureContent`) and never follows from configuring an endpoint.

## Behaviour changes to be aware of

| | |
|---|---|
| Retry counters | `llmRetryCount` and `lastError` now populate in the existing agent token-usage log. They were silently `0`/unset before — expect new values to appear in logs, not a new log line. |
| Local telemetry volume | Runs now write per-request and per-tool-call events instead of one row per run. Bounded by the existing `telemetry.retentionDays` (90 days). |

Nothing is exported unless an endpoint is configured. No migration needed.

## How to verify

- Run a collector — `docker run --rm -p 4318:4318 otel/opentelemetry-collector` — then `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 jazz run "..."`. The run should appear as one trace, the agent run as root span, LLM and tool calls nested under it.
- Point at a bogus endpoint (`http://127.0.0.1:1`) and confirm the run completes normally, exits 0, and `~/.jazz/telemetry/events/*.ndjson` is still written — export must never fail or slow a run.
- Run `jazz agent list` with an endpoint set and check the recorded `command_executed` event contains only the command path, no arguments (they carry prompts and file paths).
- With `captureContent` left off, confirm no tool arguments or results appear in the exported payload, and that long error strings are truncated.
- For Langfuse, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to `<host>/api/public/otel/v1/traces` with a Basic auth header and confirm traces land. Do not add `logs` to `signals` for Langfuse — it has no logs endpoint.

## Known limitation

Trace grouping is derived from the run id rather than a span context threaded through the agent loop, so a subagent run gets its own trace instead of nesting under the parent's tool span. Everything within a single run nests correctly. Threading real span context is follow-up work.
