### PR TITLE
chore(ci): run PR review and assistant on gpt-5.4-mini

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -2,11 +2,11 @@
   "id": "ci-reviewer",
   "name": "ci-reviewer",
   "description": "CI code review agent focused on intent, behavior, and risk",
-  "model": "inclusionai/ling-3.0-flash:free",
+  "model": "openai/gpt-5.4-mini",
   "config": {
     "persona": "coder",
-    "llmProvider": "openrouter",
-    "llmModel": "inclusionai/ling-3.0-flash:free",
+    "llmProvider": "openai",
+    "llmModel": "gpt-5.4-mini",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",

--- a/.github/jazz/agents/pr-assistant.json
+++ b/.github/jazz/agents/pr-assistant.json
@@ -2,11 +2,11 @@
   "id": "pr-assistant",
   "name": "pr-assistant",
   "description": "Pull request assistant agent for /jazz PR comments",
-  "model": "inclusionai/ling-3.0-flash:free",
+  "model": "openai/gpt-5.4-mini",
   "config": {
     "persona": "coder",
-    "llmProvider": "openrouter",
-    "llmModel": "inclusionai/ling-3.0-flash:free",
+    "llmProvider": "openai",
+    "llmModel": "gpt-5.4-mini",
     "reasoningEffort": "medium",
     "tools": [
       "context_info",

--- a/.github/workflows/jazz.yml
+++ b/.github/workflows/jazz.yml
@@ -535,7 +535,7 @@ jobs:
   # On-demand PR assistant — triggered by a /jazz comment or manual workflow dispatch.
   assistant:
     # Depends on code-review too (not just resolve) so the two jazz jobs don't
-    # burst the same free OpenRouter model concurrently. code-review no longer
+    # burst the same provider account concurrently. code-review no longer
     # hard-fails on provider errors/rate limits, but `always()` guards against
     # it being skipped or cancelled for any other reason.
     needs: [resolve, code-review]


### PR DESCRIPTION
## What changes

Both Jazz agents that run in CI on pull requests — `ci-reviewer` (inline code review) and `pr-assistant` (`/jazz` comment replies) — now run on **OpenAI `gpt-5.4-mini`** instead of the free OpenRouter model `inclusionai/ling-3.0-flash:free`.

## Why

The free OpenRouter tier was the cheap default, not a quality choice: it rate-limits under concurrency and the review quality is noticeably weaker than a frontier mini model. `gpt-5.4-mini` is the same model the `eval-judge` and `eval-ceiling` agents already use, so CI review now matches the model the evals are calibrated against.

The agents call the OpenAI provider directly rather than routing through OpenRouter. `OPENAI_API_KEY` is already set in the repo's Actions secrets and already exported to both jobs, so no workflow secret or wiring change was needed.

## Impact

- PR review comments will be posted by `gpt-5.4-mini` — the model label in the review comment footer changes to *Model: openai/gpt-5.4-mini*.
- Reviews now cost real tokens per PR instead of running free. Worth watching the spend for a few PRs.
- The `assistant` job still waits on `code-review` so the two don't hit the provider concurrently; its explanatory comment referenced "the same free OpenRouter model" and has been corrected.

## Verification

Opening this PR triggers the `code-review` job, so this branch reviews itself end-to-end on the new model. Check that:

1. The Jazz job succeeds (no provider auth or rate-limit error in the log).
2. A `## Jazz Code Review` comment lands on this PR with the `openai/gpt-5.4-mini` footer.
3. Commenting `/jazz what changed here?` gets a reply from the assistant job on the same model.
