### PR TITLE
feat(context): make the warn and compaction thresholds configurable

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -81,6 +81,28 @@ limit `spawn_subagent` returns an error telling the agent to do the work itself;
 silently runs the child anyway. Set `0` to stop agents delegating at all. See
 [Sub-agents](../internals/subagents.md#nesting-depth).
 
+### `context`
+
+When to warn the model that its context is filling, and when to compact history automatically. Both are fractions of the run's context budget — the effective model window, after any `numCtx` pin or agent `maxContextTokens` ceiling.
+
+```json
+{
+  "context": {
+    "warnThresholdRatio": 0.7,
+    "compactThresholdRatio": 0.8
+  }
+}
+```
+
+| Key | Default | Effect |
+| --- | --- | --- |
+| `warnThresholdRatio` | 0.7 | The model is told to consolidate what it has while detail still exists |
+| `compactThresholdRatio` | 0.8 | Older history is summarized automatically |
+
+The ordering `warn < compact < 0.95` is enforced. The 0.95 ceiling is the trim ratio: trimming *discards* messages rather than summarizing them, so a compaction threshold at or above it would let trimming pre-empt compaction and turn the whole scheme into a sliding window. A value that breaks the ordering — or that isn't a number strictly between 0 and 1 — is ignored with a logged warning and the default is used; the run never fails on a bad ratio.
+
+Raising `compactThresholdRatio` keeps more verbatim history but leaves less headroom, which bites hardest on local servers whose real window is smaller than advertised. Lowering it compacts earlier and more often, costing a summarizer call each time. The reserved-space figure in `/context` is derived from this setting, so the grid always reflects where compaction actually fires.
+
 ## Project Overrides: `./.jazz/config.json`
 
 Use for project-specific settings such as MCP enable/disable flags or logging level. Do not put agent storage paths here — agents always load from `~/.jazz`.

--- a/src/core/agent/context/context-thresholds.test.ts
+++ b/src/core/agent/context/context-thresholds.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import type { ContextConfig } from "@/core/types/config";
+import { resolveContextThresholds } from "./context-thresholds";
+import {
+  CONTEXT_COMPACT_THRESHOLD_RATIO,
+  CONTEXT_WARN_THRESHOLD_RATIO,
+} from "./context-window-manager";
+
+describe("resolveContextThresholds", () => {
+  it("returns the defaults when no context config is present", () => {
+    const resolved = resolveContextThresholds(undefined);
+    expect(resolved.warnThresholdRatio).toBe(CONTEXT_WARN_THRESHOLD_RATIO);
+    expect(resolved.compactThresholdRatio).toBe(CONTEXT_COMPACT_THRESHOLD_RATIO);
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("accepts an in-range compaction ratio", () => {
+    const resolved = resolveContextThresholds({ compactThresholdRatio: 0.9 });
+    expect(resolved.compactThresholdRatio).toBe(0.9);
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("accepts both ratios when they keep warn below compact", () => {
+    const resolved = resolveContextThresholds({
+      warnThresholdRatio: 0.5,
+      compactThresholdRatio: 0.6,
+    });
+    expect(resolved.warnThresholdRatio).toBe(0.5);
+    expect(resolved.compactThresholdRatio).toBe(0.6);
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("rejects a compaction ratio at or above the trim ratio", () => {
+    const resolved = resolveContextThresholds({ compactThresholdRatio: 0.95 });
+    expect(resolved.compactThresholdRatio).toBe(CONTEXT_COMPACT_THRESHOLD_RATIO);
+    expect(resolved.warnings[0]).toContain("trim ratio");
+  });
+
+  it("rejects a warn ratio that does not precede compaction", () => {
+    const resolved = resolveContextThresholds({
+      warnThresholdRatio: 0.85,
+      compactThresholdRatio: 0.8,
+    });
+    expect(resolved.warnThresholdRatio).toBe(CONTEXT_WARN_THRESHOLD_RATIO);
+    expect(resolved.compactThresholdRatio).toBe(0.8);
+    expect(resolved.warnings[0]).toContain("must stay below the compaction ratio");
+  });
+
+  it("lowers the default warn ratio to stay under a lower configured compaction ratio", () => {
+    const resolved = resolveContextThresholds({ compactThresholdRatio: 0.6 });
+    expect(resolved.compactThresholdRatio).toBe(0.6);
+    expect(resolved.warnThresholdRatio).toBeLessThanOrEqual(0.6);
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("rejects out-of-range and non-numeric values", () => {
+    for (const value of [0, 1, 1.5, -0.2, Number.NaN]) {
+      const resolved = resolveContextThresholds({ compactThresholdRatio: value });
+      expect(resolved.compactThresholdRatio).toBe(CONTEXT_COMPACT_THRESHOLD_RATIO);
+      expect(resolved.warnings).toHaveLength(1);
+    }
+
+    const fromJson = resolveContextThresholds({
+      compactThresholdRatio: "0.9",
+    } as unknown as ContextConfig);
+    expect(fromJson.compactThresholdRatio).toBe(CONTEXT_COMPACT_THRESHOLD_RATIO);
+    expect(fromJson.warnings[0]).toContain("expected a number between 0 and 1");
+  });
+});

--- a/src/core/agent/context/context-thresholds.ts
+++ b/src/core/agent/context/context-thresholds.ts
@@ -1,0 +1,67 @@
+import type { ContextConfig } from "@/core/types/config";
+import {
+  CONTEXT_COMPACT_THRESHOLD_RATIO,
+  CONTEXT_TRIM_THRESHOLD_RATIO,
+  CONTEXT_WARN_THRESHOLD_RATIO,
+} from "./context-window-manager";
+
+export interface ResolvedContextThresholds {
+  readonly warnThresholdRatio: number;
+  readonly compactThresholdRatio: number;
+  /** Reasons any configured value was rejected, for the caller to log. */
+  readonly warnings: readonly string[];
+}
+
+function isUsableRatio(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 && value < 1;
+}
+
+/**
+ * Resolve the warn and compaction thresholds from app config.
+ *
+ * Each configured value is taken only if it holds the ordering the design depends on:
+ * warn < compact < trim. A compaction threshold at or above the trim ratio would let
+ * trimming pre-empt compaction, turning the whole scheme into a sliding window that
+ * discards history instead of summarizing it, and a warn threshold at or above the
+ * compaction one would never fire before the compaction it is meant to pre-announce.
+ * Rejected values fall back to the defaults rather than failing the run.
+ */
+export function resolveContextThresholds(
+  context: ContextConfig | undefined,
+): ResolvedContextThresholds {
+  const warnings: string[] = [];
+
+  let compactThresholdRatio = CONTEXT_COMPACT_THRESHOLD_RATIO;
+  const configuredCompact = context?.compactThresholdRatio;
+  if (configuredCompact !== undefined && configuredCompact !== null) {
+    if (!isUsableRatio(configuredCompact)) {
+      warnings.push(
+        `Ignoring context.compactThresholdRatio "${String(configuredCompact)}" — expected a number between 0 and 1. Using ${CONTEXT_COMPACT_THRESHOLD_RATIO}.`,
+      );
+    } else if (configuredCompact >= CONTEXT_TRIM_THRESHOLD_RATIO) {
+      warnings.push(
+        `Ignoring context.compactThresholdRatio ${configuredCompact} — it must stay below the trim ratio ${CONTEXT_TRIM_THRESHOLD_RATIO}, or history is discarded instead of summarized. Using ${CONTEXT_COMPACT_THRESHOLD_RATIO}.`,
+      );
+    } else {
+      compactThresholdRatio = configuredCompact;
+    }
+  }
+
+  let warnThresholdRatio = Math.min(CONTEXT_WARN_THRESHOLD_RATIO, compactThresholdRatio);
+  const configuredWarn = context?.warnThresholdRatio;
+  if (configuredWarn !== undefined && configuredWarn !== null) {
+    if (!isUsableRatio(configuredWarn)) {
+      warnings.push(
+        `Ignoring context.warnThresholdRatio "${String(configuredWarn)}" — expected a number between 0 and 1. Using ${warnThresholdRatio}.`,
+      );
+    } else if (configuredWarn >= compactThresholdRatio) {
+      warnings.push(
+        `Ignoring context.warnThresholdRatio ${configuredWarn} — it must stay below the compaction ratio ${compactThresholdRatio}, or the warning never precedes compaction. Using ${warnThresholdRatio}.`,
+      );
+    } else {
+      warnThresholdRatio = configuredWarn;
+    }
+  }
+
+  return { warnThresholdRatio, compactThresholdRatio, warnings };
+}

--- a/src/core/agent/context/context-window-manager.ts
+++ b/src/core/agent/context/context-window-manager.ts
@@ -280,8 +280,15 @@ export class ContextWindowManager {
 
   /** Token count above which history is compacted. */
   get compactThresholdTokens(): number {
-    const ratio = this.config.compactThresholdRatio ?? CONTEXT_COMPACT_THRESHOLD_RATIO;
-    return Math.floor(this.contextBudgetTokens * ratio);
+    return Math.floor(this.contextBudgetTokens * this.thresholdRatios.compactThresholdRatio);
+  }
+
+  /** The resolved ratios, so callers can describe them without re-deriving defaults. */
+  get thresholdRatios(): { warnThresholdRatio: number; compactThresholdRatio: number } {
+    return {
+      warnThresholdRatio: this.config.warnThresholdRatio ?? CONTEXT_WARN_THRESHOLD_RATIO,
+      compactThresholdRatio: this.config.compactThresholdRatio ?? CONTEXT_COMPACT_THRESHOLD_RATIO,
+    };
   }
 
   /**

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import type { ProviderName } from "@/core/constants/models";
-import { type AgentConfigService } from "@/core/interfaces/agent-config";
+import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { PresentationService } from "@/core/interfaces/presentation";
@@ -10,10 +10,8 @@ import type { Agent } from "@/core/types";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
-import {
-  CONTEXT_COMPACT_THRESHOLD_RATIO,
-  DEFAULT_CONTEXT_WINDOW_MANAGER,
-} from "./context-window-manager";
+import { resolveContextThresholds } from "./context-thresholds";
+import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
 
 /** Build a token-counter hint from an agent's provider/model. */
@@ -217,12 +215,15 @@ export const Summarizer = {
     return Effect.gen(function* () {
       const logger = yield* LoggerServiceTag;
       const presentationService = yield* PresentationServiceTag;
+      const configService = yield* AgentConfigServiceTag;
+      const appConfig = yield* configService.appConfig;
 
       // Use model-specific context window or fall back to default
       const maxTokens = modelContextWindow ?? DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
       const hint = modelHintFromAgent(agent);
       const currentTokens = DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint);
-      const threshold = maxTokens * CONTEXT_COMPACT_THRESHOLD_RATIO;
+      const { compactThresholdRatio } = resolveContextThresholds(appConfig.context);
+      const threshold = maxTokens * compactThresholdRatio;
 
       // Check if summarization is needed
       if (currentTokens <= threshold) {
@@ -233,6 +234,7 @@ export const Summarizer = {
         currentTokens,
         maxTokens,
         threshold: Math.floor(threshold),
+        compactThresholdRatio,
         agentId: agent.id,
         conversationId,
         modelContextWindow,
@@ -240,7 +242,7 @@ export const Summarizer = {
 
       yield* presentationService.presentWarning(
         agent.name,
-        `Context window ~${Math.round(CONTEXT_COMPACT_THRESHOLD_RATIO * 100)}% full of ${maxTokens.toLocaleString()} tokens — auto-compacting conversation history...`,
+        `Context window ~${Math.round(compactThresholdRatio * 100)}% full of ${maxTokens.toLocaleString()} tokens — auto-compacting conversation history...`,
       );
 
       yield* logger.info("Compacting history to preserve context...", {

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -367,6 +367,16 @@ describe("executeAgentLoop", () => {
     expect(buildContextPressureMessage(500, 0)).toBeNull();
   });
 
+  it("honors configured warn and compaction ratios", () => {
+    const thresholds = { warnThresholdRatio: 0.5, compactThresholdRatio: 0.6 };
+
+    expect(buildContextPressureMessage(4_500, 10_000, thresholds)).toBeNull();
+
+    const warning = buildContextPressureMessage(5_500, 10_000, thresholds);
+    expect(warning?.content).toContain("CONTEXT WARNING");
+    expect(warning?.content).toContain("summarized automatically at 60%");
+  });
+
   it("sends the context nudge to the model without persisting it in history", async () => {
     const seenMessages: ConversationMessages[] = [];
     const strategy: CompletionStrategy = {

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect, Fiber, Option, Ref } from "effect";
-import { type AgentConfigService } from "@/core/interfaces/agent-config";
+import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { PresentationService, StreamingRenderer } from "@/core/interfaces/presentation";
@@ -13,6 +13,7 @@ import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
+import { resolveContextThresholds } from "../context/context-thresholds";
 import {
   CONTEXT_COMPACT_THRESHOLD_RATIO,
   CONTEXT_TRIM_THRESHOLD_RATIO,
@@ -77,8 +78,11 @@ const CONTEXT_CRITICAL_RATIO = 0.9;
 export function buildContextPressureMessage(
   currentTokens: number,
   budgetTokens: number,
+  thresholds?: { warnThresholdRatio: number; compactThresholdRatio: number },
 ): { role: "user"; content: string } | null {
   if (budgetTokens <= 0) return null;
+  const warnRatio = thresholds?.warnThresholdRatio ?? CONTEXT_WARN_THRESHOLD_RATIO;
+  const compactRatio = thresholds?.compactThresholdRatio ?? CONTEXT_COMPACT_THRESHOLD_RATIO;
   const ratio = currentTokens / budgetTokens;
   const percent = Math.round(ratio * 100);
   const budget = budgetTokens.toLocaleString();
@@ -89,10 +93,10 @@ export function buildContextPressureMessage(
       content: `[CONTEXT CRITICAL: ${percent}% of the ${budget}-token context budget used. Write your final output NOW from what you have already gathered. Do not open new files, run new searches, or spawn subagents — their results may not survive compaction.]`,
     };
   }
-  if (ratio >= CONTEXT_WARN_THRESHOLD_RATIO) {
+  if (ratio >= warnRatio) {
     return {
       role: "user",
-      content: `[CONTEXT WARNING: ${percent}% of the ${budget}-token context budget used. Older history is summarized automatically at ${Math.round(CONTEXT_COMPACT_THRESHOLD_RATIO * 100)}%, and detail is lost when that happens. Record any findings you need to keep in your next message, and prefer consolidating over gathering more.]`,
+      content: `[CONTEXT WARNING: ${percent}% of the ${budget}-token context budget used. Older history is summarized automatically at ${Math.round(compactRatio * 100)}%, and detail is lost when that happens. Record any findings you need to keep in your next message, and prefer consolidating over gathering more.]`,
     };
   }
   return null;
@@ -559,6 +563,7 @@ function runIteration(
     const contextMsg = buildContextPressureMessage(
       postCompactionUsage.currentTokens,
       postCompactionUsage.budgetTokens,
+      runContextWindowManager.thresholdRatios,
     );
     const budgetMsg = buildBudgetPressureMessage(iterationIndex + 1, maxIterations);
     const pressureContent = [contextMsg?.content, budgetMsg?.content].filter(Boolean).join("\n");
@@ -752,6 +757,9 @@ export function executeAgentLoop(
           maxIterations,
         } = runContext;
 
+        const configService = yield* AgentConfigServiceTag;
+        const appConfig = yield* configService.appConfig;
+
         // Fetch model's actual context window from models.dev
         const modelMetadata = yield* Effect.tryPromise({
           try: () => getModelsDevMetadata(model, provider),
@@ -778,10 +786,16 @@ export function executeAgentLoop(
         const trimBudgetTokens = Math.floor(contextWindowMaxTokens * CONTEXT_TRIM_THRESHOLD_RATIO);
         const protectedRecentTurns =
           DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().protectedRecentTurns;
+        const contextThresholds = resolveContextThresholds(appConfig.context);
+        for (const thresholdWarning of contextThresholds.warnings) {
+          yield* logger.warn(thresholdWarning, { agentId: agent.id });
+        }
         const runContextWindowManager = new ContextWindowManager({
           maxTokens: trimBudgetTokens,
           contextBudgetTokens: contextWindowMaxTokens,
           ...(protectedRecentTurns !== undefined && { protectedRecentTurns }),
+          warnThresholdRatio: contextThresholds.warnThresholdRatio,
+          compactThresholdRatio: contextThresholds.compactThresholdRatio,
           modelHint: { provider, modelId: model },
         });
 

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -24,6 +24,21 @@ export interface AppConfig {
   readonly maxIterations?: number;
   /** Iteration budget for a sub-agent run. Defaults to 30. */
   readonly maxSubagentIterations?: number;
+  readonly context?: ContextConfig;
+}
+
+export interface ContextConfig {
+  /**
+   * Fraction of the context budget at which the model is warned the window is
+   * filling up. Defaults to 0.7. Must be below `compactThresholdRatio`.
+   */
+  readonly warnThresholdRatio?: number;
+
+  /**
+   * Fraction of the context budget at which history is compacted automatically.
+   * Defaults to 0.8. Must be below the 0.95 trim ratio.
+   */
+  readonly compactThresholdRatio?: number;
 }
 
 export interface NotificationsConfig {

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -7,6 +7,7 @@ import * as fmt from "@/cli/utils/list-format";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { sortAgents } from "@/core/agent/agent-sort";
+import { resolveContextThresholds } from "@/core/agent/context/context-thresholds";
 import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
@@ -1628,8 +1629,13 @@ function contextSymbols(): { used: string; free: string; buffer: string } {
 const GRID_SIZE = 10;
 const TOTAL_CELLS = GRID_SIZE * GRID_SIZE;
 
-/** Buffer percentage reserved for autocompact (16.5% like Claude Code) */
-const AUTOCOMPACT_BUFFER_PERCENT = 0.165;
+/**
+ * Space reserved for autocompact: whatever sits above the ratio at which compaction
+ * actually fires, so the grid and the runtime agree on where the ceiling is.
+ */
+function autocompactBufferPercent(compactThresholdRatio: number): number {
+  return 1 - compactThresholdRatio;
+}
 
 /**
  * Get the model's advertised context window from models.dev, or `undefined` when
@@ -1700,9 +1706,12 @@ interface ContextUsageBreakdown {
 function calculateContextUsage(
   conversationHistory: ChatMessage[],
   contextWindow: number,
+  compactThresholdRatio: number,
 ): ContextUsageBreakdown {
   // Calculate autocompact buffer (reserved space)
-  const autocompactBuffer = Math.floor(contextWindow * AUTOCOMPACT_BUFFER_PERCENT);
+  const autocompactBuffer = Math.floor(
+    contextWindow * autocompactBufferPercent(compactThresholdRatio),
+  );
   const effectiveWindow = contextWindow - autocompactBuffer;
 
   // Separate system message from other messages
@@ -1802,9 +1811,12 @@ function handleContextCommand(
   terminal: TerminalService,
   agent: CommandContext["agent"],
   conversationHistory: CommandContext["conversationHistory"],
-): Effect.Effect<CommandResult, never, ToolRegistry> {
+): Effect.Effect<CommandResult, never, ToolRegistry | AgentConfigService> {
   return Effect.gen(function* () {
     const toolRegistry = yield* ToolRegistryTag;
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const { compactThresholdRatio } = resolveContextThresholds(appConfig.context);
 
     // Get model information
     const provider = agent.config.llmProvider;
@@ -1828,7 +1840,7 @@ function handleContextCommand(
     const toolDefinitionTokens = Math.ceil(toolDefinitionsJson.length / 4);
 
     // Calculate usage breakdown
-    const usage = calculateContextUsage(conversationHistory, contextWindow);
+    const usage = calculateContextUsage(conversationHistory, contextWindow, compactThresholdRatio);
 
     // Add tool definition tokens (these are sent with every request)
     const adjustedUsage: ContextUsageBreakdown = {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -441,6 +441,11 @@ function mergeConfig(base: AppConfig, override?: Partial<AppConfig>): AppConfig 
         }),
       },
     }),
+    // Kept even when the override omits it, so a project-local config.json does not
+    // silently drop globally configured thresholds.
+    ...((base.context ?? override.context) && {
+      context: { ...(base.context ?? {}), ...(override.context ?? {}) },
+    }),
   };
 }
 


### PR DESCRIPTION
## What & why

Jazz warns the model at 70% of its context budget and compacts history at 80%. Those numbers were hardcoded — `ContextWindowManager` took `warnThresholdRatio` and `compactThresholdRatio` as options, but nothing ever passed them, so there was no way to tune them. This adds a `context` section to `~/.jazz/config.json` (or a project-local override) that sets both.

Raising the compaction ratio keeps more verbatim history at the cost of headroom; lowering it compacts earlier and pays for a summarizer call more often. The ordering `warn < compact < 0.95` is enforced, because the 0.95 trim ratio *discards* messages instead of summarizing them — a compaction threshold above it would quietly turn context management into a sliding window. Bad values are ignored with a logged warning rather than failing the run.

Also fixes a display bug this exposed: `/context` drew its reserved "autocompact buffer" as a fixed 16.5% while compaction actually fired at 80%. The buffer is now derived from the real threshold, so the grid stops disagreeing with the runtime.

## How to verify

- With no config change, confirm behavior is unchanged: compaction still announces itself at ~80%, and `/context` shows a buffer (now 20%, matching the trigger, previously 16.5%).
- Set `{"context": {"compactThresholdRatio": 0.6}}` in `~/.jazz/config.json`, run a long conversation, and confirm compaction fires earlier and the warning reads "~60% full".
- Set `compactThresholdRatio` to `0.97` and confirm the run continues at the 0.8 default with a warning in the logs about the trim ratio — not a crash.
- Set `warnThresholdRatio` above `compactThresholdRatio` and confirm the same: default warn ratio, logged reason.
- Put `context` in `~/.jazz/config.json` and an unrelated key in `./.jazz/config.json`, then confirm the global thresholds survive the merge.
