### PR TITLE
feat(context): compaction hardening and durable task state

### DIFF
--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -247,6 +247,33 @@ compaction threshold, the summarizer's recent-message budget, and `/context`.
 Set it with `jazz agent edit` → **Max Context Tokens**; leave the prompt blank to remove the
 ceiling and go back to the model's own window.
 
+### The ladder, cheapest rung first
+
+Four mechanisms now share one budget, escalating by cost:
+
+| Rung | Fires at | Costs | Effect |
+| --- | --- | --- | --- |
+| Warn | 70% | nothing | User *and* agent are told; the agent is nudged to consolidate |
+| Clear tool results | 65% | nothing | Old raw tool output replaced by a placeholder, structure kept |
+| Compact | 80% | one LLM call | Older history summarized into the running summary |
+| Trim | 95% | nothing, but lossy | Messages dropped unsummarized — the floor, not the path |
+
+Clearing runs before compaction because it is free: a long run's tokens are mostly raw
+tool output, and most of it stops mattering once the model has read it. It fires **once per
+crossing**, not per turn, because rewriting the message prefix invalidates the provider's
+cache — the same reason the trim budget must not sit below the compaction threshold.
+
+Tool results are cleared by replacing content and keeping the message, so the
+assistant/tool pairing survives. Deleting the message would orphan the `tool_calls` that
+referenced it and provoke a provider error.
+
+### What the budget counts
+
+Tokens are messages **plus per-request overhead** — tool schemas and provider scaffolding,
+which reach 10–30k once MCP servers are attached. Overhead is measured, not estimated:
+after each call, `promptTokens − estimatedMessageTokens` is the gap, smoothed per model.
+Counting messages alone meant an agent believed it was at 79% when it was at 102%.
+
 ### Warn first, compact second
 
 Two thresholds share one budget, both defined in `context-window-manager.ts`:
@@ -271,6 +298,41 @@ The warning exists so that compaction is never a surprise: there is a window whe
 still `/compact` on your own terms, narrow the task, or raise the ceiling before the
 summarizer decides what to keep. `ContextWindowManager` owns both decisions — `usage()`
 returns the current tokens, the budget, and both flags from a single count.
+
+---
+
+## Working state outlives the context window
+
+Compaction is lossy by design, so the things that must not be lost are written outside the
+conversation, under `~/.jazz/work/<agent>/<conversation>/`:
+
+- **`journal.jsonl`** — every compaction appends its summary here *before* it enters
+  context. No extra LLM call and no extra tokens: it persists something already paid for.
+  Append-only, one JSON object per line, so a crash damages at most the final record.
+- **`state.json`** — the agent's own record of where the task stands, written through
+  `update_task_state`. Patched field by field, so a small correction cannot drop the rest.
+
+This is deliberately **not** memory. Memory holds what stays true about a person or project
+for weeks, and its own instructions tell the agent not to store one-off task details —
+which is exactly what compaction destroys. "They prefer Bun over npm" is memory; "3 of 5
+routes migrated, auth fails on token refresh" is task state, and it is discarded when the
+task ends.
+
+Two things read it back:
+
+- **Resuming a conversation** loads post-compaction messages, so whatever compaction
+  dropped is simply absent. The journal is folded back in as a bounded (~2k token)
+  preamble, framed as claims to verify rather than fact — progress records are written
+  mid-task and are habitually optimistic about what was finished.
+- **Compaction itself** is told what task state already holds, so the summary covers what
+  the transcript adds instead of restating the plan.
+
+Work items carry an explicit `unverified` status, and the prompt requires that `done` means
+something was actually run. An agent that marks its own work complete on the strength of
+having written it turns the record into a confident lie for the next session.
+
+Inspect or discard it with `/work` and `/work clear`. Journals are capped per conversation
+and pruned oldest-first, since the newest record is the one describing where the task is.
 
 ---
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -15,11 +15,11 @@ and [Security](../../SECURITY.md) for the threat model.
 
 | | Count |
 | --- | --- |
-| **Agent-facing tools** | **50** |
+| **Agent-facing tools** | **51** |
 | Hidden `execute_*` counterparts (the second half of each approval pair) | 15 |
-| Total registered | 65 |
+| Total registered | 66 |
 | `read-only` | 29 |
-| `low-risk` | 6 |
+| `low-risk` | 7 |
 | `high-risk` | 15 |
 
 Plus, registered per agent rather than globally:
@@ -138,6 +138,10 @@ Opt-in per agent (like File Management or Git) rather than always-on — see [Me
 | --- | --- | --- | --- |
 | `view_memory` | `read-only` | — | Read what you've saved about this person or project from earlier conversations. Call with no pa… |
 | `manage_memory` | `low-risk` | — | Create, edit, rename, or delete files under your persistent memory directory — the durable notes… |
+| `update_task_state` | `low-risk` | — | Record where you are in the current task so it survives compaction and resuming later. Patches o… |
+
+`update_task_state` is scoped to one conversation and discarded when the task ends, unlike
+memory which persists across conversations — see [Context management](../internals/context-management.md).
 
 ### Reminders
 

--- a/personas/summarizer/persona.md
+++ b/personas/summarizer/persona.md
@@ -18,6 +18,15 @@ You are {agentName}, {agentDescription} You compress a transcript into a summary
 5. Keep chronological order, grouping related steps, so the reader knows what is completed, what is in progress, and what remains open.
 6. Output only the summary itself — no preamble, no commentary, no closing remarks.
 
+# Updating an existing summary
+
+Often you are given an existing summary plus a new transcript, rather than a transcript alone. You are then updating a running record, not writing a fresh one.
+
+7. The existing summary is the only surviving record of everything before this transcript. Carry its content forward unless the new transcript contradicts it — a fact missing from the new transcript has not become false, it has merely stopped being discussed.
+8. Fold new material into the existing structure rather than appending a second account of the same work. One coherent summary, not a changelog of summaries.
+9. Where the new transcript corrects or supersedes something, replace it and keep the correction — not both versions.
+10. Prefer dropping detail from the oldest completed work over dropping anything still open. Finished steps compress well; unresolved questions do not.
+
 # Output Format
 
 Structured Markdown with these sections, omitting any that are empty:

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -1,6 +1,7 @@
 import { Duration, Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { buildWorkStatePreamble } from "@/core/agent/context/work-state-preamble";
 import { CommonSuggestions, getErrorMessage } from "@/core/presentation/error-handler";
 import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
 import { AgentNotFoundError } from "@/core/types/errors";
@@ -386,6 +387,26 @@ export function runAgentOnceCommand(
     const priorRecord =
       conversationKey !== undefined ? yield* loadConversation(agent.id, conversationKey) : null;
 
+    // A resumed conversation loads post-compaction messages, so anything compaction
+    // dropped is missing from them. The journal is the only surviving copy; fold it back
+    // in ahead of the persisted history.
+    const workStatePreamble =
+      conversationKey !== undefined && priorRecord !== null
+        ? yield* buildWorkStatePreamble(agent.id, conversationKey, {
+            modelHint: {
+              provider: agentForRun.config.llmProvider,
+              modelId: agentForRun.config.llmModel,
+            },
+          })
+        : undefined;
+
+    const resumedHistory =
+      priorRecord !== null
+        ? workStatePreamble !== undefined
+          ? [workStatePreamble, ...priorRecord.messages]
+          : priorRecord.messages
+        : null;
+
     // Ephemeral runs never touch disk, so prior context (if any) comes back
     // in as inline JSON from the caller rather than a `--conversation` load.
     let inlineHistory: ChatMessage[] | undefined;
@@ -407,8 +428,8 @@ export function runAgentOnceCommand(
       conversationId: conversationKey ?? runId,
       ...(inlineHistory !== undefined
         ? { conversationHistory: inlineHistory }
-        : priorRecord !== null
-          ? { conversationHistory: priorRecord.messages }
+        : resumedHistory !== null
+          ? { conversationHistory: resumedHistory }
           : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options.autoApprovedTools?.length

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -4,7 +4,12 @@ import { Effect } from "effect";
 import type { PersonaService } from "@/core/interfaces/persona-service";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { renderProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
-import { ENVIRONMENT_TEMPLATE, MEMORY_INSTRUCTIONS, SKILLS_INSTRUCTIONS } from "./prompts/shared";
+import {
+  ENVIRONMENT_TEMPLATE,
+  MEMORY_INSTRUCTIONS,
+  SKILLS_INSTRUCTIONS,
+  TASK_STATE_INSTRUCTIONS,
+} from "./prompts/shared";
 
 function formatUtcOffsetLabel(date: Date): string {
   const offsetMinutes = -date.getTimezoneOffset();
@@ -154,6 +159,9 @@ export class AgentPromptBuilder {
     // injected detail block is rebuilt whenever the trigger match changes.
     if (options.triggeredSkillNames && options.triggeredSkillNames.length > 0) {
       hash.update(`triggered:${[...options.triggeredSkillNames].sort().join(",")}`);
+    }
+    if (options.toolNames?.includes("update_task_state")) {
+      hash.update("taskstate:1");
     }
     if (options.toolNames?.includes("view_memory")) {
       hash.update("memory:1");
@@ -317,6 +325,10 @@ ${triggeredBlock}`;
 
         if (options.toolNames?.includes("view_memory")) {
           systemPrompt = systemPrompt + MEMORY_INSTRUCTIONS;
+        }
+
+        if (options.toolNames?.includes("update_task_state")) {
+          systemPrompt = systemPrompt + TASK_STATE_INSTRUCTIONS;
         }
 
         // Last, so project rules read as the most recent instruction the model

--- a/src/core/agent/context/context-telemetry.ts
+++ b/src/core/agent/context/context-telemetry.ts
@@ -1,0 +1,42 @@
+import { Effect } from "effect";
+import type { LoggerService } from "@/core/interfaces/logger";
+
+/**
+ * Which rung of the context ladder fired.
+ *
+ * The ladder escalates by cost: `clear` discards raw tool output for free,
+ * `compact` spends an LLM call to summarize, `trim` drops messages unsummarized
+ * as a last resort. Logging them under one event name makes the ladder legible —
+ * "how often does this agent reach compaction, and does clearing reduce it?" is a
+ * question you cannot answer from three unrelated log lines.
+ */
+export type ContextRung = "clear" | "compact" | "trim";
+
+export interface ContextRungEvent {
+  readonly rung: ContextRung;
+  readonly agentId: string;
+  readonly conversationId: string;
+  /** Total request tokens before the rung ran, including per-request overhead. */
+  readonly tokensBefore: number;
+  /** Total request tokens after it ran. */
+  readonly tokensAfter: number;
+  readonly budgetTokens: number;
+  readonly messagesBefore: number;
+  readonly messagesAfter: number;
+}
+
+/** Emit one structured record for a rung firing. */
+export function logContextRung(
+  logger: LoggerService,
+  event: ContextRungEvent,
+): Effect.Effect<void, never, never> {
+  const reclaimed = event.tokensBefore - event.tokensAfter;
+  return logger.info("Context rung fired", {
+    ...event,
+    tokensReclaimed: reclaimed,
+    percentOfBudgetBefore:
+      event.budgetTokens > 0 ? Math.round((event.tokensBefore / event.budgetTokens) * 100) : 0,
+    percentOfBudgetAfter:
+      event.budgetTokens > 0 ? Math.round((event.tokensAfter / event.budgetTokens) * 100) : 0,
+  });
+}

--- a/src/core/agent/context/context-window-manager.test.ts
+++ b/src/core/agent/context/context-window-manager.test.ts
@@ -309,3 +309,55 @@ describe("context budget thresholds", () => {
     expect(manager.compactThresholdTokens).toBe(9_000);
   });
 });
+
+describe("overhead in the budget", () => {
+  const messages = [makeMessage("user", "hello")];
+
+  function counterWithOverhead(overhead: number): any {
+    return {
+      countMessage: () => 100,
+      countMessages: (msgs: readonly ChatMessage[]) => msgs.length * 100,
+      overheadFor: () => overhead,
+    };
+  }
+
+  it("counts request overhead toward the budget", () => {
+    const manager = new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens: 1_000,
+      tokenCounter: counterWithOverhead(650),
+    });
+
+    const usage = manager.usage(messages);
+    expect(usage.messageTokens).toBe(100);
+    expect(usage.overheadTokens).toBe(650);
+    expect(usage.currentTokens).toBe(750);
+  });
+
+  it("crosses the compaction threshold on overhead the messages alone would not reach", () => {
+    const withoutSchemas = new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens: 1_000,
+      tokenCounter: counterWithOverhead(0),
+    });
+    const withSchemas = new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens: 1_000,
+      tokenCounter: counterWithOverhead(750),
+    });
+
+    // Identical message content; only the tool schemas differ.
+    expect(withoutSchemas.shouldCompact(messages)).toBe(false);
+    expect(withSchemas.shouldCompact(messages)).toBe(true);
+  });
+
+  it("tolerates a counter that predates overhead reporting", () => {
+    const manager = new ContextWindowManager({
+      maxTokens: 50_000,
+      contextBudgetTokens: 1_000,
+      tokenCounter: { countMessage: () => 100, countMessages: () => 100 } as any,
+    });
+
+    expect(manager.usage(messages).overheadTokens).toBe(0);
+  });
+});

--- a/src/core/agent/context/context-window-manager.ts
+++ b/src/core/agent/context/context-window-manager.ts
@@ -77,7 +77,10 @@ export interface TrimResult {
   readonly originalCount: number;
   readonly trimmedCount: number;
   readonly messagesRemoved: number;
+  /** Total request tokens after trimming, including per-request overhead. */
   readonly estimatedTokens: number;
+  /** Total request tokens before trimming, for measuring what the rung reclaimed. */
+  readonly estimatedTokensBefore: number;
 }
 
 /** Default model hint when the caller does not supply one (legacy callers). */
@@ -120,7 +123,8 @@ export class ContextWindowManager {
     never,
     LoggerService | AgentConfigService
   > {
-    const currentTokens = this.calculateTotalTokens(messages);
+    const overheadTokens = this.requestOverheadTokens();
+    const currentTokens = this.calculateTotalTokens(messages) + overheadTokens;
     if (currentTokens <= this.config.maxTokens) {
       return Effect.succeed({ messages, result: undefined });
     }
@@ -172,7 +176,7 @@ export class ContextWindowManager {
     }
 
     // Step 3: Calculate tokens for system message and protected zone
-    const systemTokens = this.counter.countMessage(messages[0], this.modelHint);
+    const systemTokens = this.counter.countMessage(messages[0], this.modelHint) + overheadTokens;
     let protectedTokens = 0;
     for (const idx of protectedIndices) {
       const msg = messages[idx];
@@ -242,7 +246,8 @@ export class ContextWindowManager {
       originalCount: originalLength,
       trimmedCount: resultMessages.length,
       messagesRemoved: originalLength - resultMessages.length,
-      estimatedTokens: this.calculateTotalTokens(resultMessages),
+      estimatedTokens: this.totalRequestTokens(resultMessages),
+      estimatedTokensBefore: currentTokens,
     };
 
     return logger
@@ -264,7 +269,7 @@ export class ContextWindowManager {
    * Check if messages need trimming
    */
   needsTrimming(messages: ChatMessage[]): boolean {
-    return this.calculateTotalTokens(messages) > this.config.maxTokens;
+    return this.totalRequestTokens(messages) > this.config.maxTokens;
   }
 
   /** Total context this run may occupy, after the agent's own ceiling. */
@@ -292,20 +297,42 @@ export class ContextWindowManager {
   }
 
   /**
+   * Tokens every request carries beyond the messages — tool schemas above all.
+   *
+   * Counting messages alone understates a request by 10-30k once MCP servers are
+   * attached, which is the difference between compacting at 80% and discovering
+   * the window was already full.
+   */
+  requestOverheadTokens(): number {
+    return this.counter.overheadFor?.(this.modelHint) ?? 0;
+  }
+
+  /** Messages plus the per-request overhead: what the window actually has to hold. */
+  totalRequestTokens(messages: ChatMessage[]): number {
+    return this.calculateTotalTokens(messages) + this.requestOverheadTokens();
+  }
+
+  /**
    * Where this conversation sits inside the budget, so callers can warn, compact,
    * or report usage from one shared accounting.
    */
   usage(messages: ChatMessage[]): {
     currentTokens: number;
+    messageTokens: number;
+    overheadTokens: number;
     budgetTokens: number;
     ratio: number;
     shouldWarn: boolean;
     shouldCompact: boolean;
   } {
-    const currentTokens = this.calculateTotalTokens(messages);
+    const messageTokens = this.calculateTotalTokens(messages);
+    const overheadTokens = this.requestOverheadTokens();
+    const currentTokens = messageTokens + overheadTokens;
     const budgetTokens = this.contextBudgetTokens;
     return {
       currentTokens,
+      messageTokens,
+      overheadTokens,
       budgetTokens,
       ratio: budgetTokens > 0 ? currentTokens / budgetTokens : 0,
       shouldWarn: currentTokens > this.warnThresholdTokens,
@@ -315,12 +342,12 @@ export class ContextWindowManager {
 
   /** True once the conversation passes the warn threshold but before compaction. */
   shouldWarn(messages: ChatMessage[]): boolean {
-    return this.calculateTotalTokens(messages) > this.warnThresholdTokens;
+    return this.totalRequestTokens(messages) > this.warnThresholdTokens;
   }
 
   /** True once the conversation passes the compaction threshold. */
   shouldCompact(messages: ChatMessage[]): boolean {
-    return this.calculateTotalTokens(messages) > this.compactThresholdTokens;
+    return this.totalRequestTokens(messages) > this.compactThresholdTokens;
   }
 
   /**

--- a/src/core/agent/context/context-window-manager.ts
+++ b/src/core/agent/context/context-window-manager.ts
@@ -13,6 +13,14 @@ import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./toke
  */
 export const CONTEXT_WARN_THRESHOLD_RATIO = 0.7;
 
+/**
+ * Fraction of the context budget at which stale tool output is cleared.
+ *
+ * Below the compaction threshold: clearing is free, so it gets first attempt at
+ * reclaiming space before an LLM call is spent summarizing.
+ */
+export const CONTEXT_CLEAR_THRESHOLD_RATIO = 0.65;
+
 /** Fraction of the context budget at which history is compacted automatically. */
 export const CONTEXT_COMPACT_THRESHOLD_RATIO = 0.8;
 
@@ -45,6 +53,9 @@ export interface ContextWindowConfig {
 
   /** Fraction of the budget that triggers compaction. Default {@link CONTEXT_COMPACT_THRESHOLD_RATIO}. */
   readonly compactThresholdRatio?: number;
+
+  /** Fraction of the budget that triggers tool-result clearing. Default {@link CONTEXT_CLEAR_THRESHOLD_RATIO}. */
+  readonly clearThresholdRatio?: number;
 
   /**
    * Number of recent turns to always keep intact (never trim).
@@ -81,6 +92,39 @@ export interface TrimResult {
   readonly estimatedTokens: number;
   /** Total request tokens before trimming, for measuring what the rung reclaimed. */
   readonly estimatedTokensBefore: number;
+}
+
+/**
+ * Index at which the protected recent zone begins.
+ *
+ * A turn starts at a "user" message and runs through every assistant/tool message
+ * until the next one, so protecting whole turns keeps tool calls with their results
+ * instead of severing them. Shared by trimming and tool-result clearing so both agree
+ * on what counts as recent — a clearing pass that reached further back than trimming
+ * would strip results the protected zone was meant to keep intact.
+ *
+ * Returns `messages.length` when there is nothing to protect.
+ */
+export function protectedZoneStartIndex(
+  messages: readonly ChatMessage[],
+  protectedTurns: number,
+): number {
+  let turnsFound = 0;
+  for (let index = messages.length - 1; index >= 1; index--) {
+    if (messages[index]?.role === "user") {
+      turnsFound++;
+      if (turnsFound >= protectedTurns) return index;
+    }
+  }
+
+  // Fewer complete turns than requested: protect from the earliest user message.
+  if (turnsFound > 0) {
+    for (let index = 1; index < messages.length; index++) {
+      if (messages[index]?.role === "user") return index;
+    }
+  }
+
+  return messages.length;
 }
 
 /** Default model hint when the caller does not supply one (legacy callers). */
@@ -131,32 +175,7 @@ export class ContextWindowManager {
 
     const originalLength = messages.length;
     const protectedTurns = this.config.protectedRecentTurns ?? 2;
-
-    // Step 1: Identify protected zone — last N complete turns.
-    // A turn starts at each "user" message and includes all subsequent
-    // assistant/tool messages until the next user message.
-    // Scan backwards to find the start index of the Nth-from-last turn.
-    let turnsFound = 0;
-    let protectedStartIndex = messages.length; // nothing protected yet
-    for (let i = messages.length - 1; i >= 1; i--) {
-      if (messages[i]?.role === "user") {
-        turnsFound++;
-        if (turnsFound >= protectedTurns) {
-          protectedStartIndex = i;
-          break;
-        }
-      }
-    }
-    // If we didn't find enough turns, protect from index 1 (after system)
-    if (turnsFound < protectedTurns && turnsFound > 0) {
-      // Find the earliest user message (after system)
-      for (let i = 1; i < messages.length; i++) {
-        if (messages[i]?.role === "user") {
-          protectedStartIndex = i;
-          break;
-        }
-      }
-    }
+    const protectedStartIndex = protectedZoneStartIndex(messages, protectedTurns);
 
     const protectedIndices = new Set<number>();
     for (let i = protectedStartIndex; i < messages.length; i++) {
@@ -281,6 +300,17 @@ export class ContextWindowManager {
   get warnThresholdTokens(): number {
     const ratio = this.config.warnThresholdRatio ?? CONTEXT_WARN_THRESHOLD_RATIO;
     return Math.floor(this.contextBudgetTokens * ratio);
+  }
+
+  /** Token count above which stale tool results are cleared. */
+  get clearThresholdTokens(): number {
+    const ratio = this.config.clearThresholdRatio ?? CONTEXT_CLEAR_THRESHOLD_RATIO;
+    return Math.floor(this.contextBudgetTokens * ratio);
+  }
+
+  /** True once the conversation passes the tool-result clearing threshold. */
+  shouldClearToolResults(messages: ChatMessage[]): boolean {
+    return this.totalRequestTokens(messages) > this.clearThresholdTokens;
   }
 
   /** Token count above which history is compacted. */

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -351,7 +351,10 @@ describe("Summarizer", () => {
         >,
       );
 
-      expect(capturedInput).toContain("[Tool Calls: read_file]");
+      // Arguments travel with the name: the summarizer is asked to preserve exact
+      // file paths, so it has to be able to see them.
+      expect(capturedInput).toContain("[Tool Calls: read_file(");
+      expect(capturedInput).toContain("/test.txt");
     });
 
     it("should create summarizer agent with correct config", async () => {
@@ -584,5 +587,63 @@ describe("Summarizer", () => {
       expect(result.length).toBe(3);
       expect(result[0]?.content).toBe("You are an assistant");
     });
+  });
+});
+
+describe("renderTranscript", () => {
+  it("includes tool call arguments, not just names", () => {
+    const rendered = Summarizer.renderTranscript([
+      {
+        role: "assistant",
+        content: "reading the file",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "read_file",
+              arguments: '{"path":"src/core/agent/context/summarizer.ts"}',
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    expect(rendered).toContain("read_file");
+    expect(rendered).toContain("src/core/agent/context/summarizer.ts");
+  });
+
+  it("truncates an oversized argument payload with a visible marker", () => {
+    const rendered = Summarizer.renderTranscript([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "write_file", arguments: `{"content":"${"x".repeat(5000)}"}` },
+          },
+        ],
+      } as any,
+    ]);
+
+    expect(rendered).toContain("write_file");
+    expect(rendered).toContain("chars)");
+    expect(rendered.length).toBeLessThan(1000);
+  });
+
+  it("renders a tool call with no arguments as a bare name", () => {
+    const rendered = Summarizer.renderTranscript([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "call_1", type: "function", function: { name: "git_status", arguments: "" } },
+        ],
+      } as any,
+    ]);
+
+    expect(rendered).toContain("[Tool Calls: git_status]");
   });
 });

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
-import { selectSummarizerModel, Summarizer, type RecursiveRunner } from "./summarizer";
+import {
+  chunkForSummarizer,
+  selectSummarizerModel,
+  Summarizer,
+  type RecursiveRunner,
+} from "./summarizer";
 import { AgentConfigServiceTag, type AgentConfigService } from "../../interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "../../interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "../../interfaces/logger";
@@ -714,5 +719,76 @@ describe("anchored iterative summarization", () => {
     expect(capturedInput).toContain("Existing summary");
     expect(capturedInput).toContain("migrated auth module");
     expect(capturedInput).toContain("updating an existing summary");
+  });
+});
+
+describe("bounded summarizer input", () => {
+  const hint = { provider: "openai", modelId: "gpt-4o" };
+
+  function messages(count: number, size: number): ChatMessage[] {
+    return Array.from({ length: count }, (_, index) => ({
+      role: "user" as const,
+      content: `message ${index} ` + "word ".repeat(size),
+    }));
+  }
+
+  it("returns a single chunk when the transcript fits", () => {
+    const chunks = chunkForSummarizer(messages(3, 10), 100_000, hint);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]?.length).toBe(3);
+  });
+
+  it("splits an oversized transcript into fitting chunks", () => {
+    const input = messages(20, 200);
+    const chunks = chunkForSummarizer(input, 500, hint);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Every message survives exactly once, in order.
+    expect(chunks.flat().length).toBe(input.length);
+    expect(chunks.flat()[0]?.content).toBe(input[0]?.content);
+  });
+
+  it("keeps a single oversized message as its own chunk rather than dropping it", () => {
+    const huge = { role: "user" as const, content: "word ".repeat(50_000) };
+    const chunks = chunkForSummarizer([huge], 100, hint);
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]?.[0]?.content).toBe(huge.content);
+  });
+
+  it("never emits an empty chunk", () => {
+    const chunks = chunkForSummarizer(messages(15, 300), 400, hint);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("folds every chunk into one summary via repeated merges", async () => {
+    const inputs: string[] = [];
+    const mockRunner: RecursiveRunner = (options) => {
+      inputs.push(options.userInput);
+      return Effect.succeed({
+        content: `summary after ${inputs.length}`,
+        conversationId: "test-conv",
+      } as AgentResponse);
+    };
+
+    // 8 sizeable messages against a deliberately small budget forces several folds.
+    const result = await Effect.runPromise(
+      Summarizer.summarizeHistory(
+        messages(8, 400),
+        createMockAgent(),
+        "session-1",
+        "conv-1",
+        mockRunner,
+      ).pipe(Effect.provide(createTestLayer())) as Effect.Effect<ChatMessage, Error, never>,
+    );
+
+    expect(result.kind).toBe("summary");
+    expect(result.content).toBe(`summary after ${inputs.length}`);
+    // Every call after the first merges into what came before.
+    for (const input of inputs.slice(1)) {
+      expect(input).toContain("Existing summary");
+    }
   });
 });

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -647,3 +647,72 @@ describe("renderTranscript", () => {
     expect(rendered).toContain("[Tool Calls: git_status]");
   });
 });
+
+describe("anchored iterative summarization", () => {
+  const systemMessage = { role: "system", content: "system" } as ChatMessage;
+  const priorSummary = {
+    role: "assistant",
+    content: "## Context\nEarlier work: migrated auth module.",
+    kind: "summary",
+  } as ChatMessage;
+
+  function longConversation(): ConversationMessages {
+    const messages: ChatMessage[] = [systemMessage, priorSummary];
+    for (let index = 0; index < 20; index++) {
+      messages.push({ role: "user", content: `ask ${index} ` + "detail ".repeat(100) });
+      messages.push({ role: "assistant", content: `answer ${index} ` + "text ".repeat(100) });
+    }
+    return messages as ConversationMessages;
+  }
+
+  it("pulls a prior summary out instead of re-summarizing it", () => {
+    const result = Summarizer.splitMessages(longConversation(), 2000);
+
+    expect(result.priorSummary?.content).toBe(priorSummary.content);
+    expect(result.messagesToSummarize).not.toContain(priorSummary);
+    for (const message of result.messagesToSummarize) {
+      expect(message.kind).toBeUndefined();
+    }
+  });
+
+  it("treats an ordinary assistant message at index 1 as history, not state", () => {
+    const messages = [
+      systemMessage,
+      { role: "assistant", content: "just an answer" },
+      ...Array.from({ length: 20 }, (_, index) => ({
+        role: "user" as const,
+        content: `ask ${index} ` + "detail ".repeat(100),
+      })),
+    ] as ConversationMessages;
+
+    const result = Summarizer.splitMessages(messages, 2000);
+    expect(result.priorSummary).toBeUndefined();
+  });
+
+  it("marks its output as a summary so the next cycle can anchor on it", async () => {
+    let capturedInput = "";
+    const mockRunner: RecursiveRunner = (options) => {
+      capturedInput = options.userInput;
+      return Effect.succeed({
+        content: "merged summary",
+        conversationId: "test-conv",
+      } as AgentResponse);
+    };
+
+    const summary = await Effect.runPromise(
+      Summarizer.summarizeHistory(
+        [{ role: "user", content: "did some work" } as ChatMessage],
+        createMockAgent(),
+        "session-1",
+        "conv-1",
+        mockRunner,
+        priorSummary,
+      ).pipe(Effect.provide(createTestLayer())) as Effect.Effect<ChatMessage, Error, never>,
+    );
+
+    expect(summary.kind).toBe("summary");
+    expect(capturedInput).toContain("Existing summary");
+    expect(capturedInput).toContain("migrated auth module");
+    expect(capturedInput).toContain("updating an existing summary");
+  });
+});

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -11,13 +11,13 @@ import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
-import { resolveContextThresholds } from "./context-thresholds";
 import { logContextRung } from "./context-telemetry";
+import { resolveContextThresholds } from "./context-thresholds";
 import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
 import { resolveEffectiveContextWindow } from "./effective-context-window";
 import { formatTaskState, readTaskState } from "./task-state";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
-import { appendJournalEntry } from "./work-journal";
+import { appendJournalEntry, pruneJournal } from "./work-journal";
 
 /** Longest tool-argument string kept verbatim in a summarizer transcript. */
 const MAX_RENDERED_ARGUMENT_CHARS = 200;
@@ -437,6 +437,7 @@ export const Summarizer = {
         messagesAfter: compactedMessages.length,
         summary: summaryMessage.content,
       });
+      yield* pruneJournal(agent.id, conversationId);
 
       yield* logContextRung(logger, {
         rung: "compact",

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -135,11 +135,17 @@ export const Summarizer = {
     modelHint?: ModelHint,
   ): {
     systemMessage: ChatMessage;
+    priorSummary: ChatMessage | undefined;
     messagesToSummarize: ChatMessage[];
     sanitizedRecentMessages: ChatMessage[];
   } {
     // Keep system message [0] and recent messages that fit in token budget
     const systemMessage = currentMessages[0];
+
+    // A summary from an earlier compaction is prior *state*, not raw history. Feeding
+    // it back through the summarizer re-summarizes a summary, and the drift compounds
+    // with every cycle. Pull it out here and hand it to the summarizer to merge into.
+    const priorSummary = currentMessages[1]?.kind === "summary" ? currentMessages[1] : undefined;
     const hint: ModelHint = modelHint ?? { provider: "", modelId: "" };
 
     // Reserve 20% of max tokens for recent context
@@ -171,7 +177,8 @@ export const Summarizer = {
     recentCount = Math.min(recentCount, currentMessages.length - 1);
 
     const recentMessages = currentMessages.slice(-recentCount);
-    const messagesToSummarize = currentMessages.slice(1, -recentCount);
+    const summarizeFrom = priorSummary ? 2 : 1;
+    const messagesToSummarize = currentMessages.slice(summarizeFrom, -recentCount);
 
     // Sanitize recent messages to avoid orphaned tool call/result references.
     // The split may land in the middle of a tool call group, leaving:
@@ -214,7 +221,7 @@ export const Summarizer = {
       return acc;
     }, []);
 
-    return { systemMessage, messagesToSummarize, sanitizedRecentMessages };
+    return { systemMessage, priorSummary, messagesToSummarize, sanitizedRecentMessages };
   },
 
   /**
@@ -307,7 +314,7 @@ export const Summarizer = {
         maxTokens,
       });
 
-      const { systemMessage, messagesToSummarize, sanitizedRecentMessages } =
+      const { systemMessage, priorSummary, messagesToSummarize, sanitizedRecentMessages } =
         Summarizer.splitMessages(currentMessages, maxTokens, hint);
 
       if (messagesToSummarize.length === 0) {
@@ -328,6 +335,7 @@ export const Summarizer = {
         sessionId,
         conversationId,
         runRecursive,
+        priorSummary,
       );
 
       // Rebuild: [system, summary, ...recent]
@@ -384,6 +392,7 @@ export const Summarizer = {
     sessionId: string,
     conversationId: string,
     runRecursive: RecursiveRunner,
+    priorSummary?: ChatMessage,
   ): Effect.Effect<
     ChatMessage,
     Error,
@@ -417,9 +426,12 @@ export const Summarizer = {
 
       const historyText = Summarizer.renderTranscript(messagesToSummarize);
 
-      const userInput =
-        "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +
-        historyText;
+      const userInput = priorSummary?.content
+        ? "You are updating an existing summary of an ongoing conversation, not writing a new one.\n\n" +
+          "Carry forward everything in the existing summary that is still true, fold in what the new transcript adds, and correct anything the new transcript contradicts. Do not drop earlier facts merely because the new transcript does not mention them — they are still the only record of what happened. Output only the updated summary, in the same structure.\n\n" +
+          `## Existing summary\n\n${priorSummary.content}\n\n## New transcript\n\n${historyText}`
+        : "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +
+          historyText;
 
       // Define specialized summarizer agent on the fly with the selected model
       const summarizerModel =
@@ -451,6 +463,7 @@ export const Summarizer = {
       return {
         role: "assistant",
         content: summaryResponse.content,
+        kind: "summary",
       };
     });
   },

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -10,9 +10,31 @@ import type { Agent } from "@/core/types";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
+<<<<<<< HEAD
 import { resolveContextThresholds } from "./context-thresholds";
 import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
+=======
+import { logContextRung } from "./context-telemetry";
+import {
+  CONTEXT_COMPACT_THRESHOLD_RATIO,
+  DEFAULT_CONTEXT_WINDOW_MANAGER,
+} from "./context-window-manager";
+>>>>>>> d5123cf (fix(context): count tool schemas, and give the summarizer its arguments)
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
+
+/** Longest tool-argument string kept verbatim in a summarizer transcript. */
+const MAX_RENDERED_ARGUMENT_CHARS = 200;
+
+/**
+ * Keep arguments readable without letting one pasted payload dominate the transcript
+ * the summarizer has to read.
+ */
+function truncateArguments(rawArguments: string | undefined): string {
+  if (!rawArguments) return "";
+  const trimmed = rawArguments.trim();
+  if (trimmed.length <= MAX_RENDERED_ARGUMENT_CHARS) return trimmed;
+  return `${trimmed.slice(0, MAX_RENDERED_ARGUMENT_CHARS)}… (${trimmed.length} chars)`;
+}
 
 /** Build a token-counter hint from an agent's provider/model. */
 function modelHintFromAgent(agent: Agent): ModelHint {
@@ -195,6 +217,32 @@ export const Summarizer = {
     return { systemMessage, messagesToSummarize, sanitizedRecentMessages };
   },
 
+  /**
+   * Render messages as the transcript handed to the summarizer.
+   *
+   * Tool call *arguments* are included, not just names. The persona is told to
+   * preserve exact file paths and command names; rendering `[Tool Calls: read_file]`
+   * stripped precisely those before the summarizer ever saw them, leaving it to
+   * describe results without knowing what was asked for.
+   */
+  renderTranscript(messages: readonly ChatMessage[]): string {
+    return messages
+      .map((message) => {
+        let content = message.content || "";
+        if (message.tool_calls) {
+          const calls = message.tool_calls
+            .map((call) => {
+              const args = truncateArguments(call.function.arguments);
+              return args ? `${call.function.name}(${args})` : call.function.name;
+            })
+            .join(", ");
+          content += `\n[Tool Calls: ${calls}]`;
+        }
+        return `[${message.role.toUpperCase()}] ${content}`;
+      })
+      .join("\n\n---\n\n");
+  },
+
   compactIfNeeded(
     currentMessages: ConversationMessages,
     agent: Agent,
@@ -221,9 +269,18 @@ export const Summarizer = {
       // Use model-specific context window or fall back to default
       const maxTokens = modelContextWindow ?? DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
       const hint = modelHintFromAgent(agent);
+<<<<<<< HEAD
       const currentTokens = DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint);
       const { compactThresholdRatio } = resolveContextThresholds(appConfig.context);
       const threshold = maxTokens * compactThresholdRatio;
+=======
+      // Include the per-request overhead (tool schemas, provider scaffolding) — the
+      // window has to hold it too, and ignoring it compacts late.
+      const currentTokens =
+        DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint) +
+        DEFAULT_TOKEN_COUNTER.overheadFor(hint);
+      const threshold = maxTokens * CONTEXT_COMPACT_THRESHOLD_RATIO;
+>>>>>>> d5123cf (fix(context): count tool schemas, and give the summarizer its arguments)
 
       // Check if summarization is needed
       if (currentTokens <= threshold) {
@@ -280,7 +337,9 @@ export const Summarizer = {
         ...sanitizedRecentMessages,
       ] as ConversationMessages;
 
-      const newTokens = DEFAULT_TOKEN_COUNTER.countMessages(compactedMessages, hint);
+      const newTokens =
+        DEFAULT_TOKEN_COUNTER.countMessages(compactedMessages, hint) +
+        DEFAULT_TOKEN_COUNTER.overheadFor(hint);
 
       yield* logger.info("Context compacted successfully", {
         originalMessages: currentMessages.length,
@@ -288,6 +347,17 @@ export const Summarizer = {
         originalTokens: currentTokens,
         compactedTokens: newTokens,
         tokensSaved: currentTokens - newTokens,
+      });
+
+      yield* logContextRung(logger, {
+        rung: "compact",
+        agentId: agent.id,
+        conversationId,
+        tokensBefore: currentTokens,
+        tokensAfter: newTokens,
+        budgetTokens: maxTokens,
+        messagesBefore: currentMessages.length,
+        messagesAfter: compactedMessages.length,
       });
 
       yield* presentationService.presentWarning(
@@ -345,15 +415,7 @@ export const Summarizer = {
         parentModel: agent.config.llmModel,
       });
 
-      const historyText = messagesToSummarize
-        .map((m) => {
-          let content = m.content || "";
-          if (m.tool_calls) {
-            content += `\n[Tool Calls: ${m.tool_calls.map((tc) => tc.function.name).join(", ")}]`;
-          }
-          return `[${m.role.toUpperCase()}] ${content}`;
-        })
-        .join("\n\n---\n\n");
+      const historyText = Summarizer.renderTranscript(messagesToSummarize);
 
       const userInput =
         "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -15,6 +15,7 @@ import { resolveContextThresholds } from "./context-thresholds";
 import { logContextRung } from "./context-telemetry";
 import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
 import { resolveEffectiveContextWindow } from "./effective-context-window";
+import { formatTaskState, readTaskState } from "./task-state";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
 import { appendJournalEntry } from "./work-journal";
 
@@ -504,6 +505,10 @@ export const Summarizer = {
         parentModel: agent.config.llmModel,
       });
 
+      // Anything already in task state is durable on disk, so the summary need not carry
+      // it. Passing it through lets the summarizer cover what the transcript adds instead.
+      const recordedState = formatTaskState(yield* readTaskState(agent.id, conversationId));
+
       // Define the specialized summarizer agent once, on the fly, with the selected model.
       const summarizerModel =
         `${summarizerModelConfig.provider}/${summarizerModelConfig.model}` as `${string}/${string}`;
@@ -548,6 +553,7 @@ export const Summarizer = {
           conversationId,
           runRecursive,
           runningSummary,
+          recordedState,
         );
         runningSummary = chunkSummary;
       }
@@ -570,6 +576,7 @@ export const Summarizer = {
     conversationId: string,
     runRecursive: RecursiveRunner,
     priorSummary?: ChatMessage,
+    recordedState?: string,
   ): Effect.Effect<
     ChatMessage,
     Error,
@@ -583,11 +590,21 @@ export const Summarizer = {
     return Effect.gen(function* () {
       const historyText = Summarizer.renderTranscript(messagesToSummarize);
 
+      // What task state already holds is safe on disk. Saying so lets the summary spend
+      // its budget on what the transcript adds rather than restating the plan.
+      const recordedStateBlock = recordedState
+        ? `## Already recorded durably (do not restate)\n\n${recordedState}\n\n` +
+          "The above is saved outside this conversation and will survive compaction. Cover " +
+          "what the transcript adds beyond it, and flag anywhere the transcript contradicts it.\n\n"
+        : "";
+
       const userInput = priorSummary?.content
         ? "You are updating an existing summary of an ongoing conversation, not writing a new one.\n\n" +
           "Carry forward everything in the existing summary that is still true, fold in what the new transcript adds, and correct anything the new transcript contradicts. Do not drop earlier facts merely because the new transcript does not mention them — they are still the only record of what happened. Output only the updated summary, in the same structure.\n\n" +
+          recordedStateBlock +
           `## Existing summary\n\n${priorSummary.content}\n\n## New transcript\n\n${historyText}`
         : "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +
+          recordedStateBlock +
           historyText;
 
       const summaryResponse = yield* runRecursive({

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -16,6 +16,7 @@ import { logContextRung } from "./context-telemetry";
 import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
 import { resolveEffectiveContextWindow } from "./effective-context-window";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
+import { appendJournalEntry } from "./work-journal";
 
 /** Longest tool-argument string kept verbatim in a summarizer transcript. */
 const MAX_RENDERED_ARGUMENT_CHARS = 200;
@@ -423,6 +424,17 @@ export const Summarizer = {
         originalTokens: currentTokens,
         compactedTokens: newTokens,
         tokensSaved: currentTokens - newTokens,
+      });
+
+      // Persist before it enters context. From here on this summary is folded into
+      // later ones; the journal keeps the version this cycle actually produced.
+      yield* appendJournalEntry(agent.id, conversationId, {
+        recordedAt: new Date().toISOString(),
+        tokensBefore: currentTokens,
+        tokensAfter: newTokens,
+        messagesBefore: currentMessages.length,
+        messagesAfter: compactedMessages.length,
+        summary: summaryMessage.content,
       });
 
       yield* logContextRung(logger, {

--- a/src/core/agent/context/summarizer.ts
+++ b/src/core/agent/context/summarizer.ts
@@ -8,18 +8,13 @@ import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
+import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { parseProviderModel } from "@/core/utils/provider-model";
 import type { AgentResponse } from "../types";
-<<<<<<< HEAD
 import { resolveContextThresholds } from "./context-thresholds";
-import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
-=======
 import { logContextRung } from "./context-telemetry";
-import {
-  CONTEXT_COMPACT_THRESHOLD_RATIO,
-  DEFAULT_CONTEXT_WINDOW_MANAGER,
-} from "./context-window-manager";
->>>>>>> d5123cf (fix(context): count tool schemas, and give the summarizer its arguments)
+import { DEFAULT_CONTEXT_WINDOW_MANAGER } from "./context-window-manager";
+import { resolveEffectiveContextWindow } from "./effective-context-window";
 import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
 
 /** Longest tool-argument string kept verbatim in a summarizer transcript. */
@@ -34,6 +29,84 @@ function truncateArguments(rawArguments: string | undefined): string {
   const trimmed = rawArguments.trim();
   if (trimmed.length <= MAX_RENDERED_ARGUMENT_CHARS) return trimmed;
   return `${trimmed.slice(0, MAX_RENDERED_ARGUMENT_CHARS)}… (${trimmed.length} chars)`;
+}
+
+/**
+ * Fraction of the summarizer's own window its input may occupy, leaving room for the
+ * system prompt and the summary it has to write.
+ */
+const SUMMARIZER_INPUT_BUDGET_RATIO = 0.6;
+
+/**
+ * Build the throwaway agent that performs summarization.
+ *
+ * The parent's window pins (`numCtx`, `maxContextTokens`) are deliberately dropped when
+ * the summarizer runs a different model: they describe the parent's runtime, and applying
+ * a 200k parent ceiling to an 8k summarizer — or vice versa — is wrong in both directions.
+ */
+function buildSummarizerAgent(
+  parentAgent: Agent,
+  summarizerModelConfig: SummarizerModelConfig,
+  summarizerModel: `${string}/${string}`,
+): Agent {
+  const sameModel =
+    summarizerModelConfig.provider === parentAgent.config.llmProvider &&
+    summarizerModelConfig.model === parentAgent.config.llmModel;
+
+  const {
+    numCtx: _numCtx,
+    maxContextTokens: _maxContextTokens,
+    ...configWithoutWindowPins
+  } = parentAgent.config;
+
+  return {
+    id: "summarizer",
+    name: "Summarizer",
+    description: "Background context compressor",
+    model: summarizerModel,
+    config: {
+      ...(sameModel ? parentAgent.config : configWithoutWindowPins),
+      llmProvider: summarizerModelConfig.provider,
+      llmModel: summarizerModelConfig.model,
+      persona: "summarizer",
+      tools: [], // No tools—summarizer should only produce text, not use tools
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+/**
+ * Split messages into chunks that each fit the summarizer's input budget.
+ *
+ * A message larger than a whole chunk is kept as its own chunk rather than dropped —
+ * the fold below will still see it, and truncation is the transport's problem, not a
+ * reason to lose the message entirely.
+ */
+export function chunkForSummarizer(
+  messages: readonly ChatMessage[],
+  budgetTokens: number,
+  hint: ModelHint,
+): ChatMessage[][] {
+  if (budgetTokens <= 0) return [[...messages]];
+
+  const chunks: ChatMessage[][] = [];
+  let current: ChatMessage[] = [];
+  let currentTokens = 0;
+
+  for (const message of messages) {
+    const tokens = DEFAULT_TOKEN_COUNTER.countMessage(message, hint);
+    if (current.length > 0 && currentTokens + tokens > budgetTokens) {
+      chunks.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(message);
+    currentTokens += tokens;
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
 }
 
 /** Build a token-counter hint from an agent's provider/model. */
@@ -276,18 +349,13 @@ export const Summarizer = {
       // Use model-specific context window or fall back to default
       const maxTokens = modelContextWindow ?? DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().maxTokens;
       const hint = modelHintFromAgent(agent);
-<<<<<<< HEAD
-      const currentTokens = DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint);
-      const { compactThresholdRatio } = resolveContextThresholds(appConfig.context);
-      const threshold = maxTokens * compactThresholdRatio;
-=======
       // Include the per-request overhead (tool schemas, provider scaffolding) — the
       // window has to hold it too, and ignoring it compacts late.
       const currentTokens =
         DEFAULT_TOKEN_COUNTER.countMessages(currentMessages, hint) +
         DEFAULT_TOKEN_COUNTER.overheadFor(hint);
-      const threshold = maxTokens * CONTEXT_COMPACT_THRESHOLD_RATIO;
->>>>>>> d5123cf (fix(context): count tool schemas, and give the summarizer its arguments)
+      const { compactThresholdRatio } = resolveContextThresholds(appConfig.context);
+      const threshold = maxTokens * compactThresholdRatio;
 
       // Check if summarization is needed
       if (currentTokens <= threshold) {
@@ -424,6 +492,83 @@ export const Summarizer = {
         parentModel: agent.config.llmModel,
       });
 
+      // Define the specialized summarizer agent once, on the fly, with the selected model.
+      const summarizerModel =
+        `${summarizerModelConfig.provider}/${summarizerModelConfig.model}` as `${string}/${string}`;
+      const summarizer = buildSummarizerAgent(agent, summarizerModelConfig, summarizerModel);
+
+      // The transcript can be most of the *parent's* window, which says nothing about
+      // what the summarizer's own model can hold. Fold it in chunks when it does not
+      // fit, reusing the merge prompt: chunk 1 becomes a summary, each later chunk is
+      // merged into it, so the result is one record rather than a pile of fragments.
+      const summarizerHint: ModelHint = {
+        provider: summarizerModelConfig.provider,
+        modelId: summarizerModelConfig.model,
+      };
+      const summarizerMetadata = yield* Effect.tryPromise({
+        try: () =>
+          getModelsDevMetadata(summarizerModelConfig.model, summarizerModelConfig.provider),
+        catch: () => new Error("Failed to fetch summarizer model metadata"),
+      }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+
+      const summarizerWindow = resolveEffectiveContextWindow({
+        provider: summarizerModelConfig.provider,
+        ...(summarizerMetadata && { modelMaxTokens: summarizerMetadata.contextWindow }),
+      }).tokens;
+      const inputBudget = Math.floor(summarizerWindow * SUMMARIZER_INPUT_BUDGET_RATIO);
+
+      const chunks = chunkForSummarizer(messagesToSummarize, inputBudget, summarizerHint);
+      if (chunks.length > 1) {
+        yield* logger.info("Folding an oversized transcript for the summarizer", {
+          chunks: chunks.length,
+          inputBudget,
+          summarizerWindow,
+          summarizerModel: `${summarizerModelConfig.provider}/${summarizerModelConfig.model}`,
+        });
+      }
+
+      let runningSummary = priorSummary;
+      for (const chunk of chunks) {
+        const chunkSummary = yield* Summarizer.summarizeChunk(
+          chunk,
+          summarizer,
+          sessionId,
+          conversationId,
+          runRecursive,
+          runningSummary,
+        );
+        runningSummary = chunkSummary;
+      }
+
+      return runningSummary ?? { role: "assistant", content: "No history to summarize." };
+    });
+  },
+
+  /**
+   * Summarize one chunk, merging into `priorSummary` when there is one.
+   *
+   * Split out from `summarizeHistory` so the fold above can call it per chunk with the
+   * summarizer agent already resolved — resolving it once per chunk would re-read config
+   * and re-log for no reason.
+   */
+  summarizeChunk(
+    messagesToSummarize: readonly ChatMessage[],
+    summarizer: Agent,
+    sessionId: string,
+    conversationId: string,
+    runRecursive: RecursiveRunner,
+    priorSummary?: ChatMessage,
+  ): Effect.Effect<
+    ChatMessage,
+    Error,
+    | LLMService
+    | ToolRegistry
+    | LoggerService
+    | AgentConfigService
+    | PresentationService
+    | ToolRequirements
+  > {
+    return Effect.gen(function* () {
       const historyText = Summarizer.renderTranscript(messagesToSummarize);
 
       const userInput = priorSummary?.content
@@ -432,25 +577,6 @@ export const Summarizer = {
           `## Existing summary\n\n${priorSummary.content}\n\n## New transcript\n\n${historyText}`
         : "Summarize the following conversation. Produce a concise, structured summary that preserves key information for continuity—goals, decisions, outcomes, key entities, current status, and open questions. Output only the summary.\n\n" +
           historyText;
-
-      // Define specialized summarizer agent on the fly with the selected model
-      const summarizerModel =
-        `${summarizerModelConfig.provider}/${summarizerModelConfig.model}` as `${string}/${string}`;
-      const summarizer: Agent = {
-        id: "summarizer",
-        name: "Summarizer",
-        description: "Background context compressor",
-        model: summarizerModel,
-        config: {
-          ...agent.config,
-          llmProvider: summarizerModelConfig.provider,
-          llmModel: summarizerModelConfig.model,
-          persona: "summarizer",
-          tools: [], // No tools—summarizer should only produce text, not use tools
-        },
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
 
       const summaryResponse = yield* runRecursive({
         agent: summarizer,

--- a/src/core/agent/context/task-state.test.ts
+++ b/src/core/agent/context/task-state.test.ts
@@ -1,0 +1,97 @@
+import * as nodeFs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { formatTaskState, patchTaskState, readTaskState, taskStatePath } from "./task-state";
+
+const runEffect = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
+  Effect.runPromise(effect);
+const now = "2026-08-15T12:00:00.000Z";
+
+describe("task state", () => {
+  let jazzHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-task-state-"));
+    previousHome = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = previousHome;
+    await nodeFs.rm(jazzHome, { recursive: true, force: true });
+  });
+
+  it("returns nothing before anything is written", async () => {
+    expect(await runEffect(readTaskState("agent-1", "conv-1"))).toBeUndefined();
+  });
+
+  it("patches one field without disturbing the rest", async () => {
+    await runEffect(
+      patchTaskState(
+        "agent-1",
+        "conv-1",
+        {
+          goal: "migrate the routes",
+          decisions: ["keep the old adapter until v3"],
+          openQuestions: ["does the legacy client still call /v1?"],
+        },
+        now,
+      ),
+    );
+
+    await runEffect(patchTaskState("agent-1", "conv-1", { nextStep: "migrate auth route" }, now));
+
+    const state = await runEffect(readTaskState("agent-1", "conv-1"));
+    expect(state?.goal).toBe("migrate the routes");
+    expect(state?.decisions).toEqual(["keep the old adapter until v3"]);
+    expect(state?.openQuestions).toEqual(["does the legacy client still call /v1?"]);
+    expect(state?.nextStep).toBe("migrate auth route");
+  });
+
+  it("replaces a field that is explicitly patched", async () => {
+    await runEffect(patchTaskState("agent-1", "conv-1", { nextStep: "first" }, now));
+    await runEffect(patchTaskState("agent-1", "conv-1", { nextStep: "second" }, now));
+
+    expect((await runEffect(readTaskState("agent-1", "conv-1")))?.nextStep).toBe("second");
+  });
+
+  it("keeps state per conversation", async () => {
+    await runEffect(patchTaskState("agent-1", "conv-1", { goal: "one" }, now));
+    await runEffect(patchTaskState("agent-1", "conv-2", { goal: "two" }, now));
+
+    expect((await runEffect(readTaskState("agent-1", "conv-1")))?.goal).toBe("one");
+    expect((await runEffect(readTaskState("agent-1", "conv-2")))?.goal).toBe("two");
+  });
+
+  it("survives a corrupt state file rather than throwing", async () => {
+    await runEffect(patchTaskState("agent-1", "conv-1", { goal: "one" }, now));
+    await nodeFs.writeFile(taskStatePath("agent-1", "conv-1"), "{not json", "utf-8");
+
+    expect(await runEffect(readTaskState("agent-1", "conv-1"))).toBeUndefined();
+  });
+
+  it("renders work item verification status", () => {
+    const formatted = formatTaskState({
+      goal: "migrate the routes",
+      workItems: [
+        { description: "auth route", status: "done", verifiedBy: "bun test src/auth.test.ts" },
+        { description: "billing route", status: "unverified" },
+      ],
+      nextStep: "verify billing",
+    });
+
+    expect(formatted).toContain("migrate the routes");
+    expect(formatted).toContain("[done] auth route (verified by: bun test src/auth.test.ts)");
+    expect(formatted).toContain("[unverified] billing route");
+    expect(formatted).toContain("**Next step:** verify billing");
+  });
+
+  it("renders nothing for empty state", () => {
+    expect(formatTaskState(undefined)).toBeUndefined();
+    expect(formatTaskState({})).toBeUndefined();
+  });
+});

--- a/src/core/agent/context/task-state.ts
+++ b/src/core/agent/context/task-state.ts
@@ -1,0 +1,138 @@
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { Effect } from "effect";
+import { getWorkStateDirectory } from "@/core/utils/paths";
+
+/**
+ * Where the agent is in the current task, as the agent understands it.
+ *
+ * Distinct from memory, which holds what stays true about a person or project across
+ * conversations. This holds what is true about *one task right now* — and is discarded
+ * when that task ends. The journal records what happened; this records intent, which
+ * only the agent knows and only while it still has it in context.
+ *
+ * JSON rather than prose because it is edited repeatedly and models patch structured
+ * documents far more reliably than they rewrite paragraphs.
+ */
+
+const TASK_STATE_FILENAME = "state.json";
+
+/**
+ * Work items stay unverified until something has actually been run.
+ *
+ * Agents habitually mark work complete on the strength of having written it, which turns
+ * a progress record into a confident lie. `done` therefore means "verified by running
+ * something", not "I believe I finished it".
+ */
+export type WorkItemStatus = "pending" | "in_progress" | "unverified" | "done" | "failing";
+
+export interface WorkItem {
+  readonly description: string;
+  readonly status: WorkItemStatus;
+  /** What was run to verify it, when status is `done`. */
+  readonly verifiedBy?: string | undefined;
+}
+
+export interface TaskState {
+  readonly goal?: string;
+  readonly constraints?: readonly string[];
+  /** Choices made and why, so a successor does not relitigate them. */
+  readonly decisions?: readonly string[];
+  readonly workItems?: readonly WorkItem[];
+  readonly filesTouched?: readonly string[];
+  readonly openQuestions?: readonly string[];
+  readonly nextStep?: string;
+  readonly updatedAt?: string;
+}
+
+export function taskStatePath(agentId: string, conversationId: string): string {
+  return path.join(getWorkStateDirectory(agentId, conversationId), TASK_STATE_FILENAME);
+}
+
+/** Read current state, or `undefined` when none has been written or it is unreadable. */
+export function readTaskState(
+  agentId: string,
+  conversationId: string,
+): Effect.Effect<TaskState | undefined, never, never> {
+  return Effect.tryPromise({
+    try: () => nodeFs.readFile(taskStatePath(agentId, conversationId), "utf-8"),
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((contents) => {
+      try {
+        const parsed: unknown = JSON.parse(contents);
+        return typeof parsed === "object" && parsed !== null ? parsed : undefined;
+      } catch {
+        return undefined;
+      }
+    }),
+    Effect.catchAll(() => Effect.succeed(undefined)),
+  );
+}
+
+/**
+ * Merge a patch into the stored state, field by field.
+ *
+ * Patching rather than replacing: an agent updating `nextStep` must not silently drop
+ * the decisions and open questions it did not mention. Only keys present in the patch
+ * are touched.
+ */
+export function patchTaskState(
+  agentId: string,
+  conversationId: string,
+  patch: Partial<TaskState>,
+  updatedAt: string,
+): Effect.Effect<TaskState, never, never> {
+  return readTaskState(agentId, conversationId).pipe(
+    Effect.flatMap((existing) => {
+      const merged: TaskState = { ...(existing ?? {}), ...patch, updatedAt };
+      return Effect.tryPromise({
+        try: async () => {
+          const directory = getWorkStateDirectory(agentId, conversationId);
+          await nodeFs.mkdir(directory, { recursive: true, mode: 0o700 });
+          await nodeFs.writeFile(
+            taskStatePath(agentId, conversationId),
+            `${JSON.stringify(merged, null, 2)}\n`,
+            "utf-8",
+          );
+          return merged;
+        },
+        catch: (error) => error,
+      }).pipe(Effect.catchAll(() => Effect.succeed(merged)));
+    }),
+  );
+}
+
+/** Render state for a prompt or a CLI view. Returns `undefined` when there is nothing to show. */
+export function formatTaskState(state: TaskState | undefined): string | undefined {
+  if (!state) return undefined;
+  const sections: string[] = [];
+
+  if (state.goal) sections.push(`**Goal:** ${state.goal}`);
+  if (state.constraints?.length) {
+    sections.push(`**Constraints:**\n${state.constraints.map((item) => `- ${item}`).join("\n")}`);
+  }
+  if (state.decisions?.length) {
+    sections.push(`**Decisions:**\n${state.decisions.map((item) => `- ${item}`).join("\n")}`);
+  }
+  if (state.workItems?.length) {
+    const items = state.workItems
+      .map((item) => {
+        const verified = item.verifiedBy ? ` (verified by: ${item.verifiedBy})` : "";
+        return `- [${item.status}] ${item.description}${verified}`;
+      })
+      .join("\n");
+    sections.push(`**Work items:**\n${items}`);
+  }
+  if (state.filesTouched?.length) {
+    sections.push(`**Files touched:** ${state.filesTouched.join(", ")}`);
+  }
+  if (state.openQuestions?.length) {
+    sections.push(
+      `**Open questions:**\n${state.openQuestions.map((item) => `- ${item}`).join("\n")}`,
+    );
+  }
+  if (state.nextStep) sections.push(`**Next step:** ${state.nextStep}`);
+
+  return sections.length > 0 ? sections.join("\n\n") : undefined;
+}

--- a/src/core/agent/context/token-counter.test.ts
+++ b/src/core/agent/context/token-counter.test.ts
@@ -292,3 +292,75 @@ describe("TokenCounter — defensive paths", () => {
     expect(counter.getRatio(hint)).toBe(3.5);
   });
 });
+
+describe("request overhead", () => {
+  const hint = { provider: "openai", modelId: "gpt-4o" };
+
+  function messages(count: number): ChatMessage[] {
+    return Array.from({ length: count }, (_, index) => ({
+      role: "user" as const,
+      content: `message ${index} ` + "content ".repeat(50),
+    }));
+  }
+
+  it("is zero before any authoritative usage report", () => {
+    const counter = new TokenCounter();
+    expect(counter.overheadFor(hint)).toBe(0);
+  });
+
+  it("measures exactly what the provider counted beyond our messages", () => {
+    const counter = new TokenCounter();
+    const msgs = messages(5);
+    const exactMessageTokens = counter.countMessages(msgs, hint);
+    const trueOverhead = 12_000;
+
+    counter.calibrate(exactMessageTokens + trueOverhead, msgs, hint);
+
+    // gpt-4o is tokenizer-backed, so the message estimate is exact and the
+    // remainder is the overhead with no approximation involved.
+    expect(counter.overheadFor(hint)).toBe(trueOverhead);
+  });
+
+  it("converges on a stable overhead across repeated reports", () => {
+    const counter = new TokenCounter();
+    const trueOverhead = 9_000;
+    const estimates: number[] = [];
+
+    for (let call = 0; call < 5; call++) {
+      const msgs = messages(3 + call);
+      const exact = counter.countMessages(msgs, hint);
+      counter.calibrate(exact + trueOverhead, msgs, hint);
+      estimates.push(counter.overheadFor(hint));
+    }
+
+    // Stable rather than oscillating: every reading lands on the true value.
+    for (const estimate of estimates) {
+      expect(estimate).toBe(trueOverhead);
+    }
+  });
+
+  it("does not go negative when the provider reports fewer tokens than estimated", () => {
+    const counter = new TokenCounter();
+    const msgs = messages(5);
+    counter.calibrate(1, msgs, hint);
+    expect(counter.overheadFor(hint)).toBe(0);
+  });
+
+  it("keeps overhead per model", () => {
+    const counter = new TokenCounter();
+    const msgs = messages(4);
+    const exact = counter.countMessages(msgs, hint);
+    counter.calibrate(exact + 5_000, msgs, hint);
+
+    expect(counter.overheadFor(hint)).toBe(5_000);
+    expect(counter.overheadFor({ provider: "openai", modelId: "gpt-4" })).toBe(0);
+  });
+
+  it("is cleared by reset", () => {
+    const counter = new TokenCounter();
+    const msgs = messages(4);
+    counter.calibrate(counter.countMessages(msgs, hint) + 3_000, msgs, hint);
+    counter.reset();
+    expect(counter.overheadFor(hint)).toBe(0);
+  });
+});

--- a/src/core/agent/context/token-counter.ts
+++ b/src/core/agent/context/token-counter.ts
@@ -147,6 +147,16 @@ export class TokenCounter {
   private calibratedRatio = new Map<string, number>();
 
   /**
+   * Per-model request overhead in tokens: everything the provider counts that is
+   * not in our message list — tool schemas above all, plus system scaffolding.
+   *
+   * Measured rather than derived. `toolDefinitionChars` reports only the schemas,
+   * while `promptTokens - estimatedMessageTokens` captures the whole gap, which is
+   * what the context window actually has to hold.
+   */
+  private overheadTokens = new Map<string, number>();
+
+  /**
    * Per-message memoization: maps message → cached count.
    * Stores modelKey at compute-time so a later calibration (which invalidates
    * the cache by replacing the WeakMap) doesn't mismatch.
@@ -238,8 +248,16 @@ export class TokenCounter {
     }
     if (totalChars === 0) return;
 
-    const observedRatio = totalChars / authoritativePromptTokens;
     const modelKey = this.modelKey(hint);
+
+    // Attribute only the message share of promptTokens to the ratio. Dividing by the
+    // raw total (which includes tool schemas) depressed the ratio and silently
+    // inflated every later estimate — compensation proportional to message size
+    // rather than to the overhead actually being missed.
+    const priorOverhead = this.overheadTokens.get(modelKey) ?? 0;
+    const messageTokens = Math.max(1, authoritativePromptTokens - priorOverhead);
+
+    const observedRatio = totalChars / messageTokens;
     const prior = this.calibratedRatio.get(modelKey);
     const smoothed =
       prior !== undefined
@@ -253,6 +271,27 @@ export class TokenCounter {
     // discard it. Hot messages are recomputed on next access; cold messages
     // (already trimmed away) are GC'd by the WeakMap.
     this.messageCache = new WeakMap<ChatMessage, number>();
+
+    // Now that the ratio is fresh, whatever the provider counted beyond our
+    // messages is the request overhead. Exact for tokenizer-backed families,
+    // smoothed for the rest so a single odd report cannot swing the budget.
+    const estimatedMessageTokens = this.countMessages(messagesAtCallTime, hint);
+    const observedOverhead = Math.max(0, authoritativePromptTokens - estimatedMessageTokens);
+    const priorOverheadValue = this.overheadTokens.get(modelKey);
+    const smoothedOverhead =
+      priorOverheadValue !== undefined
+        ? (1 - CALIBRATION_SMOOTHING) * priorOverheadValue +
+          CALIBRATION_SMOOTHING * observedOverhead
+        : observedOverhead;
+    this.overheadTokens.set(modelKey, Math.round(smoothedOverhead));
+  }
+
+  /**
+   * Tokens each request carries beyond the message list — tool schemas and provider
+   * scaffolding. Zero until the first authoritative usage report arrives.
+   */
+  overheadFor(hint: ModelHint): number {
+    return this.overheadTokens.get(this.modelKey(hint)) ?? 0;
   }
 
   /**
@@ -266,6 +305,7 @@ export class TokenCounter {
   /** Reset all calibration state. Useful for tests. */
   reset(): void {
     this.calibratedRatio.clear();
+    this.overheadTokens.clear();
     this.messageCache = new WeakMap<ChatMessage, number>();
   }
 

--- a/src/core/agent/context/tool-result-clearing.test.ts
+++ b/src/core/agent/context/tool-result-clearing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import type { ChatMessage } from "@/core/types/message";
+import { clearToolResults, KEEP_RECENT_TOOL_RESULTS } from "./tool-result-clearing";
+
+const modelHint = { provider: "openai", modelId: "gpt-4o" };
+
+const fixedCounter = {
+  countMessage: (message: ChatMessage) => Math.ceil((message.content?.length ?? 0) / 4),
+  countMessages: (messages: readonly ChatMessage[]) =>
+    messages.reduce((total, message) => total + Math.ceil((message.content?.length ?? 0) / 4), 0),
+} as any;
+
+function bigResult(callId: string): ChatMessage {
+  return { role: "tool", tool_call_id: callId, content: "x".repeat(20_000) } as ChatMessage;
+}
+
+function assistantCall(callId: string, toolName: string): ChatMessage {
+  return {
+    role: "assistant",
+    content: "",
+    tool_calls: [{ id: callId, type: "function", function: { name: toolName, arguments: "{}" } }],
+  } as ChatMessage;
+}
+
+/** system + N (assistant call, tool result) pairs + a trailing user turn. */
+function conversation(pairs: number): ChatMessage[] {
+  const messages: ChatMessage[] = [{ role: "system", content: "system" }];
+  for (let index = 0; index < pairs; index++) {
+    messages.push({ role: "user", content: `ask ${index}` });
+    messages.push(assistantCall(`call_${index}`, "read_file"));
+    messages.push(bigResult(`call_${index}`));
+  }
+  return messages;
+}
+
+describe("clearToolResults", () => {
+  it("replaces old large results with a placeholder while keeping the message", () => {
+    const messages = conversation(10);
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    expect(outcome.clearedCount).toBeGreaterThan(0);
+    expect(outcome.tokensReclaimed).toBeGreaterThan(0);
+
+    const clearedMessages = outcome.messages.filter((message) => message.cleared);
+    for (const message of clearedMessages) {
+      expect(message.role).toBe("tool");
+      expect(message.tool_call_id).toBeDefined();
+      expect(message.content).toContain("tool result cleared");
+      expect(message.content).toContain("read_file");
+    }
+  });
+
+  it("never orphans a tool result from its assistant call", () => {
+    const messages = conversation(10);
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    const toolCallIds = new Set(
+      outcome.messages.flatMap((message) => message.tool_calls?.map((call) => call.id) ?? []),
+    );
+    for (const message of outcome.messages) {
+      if (message.role === "tool" && message.tool_call_id) {
+        expect(toolCallIds.has(message.tool_call_id)).toBe(true);
+      }
+    }
+    expect(outcome.messages.length).toBe(messages.length);
+  });
+
+  it("keeps the most recent results verbatim", () => {
+    const messages = conversation(10);
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    const results = outcome.messages.filter((message) => message.role === "tool");
+    const recent = results.slice(-KEEP_RECENT_TOOL_RESULTS);
+    for (const message of recent) {
+      expect(message.cleared).toBeUndefined();
+    }
+  });
+
+  it("leaves the protected zone untouched", () => {
+    const messages = conversation(10);
+    const protectedFromIndex = messages.length - 6;
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    for (let index = protectedFromIndex; index < outcome.messages.length; index++) {
+      expect(outcome.messages[index]?.cleared).toBeUndefined();
+    }
+  });
+
+  it("ignores results below the size floor", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "system" },
+      ...Array.from({ length: 12 }, (_, index) => [
+        { role: "user", content: `ask ${index}` } as ChatMessage,
+        assistantCall(`call_${index}`, "grep"),
+        { role: "tool", tool_call_id: `call_${index}`, content: "tiny" } as ChatMessage,
+      ]).flat(),
+    ];
+
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    expect(outcome.clearedCount).toBe(0);
+    expect(outcome.tokensReclaimed).toBe(0);
+  });
+
+  it("is idempotent — a second pass clears nothing new", () => {
+    const messages = conversation(12);
+    const first = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+    const second = clearToolResults(first.messages, {
+      protectedFromIndex: first.messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    expect(first.clearedCount).toBeGreaterThan(0);
+    expect(second.clearedCount).toBe(0);
+  });
+
+  it("does nothing when there are too few results to spare any", () => {
+    const messages = conversation(3);
+    const outcome = clearToolResults(messages, {
+      protectedFromIndex: messages.length,
+      modelHint,
+      tokenCounter: fixedCounter,
+    });
+
+    expect(outcome.clearedCount).toBe(0);
+  });
+});

--- a/src/core/agent/context/tool-result-clearing.ts
+++ b/src/core/agent/context/tool-result-clearing.ts
@@ -1,0 +1,111 @@
+import type { ChatMessage } from "@/core/types/message";
+import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./token-counter";
+
+/**
+ * Reclaim context by clearing stale tool output, the cheapest rung of the ladder.
+ *
+ * A long run's tokens are overwhelmingly raw tool results — file contents, search
+ * output, API responses — and most of them stop mattering the moment the model has
+ * read them. Summarizing to recover that space costs an LLM call; clearing costs
+ * nothing.
+ *
+ * The message and its `tool_call_id` are kept and only the content is replaced, so
+ * assistant/tool pairing stays intact. Deleting the message instead would orphan the
+ * assistant `tool_calls` that referenced it and provoke a provider error.
+ */
+
+/** Results smaller than this are left alone: clearing them costs structure for no gain. */
+export const MIN_CLEARABLE_RESULT_TOKENS = 1_000;
+
+/** How many of the most recent tool results are always kept verbatim. */
+export const KEEP_RECENT_TOOL_RESULTS = 5;
+
+export interface ClearToolResultsOptions {
+  /** Messages at the end that must not be touched (the protected recent turns). */
+  readonly protectedFromIndex: number;
+  readonly modelHint: ModelHint;
+  readonly tokenCounter?: TokenCounter;
+  readonly minClearableTokens?: number;
+  readonly keepRecent?: number;
+}
+
+export interface ClearToolResultsOutcome {
+  readonly messages: ChatMessage[];
+  readonly clearedCount: number;
+  readonly tokensReclaimed: number;
+}
+
+function placeholderFor(toolName: string | undefined, tokens: number): string {
+  const name = toolName && toolName.length > 0 ? toolName : "tool";
+  return `[tool result cleared — ${name}, ~${tokens.toLocaleString()} tokens. Re-run the tool if you need this again.]`;
+}
+
+/**
+ * Replace the content of old, large tool results with a placeholder.
+ *
+ * Returns the original array untouched when nothing qualifies, so callers can treat
+ * an unchanged reference as "nothing to do" and skip the cache-invalidating rewrite.
+ */
+export function clearToolResults(
+  messages: readonly ChatMessage[],
+  options: ClearToolResultsOptions,
+): ClearToolResultsOutcome {
+  const counter = options.tokenCounter ?? DEFAULT_TOKEN_COUNTER;
+  const minTokens = options.minClearableTokens ?? MIN_CLEARABLE_RESULT_TOKENS;
+  const keepRecent = options.keepRecent ?? KEEP_RECENT_TOOL_RESULTS;
+
+  const toolNameByCallId = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role === "assistant" && message.tool_calls) {
+      for (const call of message.tool_calls) {
+        toolNameByCallId.set(call.id, call.function.name);
+      }
+    }
+  }
+
+  // Candidates: tool results outside the protected zone, not already cleared, big
+  // enough to be worth it. Walk backwards so "most recent" is cheap to determine.
+  const candidateIndices: number[] = [];
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!message || message.role !== "tool") continue;
+    if (index >= options.protectedFromIndex) continue;
+    if (message.cleared) continue;
+    candidateIndices.push(index);
+  }
+
+  const clearable = candidateIndices.slice(keepRecent);
+  if (clearable.length === 0) {
+    return { messages: [...messages], clearedCount: 0, tokensReclaimed: 0 };
+  }
+
+  const toClear = new Map<number, number>();
+  for (const index of clearable) {
+    const message = messages[index];
+    if (!message) continue;
+    const tokens = counter.countMessage(message, options.modelHint);
+    if (tokens < minTokens) continue;
+    toClear.set(index, tokens);
+  }
+
+  if (toClear.size === 0) {
+    return { messages: [...messages], clearedCount: 0, tokensReclaimed: 0 };
+  }
+
+  let tokensReclaimed = 0;
+  const next = messages.map((message, index) => {
+    const originalTokens = toClear.get(index);
+    if (originalTokens === undefined) return message;
+
+    const toolName = message.tool_call_id ? toolNameByCallId.get(message.tool_call_id) : undefined;
+    const replacement: ChatMessage = {
+      ...message,
+      content: placeholderFor(toolName, originalTokens),
+      cleared: true,
+    };
+    tokensReclaimed += originalTokens - counter.countMessage(replacement, options.modelHint);
+    return replacement;
+  });
+
+  return { messages: next, clearedCount: toClear.size, tokensReclaimed };
+}

--- a/src/core/agent/context/work-journal.test.ts
+++ b/src/core/agent/context/work-journal.test.ts
@@ -3,7 +3,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import { appendJournalEntry, journalPath, readJournal } from "./work-journal";
+import {
+  appendJournalEntry,
+  clearWorkState,
+  journalPath,
+  pruneJournal,
+  readJournal,
+  workStateSizeBytes,
+} from "./work-journal";
 
 const runEffect = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
   Effect.runPromise(effect);
@@ -70,5 +77,61 @@ describe("work journal", () => {
   it("reports failure instead of throwing when the path cannot be written", async () => {
     process.env["JAZZ_HOME"] = "/proc/nonexistent-jazz-home";
     expect(await runEffect(appendJournalEntry("agent-1", "conv-1", entry("nope")))).toBe(false);
+  });
+});
+
+describe("work state lifecycle", () => {
+  let jazzHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-journal-gc-"));
+    previousHome = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = previousHome;
+    await nodeFs.rm(jazzHome, { recursive: true, force: true });
+  });
+
+  it("reports zero size for a conversation with no state", async () => {
+    expect(await runEffect(workStateSizeBytes("agent-1", "conv-1"))).toBe(0);
+  });
+
+  it("clears a conversation's state without touching its neighbours", async () => {
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("one")));
+    await runEffect(appendJournalEntry("agent-1", "conv-2", entry("two")));
+
+    expect(await runEffect(clearWorkState("agent-1", "conv-1"))).toBe(true);
+    expect(await runEffect(readJournal("agent-1", "conv-1"))).toEqual([]);
+    expect((await runEffect(readJournal("agent-1", "conv-2")))[0]?.summary).toBe("two");
+  });
+
+  it("clearing a conversation that has no state is not an error", async () => {
+    expect(await runEffect(clearWorkState("agent-1", "never-existed"))).toBe(true);
+  });
+
+  it("prunes oldest-first once past the cap, keeping the newest records", async () => {
+    for (let index = 0; index < 20; index++) {
+      await runEffect(
+        appendJournalEntry("agent-1", "conv-1", entry(`record ${index} ` + "x".repeat(500))),
+      );
+    }
+
+    const dropped = await runEffect(pruneJournal("agent-1", "conv-1", 2_000));
+    expect(dropped).toBeGreaterThan(0);
+
+    const remaining = await runEffect(readJournal("agent-1", "conv-1"));
+    expect(remaining.length).toBeLessThan(20);
+    // The newest record is the one that describes where the task actually is.
+    expect(remaining[remaining.length - 1]?.summary).toContain("record 19");
+  });
+
+  it("leaves the journal alone while it is under the cap", async () => {
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("small")));
+    expect(await runEffect(pruneJournal("agent-1", "conv-1"))).toBe(0);
+    expect((await runEffect(readJournal("agent-1", "conv-1"))).length).toBe(1);
   });
 });

--- a/src/core/agent/context/work-journal.test.ts
+++ b/src/core/agent/context/work-journal.test.ts
@@ -1,0 +1,74 @@
+import * as nodeFs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { appendJournalEntry, journalPath, readJournal } from "./work-journal";
+
+const runEffect = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
+  Effect.runPromise(effect);
+
+function entry(summary: string) {
+  return {
+    recordedAt: "2026-08-15T10:00:00.000Z",
+    tokensBefore: 100_000,
+    tokensAfter: 30_000,
+    messagesBefore: 64,
+    messagesAfter: 12,
+    summary,
+  };
+}
+
+describe("work journal", () => {
+  let jazzHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-journal-"));
+    previousHome = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = previousHome;
+    await nodeFs.rm(jazzHome, { recursive: true, force: true });
+  });
+
+  it("returns an empty journal when nothing has been written", async () => {
+    expect(await runEffect(readJournal("agent-1", "conv-1"))).toEqual([]);
+  });
+
+  it("appends entries and reads them back oldest first", async () => {
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("first")));
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("second")));
+
+    const entries = await runEffect(readJournal("agent-1", "conv-1"));
+    expect(entries.map((item) => item.summary)).toEqual(["first", "second"]);
+    expect(entries[0]?.tokensBefore).toBe(100_000);
+  });
+
+  it("keeps journals separate per conversation and per agent", async () => {
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("one")));
+    await runEffect(appendJournalEntry("agent-1", "conv-2", entry("two")));
+    await runEffect(appendJournalEntry("agent-2", "conv-1", entry("three")));
+
+    expect((await runEffect(readJournal("agent-1", "conv-1")))[0]?.summary).toBe("one");
+    expect((await runEffect(readJournal("agent-1", "conv-2")))[0]?.summary).toBe("two");
+    expect((await runEffect(readJournal("agent-2", "conv-1")))[0]?.summary).toBe("three");
+  });
+
+  it("survives a torn final line rather than losing the file", async () => {
+    await runEffect(appendJournalEntry("agent-1", "conv-1", entry("intact")));
+    await nodeFs.appendFile(journalPath("agent-1", "conv-1"), '{"recordedAt":"2026', "utf-8");
+
+    const entries = await runEffect(readJournal("agent-1", "conv-1"));
+    expect(entries.length).toBe(1);
+    expect(entries[0]?.summary).toBe("intact");
+  });
+
+  it("reports failure instead of throwing when the path cannot be written", async () => {
+    process.env["JAZZ_HOME"] = "/proc/nonexistent-jazz-home";
+    expect(await runEffect(appendJournalEntry("agent-1", "conv-1", entry("nope")))).toBe(false);
+  });
+});

--- a/src/core/agent/context/work-journal.ts
+++ b/src/core/agent/context/work-journal.ts
@@ -85,3 +85,84 @@ export function readJournal(
     Effect.catchAll(() => Effect.succeed<JournalEntry[]>([])),
   );
 }
+
+/**
+ * Ceiling on stored working state per conversation. Journals are summaries, not
+ * transcripts, so this is generous in practice — it exists so an agent that compacts
+ * hundreds of times cannot fill the disk unnoticed.
+ */
+export const MAX_WORK_STATE_BYTES_PER_CONVERSATION = 2 * 1024 * 1024;
+
+/** Delete a conversation's working state. Used when a task is finished or abandoned. */
+export function clearWorkState(
+  agentId: string,
+  conversationId: string,
+): Effect.Effect<boolean, never, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      await nodeFs.rm(getWorkStateDirectory(agentId, conversationId), {
+        recursive: true,
+        force: true,
+      });
+      return true;
+    },
+    catch: (error) => error,
+  }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+}
+
+/** Bytes currently stored for a conversation. Zero when nothing is stored. */
+export function workStateSizeBytes(
+  agentId: string,
+  conversationId: string,
+): Effect.Effect<number, never, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      const directory = getWorkStateDirectory(agentId, conversationId);
+      const names = await nodeFs.readdir(directory);
+      let total = 0;
+      for (const name of names) {
+        const stats = await nodeFs.stat(path.join(directory, name));
+        if (stats.isFile()) total += stats.size;
+      }
+      return total;
+    },
+    catch: (error) => error,
+  }).pipe(Effect.catchAll(() => Effect.succeed(0)));
+}
+
+/**
+ * Drop the oldest journal entries until the file is back under the cap.
+ *
+ * Oldest-first because the newest records describe where the task actually is; an old
+ * record of finished work is the most expendable thing here.
+ */
+export function pruneJournal(
+  agentId: string,
+  conversationId: string,
+  maxBytes = MAX_WORK_STATE_BYTES_PER_CONVERSATION,
+): Effect.Effect<number, never, never> {
+  return workStateSizeBytes(agentId, conversationId).pipe(
+    Effect.flatMap((size) => {
+      if (size <= maxBytes) return Effect.succeed(0);
+      return readJournal(agentId, conversationId).pipe(
+        Effect.flatMap((entries) => {
+          // Halve the record count rather than trimming one at a time, so pruning is
+          // amortized instead of running on every subsequent append.
+          const keep = entries.slice(Math.ceil(entries.length / 2));
+          const dropped = entries.length - keep.length;
+          return Effect.tryPromise({
+            try: async () => {
+              await nodeFs.writeFile(
+                journalPath(agentId, conversationId),
+                keep.map((entry) => JSON.stringify(entry)).join("\n") + (keep.length ? "\n" : ""),
+                "utf-8",
+              );
+              return dropped;
+            },
+            catch: (error) => error,
+          }).pipe(Effect.catchAll(() => Effect.succeed(0)));
+        }),
+      );
+    }),
+  );
+}

--- a/src/core/agent/context/work-journal.ts
+++ b/src/core/agent/context/work-journal.ts
@@ -1,0 +1,87 @@
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { Effect } from "effect";
+import { getWorkStateDirectory } from "@/core/utils/paths";
+
+/**
+ * An append-only record of what each compaction summarized away.
+ *
+ * Compaction already produces a structured summary and then places it in context, where
+ * the *next* compaction folds it into the running summary. That is the right thing to do
+ * in context, but it means the only copy of an early summary lives inside a document
+ * being continuously rewritten. Appending it here first costs no tokens and no LLM call,
+ * and gives a record that later cycles cannot degrade.
+ *
+ * Append-only and one JSON object per line, so a crash mid-write can damage at most the
+ * final record rather than the file.
+ */
+
+const JOURNAL_FILENAME = "journal.jsonl";
+
+export interface JournalEntry {
+  /** ISO-8601. Supplied by the caller so this module stays free of ambient clock reads. */
+  readonly recordedAt: string;
+  readonly tokensBefore: number;
+  readonly tokensAfter: number;
+  readonly messagesBefore: number;
+  readonly messagesAfter: number;
+  /** The summary text produced by this compaction. */
+  readonly summary: string;
+}
+
+export function journalPath(agentId: string, conversationId: string): string {
+  return path.join(getWorkStateDirectory(agentId, conversationId), JOURNAL_FILENAME);
+}
+
+/**
+ * Append one entry. Never throws: losing a journal write must not fail the run it is
+ * describing, since the summary itself is already safely in context.
+ */
+export function appendJournalEntry(
+  agentId: string,
+  conversationId: string,
+  entry: JournalEntry,
+): Effect.Effect<boolean, never, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      const directory = getWorkStateDirectory(agentId, conversationId);
+      await nodeFs.mkdir(directory, { recursive: true, mode: 0o700 });
+      await nodeFs.appendFile(
+        path.join(directory, JOURNAL_FILENAME),
+        `${JSON.stringify(entry)}\n`,
+        "utf-8",
+      );
+      return true;
+    },
+    catch: (error) => error,
+  }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+}
+
+/**
+ * Read the journal, oldest first. Malformed lines are skipped rather than fatal — a
+ * partially written final line should not cost you the entries before it.
+ */
+export function readJournal(
+  agentId: string,
+  conversationId: string,
+): Effect.Effect<JournalEntry[], never, never> {
+  return Effect.tryPromise({
+    try: () => nodeFs.readFile(journalPath(agentId, conversationId), "utf-8"),
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((contents) => {
+      const entries: JournalEntry[] = [];
+      for (const line of contents.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) continue;
+        try {
+          entries.push(JSON.parse(trimmed) as JournalEntry);
+        } catch {
+          // Skip a torn or corrupt line; the rest of the file is still good.
+        }
+      }
+      return entries;
+    }),
+    Effect.catchAll(() => Effect.succeed<JournalEntry[]>([])),
+  );
+}

--- a/src/core/agent/context/work-state-preamble.test.ts
+++ b/src/core/agent/context/work-state-preamble.test.ts
@@ -1,0 +1,104 @@
+import * as nodeFs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { appendJournalEntry } from "./work-journal";
+import { buildWorkStatePreamble } from "./work-state-preamble";
+
+const modelHint = { provider: "openai", modelId: "gpt-4o" };
+const runEffect = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
+  Effect.runPromise(effect);
+
+function entry(summary: string, recordedAt: string) {
+  return {
+    recordedAt,
+    tokensBefore: 100_000,
+    tokensAfter: 30_000,
+    messagesBefore: 64,
+    messagesAfter: 12,
+    summary,
+  };
+}
+
+describe("work state preamble", () => {
+  let jazzHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-preamble-"));
+    previousHome = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = previousHome;
+    await nodeFs.rm(jazzHome, { recursive: true, force: true });
+  });
+
+  it("returns nothing when the conversation has no journal", async () => {
+    const preamble = await runEffect(buildWorkStatePreamble("agent-1", "conv-1", { modelHint }));
+    expect(preamble).toBeUndefined();
+  });
+
+  it("recovers what compaction dropped", async () => {
+    await runEffect(
+      appendJournalEntry(
+        "agent-1",
+        "conv-1",
+        entry("Migrated auth module; tests failing on token refresh.", "2026-08-15T10:00:00.000Z"),
+      ),
+    );
+
+    const preamble = await runEffect(buildWorkStatePreamble("agent-1", "conv-1", { modelHint }));
+
+    expect(preamble?.role).toBe("assistant");
+    expect(preamble?.content).toContain("Migrated auth module");
+    expect(preamble?.content).toContain("token refresh");
+  });
+
+  it("frames the records as claims to verify rather than fact", async () => {
+    await runEffect(
+      appendJournalEntry("agent-1", "conv-1", entry("all done", "2026-08-15T10:00:00.000Z")),
+    );
+
+    const preamble = await runEffect(buildWorkStatePreamble("agent-1", "conv-1", { modelHint }));
+    expect(preamble?.content).toContain("claims to verify");
+  });
+
+  it("keeps the newest records and drops older ones to stay in budget", async () => {
+    for (let index = 0; index < 10; index++) {
+      await runEffect(
+        appendJournalEntry(
+          "agent-1",
+          "conv-1",
+          entry(`record ${index} ` + "detail ".repeat(200), `2026-08-15T10:0${index}:00.000Z`),
+        ),
+      );
+    }
+
+    const preamble = await runEffect(
+      buildWorkStatePreamble("agent-1", "conv-1", { modelHint, tokenBudget: 500 }),
+    );
+
+    expect(preamble?.content).toContain("record 9");
+    expect(preamble?.content).not.toContain("record 0 ");
+    expect(preamble?.content).toContain("omitted to stay within budget");
+  });
+
+  it("keeps at least the most recent record even when it alone exceeds the budget", async () => {
+    await runEffect(
+      appendJournalEntry(
+        "agent-1",
+        "conv-1",
+        entry("huge " + "detail ".repeat(5000), "2026-08-15T10:00:00.000Z"),
+      ),
+    );
+
+    const preamble = await runEffect(
+      buildWorkStatePreamble("agent-1", "conv-1", { modelHint, tokenBudget: 10 }),
+    );
+    expect(preamble?.content).toContain("huge");
+  });
+});

--- a/src/core/agent/context/work-state-preamble.ts
+++ b/src/core/agent/context/work-state-preamble.ts
@@ -1,0 +1,71 @@
+import { Effect } from "effect";
+import type { ChatMessage } from "@/core/types/message";
+import { DEFAULT_TOKEN_COUNTER, type ModelHint } from "./token-counter";
+import { readJournal } from "./work-journal";
+
+/**
+ * Rebuild what a previous session compacted away, for a conversation being resumed.
+ *
+ * Resuming loads persisted *messages*, which for a run that compacted are the
+ * post-compaction messages — everything compaction dropped is already gone. The journal
+ * is the only surviving record of it, so a resumed conversation that ignores the journal
+ * starts blind to work it actually did.
+ *
+ * Framed as a claim to verify rather than as fact: a progress record is written by an
+ * agent mid-task and is habitually optimistic about what was finished.
+ */
+
+/** Ceiling on the preamble, so restoring context cannot itself consume the window. */
+export const WORK_STATE_PREAMBLE_TOKEN_BUDGET = 2_000;
+
+export interface WorkStatePreambleOptions {
+  readonly modelHint: ModelHint;
+  readonly tokenBudget?: number;
+}
+
+/**
+ * Returns a single message summarizing prior sessions, or `undefined` when there is
+ * nothing recorded — in which case resume behaves exactly as it did before.
+ */
+export function buildWorkStatePreamble(
+  agentId: string,
+  conversationId: string,
+  options: WorkStatePreambleOptions,
+): Effect.Effect<ChatMessage | undefined, never, never> {
+  return readJournal(agentId, conversationId).pipe(
+    Effect.map((entries) => {
+      if (entries.length === 0) return undefined;
+
+      const budget = options.tokenBudget ?? WORK_STATE_PREAMBLE_TOKEN_BUDGET;
+
+      // Newest first: the most recent state is the most useful, and older entries are
+      // dropped when the budget runs out rather than truncating the recent one.
+      const kept: string[] = [];
+      let usedTokens = 0;
+      for (let index = entries.length - 1; index >= 0; index--) {
+        const entry = entries[index];
+        if (!entry) continue;
+        const block = `### Session record ${index + 1} (${entry.recordedAt})\n\n${entry.summary}`;
+        const tokens = DEFAULT_TOKEN_COUNTER.countText(block, options.modelHint);
+        if (kept.length > 0 && usedTokens + tokens > budget) break;
+        kept.unshift(block);
+        usedTokens += tokens;
+      }
+
+      const omitted = entries.length - kept.length;
+      const omittedNote =
+        omitted > 0 ? `\n\n(${omitted} earlier record(s) omitted to stay within budget.)` : "";
+
+      return {
+        role: "assistant",
+        content:
+          "## Recovered context from earlier in this conversation\n\n" +
+          "History before this point was compacted away. These are the records written at " +
+          "the time. Treat them as claims to verify, not as established fact — check the " +
+          "current state before relying on anything reported as finished.\n\n" +
+          kept.join("\n\n") +
+          omittedNote,
+      } satisfies ChatMessage;
+    }),
+  );
+}

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -14,6 +14,7 @@ import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { resolveContextThresholds } from "../context/context-thresholds";
+import { logContextRung } from "../context/context-telemetry";
 import {
   CONTEXT_COMPACT_THRESHOLD_RATIO,
   CONTEXT_TRIM_THRESHOLD_RATIO,
@@ -661,8 +662,20 @@ function runIteration(
       actualConversationId,
     );
     state.currentMessages = trimUpdate.messages;
-    if (trimUpdate.result !== undefined && !options.internal) {
-      yield* observer.onHistoryTrimmed(agent.name, trimUpdate.result.messagesRemoved);
+    if (trimUpdate.result !== undefined) {
+      yield* logContextRung(logger, {
+        rung: "trim",
+        agentId: agent.id,
+        conversationId: actualConversationId,
+        tokensBefore: trimUpdate.result.estimatedTokensBefore,
+        tokensAfter: trimUpdate.result.estimatedTokens,
+        budgetTokens: runContextWindowManager.contextBudgetTokens,
+        messagesBefore: trimUpdate.result.originalCount,
+        messagesAfter: trimUpdate.result.trimmedCount,
+      });
+      if (!options.internal) {
+        yield* observer.onHistoryTrimmed(agent.name, trimUpdate.result.messagesRemoved);
+      }
     }
 
     if (completion.toolCalls && completion.toolCalls.length > 0) {

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -21,12 +21,14 @@ import {
   CONTEXT_WARN_THRESHOLD_RATIO,
   ContextWindowManager,
   DEFAULT_CONTEXT_WINDOW_MANAGER,
+  protectedZoneStartIndex,
 } from "../context/context-window-manager";
 import {
   describeContextWindowShortfall,
   resolveEffectiveContextWindow,
 } from "../context/effective-context-window";
 import { Summarizer, type RecursiveRunner } from "../context/summarizer";
+import { clearToolResults } from "../context/tool-result-clearing";
 import {
   beginIteration,
   calibrateTokenCounter,
@@ -114,6 +116,7 @@ interface LoopState {
   recentToolCalls: TrackedToolCall[];
   iterationsUsed: number;
   contextPressureWarned: boolean;
+  toolResultsCleared: boolean;
 }
 
 interface LoopDeps {
@@ -510,6 +513,41 @@ function runIteration(
       yield* observer.onThinking(agent.name, iterationIndex === 0);
     }
 
+    // Cheapest rung first: drop stale raw tool output before spending an LLM call on
+    // summarizing. Gated on `toolResultsCleared` so it runs once per crossing —
+    // rewriting the prefix every turn would reintroduce the cache churn that the
+    // trim-budget fix removed.
+    if (
+      !state.toolResultsCleared &&
+      runContextWindowManager.shouldClearToolResults(state.currentMessages)
+    ) {
+      const before = runContextWindowManager.totalRequestTokens(state.currentMessages);
+      const cleared = clearToolResults(state.currentMessages, {
+        protectedFromIndex: protectedZoneStartIndex(
+          state.currentMessages,
+          DEFAULT_CONTEXT_WINDOW_MANAGER.getConfig().protectedRecentTurns ?? 2,
+        ),
+        modelHint: { provider, modelId: model },
+      });
+      if (cleared.clearedCount > 0) {
+        state.toolResultsCleared = true;
+        state.currentMessages = [
+          state.currentMessages[0],
+          ...cleared.messages.slice(1),
+        ] as typeof state.currentMessages;
+        yield* logContextRung(logger, {
+          rung: "clear",
+          agentId: agent.id,
+          conversationId: actualConversationId,
+          tokensBefore: before,
+          tokensAfter: runContextWindowManager.totalRequestTokens(state.currentMessages),
+          budgetTokens: runContextWindowManager.contextBudgetTokens,
+          messagesBefore: state.currentMessages.length,
+          messagesAfter: state.currentMessages.length,
+        });
+      }
+    }
+
     const contextUsage = runContextWindowManager.usage(state.currentMessages);
     if (contextUsage.shouldWarn && !contextUsage.shouldCompact && !state.contextPressureWarned) {
       state.contextPressureWarned = true;
@@ -836,6 +874,7 @@ export function executeAgentLoop(
           recentToolCalls: [],
           iterationsUsed: 0,
           contextPressureWarned: false,
+          toolResultsCleared: false,
         };
         let finished = false;
         let interrupted = false;

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -13,8 +13,8 @@ import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
-import { resolveContextThresholds } from "../context/context-thresholds";
 import { logContextRung } from "../context/context-telemetry";
+import { resolveContextThresholds } from "../context/context-thresholds";
 import {
   CONTEXT_COMPACT_THRESHOLD_RATIO,
   CONTEXT_TRIM_THRESHOLD_RATIO,

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -36,6 +36,20 @@ Do not write: small talk, one-off task details that only matter for this exchang
 Never save financial account numbers, passwords, API keys, government ID numbers, or health details unless the person is explicitly asking you to store exactly that for their own later reference.
 `;
 
+export const TASK_STATE_INSTRUCTIONS = `
+# Task state
+
+Long conversations get compacted: older messages are replaced by a summary, and detail goes with them. Anything you have not recorded outside the conversation can be lost that way, and you will not notice it happening.
+
+Use update_task_state to keep a running record of where the current task stands — the goal, constraints you must respect, decisions you have made and why, the pieces of work and their status, files you have changed, open questions, and the single next thing you intend to do. Write it when something changes: you settle on a plan, you finish or fail a piece, you decide something worth not revisiting, you learn something that changes the approach. Do not save it up for the end; you may not get an end.
+
+Only the fields you pass are updated, so a small correction is a small call — you never have to restate the whole thing.
+
+This is not memory, and the two must not be mixed. Memory is what stays true about a person or project for weeks: preferences, recurring facts, standing decisions. Task state is where this one task stands right now, and it stops mattering the moment the task is done. "They prefer Bun over npm" is memory. "3 of the 5 route handlers are migrated, the auth one fails on token refresh" is task state.
+
+Mark a work item done only when you have actually run something that confirms it — a test, a build, a command whose output you read. If you believe it works but have not checked, mark it unverified and say what would check it. A record that claims finished work that was never verified is worse than no record, because the next session will trust it.
+`;
+
 export const TOOL_USAGE_GUIDELINES = `
 ## Tool selection priority
 

--- a/src/core/agent/tools/register-tools.ts
+++ b/src/core/agent/tools/register-tools.ts
@@ -14,6 +14,7 @@ import {
 import { createShellCommandTools } from "./shell-tools";
 import { createSkillTools } from "./skill-tools";
 import { createSubagentTools } from "./subagent-tools";
+import { createUpdateTaskStateTool } from "./task-state-tools";
 import { createListTodosTool, createManageTodosTool } from "./todo-tools";
 import {
   CONTEXT_CATEGORY,
@@ -221,6 +222,7 @@ export function registerMemoryTools(): Effect.Effect<void, Error, ToolRegistry> 
 
     yield* registerTool(createViewMemoryTool());
     yield* registerTool(createManageMemoryTool());
+    yield* registerTool(createUpdateTaskStateTool());
   });
 }
 

--- a/src/core/agent/tools/task-state-tools.test.ts
+++ b/src/core/agent/tools/task-state-tools.test.ts
@@ -1,0 +1,106 @@
+import * as nodeFs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { readTaskState } from "@/core/agent/context/task-state";
+import type { ToolExecutionContext } from "@/core/types/tools";
+import { createUpdateTaskStateTool } from "./task-state-tools";
+
+const tool = createUpdateTaskStateTool();
+
+function context(overrides?: Partial<ToolExecutionContext>): ToolExecutionContext {
+  return {
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    ...overrides,
+  } as ToolExecutionContext;
+}
+
+const run = <A>(effect: Effect.Effect<A, never, never>): Promise<A> => Effect.runPromise(effect);
+
+describe("update_task_state", () => {
+  let jazzHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-task-tool-"));
+    previousHome = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = previousHome;
+    await nodeFs.rm(jazzHome, { recursive: true, force: true });
+  });
+
+  it("writes the fields it is given", async () => {
+    const result = (await run(
+      tool.execute({ goal: "migrate routes", nextStep: "start with auth" }, context()) as any,
+    )) as any;
+
+    expect(result.success).toBe(true);
+    const state = await run(readTaskState("agent-1", "conv-1"));
+    expect(state?.goal).toBe("migrate routes");
+    expect(state?.nextStep).toBe("start with auth");
+    expect(state?.updatedAt).toBeDefined();
+  });
+
+  it("patches without clobbering fields it was not given", async () => {
+    await run(tool.execute({ goal: "migrate routes", decisions: ["keep v1"] }, context()) as any);
+    await run(tool.execute({ nextStep: "auth route" }, context()) as any);
+
+    const state = await run(readTaskState("agent-1", "conv-1"));
+    expect(state?.goal).toBe("migrate routes");
+    expect(state?.decisions).toEqual(["keep v1"]);
+    expect(state?.nextStep).toBe("auth route");
+  });
+
+  it("reads back current state when called with no fields", async () => {
+    await run(tool.execute({ goal: "migrate routes" }, context()) as any);
+    const result = (await run(tool.execute({}, context()) as any)) as any;
+
+    expect(result.success).toBe(true);
+    expect(result.result.formatted).toContain("migrate routes");
+  });
+
+  it("records verification status on work items", async () => {
+    await run(
+      tool.execute(
+        {
+          workItems: [
+            { description: "auth route", status: "done", verifiedBy: "bun test" },
+            { description: "billing route", status: "unverified" },
+          ],
+        },
+        context(),
+      ) as any,
+    );
+
+    const state = await run(readTaskState("agent-1", "conv-1"));
+    expect(state?.workItems?.[0]?.status).toBe("done");
+    expect(state?.workItems?.[0]?.verifiedBy).toBe("bun test");
+    expect(state?.workItems?.[1]?.status).toBe("unverified");
+  });
+
+  it("fails clearly when there is no conversation to attach state to", async () => {
+    const result = (await run(
+      tool.execute({ goal: "x" }, context({ conversationId: undefined })) as any,
+    )) as any;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No conversation");
+  });
+
+  it("keeps state out of the memory directory", async () => {
+    await run(tool.execute({ goal: "migrate routes" }, context()) as any);
+
+    const memoryDir = path.join(jazzHome, "memory");
+    const memoryExists = await nodeFs
+      .stat(memoryDir)
+      .then(() => true)
+      .catch(() => false);
+    expect(memoryExists).toBe(false);
+  });
+});

--- a/src/core/agent/tools/task-state-tools.ts
+++ b/src/core/agent/tools/task-state-tools.ts
@@ -1,0 +1,122 @@
+import { Effect } from "effect";
+import { z } from "zod";
+import {
+  formatTaskState,
+  patchTaskState,
+  readTaskState,
+  type TaskState,
+} from "@/core/agent/context/task-state";
+import type { Tool } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionResult } from "@/core/types/tools";
+import { defineTool, makeZodValidator } from "./base-tool";
+
+const workItemSchema = z.object({
+  description: z.string().min(1).describe("What this piece of work is."),
+  status: z
+    .enum(["pending", "in_progress", "unverified", "done", "failing"])
+    .describe(
+      'Use "done" only when you have actually run something that confirms it works. ' +
+        'If you believe it is finished but have not verified it, use "unverified".',
+    ),
+  verifiedBy: z
+    .string()
+    .optional()
+    .describe(
+      'What you ran to verify it, e.g. "bun test src/foo.test.ts". Required in spirit for "done".',
+    ),
+});
+
+const updateTaskStateParameters = z
+  .object({
+    goal: z.string().optional().describe("What this task is ultimately trying to achieve."),
+    constraints: z
+      .array(z.string())
+      .optional()
+      .describe("Requirements or limits that must hold, e.g. 'must not change the public API'."),
+    decisions: z
+      .array(z.string())
+      .optional()
+      .describe("Choices made and why, so a later session does not relitigate them."),
+    workItems: z.array(workItemSchema).optional().describe("The pieces of work and their status."),
+    filesTouched: z.array(z.string()).optional().describe("Paths you have created or modified."),
+    openQuestions: z.array(z.string()).optional().describe("Unresolved uncertainties."),
+    nextStep: z.string().optional().describe("The single next action you intend to take."),
+  })
+  .strict();
+
+type UpdateTaskStateArgs = z.infer<typeof updateTaskStateParameters>;
+
+/**
+ * Record where the current task stands, so it survives compaction and process death.
+ *
+ * Deliberately separate from memory: memory is what stays true about a person or project
+ * for weeks, this is what is true about this task right now. Routing task detail into
+ * memory would pollute it, which is why `MEMORY_INSTRUCTIONS` tells the agent not to.
+ */
+export function createUpdateTaskStateTool(): Tool<never> {
+  return defineTool<never, UpdateTaskStateArgs>({
+    name: "update_task_state",
+    description:
+      "Record where you are in the current task so it survives context compaction and " +
+      "picking the work back up later. Call it when you settle on a goal or plan, finish " +
+      "or fail a piece of work, make a decision worth not revisiting, or learn something " +
+      "that changes the plan — not at the end, since you may never get a clean ending. " +
+      "Only the fields you pass are changed; the rest are left as they were. This is for " +
+      "THIS task's state, not durable facts about the person or project — those belong in " +
+      "memory. Mark work 'done' only when you have run something that confirms it; use " +
+      "'unverified' when you believe it works but have not checked.",
+    parameters: updateTaskStateParameters,
+    riskLevel: "low-risk",
+    hidden: false,
+    validate: makeZodValidator(updateTaskStateParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const conversationId = context.conversationId;
+        if (!conversationId) {
+          return {
+            success: false,
+            result: null,
+            error: "No conversation is active, so there is no task state to update.",
+          } satisfies ToolExecutionResult;
+        }
+
+        // Only keys actually supplied become a patch — an omitted field must not be
+        // read as "clear this".
+        const patch: Partial<TaskState> = {
+          ...(args.goal !== undefined && { goal: args.goal }),
+          ...(args.constraints !== undefined && { constraints: args.constraints }),
+          ...(args.decisions !== undefined && { decisions: args.decisions }),
+          ...(args.workItems !== undefined && { workItems: args.workItems }),
+          ...(args.filesTouched !== undefined && { filesTouched: args.filesTouched }),
+          ...(args.openQuestions !== undefined && { openQuestions: args.openQuestions }),
+          ...(args.nextStep !== undefined && { nextStep: args.nextStep }),
+        };
+
+        if (Object.keys(patch).length === 0) {
+          const current = yield* readTaskState(context.agentId, conversationId);
+          return {
+            success: true,
+            result: {
+              formatted: formatTaskState(current) ?? "No task state recorded yet.",
+              state: current ?? {},
+            },
+          } satisfies ToolExecutionResult;
+        }
+
+        const merged = yield* patchTaskState(
+          context.agentId,
+          conversationId,
+          patch,
+          new Date().toISOString(),
+        );
+
+        return {
+          success: true,
+          result: {
+            formatted: formatTaskState(merged) ?? "Task state updated.",
+            state: merged,
+          },
+        } satisfies ToolExecutionResult;
+      }),
+  });
+}

--- a/src/core/types/message.ts
+++ b/src/core/types/message.ts
@@ -38,6 +38,18 @@ export interface ChatMessage {
    */
   tool_call_id?: string;
   /**
+   * Set when this message's original content has been replaced by a placeholder to
+   * reclaim context (see `clearToolResults`). Marks the message as already reclaimed
+   * so later passes skip it, and distinguishes a stub from a genuinely short result.
+   */
+  cleared?: true;
+  /**
+   * Marks an assistant message as a compaction summary rather than model output.
+   * Identified by flag rather than position so summarization can carry it forward
+   * as prior state instead of re-summarizing its own previous summary.
+   */
+  kind?: "summary";
+  /**
    * For role === "assistant": include tool calls emitted by the model so that
    * subsequent tool messages are valid according to the OpenAI API.
    *

--- a/src/core/utils/paths.ts
+++ b/src/core/utils/paths.ts
@@ -109,6 +109,18 @@ function getEmbeddedAssetRoot(): string | null {
 }
 
 /**
+ * Directory holding per-conversation working state: the compaction journal and the
+ * agent-maintained task state.
+ *
+ * Deliberately separate from the memory directory. Memory is what stays true about a
+ * person or project across conversations; this is where one task stands right now, and
+ * it is discarded when that task is done.
+ */
+export function getWorkStateDirectory(agentId: string, conversationId: string): string {
+  return path.join(getJazzHomeDirectory(), "work", agentId, conversationId);
+}
+
+/**
  * Finds the `jazz-ai` package root containing `package.json`.
  *
  * @returns The package root directory, or `null` when it cannot be found.

--- a/src/services/chat/commands/constants.ts
+++ b/src/services/chat/commands/constants.ts
@@ -17,6 +17,10 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "compact", description: "Summarize background history to save tokens" },
   { name: "config", description: "Show or modify agent configuration" },
   { name: "context", description: "Show context window usage and token breakdown" },
+  {
+    name: "work",
+    description: "Show saved task state and compaction records ('/work clear' discards them)",
+  },
   { name: "copy", description: "Copy the last agent response to clipboard" },
   { name: "cost", description: "Show conversation token usage and estimated cost" },
   { name: "exit", description: "Exit the chat" },

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -9,6 +9,7 @@ import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { sortAgents } from "@/core/agent/agent-sort";
 import { resolveContextThresholds } from "@/core/agent/context/context-thresholds";
 import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
+import { DEFAULT_TOKEN_COUNTER } from "@/core/agent/context/token-counter";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { ProviderName } from "@/core/constants/models";
@@ -1834,10 +1835,14 @@ function handleContextCommand(
     });
     const contextWindow = effectiveContextWindow.tokens;
 
-    // Get tool definitions for more accurate tool token estimation
+    // Prefer the overhead the provider actually reported (tool schemas plus its own
+    // scaffolding) so this display matches the number that triggers compaction.
+    // Fall back to estimating from the schemas before any usage report has arrived.
     const toolDefinitions = yield* toolRegistry.getToolDefinitions();
     const toolDefinitionsJson = JSON.stringify(toolDefinitions);
-    const toolDefinitionTokens = Math.ceil(toolDefinitionsJson.length / 4);
+    const measuredOverhead = DEFAULT_TOKEN_COUNTER.overheadFor({ provider, modelId });
+    const toolDefinitionTokens =
+      measuredOverhead > 0 ? measuredOverhead : Math.ceil(toolDefinitionsJson.length / 4);
 
     // Calculate usage breakdown
     const usage = calculateContextUsage(conversationHistory, contextWindow, compactThresholdRatio);

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -9,7 +9,9 @@ import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { sortAgents } from "@/core/agent/agent-sort";
 import { resolveContextThresholds } from "@/core/agent/context/context-thresholds";
 import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-context-window";
+import { formatTaskState, readTaskState } from "@/core/agent/context/task-state";
 import { DEFAULT_TOKEN_COUNTER } from "@/core/agent/context/token-counter";
+import { clearWorkState, readJournal, workStateSizeBytes } from "@/core/agent/context/work-journal";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { ProviderName } from "@/core/constants/models";
@@ -123,6 +125,9 @@ export function handleSpecialCommand(
 
       case "context":
         return yield* handleContextCommand(terminal, agent, conversationHistory);
+
+      case "work":
+        return yield* handleWorkCommand(terminal, agent, context.conversationId, command.args);
 
       case "cost":
         return yield* handleCostCommand(terminal, agent, context.sessionUsage);
@@ -1803,6 +1808,68 @@ function generateContextGrid(usage: ContextUsageBreakdown): string[] {
   }
 
   return rows;
+}
+
+/**
+ * Handle /work command — show or discard the working state kept for this conversation.
+ *
+ * Working state is written by compaction and by the agent itself, so without a way to
+ * read it you cannot tell whether what a resumed session "remembers" is accurate, and
+ * without a way to clear it a stale record follows the conversation forever.
+ */
+function handleWorkCommand(
+  terminal: TerminalService,
+  agent: CommandContext["agent"],
+  conversationId: string | undefined,
+  args: string[],
+): Effect.Effect<CommandResult, never, never> {
+  return Effect.gen(function* () {
+    if (!conversationId) {
+      yield* terminal.info("No active conversation, so there is no working state.");
+      return { shouldContinue: true };
+    }
+
+    if (args[0] === "clear") {
+      const cleared = yield* clearWorkState(agent.id, conversationId);
+      yield* terminal.log(
+        cleared ? fmt.heading("Working state cleared") : "Nothing to clear for this conversation.",
+      );
+      return { shouldContinue: true };
+    }
+
+    const state = yield* readTaskState(agent.id, conversationId);
+    const entries = yield* readJournal(agent.id, conversationId);
+    const sizeBytes = yield* workStateSizeBytes(agent.id, conversationId);
+
+    yield* terminal.log(fmt.heading("Working state"));
+
+    const formatted = formatTaskState(state);
+    if (formatted) {
+      yield* terminal.log(`\n${formatted}`);
+    } else {
+      yield* terminal.log("\nNo task state recorded yet.");
+    }
+
+    if (entries.length > 0) {
+      yield* terminal.log(
+        `\n${entries.length} compaction record(s), most recent ${entries[entries.length - 1]?.recordedAt}.`,
+      );
+      const latest = entries[entries.length - 1];
+      if (latest) {
+        const preview =
+          latest.summary.length > 500 ? `${latest.summary.slice(0, 500)}…` : latest.summary;
+        yield* terminal.log(`\n${preview}`);
+      }
+    } else {
+      yield* terminal.log("\nNo compaction has happened in this conversation yet.");
+    }
+
+    yield* terminal.log(
+      `\n${(sizeBytes / 1024).toFixed(1)}KB stored. Use \`/work clear\` to discard it.`,
+    );
+
+    return { shouldContinue: true };
+  });
 }
 
 /**

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -45,6 +45,8 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "skills", args };
     case "context":
       return { type: "context", args };
+    case "work":
+      return { type: "work", args };
     case "cost":
       return { type: "cost", args };
     case "workflows":

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -19,6 +19,7 @@ export type CommandType =
   | "config"
   | "skills"
   | "context"
+  | "work"
   | "cost"
   | "workflows"
   | "stats"


### PR DESCRIPTION
Implements both planning documents in full — the compaction-hardening plan and the durable-task-state plan. Ten phases, seven commits, sequenced so `git bisect` still works if a behavioural regression shows up.

Targets `main` directly — #339 merged while this was in progress, and this branch has been rebased onto current `main`, resolving against #349 (configurable thresholds). The compaction path now uses **#349's configurable ratio** for its threshold and **this PR's measured overhead** for the token count; both were kept rather than one overwriting the other.

## The ladder, after this PR

Four mechanisms share one budget and escalate by cost:

| Rung | Fires at | Costs | Effect |
| --- | --- | --- | --- |
| Clear tool results | 65% | nothing | Old raw tool output replaced by a placeholder, structure kept |
| Warn | 70% | nothing | User *and* agent told; agent nudged to consolidate |
| Compact | 80% | one LLM call | Older history merged into the running summary |
| Trim | 95% | lossy | Messages dropped unsummarized — the floor, not the path |

## What each commit does

**1 · Count tool schemas, and give the summarizer its arguments.** `countMessages` summed messages only, so tool schemas — 10–30k tokens with MCP attached — never entered the accounting. On OpenAI families the tokenizer path never consulted the calibrated ratio, leaving them entirely uncounted; elsewhere `calibrate()` divided message chars by a `promptTokens` that *included* the schemas, depressing the ratio and inflating estimates in proportion to message size rather than to the overhead being missed. Overhead is now measured (`promptTokens − estimatedMessageTokens`) and the ratio calibrated against the message share only. An agent could previously believe it was at 79% when it was at 102%. Also: the summarizer transcript rendered `[Tool Calls: read_file]` — names only — while its persona is told to preserve exact file paths. And one structured event per rung, so the ladder can be measured rather than guessed at.

**2 · Clear stale tool results.** A long run's tokens are mostly raw tool output, and most stops mattering once the model has read it. Content is replaced with a placeholder while the message and `tool_call_id` survive — deleting would orphan the `tool_calls` that reference it. Five most recent results and the protected turns are never touched. Fires once per crossing, not per turn: clearing rewrites the prefix, and doing it continuously would reintroduce the cache churn #339 removed.

**3 · Merge into the prior summary instead of re-summarizing it.** The previous summary sat at index 1 and was fed back through the summarizer every cycle, so drift compounded. Summaries are now marked (`kind: "summary"`), identified by flag rather than position, and handed to the summarizer as prior state to merge into.

**4 · Bound the summarizer's own input.** `historyText` could be most of the *parent's* window in one message, with no check the summarizer model could hold it. It is now folded in chunks sized to the summarizer's own window, reusing the merge prompt. Also stops the summarizer inheriting the parent's `numCtx`/`maxContextTokens` when it runs a different model.

**5 · Journal each compaction, restore it on resume.** Compaction already produces a summary and then folds it into later ones, so the only copy of an early summary lived inside a continuously rewritten document. Each is now appended to `journal.jsonl` first — no extra LLM call, no extra tokens. Resuming loads *post*-compaction messages, so what compaction dropped was simply absent; the journal is folded back in as a bounded (~2k token) preamble, framed as claims to verify rather than fact.

**6 · Agent-maintained task state, seeding compaction.** Memory's own instructions tell the agent not to store "one-off task details that only matter for this exchange" — exactly what compaction destroys — so there was nowhere for it to live. `update_task_state` records goal, constraints, decisions, work items, files touched, open questions, next step. JSON because it is edited repeatedly; patched field-by-field so a small correction cannot drop the rest. Compaction reads it and tells the summarizer what is already durable.

**7 · Lifecycle and `/work`.** Read the state, or `/work clear` to discard it. Journals capped per conversation, pruned oldest-first.

## Two decisions worth reviewing

**Work items are `unverified` until something is run.** The prompt requires `done` to mean a test or command was actually executed. Agents habitually mark work complete on the strength of having written it, which turns a progress record into a confident lie for the next session — the anti-pattern Anthropic's harness guidance calls out directly.

**Repo-local progress files are NOT implemented.** Anthropic recommends `claude-progress.txt` in the working tree plus descriptive commits, which is genuinely better for coding agents — visible in diffs, survives `~/.jazz` being wiped. But writing into someone's repo uncommanded is intrusive and wrong for the everyday-assistant agents this product targets. Everything is under `~/.jazz/work/` instead. **This is a product call I deliberately left open** rather than defaulting into.

## Verifying

```bash
bun test && bun run typecheck && bun run lint
```

1855 tests pass. New coverage: overhead convergence (asserting it stabilises rather than oscillating between ratio and overhead), tool-result clearing never orphaning a result from its call, idempotency, prior-summary extraction, chunk folding, journal survival of a torn write, patch semantics, and the two stores staying in their own lanes.

## What this does not do

The **kill test** — interrupt a run at 60%, resume, ask what remains — is the single most informative check for this work and it belongs in the eval harness, not the unit suite. Same for the **blind-successor test**: hand `state.json` and the journal to a fresh agent and see whether it can continue. Both plans say so; neither is implemented here. Until they exist, the fidelity claims in this PR are argued rather than measured.
