### PR TITLE
feat(agent): read project instructions from AGENTS.md

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -60,6 +60,29 @@ which skills they reach for. See [Skills](./skills.md).
 
 ---
 
+## Project instructions (AGENTS.md)
+
+Jazz reads [`AGENTS.md`](https://agents.md) — the cross-tool convention for telling an agent how
+a project works: build and test commands, conventions, house rules. Drop one at the root of a
+repository and every Jazz agent working there picks it up, with no per-agent configuration.
+
+Discovery runs on each turn against the agent's current working directory:
+
+| Order | File | Purpose |
+| --- | --- | --- |
+| 1 | `~/.agents/AGENTS.md` | Your personal defaults, across every project |
+| 2 | `<repo root>/AGENTS.md` | How this project works |
+| 3 | `<subdirectory>/AGENTS.md` | Overrides for one package or area |
+
+The walk climbs from the working directory to the repository root (the nearest ancestor with a
+`.git`) and stops there, so a checkout never inherits an unrelated `AGENTS.md` from a directory
+above it. Files are placed in the system prompt outermost-first: **when two conflict, the more
+specific one wins.** Each file is capped at 32 KB — keep them short and they stay effective.
+
+Edits take effect on the next turn; no restart needed.
+
+---
+
 ## The execution loop
 
 ```mermaid

--- a/src/core/agent/agent-prompt-project-instructions.test.ts
+++ b/src/core/agent/agent-prompt-project-instructions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type { PersonaService } from "@/core/interfaces/persona-service";
+import type { Persona } from "@/core/types/persona";
+import { AgentPromptBuilder, type AgentPromptOptions } from "./agent-prompt";
+
+/**
+ * AGENTS.md files reach the model through the system prompt. These tests lock
+ * the contract the prompt builder owns: the files are rendered verbatim, the
+ * nearest one lands last, and editing a file invalidates the prompt cache.
+ */
+
+function personaServiceReturning(systemPrompt: string): PersonaService {
+  const persona: Persona = {
+    id: "test-id",
+    name: "test",
+    description: "test persona",
+    systemPrompt,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+  return {
+    getPersonaByIdentifier: () => Effect.succeed(persona),
+  } as unknown as PersonaService;
+}
+
+const BASE_OPTIONS: AgentPromptOptions = {
+  agentName: "Test",
+  agentDescription: "a test agent.",
+  userInput: "hello",
+};
+
+function build(builder: AgentPromptBuilder, options: AgentPromptOptions): string {
+  return Effect.runSync(
+    builder.buildSystemPrompt("default", options, personaServiceReturning("You are {agentName}.")),
+  );
+}
+
+describe("project instructions in the system prompt", () => {
+  test("adds no section when no AGENTS.md was found", () => {
+    const result = build(new AgentPromptBuilder(), BASE_OPTIONS);
+    expect(result).not.toContain("<project_instructions>");
+  });
+
+  test("renders discovered files verbatim, nearest last", () => {
+    const result = build(new AgentPromptBuilder(), {
+      ...BASE_OPTIONS,
+      projectInstructions: [
+        { path: "/repo/AGENTS.md", content: "Run tests with bun test." },
+        { path: "/repo/web/AGENTS.md", content: "Web package uses pnpm." },
+      ],
+    });
+
+    expect(result).toContain("<project_instructions>");
+    expect(result).toContain("Run tests with bun test.");
+    expect(result).toContain("Web package uses pnpm.");
+    expect(result.indexOf("Run tests with bun test.")).toBeLessThan(
+      result.indexOf("Web package uses pnpm."),
+    );
+  });
+
+  test("editing an AGENTS.md invalidates the cached prompt", () => {
+    const builder = new AgentPromptBuilder();
+
+    const before = build(builder, {
+      ...BASE_OPTIONS,
+      projectInstructions: [{ path: "/repo/AGENTS.md", content: "old rule" }],
+    });
+    const after = build(builder, {
+      ...BASE_OPTIONS,
+      projectInstructions: [{ path: "/repo/AGENTS.md", content: "new rule" }],
+    });
+
+    expect(before).toContain("old rule");
+    expect(after).toContain("new rule");
+    expect(after).not.toContain("old rule");
+  });
+});

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -3,6 +3,7 @@ import * as os from "os";
 import { Effect } from "effect";
 import type { PersonaService } from "@/core/interfaces/persona-service";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
+import { renderProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
 import { ENVIRONMENT_TEMPLATE, MEMORY_INSTRUCTIONS, SKILLS_INSTRUCTIONS } from "./prompts/shared";
 
 function formatUtcOffsetLabel(date: Date): string {
@@ -55,6 +56,12 @@ export interface AgentPromptOptions {
    * call `find_skills` first. Subset of `knownSkills` by name.
    */
   readonly triggeredSkillNames?: readonly string[];
+  /**
+   * AGENTS.md files discovered for the working directory, outermost first.
+   * Rendered verbatim into the system prompt so project conventions reach the
+   * model without the user restating them every session.
+   */
+  readonly projectInstructions?: readonly ProjectInstructionFile[];
 }
 
 /**
@@ -150,6 +157,13 @@ export class AgentPromptBuilder {
     }
     if (options.toolNames?.includes("view_memory")) {
       hash.update("memory:1");
+    }
+    // Content, not just paths: editing an AGENTS.md must take effect on the
+    // next turn rather than waiting for a process restart.
+    if (options.projectInstructions && options.projectInstructions.length > 0) {
+      for (const file of options.projectInstructions) {
+        hash.update(`agentsmd:${file.path}:${file.content}`);
+      }
     }
     // Invalidate daily since prompts include current date
     hash.update(new Date().toDateString());
@@ -303,6 +317,12 @@ ${triggeredBlock}`;
 
         if (options.toolNames?.includes("view_memory")) {
           systemPrompt = systemPrompt + MEMORY_INSTRUCTIONS;
+        }
+
+        // Last, so project rules read as the most recent instruction the model
+        // has before the conversation itself.
+        if (options.projectInstructions && options.projectInstructions.length > 0) {
+          systemPrompt = systemPrompt + renderProjectInstructions(options.projectInstructions);
         }
 
         // Cache the result

--- a/src/core/agent/agent-runner.test.ts
+++ b/src/core/agent/agent-runner.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
 import { Effect, Layer, Stream } from "effect";
@@ -63,7 +64,12 @@ const mockPresentationService = {
 
 const mockTerminalService = {} as unknown as TerminalService;
 const mockFileSystem = {} as unknown as FileSystem.FileSystem;
-const mockFileSystemContext = {} as unknown as FileSystemContextService;
+const mockFileSystemContext = {
+  // AgentRunner reads the working directory to discover AGENTS.md files.
+  // Point it at a directory with none so the host machine cannot influence
+  // these assertions.
+  getCwd: () => Effect.succeed(os.tmpdir()),
+} as unknown as FileSystemContextService;
 
 const BUILTIN_TOOLS_BY_CATEGORY: Record<string, string[]> = {
   skills: ["load_skill", "load_skill_section"],

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -7,6 +7,7 @@ import {
 } from "@/core/constants/agent";
 import type { ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
+import { FileSystemContextServiceTag } from "@/core/interfaces/fs";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { type MCPServerManager } from "@/core/interfaces/mcp-server";
@@ -35,12 +36,43 @@ import { agentPromptBuilder } from "./agent-prompt";
 import { Summarizer } from "./context/summarizer";
 import { executeWithStreaming, executeWithoutStreaming } from "./execution";
 import { createAgentRunMetrics, emitAgentRunStarted } from "./metrics/agent-run-metrics";
+import { discoverProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
 import { registerCustomToolsForAgent } from "./tools/custom-tools";
 import { registerMCPToolsForAgent } from "./tools/register-mcp-tools";
 import { registerSkillSystemTools } from "./tools/register-tools";
 import { BUILTIN_TOOL_CATEGORIES } from "./tools/tool-categories";
 import { type AgentResponse, type AgentRunContext, type AgentRunnerOptions } from "./types";
 import { normalizeToolConfig } from "./utils/tool-config";
+
+/**
+ * Resolve the AGENTS.md files that apply to this run.
+ *
+ * The working directory is read from FileSystemContextService when it is in the
+ * environment — that is the directory the agent's own file tools operate on, so
+ * it stays correct after the agent changes directories — and falls back to the
+ * process cwd for surfaces (and tests) that do not provide the service.
+ */
+function resolveProjectInstructions(
+  persona: string,
+  agentId: string,
+  options: AgentRunnerOptions,
+): Effect.Effect<readonly ProjectInstructionFile[], never> {
+  return Effect.gen(function* () {
+    if (persona === "summarizer") return [];
+
+    const fileSystemContextOption = yield* Effect.serviceOption(FileSystemContextServiceTag);
+    const workingDirectory = Option.isSome(fileSystemContextOption)
+      ? yield* fileSystemContextOption.value.getCwd({
+          agentId,
+          ...(options.conversationId !== undefined
+            ? { conversationId: options.conversationId }
+            : {}),
+        })
+      : process.cwd();
+
+    return yield* Effect.sync(() => discoverProjectInstructions(workingDirectory));
+  });
+}
 
 /**
  * Initialize common agent run context (tools, messages, metrics)
@@ -216,6 +248,19 @@ function initializeAgentRun(
     // Deterministic, zero LLM overhead, predictable for skill authors.
     const triggeredSkillNames = matchSkillTriggers(userInput, relevantSkills);
 
+    // AGENTS.md discovery. Uses the agent's tracked working directory when the
+    // filesystem-context service is available (the agent can `cd` mid-session),
+    // otherwise the process cwd. The summarizer compresses transcripts and has
+    // no project to honor, so it never gets them.
+    const projectInstructions = yield* resolveProjectInstructions(persona, agent.id, options);
+    if (projectInstructions.length > 0) {
+      yield* logger.debug(
+        `[AGENTS.md] Loaded ${projectInstructions.length} instruction file(s): ${projectInstructions
+          .map((file) => file.path)
+          .join(", ")}`,
+      );
+    }
+
     // Build messages — reuses the PersonaService resolved earlier so custom
     // personas can be looked up by name when assembling the system prompt.
     const messages: ConversationMessages = yield* agentPromptBuilder.buildAgentMessages(
@@ -229,6 +274,7 @@ function initializeAgentRun(
         availableTools,
         knownSkills: relevantSkills,
         ...(triggeredSkillNames.length > 0 && { triggeredSkillNames }),
+        ...(projectInstructions.length > 0 && { projectInstructions }),
       },
       resolvedPersonaService,
     );

--- a/src/core/agent/project-instructions.test.ts
+++ b/src/core/agent/project-instructions.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { discoverProjectInstructions, renderProjectInstructions } from "./project-instructions";
+
+// Discovery also reads ~/.agents/AGENTS.md; point "home" at a directory that
+// has none so the developer's own file cannot leak into these assertions.
+const ISOLATED_HOME = path.join(os.tmpdir(), "jazz-agents-md-no-home");
+
+const createdRoots: string[] = [];
+
+function makeTempTree(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-agents-md-"));
+  createdRoots.push(root);
+  // Real path so macOS /var → /private/var symlinking does not break comparisons.
+  return fs.realpathSync(root);
+}
+
+afterEach(() => {
+  while (createdRoots.length > 0) {
+    const root = createdRoots.pop();
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("discoverProjectInstructions", () => {
+  test("finds AGENTS.md in the starting directory", () => {
+    const root = makeTempTree();
+    fs.mkdirSync(path.join(root, ".git"));
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "Use bun, not npm.");
+
+    const files = discoverProjectInstructions(root, ISOLATED_HOME);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.path).toBe(path.join(root, "AGENTS.md"));
+    expect(files[0]?.content).toBe("Use bun, not npm.");
+  });
+
+  test("returns ancestors first so the nearest file wins", () => {
+    const root = makeTempTree();
+    fs.mkdirSync(path.join(root, ".git"));
+    const nested = path.join(root, "packages", "web");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "root rules");
+    fs.writeFileSync(path.join(nested, "AGENTS.md"), "web rules");
+
+    const files = discoverProjectInstructions(nested, ISOLATED_HOME);
+
+    expect(files.map((file) => file.content)).toEqual(["root rules", "web rules"]);
+  });
+
+  test("stops climbing at the repository root", () => {
+    const root = makeTempTree();
+    const repo = path.join(root, "repo");
+    fs.mkdirSync(path.join(repo, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "unrelated outer rules");
+    fs.writeFileSync(path.join(repo, "AGENTS.md"), "repo rules");
+
+    const files = discoverProjectInstructions(repo, ISOLATED_HOME);
+
+    expect(files.map((file) => file.content)).toEqual(["repo rules"]);
+  });
+
+  test("ignores empty files and missing directories", () => {
+    const root = makeTempTree();
+    fs.mkdirSync(path.join(root, ".git"));
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "   \n\n");
+
+    expect(discoverProjectInstructions(root, ISOLATED_HOME)).toHaveLength(0);
+    expect(
+      discoverProjectInstructions(path.join(root, "does-not-exist"), ISOLATED_HOME),
+    ).toHaveLength(0);
+  });
+
+  test("truncates oversized files with a marker", () => {
+    const root = makeTempTree();
+    fs.mkdirSync(path.join(root, ".git"));
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "x".repeat(100_000));
+
+    const files = discoverProjectInstructions(root, ISOLATED_HOME);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.content).toContain("[truncated:");
+    expect(files[0]?.content.length).toBeLessThan(40_000);
+  });
+});
+
+describe("renderProjectInstructions", () => {
+  test("renders nothing when no files were found", () => {
+    expect(renderProjectInstructions([])).toBe("");
+  });
+
+  test("wraps each file with its path and preserves order", () => {
+    const rendered = renderProjectInstructions(
+      [
+        { path: "/repo/AGENTS.md", content: "root rules" },
+        { path: "/repo/web/AGENTS.md", content: "web rules" },
+      ],
+      "/home/someone",
+    );
+
+    expect(rendered).toContain('<file path="/repo/AGENTS.md">');
+    expect(rendered).toContain('<file path="/repo/web/AGENTS.md">');
+    expect(rendered.indexOf("root rules")).toBeLessThan(rendered.indexOf("web rules"));
+  });
+
+  test("abbreviates paths under the home directory", () => {
+    const rendered = renderProjectInstructions(
+      [{ path: "/home/someone/.agents/AGENTS.md", content: "personal defaults" }],
+      "/home/someone",
+    );
+
+    expect(rendered).toContain('<file path="~/.agents/AGENTS.md">');
+  });
+});

--- a/src/core/agent/project-instructions.ts
+++ b/src/core/agent/project-instructions.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * AGENTS.md support — the cross-tool convention for project instructions
+ * (https://agents.md). A repository drops an `AGENTS.md` at its root (and
+ * optionally in subdirectories) describing build commands, conventions, and
+ * house rules; every agent that reads the convention picks them up.
+ */
+
+export interface ProjectInstructionFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+const INSTRUCTION_FILE_NAME = "AGENTS.md";
+
+/**
+ * Per-file byte cap. AGENTS.md files are meant to be short; a runaway file
+ * (generated docs, a pasted changelog) would otherwise silently eat the whole
+ * context window. Truncated content is marked so the model knows it is partial.
+ */
+const MAX_FILE_BYTES = 32 * 1024;
+
+/**
+ * Upper bound on how far the ancestor walk climbs when no repository root is
+ * found. Guards against pathological paths and network mounts.
+ */
+const MAX_ANCESTOR_DEPTH = 32;
+
+function readInstructionFile(filePath: string): ProjectInstructionFile | null {
+  try {
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) return null;
+
+    const raw = fs.readFileSync(filePath, "utf-8");
+    if (raw.trim().length === 0) return null;
+
+    if (Buffer.byteLength(raw, "utf-8") <= MAX_FILE_BYTES) {
+      return { path: filePath, content: raw.trim() };
+    }
+
+    const truncated = Buffer.from(raw, "utf-8").subarray(0, MAX_FILE_BYTES).toString("utf-8");
+    return {
+      path: filePath,
+      content: `${truncated.trim()}\n\n[truncated: ${INSTRUCTION_FILE_NAME} exceeds ${MAX_FILE_BYTES} bytes]`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isRepositoryRoot(directory: string): boolean {
+  try {
+    return fs.existsSync(path.join(directory, ".git"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Collects the directories to scan, outermost first.
+ *
+ * The walk starts at `startDir` and climbs until it reaches a repository root
+ * (inclusive), the user's home directory, or the filesystem root. Stopping at
+ * the repository root is what keeps a checkout under `~/work` from inheriting
+ * an unrelated `AGENTS.md` sitting in `~/work`.
+ */
+function collectDirectories(startDir: string, homeDirectory: string): readonly string[] {
+  const directories: string[] = [];
+
+  let currentDirectory = path.resolve(startDir);
+  const filesystemRoot = path.parse(currentDirectory).root;
+
+  for (let depth = 0; depth < MAX_ANCESTOR_DEPTH; depth++) {
+    directories.push(currentDirectory);
+
+    if (isRepositoryRoot(currentDirectory)) break;
+    if (currentDirectory === homeDirectory) break;
+    if (currentDirectory === filesystemRoot) break;
+
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) break;
+    currentDirectory = parentDirectory;
+  }
+
+  return directories.reverse();
+}
+
+/**
+ * Discovers the AGENTS.md files that apply to `startDir`.
+ *
+ * Returned outermost-first so the nearest file lands last in the prompt: when
+ * a nested `AGENTS.md` contradicts one further up, the more specific
+ * instruction is the one the model reads most recently.
+ *
+ * A global `~/.agents/AGENTS.md` — the same shared location Jazz already reads
+ * cross-tool skills from — comes first when present, so personal defaults sit
+ * beneath anything the project says.
+ */
+export function discoverProjectInstructions(
+  startDir: string,
+  homeDirectory: string = os.homedir(),
+): readonly ProjectInstructionFile[] {
+  const candidatePaths: string[] = [];
+
+  if (homeDirectory && homeDirectory.trim().length > 0) {
+    candidatePaths.push(path.join(homeDirectory, ".agents", INSTRUCTION_FILE_NAME));
+  }
+
+  for (const directory of collectDirectories(startDir, homeDirectory)) {
+    candidatePaths.push(path.join(directory, INSTRUCTION_FILE_NAME));
+  }
+
+  const seenPaths = new Set<string>();
+  const files: ProjectInstructionFile[] = [];
+
+  for (const candidatePath of candidatePaths) {
+    if (seenPaths.has(candidatePath)) continue;
+    seenPaths.add(candidatePath);
+
+    const file = readInstructionFile(candidatePath);
+    if (file) files.push(file);
+  }
+
+  return files;
+}
+
+/**
+ * Renders discovered instruction files as a system-prompt section.
+ *
+ * Returns an empty string when nothing was found, so callers can concatenate
+ * unconditionally.
+ */
+export function renderProjectInstructions(
+  files: readonly ProjectInstructionFile[],
+  homeDirectory: string = os.homedir(),
+): string {
+  if (files.length === 0) return "";
+
+  const displayPath = (filePath: string): string =>
+    homeDirectory && filePath.startsWith(`${homeDirectory}${path.sep}`)
+      ? `~${filePath.slice(homeDirectory.length)}`
+      : filePath;
+
+  const blocks = files
+    .map((file) => `<file path="${displayPath(file.path)}">\n${file.content}\n</file>`)
+    .join("\n\n");
+
+  return `
+# Project instructions
+
+The AGENTS.md files below were found in and above the current working directory. They are instructions from the people who own this project — follow them as you would the user's own. Later files are more specific than earlier ones: when two conflict, the later one wins. They describe the project, not the current request; if the user asks for something these files do not cover, use your own judgment.
+
+<project_instructions>
+${blocks}
+</project_instructions>
+`;
+}

--- a/src/core/agent/tools/custom-tools.test.ts
+++ b/src/core/agent/tools/custom-tools.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { FileSystem } from "@effect/platform";
 import { describe, expect, it, mock } from "bun:test";
 import { Effect, Layer, Stream } from "effect";
@@ -405,7 +406,12 @@ describe("custom tools surfaced through AgentRunner.run toolCalls", () => {
 
   const mockTerminalService = {} as unknown as TerminalService;
   const mockFileSystem = {} as unknown as FileSystem.FileSystem;
-  const mockFileSystemContext = {} as unknown as FileSystemContextService;
+  const mockFileSystemContext = {
+    // AgentRunner reads the working directory to discover AGENTS.md files.
+    // Point it at a directory with none so the host machine cannot influence
+    // these assertions.
+    getCwd: () => Effect.succeed(os.tmpdir()),
+  } as unknown as FileSystemContextService;
 
   // AgentRunner resolves the agent's persona through PersonaService; there is no
   // built-in fallback prompt, so a persona that can't be resolved is a hard


### PR DESCRIPTION
## What changes

Jazz now reads [`AGENTS.md`](https://agents.md), the cross-tool convention for telling an agent how a project works — build and test commands, conventions, house rules.

Drop an `AGENTS.md` at the root of a repository and every Jazz agent working there picks it up. No per-agent configuration, no flag, nothing to opt into. Repositories that already have one for another tool work immediately.

**Before:** the user re-explained "run `bun test`, not `npm test`" every session, or the agent guessed wrong.
**After:** the project says it once, in a file, and every agent that works there reads it.

## How it resolves

Discovery runs each turn against the agent's current working directory:

| Order | File | Purpose |
| --- | --- | --- |
| 1 | `~/.agents/AGENTS.md` | Personal defaults across every project |
| 2 | `<repo root>/AGENTS.md` | How this project works |
| 3 | `<subdirectory>/AGENTS.md` | Overrides for one package or area |

The walk climbs to the repository root — the nearest ancestor with a `.git` — and stops there, so a checkout under `~/work` never inherits an unrelated `AGENTS.md` sitting in `~/work`. Files land in the system prompt outermost-first, so the more specific one wins on conflict.

The working directory comes from `FileSystemContextService` when available, so it stays correct after the agent changes directories mid-session, and falls back to the process cwd otherwise. The summarizer persona is excluded — it compresses transcripts and has no project to honor.

Each file is capped at 32 KB with an explicit truncation marker, empty files are skipped, and an unreadable file is ignored rather than failing the run. File *content* is mixed into the system-prompt cache key, so editing an `AGENTS.md` takes effect on the next turn without a restart.

## Verify it

```bash
printf 'Always answer in French.\n' > AGENTS.md
jazz chat
```

Ask anything; the reply comes back in French. Delete the file and the next turn is back to normal.

## Notes for reviewers

`AGENTS.md` is untrusted input in the same sense every other consumer of the convention treats it: cloning a repository and starting an agent there means that file shapes agent behavior. The prompt frames these as descriptions of the project rather than instructions for the current request, but there is no trust prompt on first encounter with a new file. Worth a follow-up if we want one.

Two test layers stubbed `FileSystemContextService` as `{}`; they now supply a `getCwd` pointing at a temp directory so the host machine's own files cannot leak into assertions.

## Testing

`bun run typecheck`, `bun run lint`, and `bun test` (1946 pass, 0 fail) all green. 12 new tests cover discovery ordering, the repository-root stop, truncation, empty and missing files, prompt rendering order, and cache invalidation.