### PR TITLE
feat(bridges): show input/output token split instead of one total

### DIFF
--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -129,7 +129,12 @@ interface JazzSuccessEnvelope {
   readonly ok: true;
   readonly answer: string;
   readonly costUSD: number;
-  readonly tokenUsage?: { readonly totalTokens?: number };
+  readonly tokenUsage?: {
+    readonly totalTokens?: number;
+    readonly promptTokens?: number;
+    readonly completionTokens?: number;
+    readonly cacheReadTokens?: number;
+  };
   readonly webApp?: JazzWebApp;
   readonly messages?: unknown[];
 }
@@ -226,6 +231,22 @@ function newRunToken(): string {
 
 function formatTokenCount(tokens: number): string {
   return tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : String(tokens);
+}
+
+/**
+ * Input and output split out, since a single total hides that the input is
+ * the whole conversation plus tool schemas re-sent on every loop iteration.
+ */
+function formatUsageLines(usage: JazzSuccessEnvelope["tokenUsage"]): string | undefined {
+  const promptTokens = usage?.promptTokens ?? 0;
+  const completionTokens = usage?.completionTokens ?? 0;
+  if (promptTokens === 0 && completionTokens === 0) return undefined;
+  const cacheReadTokens = usage?.cacheReadTokens ?? 0;
+  const cached = cacheReadTokens > 0 ? ` (${formatTokenCount(cacheReadTokens)} cached)` : "";
+  return [
+    `-# Input: ${formatTokenCount(promptTokens)}${cached}`,
+    `-# Output: ${formatTokenCount(completionTokens)}`,
+  ].join("\n");
 }
 
 async function resolveChannel(config: BridgeConfig, channelId: string): Promise<ChannelMeta> {
@@ -618,14 +639,13 @@ async function handleMessage(
       const used = reporter?.toolsUsed() ?? [];
       const parts = ["✅ **Done**"];
       if (used.length > 0) parts.push(used.map((tool) => `\`${tool}\``).join(" "));
-      const totalTokens = envelope.tokenUsage?.totalTokens;
-      if (typeof totalTokens === "number" && totalTokens > 0) {
-        parts.push(`${formatTokenCount(totalTokens)} tok`);
-      }
       if (envelope.costUSD > 0) {
         parts.push(envelope.costUSD >= 0.0001 ? `$${envelope.costUSD.toFixed(4)}` : "<$0.0001");
       }
-      await reporter?.finish(parts.join(" · "));
+      const usageLines = formatUsageLines(envelope.tokenUsage);
+      await reporter?.finish(
+        usageLines === undefined ? parts.join(" · ") : `${parts.join(" · ")}\n${usageLines}`,
+      );
       const answerMessageId = await sendReply(config, channelId, envelope.answer, {
         components: followupComponents(),
       });

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -108,7 +108,12 @@ interface JazzSuccessEnvelope {
   readonly ok: true;
   readonly answer: string;
   readonly costUSD: number;
-  readonly tokenUsage?: { readonly totalTokens?: number };
+  readonly tokenUsage?: {
+    readonly totalTokens?: number;
+    readonly promptTokens?: number;
+    readonly completionTokens?: number;
+    readonly cacheReadTokens?: number;
+  };
   readonly webApp?: JazzWebApp;
   /**
    * Only present for `--ephemeral` runs (incognito chats): the full
@@ -512,6 +517,22 @@ function formatTokenCount(tokens: number): string {
 }
 
 /**
+ * Input and output split out, since a single total hides that the input is
+ * the whole conversation plus tool schemas re-sent on every loop iteration.
+ */
+function formatUsageLines(usage: JazzSuccessEnvelope["tokenUsage"]): string | undefined {
+  const promptTokens = usage?.promptTokens ?? 0;
+  const completionTokens = usage?.completionTokens ?? 0;
+  if (promptTokens === 0 && completionTokens === 0) return undefined;
+  const cacheReadTokens = usage?.cacheReadTokens ?? 0;
+  const cached = cacheReadTokens > 0 ? ` (${formatTokenCount(cacheReadTokens)} cached)` : "";
+  return [
+    `Input: ${formatTokenCount(promptTokens)}${cached}`,
+    `Output: ${formatTokenCount(completionTokens)}`,
+  ].join("\n");
+}
+
+/**
  * Show the latest slice of a streaming thought. Short thoughts render whole;
  * longer ones show the tail from a word boundary with a leading ellipsis, so
  * the line reads as a continuation rather than a chopped-off first word.
@@ -835,14 +856,13 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       if (used.length > 0) {
         parts.push(used.map((tool) => `<code>${escapeHtml(tool)}</code>`).join(" "));
       }
-      const totalTokens = envelope.tokenUsage?.totalTokens;
-      if (typeof totalTokens === "number" && totalTokens > 0) {
-        parts.push(`${formatTokenCount(totalTokens)} tok`);
-      }
       if (envelope.costUSD > 0) {
         parts.push(envelope.costUSD >= 0.0001 ? `$${envelope.costUSD.toFixed(4)}` : "<$0.0001");
       }
-      await reporter?.finish(parts.join(" · "));
+      const usageLines = formatUsageLines(envelope.tokenUsage);
+      await reporter?.finish(
+        usageLines === undefined ? parts.join(" · ") : `${parts.join(" · ")}\n\n${usageLines}`,
+      );
       // Send with static CTAs immediately, then (optionally) upgrade to
       // contextual ones once a quick follow-up generation returns.
       const answerMessageId = await sendReply(config, chatId, envelope.answer, {

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -514,7 +514,9 @@ export function runAgentOnceCommand(
             promptTokens,
             completionTokens,
             totalTokens: promptTokens + completionTokens,
-            cacheReadTokens: runResult.usage?.cacheReadTokens ?? 0,
+            ...(runResult.usage?.cacheReadTokens !== undefined && {
+              cacheReadTokens: runResult.usage.cacheReadTokens,
+            }),
           },
           toolCalls,
           ...(webApp ? { webApp } : {}),

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -35,6 +35,8 @@ export interface OneShotTokenUsage {
   readonly promptTokens: number;
   readonly completionTokens: number;
   readonly totalTokens: number;
+  /** Share of promptTokens served from the provider's prompt cache. */
+  readonly cacheReadTokens?: number;
 }
 
 export interface OneShotToolCall {
@@ -512,6 +514,7 @@ export function runAgentOnceCommand(
             promptTokens,
             completionTokens,
             totalTokens: promptTokens + completionTokens,
+            cacheReadTokens: runResult.usage?.cacheReadTokens ?? 0,
           },
           toolCalls,
           ...(webApp ? { webApp } : {}),

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -289,6 +289,7 @@ function finalizeRun(
       usage: {
         promptTokens: runMetrics.totalPromptTokens,
         completionTokens: runMetrics.totalCompletionTokens,
+        cacheReadTokens: runMetrics.totalCacheReadTokens,
       },
       ...(costUSD !== undefined ? { costUSD } : {}),
     };

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -289,7 +289,9 @@ function finalizeRun(
       usage: {
         promptTokens: runMetrics.totalPromptTokens,
         completionTokens: runMetrics.totalCompletionTokens,
-        cacheReadTokens: runMetrics.totalCacheReadTokens,
+        ...(runMetrics.totalCacheReadTokens > 0 && {
+          cacheReadTokens: runMetrics.totalCacheReadTokens,
+        }),
       },
       ...(costUSD !== undefined ? { costUSD } : {}),
     };

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -196,7 +196,11 @@ export interface AgentResponse {
    * Token usage for this turn (prompt + completion).
    * Used by the chat session to accumulate session cost for /cost.
    */
-  readonly usage?: { readonly promptTokens: number; readonly completionTokens: number };
+  readonly usage?: {
+    readonly promptTokens: number;
+    readonly completionTokens: number;
+    readonly cacheReadTokens?: number;
+  };
   /** Total estimated cost for the full run in USD. Populated when model pricing is available. */
   readonly costUSD?: number;
 }


### PR DESCRIPTION
## What changed

The run footer ended with a single number:

```
✅ Done · web_search · 20.4k tok
```

That total is input + output summed over every model call in the run, which hides the thing worth knowing: almost all of it is input, because each loop iteration re-sends the whole conversation plus every tool schema. The footer now reads:

```
✅ Done · web_search
Input: 18.2k (12.1k cached)
Output: 2.2k
```

The cached clause appears only when the provider reports prompt-cache reads. To make that possible, `cacheReadTokens` — already tracked per run in `AgentRunMetrics` — is now carried out through the agent loop's result and the `jazz run --json` envelope, where it was previously dropped.

Applied to both the Telegram and Discord bridges so their footers stay identical; Discord renders the two lines as subtext.

## Impact

Per-message cost is legible at a glance: you can see whether a big number came from a long answer or from context being re-sent, and how much of the input the provider served from cache. Daily `/status` totals are unchanged.

## Verify

```sh
jazz run --json -a <agent> "hello" | jq .tokenUsage
```

should now include `cacheReadTokens` alongside the prompt/completion counts. In a chat, send any message and check the footer under the answer.