### PR TITLE
feat(telegram): ship himalaya/khal/vdirsyncer for mail & calendar skills

### DIFF
--- a/docs/integrations/email-calendar.md
+++ b/docs/integrations/email-calendar.md
@@ -9,7 +9,7 @@ through `execute_command`.
 > ⚠️ **This has an approval consequence.** Because these skills shell out,
 > every action they take is gated at `high-risk` — a `low-risk` unattended run **cannot
 > archive an email**. Keep the tier low and allowlist the binary instead:
-> `{"autoApprovedCommands": ["himalaya", "khal"]}` in `~/.jazz/config.json`. See
+> `{"autoApprovedCommands": ["himalaya", "khal", "gcalcli"]}` in `~/.jazz/config.json`. See
 > [Tools reference](../reference/tools.md#what-is-not-a-built-in-tool).
 
 ---
@@ -26,11 +26,13 @@ Use the **email** skill with [Himalaya CLI](https://github.com/pimalaya/himalaya
 
 ## Calendar (khal Skill)
 
-Use the **calendar** skill with [khal](https://github.com/pimutils/khal) and [vdirsyncer](https://github.com/pimutils/vdirsyncer) for event management. Works with Google Calendar, iCloud, Nextcloud, Fastmail, and any CalDAV server.
+Use the **calendar** skill with [khal](https://github.com/pimutils/khal) and [vdirsyncer](https://github.com/pimutils/vdirsyncer) for event management. Works with iCloud, Nextcloud, Fastmail, and any standards-compliant CalDAV server.
 
 - **Setup**: Install khal and vdirsyncer, configure CalDAV in vdirsyncer, point khal at the synced calendars
 - **Agents**: Load the `calendar` skill—it teaches agents to use khal for listing, creating, editing, and searching events
 - **Sync**: Run `vdirsyncer sync` before reads to ensure up-to-date data
+
+**Google Calendar is the exception** — its CalDAV endpoint rejects the discovery handshake khal/vdirsyncer need to auto-configure, and no longer accepts app-password auth either. The `calendar` skill uses [gcalcli](https://github.com/insanum/gcalcli) for Google accounts instead, which talks to the Calendar REST API directly. See the skill's [Google Calendar (gcalcli)](../../skills/calendar/SKILL.md#google-calendar-gcalcli) section for the OAuth setup.
 
 ---
 

--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -65,6 +65,12 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434/api
 # Auto-approve tools up to this risk level: read-only | low-risk | high-risk.
 JAZZ_APPROVAL_POLICY=low-risk
 
+# The image ships himalaya/khal/vdirsyncer for the email/calendar skills.
+# execute_command is high-risk, so leaving this true allowlists just those
+# three binaries (not shell commands in general) under low-risk. Set to
+# false to require approval for them too.
+# JAZZ_AUTO_APPROVE_MAIL_CALENDAR=true
+
 # Per-message agent run timeout, milliseconds.
 JAZZ_RUN_TIMEOUT_MS=300000
 

--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -66,10 +66,8 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434/api
 JAZZ_APPROVAL_POLICY=low-risk
 
 # The image ships himalaya/khal/vdirsyncer for the email/calendar skills.
-# execute_command is high-risk, so leaving this true allowlists just those
-# three binaries (not shell commands in general) under low-risk. Set to
-# false to require approval for them too.
-# JAZZ_AUTO_APPROVE_MAIL_CALENDAR=true
+# They're not allowlisted anywhere: like any other execute_command call
+# they're high-risk and prompt for approval in Telegram before running.
 
 # Per-message agent run timeout, milliseconds.
 JAZZ_RUN_TIMEOUT_MS=300000

--- a/integrations/telegram-bot/.env.example
+++ b/integrations/telegram-bot/.env.example
@@ -65,10 +65,6 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434/api
 # Auto-approve tools up to this risk level: read-only | low-risk | high-risk.
 JAZZ_APPROVAL_POLICY=low-risk
 
-# The image ships himalaya/khal/vdirsyncer for the email/calendar skills.
-# They're not allowlisted anywhere: like any other execute_command call
-# they're high-risk and prompt for approval in Telegram before running.
-
 # Per-message agent run timeout, milliseconds.
 JAZZ_RUN_TIMEOUT_MS=300000
 

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -30,6 +30,19 @@ RUN curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install
 # all, so this is required for calendar access to Google accounts.
 RUN pip3 install --break-system-packages --no-cache-dir aiohttp-oauthlib
 
+# Google's CalDAV endpoint rejects the RFC 6764 principal-discovery handshake
+# every generic CalDAV client (including vdirsyncer's own google_calendar
+# OAuth backend) depends on to auto-configure — confirmed via 403 "Given URL
+# is not a homeset URL" even with a valid OAuth token. gcalcli talks to the
+# real Calendar REST API v3 instead of CalDAV, so it's what Google accounts
+# actually need for calendar access; khal/vdirsyncer stay installed above for
+# non-Google CalDAV providers (iCloud, Nextcloud, Fastmail, ...) where
+# discovery isn't broken. --ignore-installed avoids fighting Debian's
+# python3-typing-extensions for a package apt didn't install with pip
+# metadata; the aiostream pin keeps pip from upgrading past what vdirsyncer
+# requires.
+RUN pip3 install --break-system-packages --ignore-installed --no-cache-dir "aiostream<0.5.0" gcalcli
+
 # himalaya/khal/vdirsyncer/pass/gnupg all default to files under $HOME, which
 # lives on the container's writable layer and is lost on every rebuild or
 # recreate. Point their config/data/secrets at the same /data volume Jazz

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 # actually receives voice notes installs the real thing. Debian ships ffprobe
 # only as part of the ffmpeg package.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium fonts-liberation ffmpeg curl jq khal vdirsyncer pass gnupg \
+    chromium fonts-liberation ffmpeg curl jq khal vdirsyncer pass gnupg python3-pip \
     && rm -rf /var/lib/apt/lists/*
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
@@ -23,6 +23,12 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 # the email skill's own install fallback does.
 RUN curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh \
     | PREFIX=/usr/local sh
+
+# Debian's vdirsyncer package doesn't pull aiohttp-oauthlib, so its
+# google_calendar storage (OAuth) errors "aiohttp-oauthlib not installed" —
+# CalDAV+password auth no longer works against Google's calendar backend at
+# all, so this is required for calendar access to Google accounts.
+RUN pip3 install --break-system-packages --no-cache-dir aiohttp-oauthlib
 
 # himalaya/khal/vdirsyncer/pass/gnupg all default to files under $HOME, which
 # lives on the container's writable layer and is lost on every rebuild or

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -14,10 +14,31 @@ WORKDIR /app
 # built-in afinfo for audio; Debian has no equivalent, so the bridge that
 # actually receives voice notes installs the real thing. Debian ships ffprobe
 # only as part of the ffmpeg package.
+#
+# jq, khal, vdirsyncer, pass, and gnupg back the email/calendar skills
+# (docs/integrations/email-calendar.md): himalaya's own output is piped
+# through jq, khal/vdirsyncer manage the calendar, and pass+gnupg hold the
+# CalDAV/IMAP credentials the skills tell the user to store there rather than
+# in plaintext config.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium fonts-liberation ffmpeg \
+    chromium fonts-liberation ffmpeg curl jq khal vdirsyncer pass gnupg \
     && rm -rf /var/lib/apt/lists/*
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Himalaya has no Debian package; install the upstream binary the same way
+# the email skill's own install fallback does.
+RUN curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh \
+    | PREFIX=/usr/local sh
+
+# himalaya/khal/vdirsyncer/pass/gnupg all default to files under $HOME, which
+# lives on the container's writable layer and is lost on every rebuild or
+# recreate. Point their config/data/secrets at the same /data volume Jazz
+# already persists (JAZZ_HOME below) so `docker compose exec` setup survives.
+ENV XDG_CONFIG_HOME=/data/xdg-config \
+    XDG_DATA_HOME=/data/xdg-data \
+    XDG_STATE_HOME=/data/xdg-state \
+    GNUPGHOME=/data/gnupg \
+    PASSWORD_STORE_DIR=/data/password-store
 
 # Dependencies first so the install layer caches across source edits.
 COPY package.json bun.lock bunfig.toml ./

--- a/integrations/telegram-bot/Dockerfile
+++ b/integrations/telegram-bot/Dockerfile
@@ -14,12 +14,6 @@ WORKDIR /app
 # built-in afinfo for audio; Debian has no equivalent, so the bridge that
 # actually receives voice notes installs the real thing. Debian ships ffprobe
 # only as part of the ffmpeg package.
-#
-# jq, khal, vdirsyncer, pass, and gnupg back the email/calendar skills
-# (docs/integrations/email-calendar.md): himalaya's own output is piped
-# through jq, khal/vdirsyncer manage the calendar, and pass+gnupg hold the
-# CalDAV/IMAP credentials the skills tell the user to store there rather than
-# in plaintext config.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium fonts-liberation ffmpeg curl jq khal vdirsyncer pass gnupg \
     && rm -rf /var/lib/apt/lists/*

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -115,28 +115,83 @@ the defaults new chats start from. (`/model` lists Ollama models — handy when 
 run Ollama; cloud users typically just keep the default.)
 
 **Mail & calendar.** The image ships [Himalaya](https://github.com/pimalaya/himalaya)
-(email) and [khal](https://github.com/pimutils/khal) + [vdirsyncer](https://github.com/pimutils/vdirsyncer)
-(calendar) — the same CLIs the `email`/`calendar` skills already know how to drive
-via `execute_command` (see [Email & Calendar](../../docs/integrations/email-calendar.md)).
-They aren't allowlisted anywhere: like every other shell command, each call is
+(email), [khal](https://github.com/pimutils/khal) + [vdirsyncer](https://github.com/pimutils/vdirsyncer)
+(calendar, non-Google), and [gcalcli](https://github.com/insanum/gcalcli) (calendar,
+Google) — the CLIs the `email`/`calendar` skills already know how to drive via
+`execute_command` (see [Email & Calendar](../../docs/integrations/email-calendar.md)
+and the calendar skill's [Google Calendar (gcalcli)](../../skills/calendar/SKILL.md#google-calendar-gcalcli)
+section). None of them are allowlisted: like every other shell command, each call is
 `high-risk` and shows up in Telegram as an Accept/Reject prompt before it runs.
 
 Their config/data/keyring/password-store live under `/data` (the same volume
-Jazz already persists) via `XDG_CONFIG_HOME` etc., so setup survives restarts
-and rebuilds. **Account credentials still have to go in yourself** — these
-tools' setup wizards need a real terminal and neither the bot nor the skills
-will accept a password typed into Telegram chat:
+Jazz already persists) via `XDG_CONFIG_HOME`/`XDG_DATA_HOME`, so setup survives
+restarts and rebuilds. **Account credentials still have to go in yourself** —
+these tools' setup wizards need a real terminal and neither the bot nor the
+skills will accept a password typed into Telegram chat. None of this is
+trivial, especially Google Calendar — follow it closely.
 
 ```sh
 docker compose exec jazz-telegram sh
-# then, inside the container:
-himalaya                 # interactive account wizard (IMAP/SMTP, or Gmail app password)
-gpg --full-generate-key  # one-time, for `pass` (khal/vdirsyncer store CalDAV
-                          # passwords via pass, not plaintext config)
-pass init <your-gpg-id>
-vdirsyncer discover && vdirsyncer sync
-khal configure           # or hand-write ~/.config/khal/config per the calendar skill
 ```
+
+*Email (any provider, via Himalaya):*
+
+```sh
+himalaya   # interactive account wizard — IMAP/SMTP, or a Gmail app password
+```
+For Gmail specifically, generate an [app password](https://myaccount.google.com/apppasswords)
+first (needs 2-Step Verification on). For multiple accounts, run `himalaya`
+again — bare `himalaya` offers to add another named account when a config
+already exists; target one with `himalaya --account <name> ...`.
+
+*Calendar, non-Google (iCloud, Nextcloud, Fastmail, any real CalDAV server), via khal/vdirsyncer:*
+
+```sh
+gpg --full-generate-key   # one-time, for `pass` — khal/vdirsyncer store CalDAV
+                          # passwords via pass, not plaintext config
+pass init <your-gpg-id>
+pass insert <provider>/app-password
+vdirsyncer discover && vdirsyncer sync
+khal configure            # or hand-write ~/.config/khal/config per the calendar skill
+```
+
+*Calendar, Google, via gcalcli:* **do not use khal/vdirsyncer for Google Calendar
+— it doesn't work.** Google's CalDAV endpoint rejects the standard discovery
+handshake khal/vdirsyncer need (confirmed: `403 Given URL is not a homeset URL`,
+even with a valid OAuth token), on top of no longer accepting app-password auth
+at all. gcalcli talks to the real Calendar REST API instead. One-time setup:
+
+1. [Google Cloud Console](https://console.cloud.google.com) → new/existing
+   project → enable **Google Calendar API** → **OAuth consent screen**
+   (External, add every Gmail address that will use this as a test user) →
+   **Credentials → Create Credentials → OAuth client ID**, type **Desktop app**.
+   This gives one `client_id`/`client_secret` shared across every account.
+2. Per account, authorize with its own isolated data directory — gcalcli's
+   cache path is keyed off `$XDG_DATA_HOME`, not `--config-folder`, so skipping
+   this step means the second account's login silently overwrites the first's:
+   ```sh
+   XDG_DATA_HOME=/data/xdg-data/gcalcli-personal gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+   ```
+3. **If `init` hangs after you click Allow in the browser, this is a known
+   issue, not a misconfiguration** — its local callback server can grab the
+   wrong one of two connections a browser opens and block forever. Kill it and
+   recover manually instead of retrying: build the authorization URL yourself
+   (`https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=CLIENT_ID&redirect_uri=http://localhost:8080&scope=https://www.googleapis.com/auth/calendar&access_type=offline&prompt=select_account%20consent&login_hint=ACCOUNT_EMAIL`
+   — the `redirect_uri` never needs to actually respond), click Allow, copy the
+   failed `http://localhost:8080/?...&code=...` URL from the address bar, then
+   exchange the code directly:
+   ```sh
+   curl -s -X POST https://oauth2.googleapis.com/token \
+     -d "code=$CODE" -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
+     -d "redirect_uri=http://localhost:8080" -d "grant_type=authorization_code"
+   ```
+   and write the JSON response into `$XDG_DATA_HOME/gcalcli/oauth` with keys
+   `access_token`, `client_id`, `client_secret`, `refresh_token`, `token_uri`
+   (`https://oauth2.googleapis.com/token`), `scopes` (a list) — gcalcli accepts
+   this legacy JSON shape and converts it to its normal cache on next use. Full
+   walkthrough (including the "authorizing a second account reuses the first
+   one's login" pitfall and its fix) is in the calendar skill.
+4. Verify: `XDG_DATA_HOME=/data/xdg-data/gcalcli-personal gcalcli agenda`.
 
 ## Configuration
 

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -140,58 +140,95 @@ docker compose exec jazz-telegram sh
 himalaya   # interactive account wizard — IMAP/SMTP, or a Gmail app password
 ```
 For Gmail specifically, generate an [app password](https://myaccount.google.com/apppasswords)
-first (needs 2-Step Verification on). For multiple accounts, run `himalaya`
-again — bare `himalaya` offers to add another named account when a config
-already exists; target one with `himalaya --account <name> ...`.
+first (needs 2-Step Verification on). **Repeat this step for every account**:
+running bare `himalaya` again — with a config already present — offers to add
+another named account rather than reconfiguring the existing one; target a
+specific one afterward with `himalaya --account account-a ...` /
+`himalaya --account account-b ...`.
 
 *Calendar, non-Google (iCloud, Nextcloud, Fastmail, any real CalDAV server), via khal/vdirsyncer:*
 
 ```sh
-gpg --full-generate-key   # one-time, for `pass` — khal/vdirsyncer store CalDAV
-                          # passwords via pass, not plaintext config
-pass init <your-gpg-id>
-pass insert <provider>/app-password
-vdirsyncer discover && vdirsyncer sync
-khal configure            # or hand-write ~/.config/khal/config per the calendar skill
+gpg --full-generate-key   # one-time only, for `pass` — khal/vdirsyncer store
+                          # CalDAV passwords via pass, not plaintext config
+pass init <your-gpg-id>   # also one-time; one key covers every account below
+```
+
+The rest is per account — namespace the `pass` entry and give each account
+its own `vdirsyncer` pair/storage block (see the calendar skill's advanced
+CalDAV setup) so a second account doesn't overwrite the first's credentials
+or sync target:
+
+```sh
+pass insert <provider>/account-a/app-password
+pass insert <provider>/account-b/app-password
+vdirsyncer discover && vdirsyncer sync   # syncs every configured pair/account at once
+khal configure                           # or hand-write ~/.config/khal/config, one calendar block per account
 ```
 
 *Calendar, Google, via gcalcli:* **do not use khal/vdirsyncer for Google Calendar
 — it doesn't work.** Google's CalDAV endpoint rejects the standard discovery
 handshake khal/vdirsyncer need (confirmed: `403 Given URL is not a homeset URL`,
 even with a valid OAuth token), on top of no longer accepting app-password auth
-at all. gcalcli talks to the real Calendar REST API instead. One-time setup:
+at all. gcalcli talks to the real Calendar REST API instead.
+
+Step 1 below is one-time, shared by every Google account. **Steps 2-4 are
+per-account** — the full walkthrough here authorizes two accounts,
+`account-a` and `account-b`, side by side so it's obvious how to add a
+third or fourth: pick a new account name/email and a new
+`$XDG_DATA_HOME` directory, then redo steps 2-4 unchanged otherwise.
 
 1. [Google Cloud Console](https://console.cloud.google.com) → new/existing
    project → enable **Google Calendar API** → **OAuth consent screen**
    (External, add every Gmail address that will use this as a test user) →
    **Credentials → Create Credentials → OAuth client ID**, type **Desktop app**.
-   This gives one `client_id`/`client_secret` shared across every account.
-2. Per account, authorize with its own isolated data directory — gcalcli's
-   cache path is keyed off `$XDG_DATA_HOME`, not `--config-folder`, so skipping
-   this step means the second account's login silently overwrites the first's:
+   This gives one `client_id`/`client_secret` shared across every account below.
+2. Authorize with an isolated data directory per account — gcalcli's cache
+   path is keyed off `$XDG_DATA_HOME`, not `--config-folder`, so skipping
+   this means the second account's login silently overwrites the first's:
    ```sh
-   XDG_DATA_HOME=/data/xdg-data/gcalcli-personal gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+   XDG_DATA_HOME=/data/xdg-data/gcalcli-account-a gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+   XDG_DATA_HOME=/data/xdg-data/gcalcli-account-b gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
    ```
+   Run these one at a time, completing steps 3-4 for `account-a` before
+   starting `account-b` — don't kick off both `init`s together.
 3. **If `init` hangs after you click Allow in the browser, this is a known
    issue, not a misconfiguration** — its local callback server can grab the
    wrong one of two connections a browser opens and block forever. Kill it and
    recover manually instead of retrying: build the authorization URL yourself
+   for the account you're currently on
    (`https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=CLIENT_ID&redirect_uri=http://localhost:8080&scope=https://www.googleapis.com/auth/calendar&access_type=offline&prompt=select_account%20consent&login_hint=ACCOUNT_EMAIL`
-   — the `redirect_uri` never needs to actually respond), click Allow, copy the
-   failed `http://localhost:8080/?...&code=...` URL from the address bar, then
+   — the `redirect_uri` never needs to actually respond, and `login_hint` must
+   be that specific account's address), click Allow, copy the failed
+   `http://localhost:8080/?...&code=...` URL from the address bar, then
    exchange the code directly:
    ```sh
    curl -s -X POST https://oauth2.googleapis.com/token \
      -d "code=$CODE" -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
      -d "redirect_uri=http://localhost:8080" -d "grant_type=authorization_code"
    ```
-   and write the JSON response into `$XDG_DATA_HOME/gcalcli/oauth` with keys
-   `access_token`, `client_id`, `client_secret`, `refresh_token`, `token_uri`
-   (`https://oauth2.googleapis.com/token`), `scopes` (a list) — gcalcli accepts
-   this legacy JSON shape and converts it to its normal cache on next use. Full
-   walkthrough (including the "authorizing a second account reuses the first
-   one's login" pitfall and its fix) is in the calendar skill.
-4. Verify: `XDG_DATA_HOME=/data/xdg-data/gcalcli-personal gcalcli agenda`.
+   and write the JSON response into **that account's**
+   `$XDG_DATA_HOME/gcalcli/oauth` (e.g. `.../gcalcli-account-a/gcalcli/oauth`)
+   with keys `access_token`, `client_id`, `client_secret`, `refresh_token`,
+   `token_uri` (`https://oauth2.googleapis.com/token`), `scopes` (a list) —
+   gcalcli accepts this legacy JSON shape and converts it to its normal cache
+   on next use.
+
+   **`prompt=select_account consent` and a per-account `login_hint` are not
+   optional once a second account is involved.** Omit them and Google
+   silently reuses whichever account is already logged into the browser, so
+   `account-b`'s token ends up authenticating as `account-a` — this happened
+   during initial setup and was only caught by checking step 4 below.
+4. Verify **before moving on to the next account**:
+   ```sh
+   XDG_DATA_HOME=/data/xdg-data/gcalcli-account-a gcalcli list
+   XDG_DATA_HOME=/data/xdg-data/gcalcli-account-b gcalcli list
+   ```
+   Each must show that account's own calendars. If two accounts show the
+   same calendars, redo the one that's wrong with the `login_hint`/`prompt`
+   params from step 3.
+
+Full walkthrough, including the connection-race recovery in more detail, is in the calendar skill.
 
 ## Configuration
 

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -118,9 +118,8 @@ run Ollama; cloud users typically just keep the default.)
 (email) and [khal](https://github.com/pimutils/khal) + [vdirsyncer](https://github.com/pimutils/vdirsyncer)
 (calendar) — the same CLIs the `email`/`calendar` skills already know how to drive
 via `execute_command` (see [Email & Calendar](../../docs/integrations/email-calendar.md)).
-The entrypoint allowlists exactly those three binaries in `autoApprovedCommands`
-so the skills work under the default `low-risk` policy without loosening it for
-anything else; set `JAZZ_AUTO_APPROVE_MAIL_CALENDAR=false` to turn that off.
+They aren't allowlisted anywhere: like every other shell command, each call is
+`high-risk` and shows up in Telegram as an Accept/Reject prompt before it runs.
 
 Their config/data/keyring/password-store live under `/data` (the same volume
 Jazz already persists) via `XDG_CONFIG_HOME` etc., so setup survives restarts
@@ -153,7 +152,6 @@ khal configure           # or hand-write ~/.config/khal/config per the calendar 
 | `OLLAMA_BASE_URL`                    | `http://host.docker.internal:11434/api` | Ollama endpoint (only for `provider=ollama` / `/model`).                                                                                                                                                                                                    |
 | `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`.                                                                                                                                                                                             |
 | `JAZZ_AUTO_APPROVE_TOOLS`            | —                                       | Comma-separated tool names to auto-approve regardless of policy (e.g. `execute_command`) — narrower than raising the whole tier. Tools needing approval that aren't in this list are sent to the chat as an accept/reject prompt instead of being declined. |
-| `JAZZ_AUTO_APPROVE_MAIL_CALENDAR`    | `true`                                  | Allowlists `himalaya`/`khal`/`vdirsyncer` in `autoApprovedCommands` so the email/calendar skills work under `low-risk`. Set `false` to require approval for them like any other shell command.                                                            |
 | `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                                                                                                                                                                                  |
 | `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                                                                                                                                                                     |
 | `PORT`                               | `8080`                                  | In-container health-check port.                                                                                                                                                                                                                             |

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -114,6 +114,31 @@ experience. `JAZZ_TELEGRAM_PROVIDER` / `JAZZ_TELEGRAM_MODEL` / `JAZZ_REASONING` 
 the defaults new chats start from. (`/model` lists Ollama models — handy when you
 run Ollama; cloud users typically just keep the default.)
 
+**Mail & calendar.** The image ships [Himalaya](https://github.com/pimalaya/himalaya)
+(email) and [khal](https://github.com/pimutils/khal) + [vdirsyncer](https://github.com/pimutils/vdirsyncer)
+(calendar) — the same CLIs the `email`/`calendar` skills already know how to drive
+via `execute_command` (see [Email & Calendar](../../docs/integrations/email-calendar.md)).
+The entrypoint allowlists exactly those three binaries in `autoApprovedCommands`
+so the skills work under the default `low-risk` policy without loosening it for
+anything else; set `JAZZ_AUTO_APPROVE_MAIL_CALENDAR=false` to turn that off.
+
+Their config/data/keyring/password-store live under `/data` (the same volume
+Jazz already persists) via `XDG_CONFIG_HOME` etc., so setup survives restarts
+and rebuilds. **Account credentials still have to go in yourself** — these
+tools' setup wizards need a real terminal and neither the bot nor the skills
+will accept a password typed into Telegram chat:
+
+```sh
+docker compose exec jazz-telegram sh
+# then, inside the container:
+himalaya                 # interactive account wizard (IMAP/SMTP, or Gmail app password)
+gpg --full-generate-key  # one-time, for `pass` (khal/vdirsyncer store CalDAV
+                          # passwords via pass, not plaintext config)
+pass init <your-gpg-id>
+vdirsyncer discover && vdirsyncer sync
+khal configure           # or hand-write ~/.config/khal/config per the calendar skill
+```
+
 ## Configuration
 
 | Variable                             | Default                                 | Purpose                                                                                                                                                                                                                                                     |
@@ -128,6 +153,7 @@ run Ollama; cloud users typically just keep the default.)
 | `OLLAMA_BASE_URL`                    | `http://host.docker.internal:11434/api` | Ollama endpoint (only for `provider=ollama` / `/model`).                                                                                                                                                                                                    |
 | `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`.                                                                                                                                                                                             |
 | `JAZZ_AUTO_APPROVE_TOOLS`            | —                                       | Comma-separated tool names to auto-approve regardless of policy (e.g. `execute_command`) — narrower than raising the whole tier. Tools needing approval that aren't in this list are sent to the chat as an accept/reject prompt instead of being declined. |
+| `JAZZ_AUTO_APPROVE_MAIL_CALENDAR`    | `true`                                  | Allowlists `himalaya`/`khal`/`vdirsyncer` in `autoApprovedCommands` so the email/calendar skills work under `low-risk`. Set `false` to require approval for them like any other shell command.                                                            |
 | `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                                                                                                                                                                                  |
 | `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                                                                                                                                                                     |
 | `PORT`                               | `8080`                                  | In-container health-check port.                                                                                                                                                                                                                             |

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -22,6 +22,7 @@ import { NodeFileSystem } from "@effect/platform-node";
 import { Effect } from "effect";
 import tzlookup from "tz-lookup";
 import type { ReminderRecord } from "@/core/interfaces/reminder-service";
+import { extractCommandApprovalKey } from "@/core/utils/shell";
 import { ReminderServiceImpl } from "@/services/reminder-service";
 import {
   agentIdForChat,
@@ -56,7 +57,13 @@ const activeRuns = new Map<
 >();
 // Pending human approvals keyed by toolCallId, so an Accept/Reject tap can
 // find the run to write the decision back to and the message to clear.
-const pendingApprovals = new Map<string, { chatId: number; messageId: number; runToken: string }>();
+// `commandKey` (set only for execute_command approvals) is the binary name an
+// "Always allow" tap persists to autoApprovedCommands — present only when we
+// could parse one out, since not every approval is a shell command.
+const pendingApprovals = new Map<
+  string,
+  { chatId: number; messageId: number; runToken: string; commandKey?: string }
+>();
 // Transcript for chats currently in /incognito mode. Lives only in this
 // process's memory — never written to disk — so a bridge restart drops the
 // context rather than ever falling back to a persisted history file. Cleared
@@ -440,15 +447,51 @@ function cancelKeyboard(runToken: string): Record<string, unknown> {
   return { inline_keyboard: [[{ text: "⏹ Cancel", callback_data: `x:${runToken}` }]] };
 }
 
-function approvalKeyboard(toolCallId: string): Record<string, unknown> {
-  return {
-    inline_keyboard: [
-      [
-        { text: "✅ Accept", callback_data: `a:${toolCallId}:1` },
-        { text: "❌ Reject", callback_data: `a:${toolCallId}:0` },
-      ],
+function approvalKeyboard(toolCallId: string, commandKey?: string): Record<string, unknown> {
+  const rows = [
+    [
+      { text: "✅ Accept", callback_data: `a:${toolCallId}:1` },
+      { text: "❌ Reject", callback_data: `a:${toolCallId}:0` },
     ],
-  };
+  ];
+  if (commandKey) {
+    rows.push([{ text: `♾️ Always allow "${commandKey}"`, callback_data: `a:${toolCallId}:2` }]);
+  }
+  return { inline_keyboard: rows };
+}
+
+/** Extract the binary from an execute_command approval's "Command: ..." line, if present. */
+function commandKeyFromApprovalMessage(
+  toolName: string | undefined,
+  message: string,
+): string | undefined {
+  if (toolName !== "execute_command") return undefined;
+  const match = /^Command: (.+)$/m.exec(message);
+  if (!match?.[1]) return undefined;
+  return extractCommandApprovalKey(match[1]).split(" ")[0];
+}
+
+/**
+ * Persist a command key to autoApprovedCommands in config.json so future
+ * `jazz run` invocations (each a fresh process — nothing in-memory here
+ * would survive to the next message) auto-approve it without prompting.
+ */
+async function addAutoApprovedCommand(jazzHome: string, commandKey: string): Promise<void> {
+  const configPath = join(jazzHome, "config.json");
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(await Bun.file(configPath).text());
+  } catch (error) {
+    console.error(
+      `Failed to read ${configPath} before adding auto-approved command: ${String(error)}`,
+    );
+  }
+  const existing = Array.isArray(config["autoApprovedCommands"])
+    ? (config["autoApprovedCommands"] as unknown[]).filter((entry) => typeof entry === "string")
+    : [];
+  if (existing.includes(commandKey)) return;
+  config["autoApprovedCommands"] = [...existing, commandKey];
+  await Bun.write(configPath, JSON.stringify(config));
 }
 
 function webAppKeyboard(url: string, title: string): Record<string, unknown> {
@@ -650,6 +693,7 @@ async function sendApprovalRequest(
 
   const toolName = event.toolName ?? "tool";
   const message = event.message ?? "";
+  const commandKey = commandKeyFromApprovalMessage(event.toolName, message);
   const lines = ["⚠️ <b>Approval needed</b>", `<code>${escapeHtml(toolName)}</code>`];
   if (message.length > 0) lines.push(escapeHtml(message));
   if (event.previewDiff) {
@@ -657,10 +701,15 @@ async function sendApprovalRequest(
   }
 
   const messageId = await sendReply(config, chatId, lines.join("\n"), {
-    markup: approvalKeyboard(toolCallId),
+    markup: approvalKeyboard(toolCallId, commandKey),
   });
   if (typeof messageId === "number") {
-    pendingApprovals.set(toolCallId, { chatId, messageId, runToken });
+    pendingApprovals.set(toolCallId, {
+      chatId,
+      messageId,
+      runToken,
+      ...(commandKey && { commandKey }),
+    });
   }
 }
 
@@ -1387,7 +1436,9 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
 
   if (kind === "a") {
     const toolCallId = parts[1] ?? "";
-    const approved = parts[2] === "1";
+    const decision = parts[2];
+    const approved = decision === "1" || decision === "2";
+    const always = decision === "2";
     const pending = pendingApprovals.get(toolCallId);
     const run = pending ? activeRuns.get(pending.runToken) : undefined;
     if (!pending || !run) {
@@ -1408,9 +1459,18 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
     } catch (error) {
       console.error(`Failed to write approval decision: ${String(error)}`);
     }
+    if (always && pending.commandKey) {
+      await addAutoApprovedCommand(config.jazzHome, pending.commandKey).catch((error: unknown) =>
+        console.error(`Failed to persist auto-approved command: ${String(error)}`),
+      );
+    }
     await callTelegram(config, "answerCallbackQuery", {
       callback_query_id: callback.id,
-      text: approved ? "Approved" : "Rejected",
+      text: always
+        ? `Approved — "${pending.commandKey}" always allowed from now on`
+        : approved
+          ? "Approved"
+          : "Rejected",
     });
     await callTelegram(config, "editMessageReplyMarkup", {
       chat_id: chatId,

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -634,9 +634,6 @@ function createProgressReporter(
 
 // --- Human approval --------------------------------------------------------
 
-const APPROVAL_MESSAGE_MAX_CHARS = 500;
-const APPROVAL_PREVIEW_DIFF_MAX_CHARS = 500;
-
 /**
  * Send a new Telegram message with Accept/Reject buttons for a tool awaiting
  * human approval. A new message (not an edit of the progress bubble) so
@@ -652,21 +649,16 @@ async function sendApprovalRequest(
   if (!toolCallId) return;
 
   const toolName = event.toolName ?? "tool";
-  const message = (event.message ?? "").slice(0, APPROVAL_MESSAGE_MAX_CHARS);
+  const message = event.message ?? "";
   const lines = ["⚠️ <b>Approval needed</b>", `<code>${escapeHtml(toolName)}</code>`];
   if (message.length > 0) lines.push(escapeHtml(message));
   if (event.previewDiff) {
-    const diff = event.previewDiff.slice(0, APPROVAL_PREVIEW_DIFF_MAX_CHARS);
-    lines.push(`<pre>${escapeHtml(diff)}</pre>`);
+    lines.push(`<pre>${escapeHtml(event.previewDiff)}</pre>`);
   }
 
-  const sent = (await callTelegram(config, "sendMessage", {
-    chat_id: chatId,
-    text: lines.join("\n"),
-    parse_mode: "HTML",
-    reply_markup: approvalKeyboard(toolCallId),
-  })) as { result?: { message_id?: number } } | undefined;
-  const messageId = sent?.result?.message_id;
+  const messageId = await sendReply(config, chatId, lines.join("\n"), {
+    markup: approvalKeyboard(toolCallId),
+  });
   if (typeof messageId === "number") {
     pendingApprovals.set(toolCallId, { chatId, messageId, runToken });
   }

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -20,31 +20,21 @@ mkdir -p "${XDG_CONFIG_HOME:-/data/xdg-config}" "${XDG_DATA_HOME:-/data/xdg-data
 mkdir -p "${GNUPGHOME:-/data/gnupg}"
 chmod 700 "${GNUPGHOME:-/data/gnupg}"
 
-# `execute_command` treats every shelled-out command as high-risk, so a
-# low-risk approval policy blocks the email/calendar skills entirely — they
-# only ever run himalaya/khal/vdirsyncer. Allowlisting those three (and only
-# those three) lets the skills work unattended without loosening the policy
-# for anything else. Set JAZZ_AUTO_APPROVE_MAIL_CALENDAR=false to opt out.
-AUTO_APPROVE_MAIL_CALENDAR="${JAZZ_AUTO_APPROVE_MAIL_CALENDAR:-true}"
-if [ "${AUTO_APPROVE_MAIL_CALENDAR}" = "true" ]; then
-  AUTO_APPROVED_COMMANDS_JSON='["himalaya","khal","vdirsyncer"]'
-else
-  AUTO_APPROVED_COMMANDS_JSON='[]'
-fi
-
 # Write config.json. Streaming is required so `jazz run --events` emits
 # live-progress events (non-TTY runs otherwise fall back to batch mode and emit
 # nothing). When BRAVE_API_KEY is set, also configure Brave as the web_search
 # provider — the key comes from the environment so it's never baked into the image.
+#
+# himalaya/khal/vdirsyncer are not allowlisted here: like every other
+# execute_command call they stay high-risk and prompt for approval in
+# Telegram before running, same as any other shell command.
 if [ -n "${BRAVE_API_KEY:-}" ]; then
   cat > "${JAZZ_HOME}/config.json" <<JSON
-{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}},"autoApprovedCommands":${AUTO_APPROVED_COMMANDS_JSON}}
+{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
 JSON
   echo "Configured Brave web search"
 else
-  cat > "${JAZZ_HOME}/config.json" <<JSON
-{"output":{"streaming":{"enabled":true}},"autoApprovedCommands":${AUTO_APPROVED_COMMANDS_JSON}}
-JSON
+  printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
 fi
 
 # Seed / refresh the template agent that per-chat agents are cloned from.

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -24,10 +24,6 @@ chmod 700 "${GNUPGHOME:-/data/gnupg}"
 # live-progress events (non-TTY runs otherwise fall back to batch mode and emit
 # nothing). When BRAVE_API_KEY is set, also configure Brave as the web_search
 # provider — the key comes from the environment so it's never baked into the image.
-#
-# himalaya/khal/vdirsyncer are not allowlisted here: like every other
-# execute_command call they stay high-risk and prompt for approval in
-# Telegram before running, same as any other shell command.
 if [ -n "${BRAVE_API_KEY:-}" ]; then
   cat > "${JAZZ_HOME}/config.json" <<JSON
 {"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -12,17 +12,39 @@ AGENT_TEMPLATE="/app/integrations/telegram-bot/agent.telegram.json"
 
 mkdir -p "${JAZZ_HOME}/agents"
 
+# Directories for the email/calendar skills' XDG-relocated config, data, GPG
+# keyring, and pass store (see Dockerfile) — created up front so the first
+# `docker compose exec` setup session has somewhere to write.
+mkdir -p "${XDG_CONFIG_HOME:-/data/xdg-config}" "${XDG_DATA_HOME:-/data/xdg-data}" \
+  "${XDG_STATE_HOME:-/data/xdg-state}" "${PASSWORD_STORE_DIR:-/data/password-store}"
+mkdir -p "${GNUPGHOME:-/data/gnupg}"
+chmod 700 "${GNUPGHOME:-/data/gnupg}"
+
+# `execute_command` treats every shelled-out command as high-risk, so a
+# low-risk approval policy blocks the email/calendar skills entirely — they
+# only ever run himalaya/khal/vdirsyncer. Allowlisting those three (and only
+# those three) lets the skills work unattended without loosening the policy
+# for anything else. Set JAZZ_AUTO_APPROVE_MAIL_CALENDAR=false to opt out.
+AUTO_APPROVE_MAIL_CALENDAR="${JAZZ_AUTO_APPROVE_MAIL_CALENDAR:-true}"
+if [ "${AUTO_APPROVE_MAIL_CALENDAR}" = "true" ]; then
+  AUTO_APPROVED_COMMANDS_JSON='["himalaya","khal","vdirsyncer"]'
+else
+  AUTO_APPROVED_COMMANDS_JSON='[]'
+fi
+
 # Write config.json. Streaming is required so `jazz run --events` emits
 # live-progress events (non-TTY runs otherwise fall back to batch mode and emit
 # nothing). When BRAVE_API_KEY is set, also configure Brave as the web_search
 # provider — the key comes from the environment so it's never baked into the image.
 if [ -n "${BRAVE_API_KEY:-}" ]; then
   cat > "${JAZZ_HOME}/config.json" <<JSON
-{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
+{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}},"autoApprovedCommands":${AUTO_APPROVED_COMMANDS_JSON}}
 JSON
   echo "Configured Brave web search"
 else
-  printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+  cat > "${JAZZ_HOME}/config.json" <<JSON
+{"output":{"streaming":{"enabled":true}},"autoApprovedCommands":${AUTO_APPROVED_COMMANDS_JSON}}
+JSON
 fi
 
 # Seed / refresh the template agent that per-chat agents are cloned from.

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: calendar
-description: Manage calendars using khal CLI and vdirsyncer. Use when the user wants to view, create, edit, or delete calendar events, sync calendars with CalDAV servers, manage multiple calendars, or mentions "calendar", "event", "appointment", "meeting", "schedule", "CalDAV", "khal", "vdirsyncer".
+description: Manage calendars using khal CLI and vdirsyncer for CalDAV providers, or gcalcli for Google Calendar. Use when the user wants to view, create, edit, or delete calendar events, sync calendars, manage multiple calendars, or mentions "calendar", "event", "appointment", "meeting", "schedule", "CalDAV", "khal", "vdirsyncer", "gcalcli", "Google Calendar".
 ---
 
 # Calendar Management
 
 Manage calendars using [khal](https://github.com/pimutils/khal) - a standards-based CLI calendar application, and [vdirsyncer](https://github.com/pimutils/vdirsyncer) - a tool for synchronizing calendars with CalDAV servers.
+
+**Google Calendar is the one exception: use [gcalcli](https://github.com/insanum/gcalcli) instead, not khal/vdirsyncer.** Google's CalDAV endpoint rejects the RFC 6764 principal-discovery handshake every generic CalDAV client (including vdirsyncer's own `google_calendar` OAuth backend) needs to auto-configure — confirmed via a `403 Given URL is not a homeset URL` even with a valid OAuth token, on top of app-password Basic Auth being rejected outright. gcalcli talks to the real Calendar REST API v3, not CalDAV, so it's unaffected. See [Google Calendar (gcalcli)](#google-calendar-gcalcli) below. Every other provider in the table below (iCloud, Nextcloud, Fastmail, Radicale) works fine with khal/vdirsyncer.
 
 ## Agent Usage (Power User Patterns)
 
@@ -211,17 +213,74 @@ EOF
 
 ### Provider-Specific Setup
 
-| Provider            | CalDAV URL                                         | Notes                              |
-| ------------------- | -------------------------------------------------- | ---------------------------------- |
-| **Google Calendar** | `https://apidata.googleusercontent.com/caldav/v2/` | Requires App Password or OAuth 2.0 |
+| Provider            | CalDAV URL                                        | Notes                                            |
+| ------------------- | -------------------------------------------------- | ----------------------------------------------- |
+| **Google Calendar** | not supported via CalDAV                           | Use [gcalcli](#google-calendar-gcalcli) instead |
 | **Nextcloud**       | `https://nextcloud.example.com/remote.php/dav/`    | Standard username/password         |
 | **iCloud**          | `https://caldav.icloud.com/`                       | Requires app-specific password     |
 | **Fastmail**        | `https://caldav.fastmail.com/dav/calendars/user/`  | Standard username/password         |
 | **Radicale**        | `http://localhost:5232/`                           | Self-hosted, standard auth         |
 
-**💡 Tip**: Most providers use the same app-specific password for both email and calendar. Store credentials in `pass` with consistent naming (e.g., `google/app-password`, `icloud/app-password`) to reuse them across both email and calendar skills. For multiple accounts, use a hierarchical structure (e.g., `google/personal/app-password`, `google/work/app-password`)—the `/` creates folders to keep things organized.
+**💡 Tip**: Most non-Google providers use the same app-specific password for both email and calendar. Store credentials in `pass` with consistent naming (e.g., `icloud/app-password`) to reuse them across both email and calendar skills. For multiple accounts, use a hierarchical structure (e.g., `icloud/personal/app-password`, `icloud/work/app-password`)—the `/` creates folders to keep things organized.
 
 For detailed provider configurations, see [references/providers.md](references/providers.md)
+
+---
+
+## Google Calendar (gcalcli)
+
+Google's CalDAV endpoint doesn't support the discovery handshake generic CalDAV clients rely on, and no longer accepts app-password Basic Auth either — so this is the one provider that needs a completely different tool and setup path.
+
+### Prerequisites Check
+
+```bash
+command -v gcalcli
+```
+
+If missing, install it (`pip install --break-system-packages gcalcli` on Debian-family systems where apt owns the Python environment, plain `pip install gcalcli`/`pipx install gcalcli` elsewhere).
+
+### One-time OAuth client (per deployment, not per account)
+
+1. In [Google Cloud Console](https://console.cloud.google.com): create/reuse a project, enable the **Google Calendar API**.
+2. **OAuth consent screen**: User type External, add every Google account that will use this as a **test user** (keeps the app in Testing mode — no Google verification review needed).
+3. **Credentials → Create Credentials → OAuth client ID**, application type **Desktop app**. This gives a `client_id` and `client_secret` shared across every account below.
+
+### Per-account authorization
+
+gcalcli's credential cache path is keyed off `$XDG_DATA_HOME` (specifically `$XDG_DATA_HOME/gcalcli/oauth`), **not** `--config-folder` — running it for a second account without isolating that path overwrites the first account's cache. Give each account its own data directory:
+
+```bash
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+XDG_DATA_HOME=~/.local/share/gcalcli-work gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+```
+
+`init` opens a browser consent flow. If it hangs after clicking Allow (a known issue: the local callback server can grab the wrong one of two connections a browser opens and block forever waiting for data that never arrives on it), don't keep retrying it — Google still put the authorization `code` in the browser's address bar even though the page failed to load. Recover manually:
+
+1. Build the URL yourself instead of using gcalcli's printed one — no PKCE, no port-forwarding needed, since the redirect target never has to actually respond:
+   ```
+   https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=CLIENT_ID&redirect_uri=http://localhost:8080&scope=https://www.googleapis.com/auth/calendar&access_type=offline&prompt=select_account%20consent&login_hint=ACCOUNT_EMAIL
+   ```
+   (`prompt=select_account consent` is required when authorizing more than one Google account with the same client — otherwise Google silently reuses whichever account is already logged into the browser instead of prompting, and the token ends up authenticating as the wrong account.)
+2. After clicking Allow, copy the failed `http://localhost:8080/?...&code=...` URL from the address bar and extract `code`.
+3. Exchange it directly:
+   ```bash
+   curl -s -X POST https://oauth2.googleapis.com/token \
+     -d "code=$CODE" -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
+     -d "redirect_uri=http://localhost:8080" -d "grant_type=authorization_code"
+   ```
+4. Write the response into `$XDG_DATA_HOME/gcalcli/oauth` for that account as JSON with keys `access_token`, `client_id`, `client_secret`, `refresh_token`, `token_uri` (`https://oauth2.googleapis.com/token`), `scopes` (a list) — gcalcli's legacy-JSON loader accepts this shape and converts it to its normal pickle cache on next use.
+
+### Usage
+
+Always set `XDG_DATA_HOME` to the right account's directory before invoking `gcalcli` — there's no `--account` flag, isolation is entirely by data directory:
+
+```bash
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli agenda
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli list
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli quick "Lunch with John tomorrow at noon"
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli add --title "Sprint Planning" --where "Room A" --when "2026-02-15 14:00" --duration 1h
+XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli delete "Sprint Planning"
+```
 
 ---
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -247,20 +247,24 @@ If missing, install it (`pip install --break-system-packages gcalcli` on Debian-
 
 ### Per-account authorization
 
-gcalcli's credential cache path is keyed off `$XDG_DATA_HOME` (specifically `$XDG_DATA_HOME/gcalcli/oauth`), **not** `--config-folder` — running it for a second account without isolating that path overwrites the first account's cache. Give each account its own data directory:
+**Everything in this section is per Google account — run the whole procedure once for each one.** There's no single "add another account" shortcut; each account gets its own data directory and goes through its own consent. The examples below authorize two accounts, `account-a` and `account-b`, side by side specifically so the pattern is obvious to repeat for a third, fourth, etc. — just pick a new `$ACCOUNT_NAME` and a new `$ACCOUNT_EMAIL` each time and redo every step.
+
+gcalcli's credential cache path is keyed off `$XDG_DATA_HOME` (specifically `$XDG_DATA_HOME/gcalcli/oauth`), **not** `--config-folder` — running it for a second account without isolating that path overwrites the first account's cache. Give each account its own data directory, named after the account itself:
 
 ```bash
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
-XDG_DATA_HOME=~/.local/share/gcalcli-work gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
+XDG_DATA_HOME=~/.local/share/gcalcli-account-b gcalcli --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" init
 ```
 
-`init` opens a browser consent flow. If it hangs after clicking Allow (a known issue: the local callback server can grab the wrong one of two connections a browser opens and block forever waiting for data that never arrives on it), don't keep retrying it — Google still put the authorization `code` in the browser's address bar even though the page failed to load. Recover manually:
+`$CLIENT_ID`/`$CLIENT_SECRET` are the same values for every account (one shared OAuth client from the previous step) — only the data directory and, during consent, which Google account you log in as change per account.
+
+`init` opens a browser consent flow. If it hangs after clicking Allow (a known issue: the local callback server can grab the wrong one of two connections a browser opens and block forever waiting for data that never arrives on it), don't keep retrying it — Google still put the authorization `code` in the browser's address bar even though the page failed to load. Recover manually — **again, do this once per account**, substituting that account's `$ACCOUNT_NAME`/`$ACCOUNT_EMAIL`/`$XDG_DATA_HOME` each time:
 
 1. Build the URL yourself instead of using gcalcli's printed one — no PKCE, no port-forwarding needed, since the redirect target never has to actually respond:
    ```
    https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=CLIENT_ID&redirect_uri=http://localhost:8080&scope=https://www.googleapis.com/auth/calendar&access_type=offline&prompt=select_account%20consent&login_hint=ACCOUNT_EMAIL
    ```
-   (`prompt=select_account consent` is required when authorizing more than one Google account with the same client — otherwise Google silently reuses whichever account is already logged into the browser instead of prompting, and the token ends up authenticating as the wrong account.)
+   Set `ACCOUNT_EMAIL` to the specific account you're authorizing right now (`account-a`'s address the first time through, `account-b`'s the second). `prompt=select_account consent` is **required** whenever more than one Google account will ever be authorized against this same client — omit it and Google silently reuses whichever account is already logged into the browser instead of prompting, so `account-b`'s token ends up authenticating as `account-a` (this is not hypothetical — it's exactly what happened the first time this was set up, and the fix was re-running the flow with this parameter and clearing the wrongly-written cache first).
 2. After clicking Allow, copy the failed `http://localhost:8080/?...&code=...` URL from the address bar and extract `code`.
 3. Exchange it directly:
    ```bash
@@ -268,18 +272,19 @@ XDG_DATA_HOME=~/.local/share/gcalcli-work gcalcli --client-id "$CLIENT_ID" --cli
      -d "code=$CODE" -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
      -d "redirect_uri=http://localhost:8080" -d "grant_type=authorization_code"
    ```
-4. Write the response into `$XDG_DATA_HOME/gcalcli/oauth` for that account as JSON with keys `access_token`, `client_id`, `client_secret`, `refresh_token`, `token_uri` (`https://oauth2.googleapis.com/token`), `scopes` (a list) — gcalcli's legacy-JSON loader accepts this shape and converts it to its normal pickle cache on next use.
+4. Write the response into **that account's** `$XDG_DATA_HOME/gcalcli/oauth` (e.g. `~/.local/share/gcalcli-account-a/gcalcli/oauth` for `account-a`, `~/.local/share/gcalcli-account-b/gcalcli/oauth` for `account-b`) as JSON with keys `access_token`, `client_id`, `client_secret`, `refresh_token`, `token_uri` (`https://oauth2.googleapis.com/token`), `scopes` (a list) — gcalcli's legacy-JSON loader accepts this shape and converts it to its normal pickle cache on next use.
+5. Verify **before moving to the next account**: `XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli list` should show `account-a`'s calendars, not any other account's. If two accounts ever show the same calendars, step 1's `login_hint`/`prompt` was skipped or the wrong `$XDG_DATA_HOME` was used — redo that account.
 
 ### Usage
 
-Always set `XDG_DATA_HOME` to the right account's directory before invoking `gcalcli` — there's no `--account` flag, isolation is entirely by data directory:
+Always set `XDG_DATA_HOME` to the right account's directory before invoking `gcalcli` — there's no `--account` flag, isolation is entirely by data directory. The same command works for any account; only the directory changes:
 
 ```bash
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli agenda
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli list
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli quick "Lunch with John tomorrow at noon"
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli add --title "Sprint Planning" --where "Room A" --when "2026-02-15 14:00" --duration 1h
-XDG_DATA_HOME=~/.local/share/gcalcli-personal gcalcli delete "Sprint Planning"
+XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli agenda
+XDG_DATA_HOME=~/.local/share/gcalcli-account-b gcalcli agenda
+
+XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli quick "Lunch with John tomorrow at noon"
+XDG_DATA_HOME=~/.local/share/gcalcli-account-b gcalcli add --title "Sprint Planning" --where "Room A" --when "2026-02-15 14:00" --duration 1h
 ```
 
 ---

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect } from "effect";
+import { Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { buildWorkStatePreamble } from "@/core/agent/context/work-state-preamble";
@@ -8,6 +8,7 @@ import { AgentNotFoundError } from "@/core/types/errors";
 import type { ChatMessage } from "@/core/types/message";
 import type { StreamEvent } from "@/core/types/streaming";
 import type { AutoApprovePolicy } from "@/core/types/tools";
+import { createRunDeadline } from "@/core/utils/run-deadline";
 import {
   loadConversation,
   saveConversation,
@@ -365,6 +366,10 @@ export function runAgentOnceCommand(
   options: RunAgentOnceOptions,
 ) {
   const outputOptions: OneShotOutputOptions = { json: options.json };
+  // Deadline can be pushed out while blocked on a human approval decision (see
+  // requestApproval in OneShotPresentationService) so waiting on a person
+  // doesn't count against the same budget as the agent's own work.
+  const deadline = options.timeoutMs != null ? createRunDeadline(options.timeoutMs) : undefined;
 
   return Effect.gen(function* () {
     const normalizedIdentifier = agentIdentifier.trim();
@@ -464,14 +469,7 @@ export function runAgentOnceCommand(
       ...(ephemeral ? { disablePersistence: true } : {}),
     });
 
-    const runResult = yield* options.timeoutMs != null
-      ? runEffect.pipe(
-          Effect.timeoutFail({
-            duration: Duration.millis(options.timeoutMs),
-            onTimeout: () => new Error(`Run exceeded the ${options.timeoutMs}ms timeout.`),
-          }),
-        )
-      : runEffect;
+    const runResult = yield* deadline ? Effect.race(runEffect, deadline.watch) : runEffect;
 
     if (conversationKey !== undefined) {
       const record = buildConversationRecord({
@@ -527,6 +525,13 @@ export function runAgentOnceCommand(
     );
   }).pipe(
     Effect.catchAll((error) => failOneShot(getErrorMessage(error), outputOptions)),
-    Effect.provide(makeOneShotPresentationServiceLayer(options.eventTypes ?? new Set())),
+    Effect.provide(
+      makeOneShotPresentationServiceLayer(
+        options.eventTypes ?? new Set(),
+        deadline && options.timeoutMs != null
+          ? () => deadline.extend(options.timeoutMs!)
+          : undefined,
+      ),
+    ),
   );
 }

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -100,6 +100,7 @@ export class OneShotPresentationService implements PresentationService {
     _displayConfig = DEFAULT_DISPLAY_CONFIG,
     private readonly emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
     private readonly stdinStream: NodeJS.ReadableStream = process.stdin,
+    private readonly onApprovalWaitStart?: () => void,
   ) {}
 
   /**
@@ -286,7 +287,10 @@ export class OneShotPresentationService implements PresentationService {
     // Events are active, so an external consumer (e.g. the Telegram bridge) may
     // be watching the `approval_required` NDJSON event and can write a matching
     // `approval_decision` line back on stdin. Block until that happens (or the
-    // run is interrupted/killed by its own timeout — no separate timeout here).
+    // run's deadline expires — onApprovalWaitStart pushes that deadline out
+    // first, so time spent waiting on a human doesn't count against the same
+    // budget as the agent's own work).
+    this.onApprovalWaitStart?.();
     this.ensureStdinReaderStarted();
     const toolCallId = request.toolCallId;
     const pendingApprovals = this.pendingApprovals;
@@ -336,6 +340,7 @@ export class OneShotPresentationService implements PresentationService {
  */
 export function makeOneShotPresentationServiceLayer(
   emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
+  onApprovalWaitStart?: () => void,
 ) {
   return Layer.effect(
     PresentationServiceTag,
@@ -344,7 +349,12 @@ export function makeOneShotPresentationServiceLayer(
       const displayConfig = Option.isSome(configServiceOption)
         ? resolveDisplayConfig(yield* configServiceOption.value.appConfig)
         : DEFAULT_DISPLAY_CONFIG;
-      return new OneShotPresentationService(displayConfig, emitEventTypes);
+      return new OneShotPresentationService(
+        displayConfig,
+        emitEventTypes,
+        undefined,
+        onApprovalWaitStart,
+      );
     }),
   );
 }

--- a/src/core/utils/env.test.ts
+++ b/src/core/utils/env.test.ts
@@ -73,6 +73,22 @@ describe("createSanitizedEnv", () => {
     }
   });
 
+  it("passes PASSWORD_STORE_DIR through despite matching the sensitive-name scrub", () => {
+    const originalValue = process.env["PASSWORD_STORE_DIR"];
+    process.env["PASSWORD_STORE_DIR"] = "/data/password-store";
+
+    try {
+      const sanitized = createSanitizedEnv();
+      expect(sanitized["PASSWORD_STORE_DIR"]).toBe("/data/password-store");
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env["PASSWORD_STORE_DIR"];
+      } else {
+        process.env["PASSWORD_STORE_DIR"] = originalValue;
+      }
+    }
+  });
+
   it("still blocks SSH_* vars even when allowlisted", () => {
     const originalValue = process.env["SSH_AUTH_SOCK"];
     process.env["SSH_AUTH_SOCK"] = "/tmp/ssh-agent.sock";

--- a/src/core/utils/env.ts
+++ b/src/core/utils/env.ts
@@ -7,6 +7,19 @@
 export type ProcessEnvRecord = Record<string, string | undefined>;
 
 /**
+ * Var names that match the sensitive-name scrub by coincidence but never
+ * hold a secret value themselves — a directory path, not a credential. The
+ * scrub matches on substring, so `PASSWORD_STORE_DIR` (the standard `pass`
+ * env var jazz's own email/calendar skills tell users to rely on) contains
+ * "PASSWORD" and was being silently stripped, pointing `pass` at its default
+ * (empty) store instead of wherever the operator actually configured it —
+ * `pass`/`himalaya` then failed in a way that looked like missing secrets
+ * rather than a stripped env var. Safe to always pass through, independent
+ * of any agent's `envAllowlist`.
+ */
+const ALWAYS_SAFE_DESPITE_SENSITIVE_NAME = new Set(["PASSWORD_STORE_DIR"]);
+
+/**
  * Build a sanitized environment for child process execution.
  * Strips sensitive vars while preserving essentials like PATH.
  *
@@ -45,7 +58,7 @@ export function createSanitizedEnv(
       continue;
     }
 
-    const isAllowlisted = allowlist.includes(key);
+    const isAllowlisted = allowlist.includes(key) || ALWAYS_SAFE_DESPITE_SENSITIVE_NAME.has(key);
 
     if (
       (!isAllowlisted && /API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH/i.test(key)) ||

--- a/src/core/utils/run-deadline.test.ts
+++ b/src/core/utils/run-deadline.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { createRunDeadline } from "./run-deadline";
+
+describe("createRunDeadline", () => {
+  it("fails watch once the timeout elapses", async () => {
+    const deadline = createRunDeadline(50);
+    await expect(Effect.runPromise(deadline.watch)).rejects.toThrow(/50ms timeout/);
+  });
+
+  it("does not fire before the timeout elapses", async () => {
+    const deadline = createRunDeadline(500);
+    const result = await Effect.runPromise(
+      Effect.race(deadline.watch, Effect.succeed("done").pipe(Effect.delay(50))),
+    );
+    expect(result).toBe("done");
+  });
+
+  it("extend() pushes the deadline out so a pending watch does not fire early", async () => {
+    const deadline = createRunDeadline(100);
+    // Simulate an approval wait starting right away: push the deadline out
+    // far enough that the original 100ms budget would have already expired.
+    deadline.extend(400);
+    const result = await Effect.runPromise(
+      Effect.race(
+        deadline.watch,
+        Effect.succeed("resolved-before-original-deadline").pipe(Effect.delay(200)),
+      ),
+    );
+    expect(result).toBe("resolved-before-original-deadline");
+  });
+
+  it("extend() never shortens an already-later deadline", async () => {
+    const deadline = createRunDeadline(500);
+    // A shorter extend() than the remaining budget must not bring the
+    // deadline closer — only ever push it further out.
+    deadline.extend(50);
+    const result = await Effect.runPromise(
+      Effect.race(deadline.watch, Effect.succeed("done").pipe(Effect.delay(200))),
+    );
+    expect(result).toBe("done");
+  });
+});

--- a/src/core/utils/run-deadline.ts
+++ b/src/core/utils/run-deadline.ts
@@ -1,0 +1,46 @@
+import { Duration, Effect } from "effect";
+
+/**
+ * A run's wall-clock timeout budget that can be pushed out while the run is
+ * blocked waiting on a human (e.g. an execute_command approval relayed
+ * through the Telegram bridge). Without this, time spent waiting for a person
+ * to tap Accept/Reject counts against the same budget as the agent's own
+ * work, so a run can be killed mid-approval — and the tap arrives to find the
+ * process already gone.
+ */
+export interface RunDeadline {
+  /**
+   * Push the deadline out so it is at least `minMs` from now. Called each
+   * time the run starts blocking on human input; a stale deadline from
+   * before the wait began is never allowed to fire while still waiting.
+   */
+  readonly extend: (minMs: number) => void;
+  /** Effect that fails once the deadline passes. Race this against the run. */
+  readonly watch: Effect.Effect<never, Error>;
+}
+
+const POLL_INTERVAL_MS = 1000;
+
+export function createRunDeadline(timeoutMs: number): RunDeadline {
+  let deadline = Date.now() + timeoutMs;
+
+  const extend = (minMs: number): void => {
+    const candidate = Date.now() + minMs;
+    if (candidate > deadline) deadline = candidate;
+  };
+
+  const watch: Effect.Effect<never, Error> = Effect.gen(function* () {
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        return yield* Effect.fail(new Error(`Run exceeded the ${timeoutMs}ms timeout.`));
+      }
+      // Poll in short increments rather than sleeping for the full remaining
+      // duration up front, so an extend() call made mid-sleep is honored
+      // promptly instead of only on the next (already-scheduled) wakeup.
+      yield* Effect.sleep(Duration.millis(Math.min(remaining, POLL_INTERVAL_MS)));
+    }
+  });
+
+  return { extend, watch };
+}


### PR DESCRIPTION
## What & why
The Telegram bot already has `email`/`calendar` skills that know how to drive Himalaya and khal/vdirsyncer for reading and managing mail and calendar events, but the bot's Docker image never shipped those CLIs — so the skills had nothing to run. This installs them into the image and persists their config, keyring, and password store under the bot's existing data volume, so setup done once (account login, GPG key, calendar sync) survives restarts and image rebuilds.

`execute_command` is gated as high-risk, which would otherwise force every himalaya/khal/vdirsyncer call behind a manual approval tap in Telegram. The entrypoint now allowlists exactly those three binaries under the bot's low-risk policy — nothing else gets a wider approval net.

## Breaking changes / migration
None for existing deployments — the new binaries and allowlist are additive, and mail/calendar stay inert until an operator logs the account in.

## How to verify
- `docker compose up -d --build`, then `docker compose exec jazz-telegram sh` and confirm `himalaya --version`, `khal --version`, `vdirsyncer --version`, and `pass version` all resolve.
- Run the one-time account setup inside the container (`himalaya`'s wizard, `gpg --full-generate-key` + `pass init`, `vdirsyncer discover && vdirsyncer sync`) and confirm `~/.config/himalaya` and the vdirsyncer/khal config end up under `/data` (i.e. survive `docker compose restart`).
- Ask the bot something mail- or calendar-shaped ("what's on my calendar today") and confirm it runs the skill without hitting an approval prompt.
- Edge case: set `JAZZ_AUTO_APPROVE_MAIL_CALENDAR=false` and confirm a mail/calendar request now surfaces the normal accept/reject approval buttons instead of running silently.
