### PR TITLE
feat(agent): keep going on missing CLIs and guide first-run setup

### DIFF
--- a/docs/cookbook/inbox-triage.md
+++ b/docs/cookbook/inbox-triage.md
@@ -94,25 +94,25 @@ Write a markdown summary to `$HOME/.jazz/inbox-triage/$(date +%Y-%m-%d).md` with
 ## How to install
 
 ```bash
-# 1. Himalaya: optional. The email skill fetches the live README and
-#    installs the CLI if `himalaya` is not on PATH. To do it yourself:
-# brew install himalaya            # macOS
+# 1. Install Himalaya and configure at least one account *before* scheduling.
+#    This recipe cannot bootstrap a fresh machine — the weekday run is
+#    unattended. First-time setup is a separate interactive session
+#    (ask Jazz "check my latest emails", or do it yourself):
+brew install himalaya            # macOS
 # or: cargo install --locked --git https://github.com/pimalaya/himalaya.git
-
-# 2. Configure at least one account (interactive wizard)
 himalaya account configure default
 
-# 3. Drop the workflow into your global Jazz workflows dir
+# 2. Drop the workflow into your global Jazz workflows dir
 mkdir -p ~/.jazz/workflows/inbox-triage
 $EDITOR ~/.jazz/workflows/inbox-triage/WORKFLOW.md   # paste the file above
 
-# 4. Verify Jazz sees it
+# 3. Verify Jazz sees it
 jazz workflow list | grep inbox-triage
 
-# 5. Run it once foreground, watch what it does
+# 4. Run it once foreground, watch what it does
 jazz workflow run inbox-triage
 
-# 6. Once you trust it, schedule it
+# 5. Once you trust it, schedule it
 jazz workflow schedule inbox-triage
 
 # Tail the log on the next run
@@ -134,5 +134,5 @@ tail -f ~/.jazz/logs/inbox-triage.log
 
 ## Limits
 
-- Requires the `email` skill. The skill ships with Jazz and will fetch the Himalaya README and install the CLI if it is missing; you still need to configure at least one account (`himalaya account configure` / the wizard).
+- Requires a working Himalaya install and at least one configured account *before* you schedule it. The email skill can walk you through that in an interactive session; the weekday cron run will not.
 - `low-risk` policy auto-approves the `move` command. If you'd rather hand-approve, drop to `read-only` and run interactively.

--- a/docs/cookbook/inbox-triage.md
+++ b/docs/cookbook/inbox-triage.md
@@ -94,9 +94,10 @@ Write a markdown summary to `$HOME/.jazz/inbox-triage/$(date +%Y-%m-%d).md` with
 ## How to install
 
 ```bash
-# 1. Install Himalaya if you don't have it
-brew install himalaya            # macOS
-# or: cargo install himalaya --locked
+# 1. Himalaya: optional. The email skill fetches the live README and
+#    installs the CLI if `himalaya` is not on PATH. To do it yourself:
+# brew install himalaya            # macOS
+# or: cargo install --locked --git https://github.com/pimalaya/himalaya.git
 
 # 2. Configure at least one account (interactive wizard)
 himalaya account configure default
@@ -133,5 +134,5 @@ tail -f ~/.jazz/logs/inbox-triage.log
 
 ## Limits
 
-- Requires the `email` skill and a working `himalaya` install. The skill ships with Jazz; Himalaya is a third-party CLI you install yourself.
+- Requires the `email` skill. The skill ships with Jazz and will fetch the Himalaya README and install the CLI if it is missing; you still need to configure at least one account (`himalaya account configure` / the wizard).
 - `low-risk` policy auto-approves the `move` command. If you'd rather hand-approve, drop to `read-only` and run interactively.

--- a/docs/integrations/email-calendar.md
+++ b/docs/integrations/email-calendar.md
@@ -20,7 +20,7 @@ Jazz uses **skills** for email and calendar—agents run Himalaya and khal via `
 
 Use the **email** skill with [Himalaya CLI](https://github.com/pimalaya/himalaya) for inbox management. Himalaya works with Gmail, Outlook, iCloud, Proton Mail, and more via IMAP/SMTP.
 
-- **Setup**: Install Himalaya (`brew install himalaya`), run `himalaya account configure` for your provider
+- **Setup**: Load the `email` skill — it installs Himalaya if missing (from the live README) and walks you through account setup, then you can check mail
 - **Agents**: Load the `email` skill—it teaches agents to use Himalaya for list, read, send, reply, search, and organize
 - **Provider-agnostic**: One setup works across Gmail, Outlook, iCloud, Fastmail, etc.
 

--- a/personas/coder/persona.md
+++ b/personas/coder/persona.md
@@ -66,7 +66,7 @@ When you've used the web to confirm an API or a fact, cite the source so the use
 
 # Working with tools and skills
 
-Do the work, don't narrate how the user could do it. When the request is to fix or build something, reach for the tool and make the change rather than printing instructions to follow — the edit is the help.
+Do the work, don't narrate how the user could do it. When you can finish with tools, do it — the edit is the help. When the next step needs something only they can provide (a credential, a choice, a wizard in their terminal), walk them through that step and then continue. Do not dump a link and stop.
 
 Reach for the sharpest instrument available. When a skill matches the task, prefer it over improvising from scratch — it encodes a tested way to do the thing. Prefer a dedicated tool over a raw shell command when one exists, and fall back to general shell and scripting when nothing more specific fits.
 

--- a/personas/default/persona.md
+++ b/personas/default/persona.md
@@ -58,7 +58,7 @@ When you do need to ask the user something, ask through the dedicated question t
 
 # Working with tools and skills
 
-Do things, don't narrate how the user could do them. When the request is to accomplish something, reach for the tool and accomplish it rather than printing a set of instructions to follow — the tool call is the help.
+Do things, don't narrate how the user could do them. When you can finish the request with tools, do it — the tool call is the help. When the next step needs something only they can provide (a password, a provider choice, a wizard in their terminal), walk them through that step and then continue the original request. Do not dump a link and stop.
 
 Reach for the sharpest instrument available. When a skill matches the task, prefer it over improvising from scratch — it encodes a tested way to do the thing. Prefer a dedicated tool over a raw shell command when one exists. Fall back to general shell and scripting when nothing more specific fits.
 

--- a/skills/email/SKILL.md
+++ b/skills/email/SKILL.md
@@ -11,6 +11,8 @@ Manage emails using [Himalaya CLI](https://github.com/pimalaya/himalaya) - a pow
 
 **When using this skill as an agent**, run commands via `execute_command`. Prefer these patterns:
 
+0. **Install and set up if needed.** Run [Prerequisites Check](#prerequisites-check) before the first Himalaya command. If `himalaya` is missing, fetch the live README and install it. If no account is configured, walk the user through [Account Setup](#account-setup), then continue the original request (check mail, etc.). Do not stop at "go install Himalaya".
+
 1. **Always use `--output json`** when you need to parse results (subject, from, id). Example:
    ```bash
    himalaya envelope list --folder INBOX --page-size 20 --output json | jq '.[] | {id, subject, from, date}'
@@ -32,71 +34,98 @@ Manage emails using [Himalaya CLI](https://github.com/pimalaya/himalaya) - a pow
 
 ## Prerequisites Check
 
-Before any email operation, verify Himalaya is installed and configured:
+Before any email operation:
 
-```bash
-# Check if installed
-which himalaya
+1. Check whether Himalaya is on PATH:
 
-# Check if configured (lists accounts)
-himalaya account list
-```
+   ```bash
+   command -v himalaya
+   ```
 
-If not installed → Guide through [Installation](#installation)
-If no accounts → Guide through [Account Setup](#account-setup)
+2. **If it is missing, install it.** Do not just tell the user to install it. Follow [Install Himalaya](#install-himalaya), then re-check `command -v himalaya`.
+
+3. Check configuration:
+
+   ```bash
+   himalaya account list
+   ```
+
+   If no accounts → walk them through [Account Setup](#account-setup), then continue what they asked. Do not invent credentials. The wizard needs a real TTY; do not run it via `execute_command`. In a headless run, write a one-line failure note and stop.
 
 ---
 
-## Installation
+## Install Himalaya
 
-### pre-built binary
+Himalaya is a third-party CLI ([pimalaya/himalaya](https://github.com/pimalaya/himalaya)). Install methods change; **fetch the live README and follow its Installation section** rather than memorizing this page.
 
-curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+1. Fetch the README with `web_fetch` (or `http_request` GET if `web_fetch` is unavailable):
+   `https://raw.githubusercontent.com/pimalaya/himalaya/master/README.md`
+   If that fails, try `https://github.com/pimalaya/himalaya`. Read the **Installation** section. If fetch is unavailable, use the table below.
 
-### macOS (Homebrew)
+2. Detect the host (`uname -s`) and which of `brew`, `pacman`, `scoop`, `nix`, `cargo` exist.
 
-```bash
-brew install himalaya
-```
+3. Install using the README method that matches, in this preference order:
 
-### Arch Linux
+   | Host | Typical command (confirm against the README) |
+   | --- | --- |
+   | macOS with Homebrew | `brew install himalaya` |
+   | Arch | `pacman -S himalaya` |
+   | Windows with Scoop | `scoop install himalaya` |
+   | Nix | `nix profile install github:pimalaya/himalaya` |
+   | Any OS, no root | `curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh \| PREFIX=~/.local sh` |
+   | Cargo last resort | `cargo install --locked --git https://github.com/pimalaya/himalaya.git` |
 
-```bash
-pacman -S himalaya
-```
+4. **Never `sudo` the installer** unless the user explicitly asks. Prefer the user-prefix install (`PREFIX=~/.local`).
 
-### Cargo (Any OS)
+5. If you installed to `~/.local/bin` and `command -v himalaya` still fails, prepend that directory for the rest of this session. Each `execute_command` is a fresh shell, so include it on later commands:
 
-```bash
-cargo install himalaya --locked
-```
+   ```bash
+   export PATH="$HOME/.local/bin:$PATH"
+   command -v himalaya
+   ```
 
-### Other Methods
+   Tell the user to add `~/.local/bin` to PATH permanently if it is not already.
 
-Direct user to: https://github.com/pimalaya/himalaya#installation
+6. Verify with `himalaya --version` (or `himalaya -V`). If a later command fails with unknown flags, re-read the README Usage section and `himalaya --help` — prefer those over this skill's examples.
+
+If fetch and every install method fail, tell the user what you tried and point them at https://github.com/pimalaya/himalaya#installation.
 
 ---
 
 ## Account Setup
 
-**Recommended approach**: Use Himalaya's built-in wizard which auto-discovers settings.
+Himalaya with no config starts an interactive TTY wizard. **Do not run bare `himalaya` via `execute_command`** — it will hang waiting for a terminal. Guide the user instead, then continue the original request.
 
-### Interactive Setup (Easiest)
+Fetch the live README Configuration section if the wizard flags have changed: `https://raw.githubusercontent.com/pimalaya/himalaya/master/README.md`. Prefer that over this page.
 
-```bash
-# First-time setup - wizard starts automatically
-himalaya
+### First-run (interactive chat)
 
-# Or configure a specific account
-himalaya account configure <account-name>
-```
+When `himalaya account list` is empty or errors because nothing is configured — e.g. the user just asked "check my latest emails":
 
-The wizard will:
+1. Say in one or two lines that mail isn't set up yet, and you will walk them through it so you can then do what they asked. Setup is part of the request, not a detour.
+2. Ask the provider with `ask_user_question`: Gmail, Outlook / Microsoft 365, iCloud, Proton Mail, Fastmail, other IMAP.
+3. Load [references/providers.md](references/providers.md) for that provider. Tell them the one thing they need *before* the wizard:
+   - **Gmail** — App Password at https://myaccount.google.com/apppasswords (2-Step Verification must be on).
+   - **Outlook** — OAuth 2.0; basic auth is retired.
+   - **iCloud** — app-specific password; IMAP login is the local-part only (`johnappleseed`, not the full address).
+   - **Proton Mail** — Proton Bridge running locally; the password is the Bridge password.
+   - **Fastmail** — app password for IMAP/SMTP, or an API token for JMAP.
+4. Ask them to run the wizard in **their** terminal (a new tab is fine):
 
-1. Ask for email address
-2. Auto-discover IMAP/SMTP settings
-3. Prompt for password (stored securely in system keyring)
-4. Test the connection
+   ```bash
+   himalaya
+   ```
+
+   If their version has `himalaya account configure <name>`, that works too. Prefer whatever `himalaya --help` and the live README show. The wizard asks for an email address and discovers IMAP/SMTP. **Never ask them to paste a password into this chat.** Secrets belong in the wizard, `pass`, or `secret-tool`.
+5. When they say the wizard finished, re-run `himalaya account list` (and `himalaya account check` if it exists). If it works, immediately continue the original request. Do not wait to be asked again.
+
+### Headless / unattended
+
+Do not start a wizard. Write a one-line failure that Himalaya has no account configured, and stop.
+
+### Writing config yourself
+
+If they already use `pass` (or similar) and want you to write `~/.config/himalaya/config.toml`, fetch the live README Configuration section — the TOML shape changes across versions — and `load_skill_section` for [references/providers.md](references/providers.md). Never put a raw password in the file or in chat.
 
 ### Provider-Specific Notes
 
@@ -107,7 +136,7 @@ The wizard will:
 | **iCloud**      | IMAP login is username only (not full email) |
 | **Proton Mail** | Requires Proton Bridge running locally       |
 
-**💡 Tip**: Many providers use the same app-specific password for both email and calendar. Store credentials in `pass` with consistent naming (e.g., `google/app-password`, `icloud/app-password`) to reuse them across both email and calendar skills. For multiple accounts, use a hierarchical structure (e.g., `google/personal/app-password`, `google/work/app-password`)—the `/` creates folders to keep things organized.
+Many providers use the same app-specific password for both email and calendar. Store credentials in `pass` with consistent naming (e.g., `google/app-password`, `icloud/app-password`) to reuse them across both skills. For multiple accounts, use a hierarchical structure (e.g., `google/personal/app-password`) — the `/` creates folders.
 
 For detailed provider configs, see [references/providers.md](references/providers.md)
 

--- a/src/core/agent/agent-prompt-instructions.test.ts
+++ b/src/core/agent/agent-prompt-instructions.test.ts
@@ -49,6 +49,9 @@ describe("completion instructions injection", () => {
     expect(result).toContain("# Seeing work through");
     expect(result).toContain("Never guess a value you can fetch");
     expect(result).toContain("answer from the record");
+    expect(result).toContain("Do not stay stuck");
+    expect(result).toContain("Do not dump a URL and stop");
+    expect(result).toContain("Look up live docs");
   });
 
   test("summarizer never receives the completion contract", () => {
@@ -91,6 +94,7 @@ describe("tool guidance injection", () => {
     const withTool = build("default", { toolNames: ["http_request", "ask_user_question"] });
     expect(withTool).toContain("# Asking the user questions");
     expect(withTool).toContain("Permission to do work the user already requested");
+    expect(withTool).toContain("A required CLI or account is not set up");
   });
 });
 

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -53,11 +53,11 @@ Mark a work item done only when you have actually run something that confirms it
 export const COMPLETION_INSTRUCTIONS = `
 # Seeing work through
 
-1. Carry the request to a real finish. Done means the user could act on the result without coming back to fill a gap you left.
+1. Carry the request to a real finish. Done means the user could act on the result without coming back to fill a gap you left. Do not stay stuck. If you can take an action that moves the request forward, take it. If the next step needs the user — a credential, a provider choice, a TTY wizard — involve them: say where you are, walk them through that step, then continue the original request. Do not dump a URL and stop.
 2. Never stop mid-task to ask "do you want me to do X?" when X is part of finishing the request. If X is needed, do X now.
 3. Never end your turn by offering to do the work that was just requested ("Want me to write it?", "Shall I retry?", "Reply 1 or 2"). Do it, then report what happened.
-4. If a step fails, try a different approach before coming back. When you must report failure, say what you tried and what you would try next — never hand the user a menu of recovery options you could evaluate yourself.
-5. Never guess a value you can fetch. If a tool call can resolve a URL, an ID, a number, or a fact, make the call — a wrong guess costs more than one more tool call.
+4. If a step fails, try a different approach before coming back. Look up current documentation (README, --help, upstream site), try another method, then continue. When you must report failure, say what you tried and the next step that would unblock you — never hand the user a menu of recovery options you could evaluate yourself.
+5. Never guess a value you can fetch. If a tool call can resolve a URL, an ID, a number, or a fact, make the call — a wrong guess costs more than one more tool call. Look up live docs instead of relying on training for how a CLI is installed or configured.
 6. When asked about something you did earlier, answer from the record — re-read the file, re-fetch the resource, check the actual tool results. Never reconstruct your own past actions from memory or from what seems plausible.
 7. Once the job is done and verified, a brief offer of optional follow-up work is fine. Asking permission to do the requested work is not.
 `;
@@ -114,6 +114,7 @@ Ask only when you are truly blocked:
 - A scope or approach decision that changes what you will do next, with no clearly best option.
 - A destructive or irreversible action that needs explicit sign-off.
 - Information that is not inferable from context and not fetchable with any tool.
+- A required CLI or account is not set up, and only the user can choose the provider or supply a secret. Guide them through that step, then continue the original request.
 
 Do NOT ask:
 - Permission to do work the user already requested — do the work.


### PR DESCRIPTION
## What & why
A first-time "check my latest emails" used to die on a missing Himalaya install or an unconfigured account. The agent now installs what it can from the live README, involves the user only for things it cannot do (provider, password, TTY wizard), then continues the original request.

The same "don't stay stuck" contract is in the default completion prompt, so other missing CLIs get a path to resolution instead of a dumped URL.

## How to verify
- Interactive chat, Himalaya not installed: ask "check my latest emails". Confirm Jazz fetches the Himalaya README, installs the CLI (Homebrew or `PREFIX=~/.local`), and does not `sudo`.
- Interactive chat, Himalaya installed but no account: same ask. Confirm it asks for the provider, tells you the one prerequisite (e.g. Gmail app password), has you run `himalaya` in your own terminal, then lists mail after you say the wizard finished. Confirm it never asks you to paste a password into chat, and never runs bare `himalaya` via `execute_command`.
- Headless `jazz run` with no account: confirm it fails in one line instead of hanging on a wizard.
- `bun test src/core/agent/agent-prompt-instructions.test.ts` — completion contract still injects "Do not stay stuck" / "Look up live docs".