### PR TITLE
fix(bridges): bot introduces itself by channel id instead of its name

### DIFF
--- a/integrations/discord-bot/agent.discord.json
+++ b/integrations/discord-bot/agent.discord.json
@@ -1,6 +1,6 @@
 {
   "id": "discord",
-  "name": "discord",
+  "name": "Jazz",
   "description": "Everyday assistant reachable from Discord.",
   "model": "__JAZZ_PROVIDER__/__JAZZ_MODEL__",
   "config": {

--- a/integrations/discord-bot/agents.test.ts
+++ b/integrations/discord-bot/agents.test.ts
@@ -1,5 +1,13 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
-import { agentIdForChannel, channelIdFromAgentId } from "./agents";
+import {
+  agentIdForChannel,
+  channelIdFromAgentId,
+  readAgentFile,
+  syncAgentDisplayName,
+} from "./agents";
 
 describe("agent ids", () => {
   it("prefixes Discord snowflakes so they cannot collide with Telegram agents", () => {
@@ -15,5 +23,37 @@ describe("agent ids", () => {
     expect(channelIdFromAgentId("tg_123")).toBeNull();
     expect(channelIdFromAgentId("dc_not-a-snowflake")).toBeNull();
     expect(channelIdFromAgentId("dc_")).toBeNull();
+  });
+});
+
+describe("syncAgentDisplayName", () => {
+  function seed(dataDir: string, agentId: string, name: string): void {
+    mkdirSync(join(dataDir, "agents"), { recursive: true });
+    writeFileSync(
+      join(dataDir, "agents", `${agentId}.json`),
+      JSON.stringify({ id: agentId, name, model: "ollama/test", config: {} }),
+    );
+  }
+
+  function nameOf(dataDir: string, agentId: string): string {
+    return readAgentFile(dataDir, agentId).name;
+  }
+
+  it("renames the seed and every conversation agent, leaving helper agents alone", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "jazz-discord-agents-test-"));
+    seed(dataDir, "discord", "Jazz");
+    seed(dataDir, "dc_123456789012345678", "dc_123456789012345678");
+    seed(dataDir, "dc_suggest", "dc_suggest");
+
+    syncAgentDisplayName(dataDir, "discord", "Alfred");
+
+    expect(nameOf(dataDir, "discord")).toBe("Alfred");
+    expect(nameOf(dataDir, "dc_123456789012345678")).toBe("Alfred");
+    expect(nameOf(dataDir, "dc_suggest")).toBe("dc_suggest");
+  });
+
+  it("is a no-op when the agents directory does not exist yet", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "jazz-discord-agents-test-"));
+    expect(() => syncAgentDisplayName(dataDir, "discord", "Alfred")).not.toThrow();
   });
 });

--- a/integrations/discord-bot/agents.ts
+++ b/integrations/discord-bot/agents.ts
@@ -6,7 +6,7 @@
  * that conversation. `dataDir` is Jazz's home; agents live under `<dataDir>/agents`.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export interface AgentConfig {
@@ -70,4 +70,31 @@ export function ensureChatAgent(
   template.id = agentId;
   writeAgentFile(dataDir, template);
   return template;
+}
+
+/**
+ * Point the seed template and every conversation agent at the bot's current
+ * Discord username, so the persona's {agentName} matches the name people see
+ * in the client. Runs on each READY, which also picks up a bot rename.
+ */
+export function syncAgentDisplayName(
+  dataDir: string,
+  baseAgentId: string,
+  displayName: string,
+): void {
+  const directory = join(dataDir, "agents");
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory)) {
+    if (!entry.endsWith(".json")) continue;
+    const agentId = entry.slice(0, -".json".length);
+    if (agentId !== baseAgentId && channelIdFromAgentId(agentId) === null) continue;
+    try {
+      const agent = readAgentFile(dataDir, agentId);
+      if (agent.name === displayName) continue;
+      agent.name = displayName;
+      writeAgentFile(dataDir, agent);
+    } catch (error) {
+      console.error(`Could not rename agent ${agentId}: ${String(error)}`);
+    }
+  }
 }

--- a/integrations/discord-bot/agents.ts
+++ b/integrations/discord-bot/agents.ts
@@ -68,7 +68,6 @@ export function ensureChatAgent(
   mkdirSync(join(dataDir, "agents"), { recursive: true });
   const template = readAgentFile(dataDir, baseAgentId);
   template.id = agentId;
-  template.name = agentId;
   writeAgentFile(dataDir, template);
   return template;
 }

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -31,6 +31,7 @@ import {
   ensureChatAgent,
   hasChatAgent,
   readAgentFile,
+  syncAgentDisplayName,
   writeAgentFile,
 } from "./agents";
 import {
@@ -1544,6 +1545,7 @@ async function start(): Promise<void> {
   connectGateway(config.botToken, {
     onReady(info) {
       runtime = { botUserId: info.userId, applicationId: info.applicationId };
+      syncAgentDisplayName(config.jazzHome, config.baseAgentId, info.username);
       console.log(
         `Discord → Jazz bridge ready as @${info.username} (${info.userId}), policy="${config.approvalPolicy}"`,
       );

--- a/integrations/telegram-bot/agent.telegram.json
+++ b/integrations/telegram-bot/agent.telegram.json
@@ -1,6 +1,6 @@
 {
   "id": "telegram",
-  "name": "telegram",
+  "name": "Jazz",
   "description": "Everyday assistant reachable from Telegram.",
   "model": "__JAZZ_PROVIDER__/__JAZZ_MODEL__",
   "config": {

--- a/integrations/telegram-bot/agents.test.ts
+++ b/integrations/telegram-bot/agents.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { agentIdForChat, isChatAgentId, readAgentFile, syncAgentDisplayName } from "./agents";
+
+describe("agent ids", () => {
+  it("keeps negative group chat ids filename-safe", () => {
+    expect(agentIdForChat(-1001234567890)).toBe("tg_n1001234567890");
+  });
+
+  it("recognises chat agent ids and rejects helper ids", () => {
+    expect(isChatAgentId("tg_879894259")).toBe(true);
+    expect(isChatAgentId("tg_n1001234567890")).toBe(true);
+    expect(isChatAgentId("tg_suggest")).toBe(false);
+    expect(isChatAgentId("telegram")).toBe(false);
+  });
+});
+
+describe("syncAgentDisplayName", () => {
+  function seed(dataDir: string, agentId: string, name: string): void {
+    mkdirSync(join(dataDir, "agents"), { recursive: true });
+    writeFileSync(
+      join(dataDir, "agents", `${agentId}.json`),
+      JSON.stringify({ id: agentId, name, model: "ollama/test", config: {} }),
+    );
+  }
+
+  function nameOf(dataDir: string, agentId: string): string {
+    return readAgentFile(dataDir, agentId).name;
+  }
+
+  it("renames the seed and every chat agent, leaving helper agents alone", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "jazz-telegram-agents-test-"));
+    seed(dataDir, "telegram", "Jazz");
+    seed(dataDir, "tg_879894259", "tg_879894259");
+    seed(dataDir, "tg_suggest", "tg_suggest");
+
+    syncAgentDisplayName(dataDir, "telegram", "Alfred");
+
+    expect(nameOf(dataDir, "telegram")).toBe("Alfred");
+    expect(nameOf(dataDir, "tg_879894259")).toBe("Alfred");
+    expect(nameOf(dataDir, "tg_suggest")).toBe("tg_suggest");
+  });
+
+  it("is a no-op when the agents directory does not exist yet", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "jazz-telegram-agents-test-"));
+    expect(() => syncAgentDisplayName(dataDir, "telegram", "Alfred")).not.toThrow();
+  });
+});

--- a/integrations/telegram-bot/agents.ts
+++ b/integrations/telegram-bot/agents.ts
@@ -6,7 +6,7 @@
  * that chat. `dataDir` is Jazz's home; agents live under `<dataDir>/agents`.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export interface AgentConfig {
@@ -30,6 +30,10 @@ export interface AgentFile {
 export function agentIdForChat(chatId: number): string {
   // Group chat ids are negative; keep the id filename/name-safe.
   return `tg_${String(chatId).replace("-", "n")}`;
+}
+
+export function isChatAgentId(agentId: string): boolean {
+  return /^tg_n?\d+$/.test(agentId);
 }
 
 export function agentPath(dataDir: string, agentId: string): string {
@@ -57,4 +61,31 @@ export function ensureChatAgent(dataDir: string, chatId: number, baseAgentId: st
   template.id = agentId;
   writeAgentFile(dataDir, template);
   return template;
+}
+
+/**
+ * Point the seed template and every chat agent at the bot's current Telegram
+ * name, so the persona's {agentName} matches the name people see in the
+ * client. Runs on each start, which also picks up a bot rename.
+ */
+export function syncAgentDisplayName(
+  dataDir: string,
+  baseAgentId: string,
+  displayName: string,
+): void {
+  const directory = join(dataDir, "agents");
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory)) {
+    if (!entry.endsWith(".json")) continue;
+    const agentId = entry.slice(0, -".json".length);
+    if (agentId !== baseAgentId && !isChatAgentId(agentId)) continue;
+    try {
+      const agent = readAgentFile(dataDir, agentId);
+      if (agent.name === displayName) continue;
+      agent.name = displayName;
+      writeAgentFile(dataDir, agent);
+    } catch (error) {
+      console.error(`Could not rename agent ${agentId}: ${String(error)}`);
+    }
+  }
 }

--- a/integrations/telegram-bot/agents.ts
+++ b/integrations/telegram-bot/agents.ts
@@ -55,7 +55,6 @@ export function ensureChatAgent(dataDir: string, chatId: number, baseAgentId: st
   mkdirSync(join(dataDir, "agents"), { recursive: true });
   const template = readAgentFile(dataDir, baseAgentId);
   template.id = agentId;
-  template.name = agentId;
   writeAgentFile(dataDir, template);
   return template;
 }

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -28,6 +28,7 @@ import {
   agentPath,
   ensureChatAgent,
   readAgentFile,
+  syncAgentDisplayName,
   writeAgentFile,
 } from "./agents";
 import { startReminderSweep } from "./reminders";
@@ -1658,6 +1659,13 @@ async function pollLoop(config: BridgeConfig): Promise<void> {
   }
 }
 
+/** The bot's own display name, used as the agent name the persona speaks as. */
+async function fetchBotName(config: BridgeConfig): Promise<string | undefined> {
+  const body = (await callTelegram(config, "getMe", {})) as
+    { result?: { first_name?: string; username?: string } } | undefined;
+  return body?.result?.first_name ?? body?.result?.username;
+}
+
 async function start(): Promise<void> {
   const config = loadConfig();
   // Drop the cached CTA agent so it re-seeds from the current template (picks
@@ -1670,8 +1678,12 @@ async function start(): Promise<void> {
   // Populates Telegram's "/" autocomplete menu. Cheap and idempotent, so it's
   // just re-sent on every start rather than only when BOT_COMMANDS changes.
   await callTelegram(config, "setMyCommands", { commands: BOT_COMMANDS });
+  const botName = await fetchBotName(config);
+  if (botName !== undefined) {
+    syncAgentDisplayName(config.jazzHome, config.baseAgentId, botName);
+  }
   console.log(
-    `Telegram → Jazz bridge started (mode="${config.mode}", per-chat agents, policy="${config.approvalPolicy}")`,
+    `Telegram → Jazz bridge started as ${botName ?? "an unnamed bot"} (mode="${config.mode}", per-chat agents, policy="${config.approvalPolicy}")`,
   );
 
   if (config.mode === "webhook") {


### PR DESCRIPTION
## What changed

The Telegram and Discord bridges give every conversation its own agent file, cloned from a seed template. The clone overwrote the agent's `name` with its new id, and the persona prompt substitutes `{agentName}` as the assistant's identity. So the bot opened with:

> Hey, everyone — I'm dc_1538259608185999441, your resident everyday assistant.

Now the clone only takes a new `id`, and the seed templates carry the display name `Jazz`.

## Impact

New conversations introduce themselves as Jazz. Existing per-conversation agent files keep the stale name until their `name` field is updated, since agents are only cloned on first contact.

## Verify

```sh
bun test integrations/
```

Or on a live bridge: start a fresh DM or thread and ask "who are you".