### PR TITLE
fix(secrets): keep the OTLP export credential out of plaintext config

### DIFF
--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -491,6 +491,17 @@ function collectSecretPaths(config: Partial<AppConfig>): string[] {
     }
   }
 
+  // Pick up OTLP headers by whatever name the backend uses, so a credential
+  // under a non-standard header still migrates out of the file.
+  const otlpHeaders = (record["telemetry"] as Record<string, unknown> | undefined)?.["otlp"] as
+    Record<string, unknown> | undefined;
+  const headers = otlpHeaders?.["headers"];
+  if (headers && typeof headers === "object") {
+    for (const [name, value] of Object.entries(headers)) {
+      if (typeof value === "string") paths.push(`telemetry.otlp.headers.${name}`);
+    }
+  }
+
   return paths;
 }
 

--- a/src/services/secrets/registry.test.ts
+++ b/src/services/secrets/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { SECRET_ENV_VARS, envVarForSecretPath, isSecretPath } from "./registry";
+import { SECRET_ENV_VARS, SECRET_PATHS, envVarForSecretPath, isSecretPath } from "./registry";
 
 describe("secret registry", () => {
   it("treats known LLM, web search, and Google secret paths as secrets", () => {
@@ -29,5 +29,25 @@ describe("secret registry", () => {
   it("gives every registered secret path a distinct environment variable", () => {
     const envVars = Object.values(SECRET_ENV_VARS);
     expect(new Set(envVars).size).toBe(envVars.length);
+  });
+
+  it("treats OTLP export headers as secrets", () => {
+    // These carry the collector credential (e.g. a Langfuse key pair).
+    expect(isSecretPath("telemetry.otlp.headers.authorization")).toBe(true);
+    expect(isSecretPath("telemetry.otlp.headers.x-api-key")).toBe(true);
+  });
+
+  it("does not treat non-header telemetry settings as secrets", () => {
+    expect(isSecretPath("telemetry.otlp.endpoint")).toBe(false);
+    expect(isSecretPath("telemetry.otlp.captureContent")).toBe(false);
+    expect(isSecretPath("telemetry.enabled")).toBe(false);
+  });
+
+  it("checks the keyring for the OTLP authorization header on load", () => {
+    expect(SECRET_PATHS).toContain("telemetry.otlp.headers.authorization");
+  });
+
+  it("has no env var for OTLP headers, which OTEL_EXPORTER_OTLP_HEADERS supplies as a set", () => {
+    expect(envVarForSecretPath("telemetry.otlp.headers.authorization")).toBeUndefined();
   });
 });

--- a/src/services/secrets/registry.ts
+++ b/src/services/secrets/registry.ts
@@ -58,8 +58,24 @@ function buildSecretEnvVars(): Record<string, string> {
 /** Config path -> environment variable name, for every known secret. */
 export const SECRET_ENV_VARS: Record<string, string> = buildSecretEnvVars();
 
+/**
+ * Headers sent to the OTLP export endpoint.
+ *
+ * These carry the collector's credential — a Langfuse key pair, a vendor API
+ * token — so they are secrets even though they are not `api_key` shaped. There
+ * is no per-header env var: `OTEL_EXPORTER_OTLP_HEADERS` supplies the whole set
+ * at once and is read by the telemetry layer, not resolved per path here.
+ */
+const OTLP_HEADER_PATH = /^telemetry\.otlp\.headers\.[^.]+$/;
+
+/** The header operators actually set; listed so the keyring is checked for it on load. */
+export const OTLP_AUTHORIZATION_PATH = "telemetry.otlp.headers.authorization";
+
 /** Every config path Jazz treats as a secret. */
-export const SECRET_PATHS: readonly string[] = Object.keys(SECRET_ENV_VARS);
+export const SECRET_PATHS: readonly string[] = [
+  ...Object.keys(SECRET_ENV_VARS),
+  OTLP_AUTHORIZATION_PATH,
+];
 
 /**
  * Whether a config path holds a secret.
@@ -69,6 +85,10 @@ export const SECRET_PATHS: readonly string[] = Object.keys(SECRET_ENV_VARS);
  */
 export function isSecretPath(path: string): boolean {
   if (path in SECRET_ENV_VARS) return true;
+  // Every OTLP header is treated as a secret, not just `authorization`: a
+  // backend may name its credential header anything, and guessing wrong writes
+  // it to disk in plaintext.
+  if (OTLP_HEADER_PATH.test(path)) return true;
   return /^(llm|web_search)\.[^.]+\.api_key$/.test(path);
 }
 


### PR DESCRIPTION
## What & why

The OTLP export headers added in #346 hold the collector credential — a Langfuse key pair, a vendor token — but `telemetry.otlp.headers.*` was never registered as a secret path. So `jazz config set telemetry.otlp.headers.authorization "Basic ..."` wrote the credential straight into `~/.jazz/config.json` in plaintext, bypassing the keyring that #338 had just introduced for exactly this reason.

This registers OTLP headers as secrets, so they route to the Keychain/libsecret like every provider API key. Anyone who already set one in plaintext gets it migrated into the keyring automatically on next load, via the same path the provider keys use.

Every header name is treated as a secret, not just `authorization` — a backend may call its credential header anything, and guessing wrong is precisely what leaves a secret on disk.

## How to verify

- `jazz config set telemetry.otlp.headers.authorization "Basic <base64>"`, then confirm `~/.jazz/config.json` contains the endpoint but no credential, and that the value is in the keyring (`security find-generic-password -s jazz -a telemetry.otlp.headers.authorization -w` on macOS).
- Run any agent with no `OTEL_*` env vars set and confirm the export still authenticates — the header has to come back out of the keyring for the request to succeed.
- Put a plaintext header into `config.json` by hand, start Jazz, and confirm it disappears from the file and appears in the keyring.
- Confirm non-credential telemetry settings are untouched: `telemetry.otlp.endpoint` and `telemetry.otlp.captureContent` still live in the config file.
- On a machine with no usable keyring, confirm the value stays in the config file, which is already written mode 0600 — no crash, no silent drop.

## Verified against a live backend

Set up end to end against Langfuse Cloud with the credential in the macOS Keychain and only the endpoint in `config.json`. Two real `jazz run` invocations exported with no auth failure; the sole 401 in the log predates storing the credential.
