### PR TITLE
fix(docs): label the sub-agent nesting fence so markdownlint passes

### DIFF
--- a/docs/internals/subagents.md
+++ b/docs/internals/subagents.md
@@ -99,7 +99,7 @@ working after 30 iterations has usually misunderstood the brief rather than foun
 That means the parent's remaining budget bounds nothing. Depth does. Each run carries how many
 levels sit above it, and `spawn_subagent` refuses once the limit is reached:
 
-```
+```text
 Sub-agent nesting limit reached (depth 3 of 3). Do this task yourself instead of delegating it further.
 ```
 


### PR DESCRIPTION
`main` has been red since #341. Its unlabelled code fence in `docs/internals/subagents.md` trips markdownlint's MD040, failing the `docs` job on every run — on `main` itself and on every open PR that branches from it, including #342 (already merged) and #344.

One-character fix: the block is example CLI output, so it gets `text`, matching the 16 other ```text blocks in `docs/`.

`bunx markdownlint-cli2` locally: **0 issues in 0 files** across 57 files (was 1 issue in 1 file).