### PR TITLE
fix(llm): stop retrying requests the provider rejected before sending

### DIFF
--- a/src/core/agent/execution/llm-retry-present.test.ts
+++ b/src/core/agent/execution/llm-retry-present.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Ref } from "effect";
+import { LLMRequestError } from "@/core/types/errors";
+import { makeUserVisibleLlmRetrySchedule } from "./llm-retry-present";
+
+/**
+ * The retry notice is the only thing the user sees while an agent is stalled, so it has to
+ * describe what is actually about to happen.
+ */
+function collectNotices(maxRetries: number, error: unknown) {
+  return Effect.gen(function* () {
+    const notices: string[] = [];
+    const attemptRef = yield* Ref.make(0);
+    const schedule = makeUserVisibleLlmRetrySchedule(
+      maxRetries,
+      "agent",
+      (message) => {
+        notices.push(message);
+        return Effect.void;
+      },
+      attemptRef,
+    );
+
+    // Always-failing effect, so the schedule runs to exhaustion.
+    yield* Effect.fail(error).pipe(
+      Effect.retry(schedule),
+      Effect.catchAll(() => Effect.void),
+    );
+    return notices;
+  });
+}
+
+describe("makeUserVisibleLlmRetrySchedule", () => {
+  // Retry counts stay at 2 throughout: the schedule uses real exponential backoff, so each
+  // extra retry adds seconds of wall-clock to the suite for no extra coverage.
+  it("never announces more attempts than it will make", async () => {
+    // The schedule also receives the failure that exhausts it, so the counter reached
+    // maxRetries + 1 and printed "attempt 11 of up to 10" — promising a retry that never came.
+    const transient = new LLMRequestError({ provider: "ollama", message: "fetch failed" });
+    const notices = await Effect.runPromise(collectNotices(2, transient));
+
+    expect(notices.length).toBeLessThanOrEqual(2);
+    expect(notices.join(" ")).not.toContain("attempt 3 of up to 2");
+  }, 20_000);
+
+  it("says nothing at all for a request the provider rejected outright", async () => {
+    const permanent = new LLMRequestError({
+      provider: "ollama",
+      message: "'file part media type audio/ogg' functionality not supported.",
+      permanent: true,
+    });
+    expect(await Effect.runPromise(collectNotices(2, permanent))).toEqual([]);
+  }, 20_000);
+
+  it("still reports a genuine transient failure", async () => {
+    const transient = new LLMRequestError({ provider: "ollama", message: "fetch failed" });
+    const notices = await Effect.runPromise(collectNotices(2, transient));
+
+    expect(notices.length).toBeGreaterThan(0);
+    expect(notices[0]).toContain("network issue");
+    expect(notices[0]).toContain("attempt 1 of up to 2");
+  }, 20_000);
+});

--- a/src/core/agent/execution/llm-retry-present.ts
+++ b/src/core/agent/execution/llm-retry-present.ts
@@ -43,6 +43,10 @@ export function makeUserVisibleLlmRetrySchedule(
       isRetryableLLMError(error)
         ? Effect.gen(function* () {
             const attempt = yield* Ref.updateAndGet(attemptRef, (count) => count + 1);
+            // The schedule also receives the failure that exhausts it, so this fires once more
+            // than there are retries. Announcing "attempt 11 of up to 10" promised a retry that
+            // was never going to happen.
+            if (attempt > maxRetries) return;
             const reason = describeRetryableLLMError(error);
             yield* presentStatus(
               `${agentName} hit a ${reason}. Trying again (attempt ${attempt} of up to ${maxRetries})…`,

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -230,6 +230,15 @@ export class LLMRequestError extends Data.TaggedError("LLMRequestError")<{
   readonly message: string;
   readonly statusCode?: number;
   readonly suggestion?: string;
+  /**
+   * Set when the request failed for a reason no retry can change — the request was rejected
+   * locally, before it ever reached the provider.
+   *
+   * Needed because an absent `statusCode` otherwise means "the request never got a response",
+   * which the retry policy treats as a transient connection failure. A malformed request looks
+   * identical by that measure and would be retried to exhaustion.
+   */
+  readonly permanent?: boolean;
 }> {}
 
 export class LLMRateLimitError extends Data.TaggedError("LLMRateLimitError")<{

--- a/src/core/utils/llm-error.test.ts
+++ b/src/core/utils/llm-error.test.ts
@@ -1,3 +1,4 @@
+import { UnsupportedFunctionalityError } from "@ai-sdk/provider";
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "bun:test";
 import { LLMRateLimitError, LLMRequestError } from "@/core/types/errors";
@@ -6,6 +7,7 @@ import {
   describeRetryableLLMError,
   extractCleanErrorMessage,
   isConnectionError,
+  isPermanentRequestError,
   isRetryableLLMError,
   localServerUnreachableMessage,
   truncateRequestBodyValues,
@@ -122,5 +124,70 @@ describe("describeRetryableLLMError", () => {
 
   it("falls back to a generic description for unrecognized errors", () => {
     expect(describeRetryableLLMError(new Error("boom"))).toBe("unknown issue");
+  });
+});
+
+describe("locally-rejected requests are not retried", () => {
+  /**
+   * The real shape: an audio attachment sent to Ollama, whose provider transports only images.
+   * Constructed with the SDK's own error class rather than a hand-written stub, so the test
+   * still holds if the SDK renames or restructures it.
+   */
+  function unsupportedMediaError(): UnsupportedFunctionalityError {
+    return new UnsupportedFunctionalityError({
+      functionality: "file part media type audio/ogg",
+    });
+  }
+
+  it("recognizes a request the SDK rejected before sending it", () => {
+    expect(isPermanentRequestError(unsupportedMediaError())).toBe(true);
+  });
+
+  it("finds the cause even when it is wrapped", () => {
+    // Providers raise these from deep inside the SDK, so the interesting name is usually nested.
+    const wrapped = new Error("Failed to generate text", { cause: unsupportedMediaError() });
+    expect(isPermanentRequestError(wrapped)).toBe(true);
+  });
+
+  it("does not flag an ordinary connection failure", () => {
+    expect(isPermanentRequestError(new Error("fetch failed"))).toBe(false);
+  });
+
+  it("survives a cyclic cause chain", () => {
+    const first = new Error("first") as Error & { cause?: unknown };
+    const second = new Error("second", { cause: first }) as Error & { cause?: unknown };
+    first.cause = second;
+    expect(isPermanentRequestError(first)).toBe(false);
+  });
+
+  it("marks the converted error permanent", () => {
+    const converted = convertToLLMError(unsupportedMediaError(), "ollama");
+    expect(converted).toBeInstanceOf(LLMRequestError);
+    expect((converted as LLMRequestError).permanent).toBe(true);
+  });
+
+  it("does not retry it", () => {
+    // The bug: with no statusCode this was indistinguishable from a dropped connection, so it
+    // burned the whole backoff schedule — eleven identical attempts — before surfacing.
+    expect(isRetryableLLMError(convertToLLMError(unsupportedMediaError(), "ollama"))).toBe(false);
+  });
+
+  it("does not call it a network issue", () => {
+    // Describing a local rejection as a network problem sent users hunting for a connectivity
+    // fault that did not exist.
+    const converted = convertToLLMError(unsupportedMediaError(), "ollama");
+    expect(describeRetryableLLMError(converted)).toBe("rejected request");
+  });
+
+  it("still retries a genuine connection failure with no status code", () => {
+    // The guard must not narrow the transient case it was carved out of.
+    const transient = new LLMRequestError({ provider: "ollama", message: "fetch failed" });
+    expect(isRetryableLLMError(transient)).toBe(true);
+  });
+
+  it("leaves the API-key path alone", () => {
+    // AI_LoadAPIKeyError is excluded on purpose so the friendlier key guidance still wins.
+    const converted = convertToLLMError(new Error("Missing API key"), "openai");
+    expect((converted as LLMRequestError).permanent).toBeUndefined();
   });
 });

--- a/src/core/utils/llm-error.ts
+++ b/src/core/utils/llm-error.ts
@@ -202,6 +202,58 @@ export function isConnectionError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * AI SDK errors raised while *building* a request, rather than in response to one.
+ *
+ * These carry no HTTP status because they never reached the provider, which is exactly what the
+ * retry policy reads as "connection failure, try again". They are deterministic: the same inputs
+ * fail the same way every time, so retrying burns the full backoff schedule — around 30 seconds
+ * and eleven identical attempts — before surfacing the error the caller could have seen
+ * immediately.
+ *
+ * The observed case: sending an audio attachment to Ollama, whose provider transports only
+ * images, raises UnsupportedFunctionalityError and was retried eleven times.
+ *
+ * Deliberately excluded: `AI_LoadAPIKeyError`, so the friendlier API-key guidance below still
+ * wins; and response-side failures (`AI_JSONParseError`, `AI_EmptyResponseBodyError`,
+ * `AI_NoContentGeneratedError`), where a retry can legitimately succeed against a flaky server.
+ */
+const PERMANENT_REQUEST_ERROR_NAMES = new Set([
+  "AI_UnsupportedFunctionalityError",
+  "AI_UnsupportedModelVersionError",
+  "AI_InvalidArgumentError",
+  "AI_InvalidPromptError",
+  "AI_InvalidDataContentError",
+  "AI_InvalidMessageRoleError",
+  "AI_MessageConversionError",
+  "AI_TypeValidationError",
+  "AI_NoSuchModelError",
+  "AI_NoSuchProviderError",
+  "AI_NoSuchToolError",
+  "AI_InvalidToolInputError",
+  "AI_TooManyEmbeddingValuesForCallError",
+]);
+
+/**
+ * Whether this error was raised locally and will fail identically on every attempt.
+ *
+ * Walks the cause chain for the same reason `isConnectionError` does: a provider raises these
+ * from deep inside the SDK, so by the time the error surfaces the interesting name is nested.
+ */
+export function isPermanentRequestError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const record = current as { name?: unknown; cause?: unknown };
+    if (typeof record.name === "string" && PERMANENT_REQUEST_ERROR_NAMES.has(record.name)) {
+      return true;
+    }
+    current = record.cause;
+  }
+  return false;
+}
+
 // Start-the-server guidance for local providers; undefined for everything else.
 export function localServerUnreachableMessage(providerName: ProviderName): string | undefined {
   if (!isLocalServerProvider(providerName)) {
@@ -224,6 +276,16 @@ export function localServerUnreachableMessage(providerName: ProviderName): strin
 export function convertToLLMError(error: unknown, providerName: ProviderName): LLMError {
   // Use clean message for user-facing error (keeps terminal output readable)
   const cleanMessage = extractCleanErrorMessage(error);
+
+  // Checked before anything else: these carry no status code, so every branch below would
+  // classify them as a transient connection failure.
+  if (isPermanentRequestError(error)) {
+    return new LLMRequestError({
+      provider: providerName,
+      message: cleanMessage || "The provider rejected this request",
+      permanent: true,
+    });
+  }
 
   // No statusCode keeps this retryable, so a server that starts mid-retry recovers.
   if (isConnectionError(error)) {
@@ -310,6 +372,8 @@ Or update it in the interactive wizard: jazz wizard -> Update configuration`;
 export function isRetryableLLMError(error: unknown): boolean {
   if (error instanceof LLMRateLimitError) return true;
   if (error instanceof LLMRequestError) {
+    // Rejected locally: the same request will be rejected the same way next time.
+    if (error.permanent === true) return false;
     // No status code means the request never got a response (connection / DNS / timeout).
     // 5xx means the server had a transient failure.
     // Both are worth retrying.
@@ -325,6 +389,9 @@ export function isRetryableLLMError(error: unknown): boolean {
 export function describeRetryableLLMError(error: unknown): string {
   if (error instanceof LLMRateLimitError) return "rate limit";
   if (error instanceof LLMRequestError) {
+    // A locally-rejected request is not a network issue, and calling it one sent users looking
+    // for a connectivity problem that did not exist.
+    if (error.permanent === true) return "rejected request";
     if (error.statusCode === undefined) return "network issue";
     return `server error (${error.statusCode})`;
   }


### PR DESCRIPTION
## The problem

Some requests are rejected **before they are ever sent** — the provider looks at what jazz built and refuses it locally. The obvious example: attaching a voice note when the provider can only carry images.

Jazz retried those requests. Ten times, with exponential backoff, announcing a network problem each time.

Nothing changed between attempts. The request was malformed on the first try and identically malformed on the tenth.

## What a jazz user saw

An agent that appeared to hang for **three minutes**, blaming the network, then failed with something that had nothing to do with the network:

```
⏳ agent hit a network issue. Trying again (attempt 1 of up to 10)…
⏳ agent hit a network issue. Trying again (attempt 2 of up to 10)…
⏳ agent hit a network issue. Trying again (attempt 3 of up to 10)…
   … 1s, 2s, 4s, 8s, 16s, then 30s between each of the rest …
⏳ agent hit a network issue. Trying again (attempt 10 of up to 10)…
⏳ agent hit a network issue. Trying again (attempt 11 of up to 10)…
'file part media type audio/ogg' functionality not supported.
```

Three separate things went wrong for that person:

| | |
|---|---|
| **181 seconds wasted** | The backoff runs 1+2+4+8+16+30×5. Every second of it was spent re-sending a request that could never succeed. |
| **Pointed at the wrong cause** | "network issue" sends you to check your connection, your server, your VPN. The network was fine. |
| **Promised a retry it never made** | "attempt 11 of up to 10" — the counter ran one past the end of the schedule. |

Worse when nobody is watching: an unattended run or a Telegram bot burns three minutes per occurrence, silently, and a retry loop looks like a slow model rather than a bug.

## Why it happened

The retry policy decided using HTTP status:

- **no status** → the request never reached the server → transient → **retry**
- **5xx** → server had a bad moment → **retry**
- **4xx** → we sent something wrong → don't retry

A locally-rejected request has no HTTP status, because it never became an HTTP request at all. So it landed in the "connection failure" bucket. `convertToLLMError` also discarded the original error, so nothing downstream could tell the two apart.

## The fix

`LLMRequestError` gains a `permanent` flag, set when the error's **cause chain** names an AI SDK error that is raised locally and deterministically — providers throw these from deep inside the SDK, so the useful name is usually nested. It is checked before every other branch, since each of them would otherwise classify it as transient.

Deliberately **not** marked permanent, so genuine retries keep working:

- response-side failures (`JSONParseError`, `EmptyResponseBodyError`, `NoContentGenerated`) — a retry against a flaky server can succeed
- `LoadAPIKeyError` — the existing, friendlier API-key guidance should still win
- anything with a 5xx, and rate limits — untouched

The retry notice also stops counting past the end of the schedule.

## Before / after

```
before ── 181s, wrong diagnosis, then the real error
  ⏳ hit a network issue… (×11, over three minutes)
  'file part media type audio/ogg' functionality not supported.

after ── immediate, correctly named
  agent hit a rejected request.
  'file part media type audio/ogg' functionality not supported.
```

A genuine connection failure is unchanged, except that the counter now stops where the schedule does:

```
before                                   after
  ⏳ attempt 10 of up to 10…               ⏳ attempt 10 of up to 10…
  ⏳ attempt 11 of up to 10…    ←gone      Cannot reach the Ollama server…
  Cannot reach the Ollama server…
```

## Scope beyond the case that found it

Audio-to-Ollama is one instance. The same class covers, from the provider packages: a file part whose media type they don't accept, an uploaded file reference on a provider that can't consume one, a PDF part passed as a URL, attachments or tool messages on a completion-style endpoint, and an unsupported tool-choice value. From the SDK core: an unknown model or provider id, invalid call settings, and a malformed prompt sequence.

The most likely one to hit a real user is a **typo in an agent's model id** — previously three minutes of "network issue" before being told the model doesn't exist.

## How to verify

- Point an agent at a dead port: `OLLAMA_BASE_URL=http://127.0.0.1:59999 jazz run --agent <a> "hi"`. It should still retry — this is the path that must not regress — and the last notice should read "attempt 10 of up to 10", never 11, before the "Cannot reach the Ollama server" guidance.
- Give an agent a model id that doesn't exist. It should say so straight away instead of retrying.
- Confirm a rate limit or a 5xx still retries.

Verified against a live Ollama: the real `AI_UnsupportedFunctionalityError` is now recognized (`would retry: false`, described as `rejected request`), and an unreachable server still retries and stops at 10.
