### PR TITLE
fix(telemetry): stop double-counting run cost and emitting junk traces

### DIFF
--- a/src/services/telemetry/otlp-mapping.ts
+++ b/src/services/telemetry/otlp-mapping.ts
@@ -156,36 +156,47 @@ export function eventToAttributes(event: TelemetryEvent, captureContent: boolean
   const data = event.data;
   const consumed = new Set<string>();
 
-  const provider = data["provider"];
-  if (typeof provider === "string") {
-    attributes.push(stringAttribute("gen_ai.system", provider));
-    consumed.add("provider");
-  }
+  // GenAI attributes describe one model call. An agent run is a rollup of many,
+  // so tagging it with them makes observability backends read it as a further
+  // LLM call and price its totals on top of the calls they already summarise —
+  // double-counting every run's tokens and cost. The rollup keeps its numbers
+  // under jazz.* instead.
+  const describesSingleLLMCall = event.type === "llm_usage" || event.type === "llm_retry";
 
-  const model = data["model"];
-  if (typeof model === "string") {
-    attributes.push(stringAttribute("gen_ai.request.model", model));
-    attributes.push(stringAttribute("gen_ai.response.model", model));
-    consumed.add("model");
-  }
+  if (describesSingleLLMCall) {
+    const provider = data["provider"];
+    if (typeof provider === "string") {
+      attributes.push(stringAttribute("gen_ai.system", provider));
+      consumed.add("provider");
+    }
 
-  if (event.type === "llm_usage" || event.type === "agent_run_completed") {
+    const model = data["model"];
+    if (typeof model === "string") {
+      attributes.push(stringAttribute("gen_ai.request.model", model));
+      attributes.push(stringAttribute("gen_ai.response.model", model));
+      consumed.add("model");
+    }
+
     attributes.push(stringAttribute("gen_ai.operation.name", "chat"));
   }
 
   const usage = data["usage"];
   if (usage && typeof usage === "object") {
     const usageRecord = usage as Record<string, unknown>;
-    const promptTokens = usageRecord["promptTokens"];
-    const completionTokens = usageRecord["completionTokens"];
-    if (typeof promptTokens === "number") {
-      attributes.push(intAttribute("gen_ai.usage.input_tokens", promptTokens));
+
+    if (describesSingleLLMCall) {
+      const promptTokens = usageRecord["promptTokens"];
+      const completionTokens = usageRecord["completionTokens"];
+      if (typeof promptTokens === "number") {
+        attributes.push(intAttribute("gen_ai.usage.input_tokens", promptTokens));
+      }
+      if (typeof completionTokens === "number") {
+        attributes.push(intAttribute("gen_ai.usage.output_tokens", completionTokens));
+      }
     }
-    if (typeof completionTokens === "number") {
-      attributes.push(intAttribute("gen_ai.usage.output_tokens", completionTokens));
-    }
-    // The remaining usage fields (cache, reasoning, tool-token estimates) have
-    // no semconv equivalent and stay under jazz.usage.*.
+
+    // Everything else (cache, reasoning, tool-token estimates, and the run
+    // rollup's totals) has no semconv equivalent and stays under jazz.usage.*.
     flattenData(usageRecord, "jazz.usage.", new Set(), captureContent, attributes);
     consumed.add("usage");
   }

--- a/src/services/telemetry/otlp-trace-mapping.test.ts
+++ b/src/services/telemetry/otlp-trace-mapping.test.ts
@@ -110,21 +110,11 @@ describe("toSpan", () => {
   });
 
   it("makes an event with neither run nor conversation its own root span", () => {
-    const span = toSpan(makeEvent("command_executed", { command: "agent list" }), false);
+    const span = toSpan(makeEvent("custom", { note: "standalone" }), false);
 
     expect(span.traceId).toHaveLength(32);
-    expect(span.name).toBe("jazz agent list");
     // Parenting it to a run root that will never be emitted would orphan it.
     expect(span.parentSpanId).toBeUndefined();
-  });
-
-  it("still parents a run-scoped command to its run", () => {
-    const span = toSpan(
-      makeEvent("command_executed", { command: "run", runId: "run-1", durationMs: 10 }),
-      false,
-    );
-
-    expect(span.parentSpanId).toBe(rootSpanIdForRun("run-1"));
   });
 
   it("carries the GenAI attributes from the log mapping", () => {
@@ -149,6 +139,100 @@ describe("isSpanEvent", () => {
   it("excludes agent_run_started, whose span comes from the terminal event", () => {
     expect(isSpanEvent(makeEvent("agent_run_started", {}))).toBe(false);
     expect(isSpanEvent(makeEvent("agent_run_completed", {}))).toBe(true);
+  });
+
+  it("excludes command_executed, which would emit a junk trace beside every run", () => {
+    expect(isSpanEvent(makeEvent("command_executed", { command: "run" }))).toBe(false);
+  });
+});
+
+describe("run rollup spans do not double-count usage", () => {
+  const usage = { promptTokens: 11654, completionTokens: 237, totalTokens: 11891 };
+
+  it("keeps the run rollup free of GenAI usage attributes", () => {
+    const span = toSpan(
+      makeEvent("agent_run_completed", {
+        runId: "run-1",
+        agentName: "researcher",
+        provider: "openai",
+        model: "gpt-5.4-nano",
+        durationMs: 6000,
+        usage,
+      }),
+      false,
+    );
+
+    const keys = span.attributes.map((attribute) => attribute.key);
+    // Any gen_ai.* on the rollup makes a backend price it as a further LLM call,
+    // on top of the per-request spans it summarises.
+    expect(keys.filter((key) => key.startsWith("gen_ai."))).toEqual([]);
+    // The totals are still reported, just not as semconv usage.
+    expect(keys).toContain("jazz.usage.promptTokens");
+    expect(keys).toContain("jazz.model");
+  });
+
+  it("keeps GenAI usage on the per-request span", () => {
+    const span = toSpan(
+      makeEvent("llm_usage", {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4-nano",
+        durationMs: 3538,
+        usage,
+      }),
+      false,
+    );
+
+    const attributes = Object.fromEntries(
+      span.attributes.map((attribute) => [attribute.key, Object.values(attribute.value)[0]]),
+    );
+    expect(attributes["gen_ai.usage.input_tokens"]).toBe("11654");
+    expect(attributes["gen_ai.usage.output_tokens"]).toBe("237");
+    expect(attributes["gen_ai.request.model"]).toBe("gpt-5.4-nano");
+  });
+
+  it("totals across per-request spans equal the rollup, counted once", () => {
+    const events = [
+      makeEvent(
+        "llm_usage",
+        { runId: "run-1", model: "gpt-5.4-nano", durationMs: 3538, usage },
+        { id: "e1" },
+      ),
+      makeEvent(
+        "llm_usage",
+        {
+          runId: "run-1",
+          model: "gpt-5.4-nano",
+          durationMs: 2284,
+          usage: { promptTokens: 10819, completionTokens: 58, totalTokens: 10877 },
+        },
+        { id: "e2" },
+      ),
+      makeEvent(
+        "agent_run_completed",
+        {
+          runId: "run-1",
+          durationMs: 6158,
+          usage: { promptTokens: 22473, completionTokens: 295, totalTokens: 22768 },
+        },
+        { id: "e3" },
+      ),
+    ];
+
+    const payload = buildTracesPayload(events, {
+      serviceName: "jazz",
+      serviceVersion: "1.0.0",
+      captureContent: false,
+    });
+
+    const spans = payload.resourceSpans[0]!.scopeSpans[0]!.spans;
+    const billedInput = spans
+      .flatMap((span) => span.attributes)
+      .filter((attribute) => attribute.key === "gen_ai.usage.input_tokens")
+      .reduce((total, attribute) => total + Number(Object.values(attribute.value)[0]), 0);
+
+    // 11654 + 10819 — the rollup's 22473 must not be added a second time.
+    expect(billedInput).toBe(22473);
   });
 });
 

--- a/src/services/telemetry/otlp-trace-mapping.ts
+++ b/src/services/telemetry/otlp-trace-mapping.ts
@@ -98,10 +98,6 @@ function spanNameOf(event: TelemetryEvent): string {
       const toolName = data["toolName"];
       return typeof toolName === "string" ? `tool ${toolName}` : "tool";
     }
-    case "command_executed": {
-      const command = data["command"];
-      return typeof command === "string" ? `jazz ${command}` : "command";
-    }
     default:
       return event.type;
   }
@@ -117,12 +113,19 @@ const ERROR_EVENT_TYPES = new Set(["agent_run_failed", "tool_error"]);
 /**
  * Event types that do not become spans.
  *
- * `agent_run_started` is deliberately excluded: the run's span is built entirely
- * from the terminal event, which carries `durationMs`. Deriving both endpoints
- * from one event keeps the mapping stateless — no correlation buffer waiting for
- * a matching start, and nothing lost when a process exits mid-run.
+ * `agent_run_started` is excluded because the run's span is built entirely from
+ * the terminal event, which carries `durationMs`. Deriving both endpoints from
+ * one event keeps the mapping stateless — no correlation buffer waiting for a
+ * matching start, and nothing lost when a process exits mid-run.
+ *
+ * `command_executed` is excluded because a CLI invocation is not agent work. It
+ * carries no run id, so it could only ever be its own root, which meant every
+ * command emitted a second single-span trace next to the run it wrapped — half
+ * the trace list was noise. Commands that spawn no run (`jazz agent list`) now
+ * produce no trace at all, which is the honest answer: there was nothing to
+ * observe. The event is still recorded locally and exported as a log record.
  */
-const NON_SPAN_EVENT_TYPES = new Set(["agent_run_started"]);
+const NON_SPAN_EVENT_TYPES = new Set(["agent_run_started", "command_executed"]);
 
 export function isSpanEvent(event: TelemetryEvent): boolean {
   return !NON_SPAN_EVENT_TYPES.has(event.type);


### PR DESCRIPTION
## What & why

Two bugs in the OTLP trace mapping from #346, both obvious the moment real runs reached a live Langfuse project.

**Cost and token counts were exactly doubled.** The agent-run rollup span carried `gen_ai.*` attributes, so an observability backend reads it as one more LLM call and prices its totals *on top of* the per-request spans it summarises. A run that cost $0.0049 reported $0.0097. GenAI attributes now describe a single model call only; the rollup keeps its totals under `jazz.usage.*` and renders as a plain span. Anyone already exporting to Langfuse has inflated cost history for the affected period.

**Every CLI invocation emitted a junk trace.** `command_executed` became its own root span, producing a second single-observation trace beside the run it wrapped — half the trace list was noise. It carries no run id, so it could never have parented to the run correctly. It is now log-only: commands that spawn no agent run produce no trace at all, which is the honest answer, and the event is still recorded locally and exported as a log record.

## How to verify

- Point Jazz at a collector or Langfuse, run an agent that makes two or more LLM calls, and confirm the trace's total cost equals the sum of the individual `chat <model>` observations — not twice it.
- Confirm the run's root observation renders as a plain span with no token counts, while still exposing the rollup under `jazz.usage.*`.
- Confirm exactly one trace per run, with no separate `jazz run` trace beside it.
- Run a command that starts no agent (`jazz agent list`) with export configured and confirm no trace is created, while the `command_executed` row still appears in `~/.jazz/telemetry/events/*.ndjson`.
- Confirm tool calls still appear as child spans under the run.

## Verified against a live backend

Same two-call run before and after, in Langfuse Cloud:

| | before | after |
|---|---|---|
| run root observation | `GENERATION`, 22473 input tokens, priced | `SPAN`, 0 tokens, $0 |
| trace total cost | $0.00972 | $0.00496 |
| stray `jazz run` trace | present | gone |
