### PR TITLE
fix(ui): stop prompt dismissal from cropping the previous response

### DIFF
--- a/src/cli/ui/prompt-frame-erase.test.ts
+++ b/src/cli/ui/prompt-frame-erase.test.ts
@@ -1,0 +1,143 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test } from "bun:test";
+import { Box, Static, Text, render } from "ink";
+import React from "react";
+import { INK_RENDER_OPTIONS } from "@/services/terminal";
+
+/**
+ * Regression: dismissing a prompt used to crop the tail of the previous
+ * agent response out of scrollback.
+ *
+ * `store.setPrompt(null)` called Ink's `instance.clear()` to erase the prompt
+ * frame eagerly. `Ink.clear()` erases the frame and then re-syncs log-update
+ * to believe those lines are still painted, so the next render erased the
+ * same line count a second time — walking (frameHeight - 1) lines up into
+ * settled scrollback and overwriting them with the next entry.
+ *
+ * These tests pin the two halves of the fix: Ink cleans up a shrinking frame
+ * on its own, and it only does so once.
+ */
+
+const ERASE_LINE = "[2K";
+
+class FakeTty extends EventEmitter {
+  isTTY = true;
+  columns = 80;
+  rows = 30;
+  writes: string[] = [];
+  write(data: string): boolean {
+    this.writes.push(data);
+    return true;
+  }
+  get writableLength(): number {
+    return 0;
+  }
+}
+
+function createFakeStdin(): NodeJS.ReadStream {
+  const stdin = new EventEmitter() as unknown as NodeJS.ReadStream & { setRawMode: () => void };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = (() => stdin) as NodeJS.ReadStream["resume"];
+  stdin.pause = (() => stdin) as NodeJS.ReadStream["pause"];
+  stdin.ref = (() => stdin) as NodeJS.ReadStream["ref"];
+  stdin.unref = (() => stdin) as NodeJS.ReadStream["unref"];
+  stdin.read = (() => null) as NodeJS.ReadStream["read"];
+  return stdin;
+}
+
+const PROMPT_FRAME_LINES = ["PROMPT-A", "PROMPT-B", "PROMPT-C", "FOOTER"];
+
+function countErasedLines(writes: readonly string[]): number {
+  return writes.join("").split(ERASE_LINE).length - 1;
+}
+
+interface Harness {
+  stdout: FakeTty;
+  dismissPromptAndEcho: () => void;
+  unmount: () => void;
+}
+
+function mountHarness(): Harness {
+  const stdout = new FakeTty();
+  let setPromptOpen: (open: boolean) => void = () => {};
+  let setEntries: (update: (prev: readonly string[]) => string[]) => void = () => {};
+
+  function Harness(): React.ReactElement {
+    const [entries, updateEntries] = React.useState<readonly string[]>([
+      "response line 1",
+      "response line 2",
+    ]);
+    const [promptOpen, updatePromptOpen] = React.useState(true);
+    setEntries = updateEntries;
+    setPromptOpen = updatePromptOpen;
+    return React.createElement(
+      Box,
+      { flexDirection: "column" },
+      React.createElement(Static, { items: entries as string[] }, (item: string) =>
+        React.createElement(Text, { key: item }, item),
+      ),
+      promptOpen
+        ? React.createElement(
+            Box,
+            { flexDirection: "column" },
+            ...PROMPT_FRAME_LINES.map((line) => React.createElement(Text, { key: line }, line)),
+          )
+        : null,
+    );
+  }
+
+  const instance = render(React.createElement(Harness), {
+    ...INK_RENDER_OPTIONS,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: createFakeStdin(),
+  });
+
+  return {
+    stdout,
+    dismissPromptAndEcho: () => {
+      setPromptOpen(false);
+      setEntries((prev) => [...prev, "> A and C"]);
+    },
+    unmount: () => instance.unmount(),
+  };
+}
+
+const settle = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 150));
+};
+
+describe("prompt dismissal does not crop scrollback", () => {
+  test("Ink erases the shrinking prompt frame exactly once", async () => {
+    const harness = mountHarness();
+    await settle();
+
+    harness.stdout.writes.length = 0;
+    harness.dismissPromptAndEcho();
+    await settle();
+
+    const erased = countErasedLines(harness.stdout.writes);
+    // The painted frame is the prompt lines plus Ink's trailing newline row.
+    expect(erased).toBe(PROMPT_FRAME_LINES.length + 1);
+
+    harness.unmount();
+  });
+
+  test("the new scrollback entry is written after the frame erase, not over it", async () => {
+    const harness = mountHarness();
+    await settle();
+
+    harness.stdout.writes.length = 0;
+    harness.dismissPromptAndEcho();
+    await settle();
+
+    const combined = harness.stdout.writes.join("");
+    expect(combined).toContain("> A and C");
+    // Nothing may be erased once the entry has landed — a second erase pass
+    // is what used to eat the settled lines above it.
+    const afterEntry = combined.slice(combined.indexOf("> A and C"));
+    expect(afterEntry).not.toContain(ERASE_LINE);
+
+    harness.unmount();
+  });
+});

--- a/src/cli/ui/prompt-frame-erase.test.ts
+++ b/src/cli/ui/prompt-frame-erase.test.ts
@@ -91,6 +91,10 @@ function mountHarness(): Harness {
     ...INK_RENDER_OPTIONS,
     stdout: stdout as unknown as NodeJS.WriteStream,
     stdin: createFakeStdin(),
+    // Ink defaults to non-interactive under CI and never emits erase escapes
+    // there. The bug only exists on the interactive path a real terminal
+    // takes, so pin it explicitly rather than letting the environment decide.
+    interactive: true,
   });
 
   return {

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -148,7 +148,6 @@ export class UIStore {
   private chatBusySetter: ((busy: boolean) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
   private modeSetter: ((isYolo: boolean) => void) | null = null;
-  private frameClearHandler: (() => void) | null = null;
 
   // ── Public API (called by consumers) ──────────────────────────────
 
@@ -206,15 +205,13 @@ export class UIStore {
   };
 
   setPrompt = (prompt: PromptState | null): void => {
-    const dismissing = this.promptSnapshot !== null && prompt === null;
     this.promptSnapshot = prompt;
-    // Erase the painted prompt frame (input line + suggestion dropdown)
-    // before React swaps in the shorter busy-phase UI. Under heavy <Static>
-    // churn Ink does not reliably erase lines freed by a shrinking live
-    // region, which left the dropdown visible until the turn completed.
-    if (dismissing && this.frameClearHandler) {
-      this.frameClearHandler();
-    }
+    // Do NOT eagerly erase Ink's frame here. `Ink.clear()` erases the frame
+    // and then re-syncs log-update to believe those lines are still painted,
+    // so the very next render erases the same line count a second time —
+    // chewing (frameHeight - 1) lines of settled scrollback and overwriting
+    // them with the next entry. Ink's own render already fully erases the
+    // previous frame before repainting, so a shrinking prompt cleans up.
     if (this.promptSetter) {
       this.promptSetter(prompt);
     }
@@ -600,15 +597,6 @@ export class UIStore {
 
   registerPromptSetter(setter: (prompt: PromptState | null) => void): void {
     this.promptSetter = setter;
-  }
-
-  /**
-   * Register a callback that erases Ink's current dynamic frame from the
-   * terminal (the Ink instance's `clear()`). Invoked when a prompt is
-   * dismissed so stale prompt chrome never lingers on screen.
-   */
-  registerFrameClearHandler(handler: (() => void) | null): void {
-    this.frameClearHandler = handler;
   }
 
   registerWorkingDirectorySetter(setter: (wd: string | null) => void): void {

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -106,9 +106,6 @@ export class InkTerminalService implements TerminalService {
       ),
       INK_RENDER_OPTIONS,
     );
-    store.registerFrameClearHandler(() => {
-      this.inkInstance?.clear();
-    });
     instanceExists = true;
   }
 
@@ -117,7 +114,6 @@ export class InkTerminalService implements TerminalService {
    * Called when the command completes
    */
   cleanup(): void {
-    store.registerFrameClearHandler(null);
     if (this.inkInstance) {
       this.inkInstance.unmount();
       this.inkInstance = null;


### PR DESCRIPTION
## What & why

Sending a message in chat silently ate the last few lines of the agent's previous answer, so replies that ended in a list or a question got cut off and were unrecoverable by scrolling. The cause was an eager frame erase on prompt dismissal: Ink's `clear()` wipes the prompt frame but then tells its renderer those lines are still on screen, so the next repaint erased the same line count a second time — walking up into settled scrollback and overwriting it with the user's own echo. Ink already erases the previous frame before repainting, so the workaround was both unnecessary and destructive.

The number of lost lines tracked the height of the dismissed prompt, which is why it looked intermittent rather than like a consistent truncation bug.

## How to verify

- Start a chat, ask something that produces a long multi-paragraph answer, then send a follow-up. The full previous answer should remain intact above your message.
- Repeat with the slash-command dropdown open when you hit enter — the taller frame is the worst case, and it should still leave scrollback untouched.
- Confirm no stale prompt chrome (input line or suggestion list) lingers on screen after submitting; that lingering artifact is what the removed workaround originally targeted.
- Answer an agent questionnaire prompt and check the question text above it survives.
