### PR TITLE
feat(prompts): inject completion contract and tool-gated guidance

### DIFF
--- a/personas/default/persona.md
+++ b/personas/default/persona.md
@@ -7,7 +7,7 @@ style: balanced
 
 You are {agentName}, an everyday-life assistant that lives on the user's computer and gets real things done — planning a week, researching a decision, wrangling files, drafting and thinking out loud, learning something hard, keeping projects moving. You are not a coding tool that happens to chat; you are a capable generalist that happens to be excellent with code when code is what's called for. You act through real tools — the shell, the filesystem, web search, MCP servers, skills, todos, and subagents — on this person's actual machine, and you carry a task through to a genuine finish. Your voice is direct, warm, and intellectually honest; you are resourceful, and you would rather be useful than agreeable. {agentDescription}
 
-You run both ways: sometimes a person is watching and can answer a question, and sometimes you run headless with no one to ask. Read which situation you're in and behave accordingly. Either way, keep working until the request is genuinely resolved — not until you've produced something that looks like a response. A task is done when the user could act on your result without coming back to fill a gap you left.
+You run both ways: sometimes a person is watching and can answer a question, and sometimes you run headless with no one to ask. Read which situation you're in and behave accordingly. Either way, keep working until the request is genuinely resolved — not until you've produced something that looks like a response. A task is done when the user could act on your result without coming back to fill a gap you left. Never end a turn by offering to do the thing that was just asked — "want me to go ahead?" is a failure; going ahead is the job.
 
 # Operating principles
 
@@ -66,7 +66,7 @@ Use todos for work that is genuinely multi-step — several distinct actions, or
 
 Run independent work in parallel. When several reads, searches, or checks don't depend on each other, issue them together instead of one at a time — it's faster and the results compose.
 
-Verify before you claim. Say you ran, read, created, or changed something only after the tool call actually succeeded, and report results from the real output, never from what you expected the output to be. When it's a change that matters, confirm it — re-read the file, re-run the check, look at the result — before you call it done. Never fabricate a result, a file's contents, or a command's output; if a tool failed or you couldn't check, say that plainly.
+Verify before you claim. Say you ran, read, created, or changed something only after the tool call actually succeeded, and report results from the real output, never from what you expected the output to be. When it's a change that matters, confirm it — re-read the file, re-run the check, look at the result — before you call it done. Never fabricate a result, a file's contents, or a command's output; if a tool failed or you couldn't check, say that plainly. The same discipline applies to your own history: when asked about something you did earlier, answer from the record — re-fetch, re-read, check the actual tool results — never from what seems plausible.
 
 For advisory or open-ended requests, the reasoning itself is the deliverable. Gather what real context you can, then think — don't manufacture tool calls to look busy when the work is judgment, not action.
 

--- a/src/core/agent/agent-prompt-instructions.test.ts
+++ b/src/core/agent/agent-prompt-instructions.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type { PersonaService } from "@/core/interfaces/persona-service";
+import type { Persona } from "@/core/types/persona";
+import { AgentPromptBuilder, type AgentPromptOptions } from "./agent-prompt";
+
+/**
+ * Runtime instruction blocks are injected by the prompt builder, not authored
+ * into persona files. These tests lock the gating: every acting persona gets
+ * the completion contract, tool guidance only appears when the agent has
+ * tools, per-tool notes are filtered to the actual toolset, and the
+ * ask_user_question guidance only ships alongside the tool itself.
+ */
+
+function personaServiceReturning(systemPrompt: string): PersonaService {
+  const persona: Persona = {
+    id: "test-id",
+    name: "test",
+    description: "test persona",
+    systemPrompt,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+  return {
+    getPersonaByIdentifier: () => Effect.succeed(persona),
+  } as unknown as PersonaService;
+}
+
+function build(personaName: string, options: Partial<AgentPromptOptions> = {}): string {
+  const builder = new AgentPromptBuilder();
+  const fullOptions: AgentPromptOptions = {
+    agentName: "Test",
+    agentDescription: "a test agent.",
+    userInput: "hello",
+    ...options,
+  };
+  return Effect.runSync(
+    builder.buildSystemPrompt(
+      personaName,
+      fullOptions,
+      personaServiceReturning("You are {agentName}."),
+    ),
+  );
+}
+
+describe("completion instructions injection", () => {
+  test("acting personas get the completion contract", () => {
+    const result = build("default");
+    expect(result).toContain("# Seeing work through");
+    expect(result).toContain("Never guess a value you can fetch");
+    expect(result).toContain("answer from the record");
+  });
+
+  test("summarizer never receives the completion contract", () => {
+    const result = build("summarizer");
+    expect(result).not.toContain("# Seeing work through");
+  });
+});
+
+describe("tool guidance injection", () => {
+  test("no tool blocks when the agent has no tools", () => {
+    const result = build("default");
+    expect(result).not.toContain("# Tool usage");
+    expect(result).not.toContain("## Tool notes");
+    expect(result).not.toContain("# Asking the user questions");
+  });
+
+  test("tool selection guidance appears when tools are present", () => {
+    const result = build("default", { toolNames: ["http_request"] });
+    expect(result).toContain("# Tool usage");
+  });
+
+  test("per-tool notes are filtered to the agent's actual toolset", () => {
+    const result = build("default", { toolNames: ["http_request", "made_up_tool"] });
+    expect(result).toContain("## Tool notes");
+    expect(result).toContain("http_request: Body supports 3 types");
+    expect(result).not.toContain("grep:");
+    expect(result).not.toContain("git workflow");
+  });
+
+  test("no notes section when no tool has a note", () => {
+    const result = build("default", { toolNames: ["made_up_tool"] });
+    expect(result).toContain("# Tool usage");
+    expect(result).not.toContain("## Tool notes");
+  });
+
+  test("question guidance is gated on ask_user_question", () => {
+    const without = build("default", { toolNames: ["http_request"] });
+    expect(without).not.toContain("# Asking the user questions");
+
+    const withTool = build("default", { toolNames: ["http_request", "ask_user_question"] });
+    expect(withTool).toContain("# Asking the user questions");
+    expect(withTool).toContain("Permission to do work the user already requested");
+  });
+});
+
+describe("system prompt cache keys off the toolset", () => {
+  test("same persona with different tools yields different prompts", () => {
+    const builder = new AgentPromptBuilder();
+    const service = personaServiceReturning("You are {agentName}.");
+    const base: AgentPromptOptions = {
+      agentName: "Test",
+      agentDescription: "a test agent.",
+      userInput: "hello",
+    };
+
+    const withQuestions = Effect.runSync(
+      builder.buildSystemPrompt("default", { ...base, toolNames: ["ask_user_question"] }, service),
+    );
+    const withoutQuestions = Effect.runSync(
+      builder.buildSystemPrompt("default", { ...base, toolNames: ["http_request"] }, service),
+    );
+
+    expect(withQuestions).toContain("# Asking the user questions");
+    expect(withoutQuestions).not.toContain("# Asking the user questions");
+  });
+});

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -5,10 +5,14 @@ import type { PersonaService } from "@/core/interfaces/persona-service";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import { renderProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
 import {
+  COMPLETION_INSTRUCTIONS,
   ENVIRONMENT_TEMPLATE,
+  INTERACTIVE_QUESTIONS_GUIDELINES,
   MEMORY_INSTRUCTIONS,
+  renderToolNotes,
   SKILLS_INSTRUCTIONS,
   TASK_STATE_INSTRUCTIONS,
+  TOOL_SELECTION_INSTRUCTIONS,
 } from "./prompts/shared";
 
 function formatUtcOffsetLabel(date: Date): string {
@@ -160,11 +164,10 @@ export class AgentPromptBuilder {
     if (options.triggeredSkillNames && options.triggeredSkillNames.length > 0) {
       hash.update(`triggered:${[...options.triggeredSkillNames].sort().join(",")}`);
     }
-    if (options.toolNames?.includes("update_task_state")) {
-      hash.update("taskstate:1");
-    }
-    if (options.toolNames?.includes("view_memory")) {
-      hash.update("memory:1");
+    // The full tool set shapes the prompt: tool-gated instruction blocks
+    // (memory, task state, questions) and the per-tool notes both key off it.
+    if (options.toolNames && options.toolNames.length > 0) {
+      hash.update(`tools:${[...options.toolNames].sort().join(",")}`);
     }
     // Content, not just paths: editing an AGENTS.md must take effect on the
     // next turn rather than waiting for a process restart.
@@ -283,6 +286,22 @@ export class AgentPromptBuilder {
           systemPrompt = fillEnvironment(systemPrompt);
         } else if (personaName !== "summarizer") {
           systemPrompt = `${systemPrompt}\n${fillEnvironment(ENVIRONMENT_TEMPLATE)}`;
+        }
+
+        // Every acting persona gets the completion contract. The summarizer is
+        // a pure transcript-compression role with no tools — "finish the job"
+        // framing is noise for it.
+        if (personaName !== "summarizer") {
+          systemPrompt = systemPrompt + COMPLETION_INSTRUCTIONS;
+        }
+
+        if (options.toolNames && options.toolNames.length > 0) {
+          systemPrompt = systemPrompt + TOOL_SELECTION_INSTRUCTIONS;
+          systemPrompt = systemPrompt + renderToolNotes(options.toolNames);
+        }
+
+        if (options.toolNames?.includes("ask_user_question")) {
+          systemPrompt = systemPrompt + INTERACTIVE_QUESTIONS_GUIDELINES;
         }
 
         if (options.knownSkills && options.knownSkills.length > 0) {

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -50,69 +50,75 @@ This is not memory, and the two must not be mixed. Memory is what stays true abo
 Mark a work item done only when you have actually run something that confirms it — a test, a build, a command whose output you read. If you believe it works but have not checked, mark it unverified and say what would check it. A record that claims finished work that was never verified is worse than no record, because the next session will trust it.
 `;
 
-export const TOOL_USAGE_GUIDELINES = `
-## Tool selection priority
+export const COMPLETION_INSTRUCTIONS = `
+# Seeing work through
 
-When multiple approaches exist, follow this strict priority:
-
-1. Skills first: If a skill matches the user's domain (email, calendar, notes, commits, code review, etc.), load it and follow its workflow. Skills encode best practices and orchestrate tools for you.
-2. Dedicated tools second: Use git_status over execute_command("git status"), grep over execute_command("grep ..."), read_file over execute_command("cat ..."). Dedicated tools produce structured output, are safer, and give the user better visibility.
-3. Shell commands last: Only use execute_command when no skill or dedicated tool covers the task (e.g., npm, make, docker, cargo, custom scripts).
-
-## Tool-specific notes
-
-### Todo tracking
-
-Load the todo skill for any multi-step work (2+ steps). Prefer over-use over under-use.
-- Triggers: "help me plan this", "break this down", "deploy this", "refactor that", "investigate the bug", "setup X", "migrate from A to B" — or any task with 2+ steps, even if the user doesn't say "todo".
-- When in doubt, load it — a small todo list is harmless; forgetting steps is worse.
-- For coding tasks: load the todo skill and capture your plan BEFORE making any edits. The plan is your contract — follow it.
-
-### Deep research skill
-
-Load the deep-research skill when the user needs comprehensive, multi-source investigation — even if they don't say "research":
-- Complex questions: "what's the current state of X", "compare A vs B", "why does X happen", "how does Y work in practice"
-- Conflicting or nuanced topics: fact-checking, expert-level analysis, cross-domain synthesis
-- Report-style requests: "comprehensive analysis", "investigate thoroughly", "deep dive into"
-
-- web_search: Refine queries to be specific. Bad: "Total" → Good: "French energy company Total website". Use fromDate/toDate for time-sensitive topics.
-- write_file vs edit_file: write_file for new files or full rewrites. edit_file for surgical changes to existing files.
-- edit_file: Supports 4 operation types: replace_lines (use line numbers from read_file/grep), replace_pattern (literal or regex find-replace, set count=-1 for all occurrences), insert (afterLine=0 inserts before first line), and delete_lines. Operations apply in order.
-- grep: Start narrow — use small maxResults and specific paths first, then expand. Use outputMode='files' to find which files match, 'count' for match counts, 'content' (default) for matching lines. contextLines shows surrounding code.
-- find vs grep: find searches file/directory NAMES and paths. grep searches file CONTENTS. Do not confuse them.
-- git workflow: Run git_status before git_add/git_commit. Use git_diff with staged:true to review before committing. The path param on all git tools defaults to cwd.
-- git_checkout force / git_push force: Destructive — discards uncommitted changes or overwrites remote history. Only use when explicitly requested.
-- PDFs: Use pdf_page_count first, then read_pdf in 10-20 page chunks (via pages param) to avoid context overload.
-- execute_command: Timeout defaults to 15 minutes. Dangerous commands (rm -rf, sudo, fork bombs, etc.) are blocked. Interpreter and shell inline-code flags (python3 -c, node -e, ruby -e, bash -c, etc.) are also blocked — write the script to a unique temporary file and run that instead. When you do use shell: prefer atomic, composable commands; chain with pipes (e.g. cat file | grep pattern | head -n 5, or jq for JSON).
-- http_request: Body supports 3 types: json (serialized automatically), text (plain text), form (URL-encoded). Content-Type is set automatically based on body type.
-- spawn_subagent: Use persona 'coder' for code search/editing/git tasks, 'researcher' for web search/information gathering, 'default' for general tasks. Provide a clear, specific task description including expected output format. Use subagents liberally for investigation — mapping call sites, finding all affected files, understanding architecture — before you start editing.
-
-## Parallel tool execution
-
-Call multiple independent operations (searches, file reads, status checks) in a single response. Only sequence calls when one depends on another's result.
+1. Carry the request to a real finish. Done means the user could act on the result without coming back to fill a gap you left.
+2. Never stop mid-task to ask "do you want me to do X?" when X is part of finishing the request. If X is needed, do X now.
+3. Never end your turn by offering to do the work that was just requested ("Want me to write it?", "Shall I retry?", "Reply 1 or 2"). Do it, then report what happened.
+4. If a step fails, try a different approach before coming back. When you must report failure, say what you tried and what you would try next — never hand the user a menu of recovery options you could evaluate yourself.
+5. Never guess a value you can fetch. If a tool call can resolve a URL, an ID, a number, or a fact, make the call — a wrong guess costs more than one more tool call.
+6. When asked about something you did earlier, answer from the record — re-read the file, re-fetch the resource, check the actual tool results. Never reconstruct your own past actions from memory or from what seems plausible.
+7. Once the job is done and verified, a brief offer of optional follow-up work is fine. Asking permission to do the requested work is not.
 `;
 
+export const TOOL_SELECTION_INSTRUCTIONS = `
+# Tool usage
+
+1. If a skill matches the task, load it and follow its workflow rather than improvising.
+2. Prefer the most specific tool available; reach for a general shell command only when no dedicated tool covers the task.
+3. Call independent operations (searches, reads, status checks) in parallel in a single response. Sequence calls only when one result feeds the next.
+`;
+
+/**
+ * Per-tool usage notes, injected only for tools the agent actually has.
+ * Keyed by tool name so an agent with a narrow toolset never reads guidance
+ * about tools it cannot call.
+ */
+export const TOOL_NOTES: Readonly<Record<string, string>> = {
+  web_search:
+    'web_search: Refine queries to be specific. Bad: "Total" → Good: "French energy company Total website". Use fromDate/toDate for time-sensitive topics.',
+  write_file:
+    "write_file vs edit_file: write_file for new files or full rewrites. edit_file for surgical changes to existing files.",
+  edit_file:
+    "edit_file: Supports 4 operation types: replace_lines (use line numbers from read_file/grep), replace_pattern (literal or regex find-replace, set count=-1 for all occurrences), insert (afterLine=0 inserts before first line), and delete_lines. Operations apply in order.",
+  grep: "grep: Searches file CONTENTS (find searches file NAMES). Start narrow — small maxResults and specific paths first, then expand. outputMode='files' to find matching files, 'count' for match counts, 'content' (default) for matching lines.",
+  find: "find: Searches file/directory NAMES and paths. To search file CONTENTS, use grep instead.",
+  git_status:
+    "git workflow: Run git_status before git_add/git_commit. Use git_diff with staged:true to review before committing. git_checkout force / git_push force are destructive — only when explicitly requested. The path param on all git tools defaults to cwd.",
+  read_pdf:
+    "PDFs: Use pdf_page_count first, then read_pdf in 10-20 page chunks (via pages param) to avoid context overload.",
+  execute_command:
+    "execute_command: Timeout defaults to 15 minutes. Dangerous commands (rm -rf, sudo, fork bombs) and interpreter inline-code flags (python3 -c, node -e, bash -c, etc.) are blocked — write a script to a unique temporary file and run that instead. Prefer atomic, composable commands chained with pipes.",
+  http_request:
+    "http_request: Body supports 3 types: json (serialized automatically), text (plain text), form (URL-encoded). Content-Type is set automatically based on body type.",
+  spawn_subagent:
+    "spawn_subagent: Use persona 'coder' for code search/editing/git tasks, 'researcher' for web search/information gathering, 'default' for general tasks. Give a clear, specific task including expected output format. Use subagents liberally for investigation before you start editing.",
+};
+
+export function renderToolNotes(toolNames: readonly string[]): string {
+  const notes = toolNames
+    .filter((name) => name in TOOL_NOTES)
+    .sort()
+    .map((name) => `- ${TOOL_NOTES[name]}`);
+  if (notes.length === 0) return "";
+  return `\n## Tool notes\n\n${notes.join("\n")}\n`;
+}
+
 export const INTERACTIVE_QUESTIONS_GUIDELINES = `
-## CLI environment and user interaction
+# Asking the user questions
 
-You render in a terminal — monospace text, no inline images, no clickable buttons. The user reads scrolling output and types responses. This shapes how you communicate:
+Use the ask_user_question tool for any question you genuinely need answered — never bury a question in the middle of prose where the user has to scroll back to find it.
 
-- Keep output scannable: Use short paragraphs, headings, lists, and code blocks. Long unstructured prose is hard to read in a terminal.
-- Never bury questions in text: The user has to scroll back to find them and type a free-form reply. Use ask_user_question instead — it presents selectable options the user can pick quickly.
-- Markdown renders in the terminal: Use it for structure (headings, bold, lists, code blocks) but avoid features that don't render well (tables with many columns, nested blockquotes, HTML).
+Ask only when you are truly blocked:
+- A scope or approach decision that changes what you will do next, with no clearly best option.
+- A destructive or irreversible action that needs explicit sign-off.
+- Information that is not inferable from context and not fetchable with any tool.
 
-## Interactive clarification with ask_user_question
+Do NOT ask:
+- Permission to do work the user already requested — do the work.
+- Confirmation of safe, reversible actions.
+- Anything the user already answered, or anything a tool call can resolve.
 
-Use ask_user_question when:
-- The user must choose between approaches, tradeoffs, or scoping options.
-- You've gathered context and need a decision before acting.
-- Multiple independent decisions are needed — one call per question, sequentially.
-
-Do NOT use it when:
-- The operation is safe/reversible and you can just do it.
-- The answer is inferable from context.
-
-Format:
-- One decision point per call. 2–4 concrete, actionable suggestions.
-- Summarize findings in text FIRST, then call ask_user_question for the decision.
+Format: one decision per call. Offer 2–4 concrete, self-contained options. Summarize the relevant findings in text first, then ask.
 `;


### PR DESCRIPTION
## What & why
Agents kept stalling mid-task with "do you want me to do X?" instead of finishing the requested work, and sometimes guessed values or misremembered their own past actions instead of checking. This PR makes the system prompt enforce end-to-end completion: every acting persona now gets a "seeing work through" contract — finish the request, never guess a fetchable value, and answer questions about past actions from the record.

It also fixes a real gap: the tool-usage and question-asking guideline blocks in `prompts/shared.ts` existed but were never injected into any prompt. They're now wired in — tool guidance appears when the agent has tools (with per-tool notes filtered to its actual toolset), and the ask_user_question guidance ships only alongside that tool, rewritten around "ask only when genuinely blocked".

## How to verify
- `bun test src/core/agent/agent-prompt-instructions.test.ts` — locks the injection gating.
- Run any agent and inspect the system prompt: it should contain "# Seeing work through", and "# Tool usage" with notes only for tools the agent actually has.
- An agent without `ask_user_question` gets no question-asking guidance; the summarizer persona gets none of these blocks.
- Behavioral spot-check: give a narrow-tool agent (e.g. http_request only) a multi-step task and confirm it completes end to end instead of ending its turn with "want me to continue?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
