### PR TITLE
feat(agent): per-subagent reasoningEffort override on spawn_subagent

### DIFF
--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -168,6 +168,117 @@ describe("spawn_subagent persona handling", () => {
   });
 });
 
+describe("spawn_subagent reasoning effort", () => {
+  function captureSpawn(): {
+    readonly captured: () => Omit<AgentRunnerOptions, "internal"> | undefined;
+    readonly spy: ReturnType<typeof spyOn>;
+  } {
+    let seen: Omit<AgentRunnerOptions, "internal"> | undefined;
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation((options) => {
+      seen = options;
+      return Effect.succeed({ content: "done", messages: [] }) as ReturnType<
+        typeof AgentRunner.runRecursive
+      >;
+    });
+    return { captured: () => seen, spy };
+  }
+
+  function runSpawnWithArgs(
+    presentation: PresentationService,
+    args: Record<string, unknown>,
+  ): Promise<unknown> {
+    const tool = getSpawnTool();
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, presentation),
+    );
+    return Effect.runPromise(
+      (
+        tool.execute(args, { agentId: parentAgent.id, parentAgent }) as Effect.Effect<
+          unknown,
+          unknown,
+          LoggerService | PresentationService
+        >
+      ).pipe(Effect.provide(testLayer)),
+    );
+  }
+
+  it("overrides the parent's effort when provided", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const effortParent: Agent = {
+        ...parentAgent,
+        config: { persona: "default", reasoningEffort: "medium" } as Agent["config"],
+      };
+      const tool = getSpawnTool();
+      const testLayer = Layer.mergeAll(
+        Layer.succeed(LoggerServiceTag, mockLogger),
+        Layer.succeed(PresentationServiceTag, presentation),
+      );
+      await Effect.runPromise(
+        (
+          tool.execute(
+            { task: "deep review", persona: "coder", reasoningEffort: "high" },
+            { agentId: effortParent.id, parentAgent: effortParent },
+          ) as Effect.Effect<unknown, unknown, LoggerService | PresentationService>
+        ).pipe(Effect.provide(testLayer)),
+      );
+
+      expect(captured()?.agent.config.reasoningEffort).toBe("high");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("inherits the parent's effort when omitted", async () => {
+    const { captured, spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const effortParent: Agent = {
+        ...parentAgent,
+        config: { persona: "default", reasoningEffort: "medium" } as Agent["config"],
+      };
+      const tool = getSpawnTool();
+      const testLayer = Layer.mergeAll(
+        Layer.succeed(LoggerServiceTag, mockLogger),
+        Layer.succeed(PresentationServiceTag, presentation),
+      );
+      await Effect.runPromise(
+        (
+          tool.execute(
+            { task: "do a thing", persona: "default" },
+            { agentId: effortParent.id, parentAgent: effortParent },
+          ) as Effect.Effect<unknown, unknown, LoggerService | PresentationService>
+        ).pipe(Effect.provide(testLayer)),
+      );
+
+      expect(captured()?.agent.config.reasoningEffort).toBe("medium");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects an invalid effort value", async () => {
+    const { spy } = captureSpawn();
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const result = (await runSpawnWithArgs(presentation, {
+        task: "do a thing",
+        reasoningEffort: "maximum",
+      })) as { success: boolean; error?: string };
+
+      expect(result.success).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("spawn_subagent tool ceiling", () => {
   it("caps the child at the parent's effective tools", async () => {
     let captured: Omit<AgentRunnerOptions, "internal"> | undefined;

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -44,6 +44,13 @@ const spawnSubagentSchema = z.object({
     .describe(
       "'coder' for code/git tasks, 'researcher' for research tasks, 'default' for general (default: 'default')",
     ),
+  reasoningEffort: z
+    .enum(["disable", "low", "medium", "high"])
+    .optional()
+    .describe(
+      "Reasoning effort for this sub-agent. Omit to inherit the parent's effort. " +
+        "Raise it for hard analysis tasks (deep review, root-cause hunting); lower it for mechanical ones.",
+    ),
 });
 
 type SpawnSubagentArgs = z.infer<typeof spawnSubagentSchema>;
@@ -70,7 +77,8 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
       timeoutMs: SUBAGENT_TIMEOUT_MS,
       description:
         "Spawn a sub-agent with fresh context for a specific task. Personas: coder, researcher, default. " +
-        "Pass a short 'name' to label each sub-agent by its role so parallel sub-agents stay distinguishable.",
+        "Pass a short 'name' to label each sub-agent by its role so parallel sub-agents stay distinguishable. " +
+        "Pass 'reasoningEffort' to override the parent's effort for this sub-agent only.",
       parameters: spawnSubagentSchema,
       hidden: false,
       riskLevel: "low-risk",
@@ -131,6 +139,7 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
             config: {
               ...parentAgent.config,
               persona: args.persona ?? "default",
+              ...(args.reasoningEffort ? { reasoningEffort: args.reasoningEffort } : {}),
             },
             createdAt: new Date(),
             updatedAt: new Date(),


### PR DESCRIPTION
## What & why
An agent can now spawn sub-agents that think harder (or less hard) than itself: `spawn_subagent` accepts an optional `reasoningEffort` (`disable`/`low`/`medium`/`high`) that overrides the parent's effort for that child only, inheriting as before when omitted. This lets a cheap orchestrator delegate the expensive analysis — the concrete motivator is the CI review board (#357), where the lead can stay at medium while each specialist lens reviews at high.

## How to verify
- Ask any agent to spawn a sub-agent "with reasoningEffort high" and confirm the child's run uses high effort while the parent stays unchanged.
- Spawn without the parameter and confirm the child inherits the parent's configured effort.
- Pass an invalid value (e.g. `maximum`) and confirm the tool returns a validation error instead of spawning.
- `bun test src/core/agent/tools/subagent-tools.test.ts` covers all three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)