### PR TITLE
fix(ui): show http_request query params and bill cached input at the …

### DIFF
--- a/src/cli/presentation/cli-renderer.ts
+++ b/src/cli/presentation/cli-renderer.ts
@@ -11,6 +11,7 @@ import {
   formatToolArguments as formatToolArgumentsShared,
   formatToolResult as formatToolResultShared,
 } from "@/core/utils/tool-formatter";
+import { computeUsageCostUSD } from "@/core/utils/usage-cost";
 import { formatMarkdown, formatMarkdownHybrid } from "./markdown-formatter";
 import { createTheme, detectColorProfile } from "./output-theme";
 import type { OutputWriter } from "./output-writer";
@@ -82,6 +83,7 @@ export class CLIRenderer {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
+    cacheReadTokens?: number;
   } | null = null;
   private currentProvider: string | null = null;
   private currentModel: string | null = null;
@@ -448,11 +450,10 @@ export class CLIRenderer {
     ) {
       const meta = getModelsDevMetadataSync(this.currentModel, this.currentProvider);
       if (meta?.inputPricePerMillion !== undefined || meta?.outputPricePerMillion !== undefined) {
-        const inputPrice = meta.inputPricePerMillion ?? 0;
         const outputPrice = meta.outputPricePerMillion ?? 0;
-        const inputCost = (this.accumulatedUsage.promptTokens / 1_000_000) * inputPrice;
         const outputCost = (this.accumulatedUsage.completionTokens / 1_000_000) * outputPrice;
-        const totalCost = inputCost + outputCost;
+        const totalCost = computeUsageCostUSD(this.accumulatedUsage, meta) ?? 0;
+        const inputCost = totalCost - outputCost;
 
         const fmt = (cost: number): string => {
           if (cost === 0) return "$0.00";

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -26,6 +26,7 @@ import type { ApprovalOutcome, ApprovalRequest } from "@/core/types/tools";
 import { getModelsDevMetadata, getModelsDevMetadataSync } from "@/core/utils/models-dev";
 import { extractCommandApprovalKey } from "@/core/utils/shell";
 import { expandableToolResultPayload } from "@/core/utils/tool-formatter";
+import { computeUsageCostUSD, type UsageCostPricing } from "@/core/utils/usage-cost";
 import { createAccumulator, reduceEvent } from "./activity-reducer";
 import {
   formatToolArguments,
@@ -726,8 +727,13 @@ export class InkStreamingRenderer implements StreamingRenderer {
 
     const usage = event.response.usage;
     if (usage) {
+      const cacheReadTokens = Math.min(usage.cacheReadTokens ?? 0, usage.promptTokens);
+      const cachedShare =
+        usage.promptTokens > 0 && cacheReadTokens > 0
+          ? ` (${Math.round((cacheReadTokens / usage.promptTokens) * 100)}% cached)`
+          : "";
       parts.push(
-        `${compactTokens(usage.promptTokens)} in → ${compactTokens(usage.completionTokens)} out`,
+        `${compactTokens(usage.promptTokens)} in${cachedShare} → ${compactTokens(usage.completionTokens)} out`,
       );
       // Push the prompt-side count to the persistent footer so users have
       // visibility on context-window pressure between turns.
@@ -740,16 +746,8 @@ export class InkStreamingRenderer implements StreamingRenderer {
     const provider = this.acc.currentProvider;
     const model = this.acc.currentModel;
     if (usage && provider && model) {
-      const computeCost = (
-        meta: { inputPricePerMillion?: number; outputPricePerMillion?: number } | undefined,
-      ): number | null => {
-        if (meta?.inputPricePerMillion === undefined && meta?.outputPricePerMillion === undefined) {
-          return null;
-        }
-        const inputCost = (usage.promptTokens / 1_000_000) * (meta.inputPricePerMillion ?? 0);
-        const outputCost = (usage.completionTokens / 1_000_000) * (meta.outputPricePerMillion ?? 0);
-        return inputCost + outputCost;
-      };
+      const computeCost = (meta: UsageCostPricing | undefined): number | null =>
+        computeUsageCostUSD(usage, meta);
       const rollIntoFooter = (totalCost: number): void => {
         this.acc.cumulativeCostUSD += totalCost;
         // Accumulate into the shared session total so sub-agent renderers add

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -11,6 +11,7 @@ import type { DisplayConfig } from "@/core/types/output";
 import type { StreamEvent } from "@/core/types/streaming";
 import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
+import { computeUsageCostUSD, type UsageCostPricing } from "@/core/utils/usage-cost";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { logContextRung } from "../context/context-telemetry";
@@ -220,7 +221,7 @@ interface FinalizeInput {
   response: AgentResponse;
   currentMessages: ConversationMessages;
   runMetrics: AgentRunMetrics;
-  modelMetadata: { inputPricePerMillion?: number; outputPricePerMillion?: number } | undefined;
+  modelMetadata: UsageCostPricing | undefined;
   iterationsUsed: number;
   finished: boolean;
   interrupted: boolean;
@@ -268,13 +269,15 @@ function finalizeRun(
     );
     yield* Ref.set(finalizeFiberRef, Option.some(finalizeFiber));
 
-    const inputPrice = modelMetadata?.inputPricePerMillion ?? 0;
-    const outputPrice = modelMetadata?.outputPricePerMillion ?? 0;
     const ownCostUSD =
-      inputPrice > 0 || outputPrice > 0
-        ? (runMetrics.totalPromptTokens / 1_000_000) * inputPrice +
-          (runMetrics.totalCompletionTokens / 1_000_000) * outputPrice
-        : undefined;
+      computeUsageCostUSD(
+        {
+          promptTokens: runMetrics.totalPromptTokens,
+          completionTokens: runMetrics.totalCompletionTokens,
+          cacheReadTokens: runMetrics.totalCacheReadTokens,
+        },
+        modelMetadata,
+      ) ?? undefined;
     // Report the run's own cost plus any sub-agent cost. Emit a figure whenever
     // either side is known — a run with unpriced parent tokens but priced
     // sub-agents should still surface the sub-agent spend.

--- a/src/core/utils/models-dev.ts
+++ b/src/core/utils/models-dev.ts
@@ -46,6 +46,8 @@ export interface ModelsDevMetadata {
   readonly inputPricePerMillion?: number;
   /** Output price in USD per 1M tokens (from models.dev cost.output). */
   readonly outputPricePerMillion?: number;
+  /** Cached-input price in USD per 1M tokens (from models.dev cost.cache_read). */
+  readonly cacheReadPricePerMillion?: number;
 }
 
 /** One model as listed under a models.dev provider, with resolved metadata. */
@@ -70,7 +72,7 @@ type ModelsDevModelSpec = {
   reasoning?: boolean;
   temperature?: boolean;
   modalities?: { input?: string[]; output?: string[] };
-  cost?: { input?: number; output?: number };
+  cost?: { input?: number; output?: number; cache_read?: number };
 };
 
 type ModelsDevProvider = {
@@ -124,6 +126,10 @@ function toMetadata(spec: ModelsDevModelSpec): ModelsDevMetadata {
     typeof spec.cost?.input === "number" && spec.cost.input >= 0 ? spec.cost.input : undefined;
   const outputPrice =
     typeof spec.cost?.output === "number" && spec.cost.output >= 0 ? spec.cost.output : undefined;
+  const cacheReadPrice =
+    typeof spec.cost?.cache_read === "number" && spec.cost.cache_read >= 0
+      ? spec.cost.cache_read
+      : undefined;
 
   const inputModalities = Array.isArray(spec.modalities?.input) ? spec.modalities.input : [];
 
@@ -136,6 +142,7 @@ function toMetadata(spec: ModelsDevModelSpec): ModelsDevMetadata {
     supportsTemperature: spec.temperature !== false,
     ...(inputPrice !== undefined && { inputPricePerMillion: inputPrice }),
     ...(outputPrice !== undefined && { outputPricePerMillion: outputPrice }),
+    ...(cacheReadPrice !== undefined && { cacheReadPricePerMillion: cacheReadPrice }),
   };
 }
 

--- a/src/core/utils/tool-formatter.test.ts
+++ b/src/core/utils/tool-formatter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { formatToolArguments } from "./tool-formatter";
+
+describe("formatToolArguments http_request", () => {
+  test("merges query params into the displayed URL", () => {
+    const formatted = formatToolArguments(
+      "http_request",
+      {
+        method: "GET",
+        url: "https://duckduckgo.com/html/",
+        query: { q: "Ye latest concert 2025" },
+      },
+      { style: "plain" },
+    );
+    expect(formatted).toContain("https://duckduckgo.com/html/?q=Ye%20latest%20concert%202025");
+  });
+
+  test("appends with & when the URL already has a query string", () => {
+    const formatted = formatToolArguments(
+      "http_request",
+      {
+        method: "GET",
+        url: "https://example.com/search?page=2",
+        query: { q: "tickets" },
+      },
+      { style: "plain" },
+    );
+    expect(formatted).toContain("https://example.com/search?page=2&q=tickets");
+  });
+
+  test("leaves the URL untouched without query params", () => {
+    const formatted = formatToolArguments(
+      "http_request",
+      { method: "GET", url: "https://example.com/" },
+      { style: "plain" },
+    );
+    expect(formatted).toContain("url: https://example.com/");
+    expect(formatted).not.toContain("?");
+  });
+});

--- a/src/core/utils/tool-formatter.ts
+++ b/src/core/utils/tool-formatter.ts
@@ -16,6 +16,22 @@ const MAX_EXPANDABLE_CHARS = 100_000;
 
 type FormatStyle = "plain" | "colored";
 
+/**
+ * Merge an http_request `query` argument into the displayed URL so searches
+ * read as the request actually sent (`…/html/?q=…`), not the bare base URL.
+ */
+function appendQueryParams(url: string, query: unknown): string {
+  if (typeof query !== "object" || query === null || Array.isArray(query)) return url;
+  const entries = Object.entries(query as Record<string, unknown>).filter(
+    ([, value]) => value !== undefined && value !== null,
+  );
+  if (entries.length === 0) return url;
+  const queryString = entries
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(safeString(value))}`)
+    .join("&");
+  return `${url}${url.includes("?") ? "&" : "?"}${queryString}`;
+}
+
 interface FormatOptions {
   style?: FormatStyle;
   /** Executor hints for display (e.g. web_search backend: builtin vs configured provider). */
@@ -283,10 +299,11 @@ export function formatToolArguments(
       }
       const url = safeString(args["url"]);
       if (url) {
+        const resolvedUrl = appendQueryParams(url, args["query"]);
         if (usePlain) {
-          parts.push(`url: ${url}`);
+          parts.push(`url: ${resolvedUrl}`);
         } else {
-          parts.push(` ${chalk.cyan(url)}`);
+          parts.push(` ${chalk.cyan(resolvedUrl)}`);
         }
       }
       return formatParts(parts);

--- a/src/core/utils/usage-cost.test.ts
+++ b/src/core/utils/usage-cost.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { computeUsageCostUSD } from "./usage-cost";
+
+describe("computeUsageCostUSD", () => {
+  test("returns null when no pricing is known", () => {
+    expect(
+      computeUsageCostUSD({ promptTokens: 1000, completionTokens: 100 }, undefined),
+    ).toBeNull();
+    expect(computeUsageCostUSD({ promptTokens: 1000, completionTokens: 100 }, {})).toBeNull();
+  });
+
+  test("prices uncached input and output at full rates", () => {
+    const cost = computeUsageCostUSD(
+      { promptTokens: 1_000_000, completionTokens: 500_000 },
+      { inputPricePerMillion: 2, outputPricePerMillion: 8 },
+    );
+    expect(cost).toBeCloseTo(2 + 4, 10);
+  });
+
+  test("bills the cached share at the cache-read rate", () => {
+    const cost = computeUsageCostUSD(
+      { promptTokens: 1_000_000, completionTokens: 0, cacheReadTokens: 900_000 },
+      { inputPricePerMillion: 2, outputPricePerMillion: 8, cacheReadPricePerMillion: 0.2 },
+    );
+    expect(cost).toBeCloseTo(0.1 * 2 + 0.9 * 0.2, 10);
+  });
+
+  test("falls back to the full input rate when no cache-read price exists", () => {
+    const cost = computeUsageCostUSD(
+      { promptTokens: 1_000_000, completionTokens: 0, cacheReadTokens: 900_000 },
+      { inputPricePerMillion: 2 },
+    );
+    expect(cost).toBeCloseTo(2, 10);
+  });
+
+  test("clamps cacheReadTokens to promptTokens", () => {
+    const cost = computeUsageCostUSD(
+      { promptTokens: 100, completionTokens: 0, cacheReadTokens: 500 },
+      { inputPricePerMillion: 2, cacheReadPricePerMillion: 0.2 },
+    );
+    expect(cost).toBeCloseTo((100 / 1_000_000) * 0.2, 12);
+  });
+});

--- a/src/core/utils/usage-cost.ts
+++ b/src/core/utils/usage-cost.ts
@@ -1,0 +1,41 @@
+export interface UsageCostPricing {
+  readonly inputPricePerMillion?: number;
+  readonly outputPricePerMillion?: number;
+  readonly cacheReadPricePerMillion?: number;
+}
+
+export interface UsageCostTokens {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+  readonly cacheReadTokens?: number;
+}
+
+/**
+ * Price a usage sample, billing the cached share of the prompt at the
+ * provider's cache-read rate. Providers report cacheReadTokens as a subset of
+ * promptTokens, so the uncached share is promptTokens minus cacheReadTokens.
+ * Without a cache-read price, cached tokens fall back to the full input rate
+ * (an overestimate, but never an understatement of the bill).
+ *
+ * Returns null when no pricing is known at all.
+ */
+export function computeUsageCostUSD(
+  tokens: UsageCostTokens,
+  pricing: UsageCostPricing | undefined,
+): number | null {
+  if (pricing?.inputPricePerMillion === undefined && pricing?.outputPricePerMillion === undefined) {
+    return null;
+  }
+  const inputPrice = pricing.inputPricePerMillion ?? 0;
+  const outputPrice = pricing.outputPricePerMillion ?? 0;
+  const cacheReadPrice = pricing.cacheReadPricePerMillion ?? inputPrice;
+
+  const cacheReadTokens = Math.min(tokens.cacheReadTokens ?? 0, tokens.promptTokens);
+  const uncachedPromptTokens = tokens.promptTokens - cacheReadTokens;
+
+  return (
+    (uncachedPromptTokens / 1_000_000) * inputPrice +
+    (cacheReadTokens / 1_000_000) * cacheReadPrice +
+    (tokens.completionTokens / 1_000_000) * outputPrice
+  );
+}


### PR DESCRIPTION
…cache-read rate

Two display bugs surfaced by the same mini-coder session:

- http_request tool calls rendered as the bare base URL (GET: https://duckduckgo.com/html/) because the formatter dropped the query argument — searches looked like repeated homepage fetches. The displayed URL now includes the merged query string.

- Cost figures priced the entire prompt at the full input rate even when the provider reported most of it as cache reads (89% on the observed run), overstating spend several-fold. models.dev cost.cache_read now flows into a shared computeUsageCostUSD helper used by the Ink outro, the legacy CLI renderer, and the run envelope, and the outro shows the cached share: '41k in (89% cached) -> 374 out'.