### PR TITLE
fix(cli): stop truncating approval_required event fields at 200 chars

### DIFF
--- a/src/core/agent/tools/shell-tools.test.ts
+++ b/src/core/agent/tools/shell-tools.test.ts
@@ -143,6 +143,12 @@ describe("Shell Tools", () => {
     expect(result.result).toHaveProperty("approvalRequired", true);
     expect(result.result).toHaveProperty("message");
     expect(result.error).toContain("Command execution requires explicit user approval");
+
+    // Timeout is shown to the human approving the command, so it must read as
+    // an answer ("15m") rather than a raw millisecond count ("900000ms").
+    const message = (result.result as { message: string }).message;
+    expect(message).toContain("Timeout: 15m");
+    expect(message).not.toContain("ms\n");
   });
 
   it("should validate command arguments", async () => {

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -21,6 +21,19 @@ import {
 import { buildKeyFromContext } from "./context-utils";
 
 /**
+ * Format a timeout duration for the approval prompt. Unlike `formatDuration`
+ * (built for logging elapsed time, where fractional seconds are meaningful),
+ * timeouts are always round config values — "15m 0.0s" reads as noise where
+ * "15m" reads as an answer.
+ */
+function formatTimeoutForApproval(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+/**
  * Patterns that block obviously dangerous shell commands before execution.
  *
  * This is a defense-in-depth denylist, not a sandbox. It cannot stop a
@@ -440,7 +453,7 @@ export function createShellCommandTools(): ApprovalToolPair<ShellCommandDeps> {
         return `Command: ${args.command}
 Description: ${description}
 Working Directory: ${workingDir}
-Timeout: ${timeout}ms
+Timeout: ${formatTimeoutForApproval(timeout)}
 
 This command will be executed on your system. Only approve commands you trust.`;
       }),

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -112,6 +112,31 @@ describe("OneShotPresentationService streaming renderer", () => {
     expect(parsed.result.startsWith("x".repeat(200))).toBe(true);
   });
 
+  it("does not truncate approval_required fields, unlike other event types", () => {
+    const longMessage = `Command: ${"x".repeat(500)}\nDescription: something a human needs to read in full before approving`;
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["approval_required"]),
+    );
+    const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));
+
+    const captured = captureStderr();
+    Effect.runSync(
+      renderer.handleEvent({
+        type: "approval_required",
+        toolCallId: "call_1",
+        toolName: "execute_command",
+        message: longMessage,
+        riskLevel: "high-risk",
+      }),
+    );
+
+    expect(captured.lines).toHaveLength(1);
+    const parsed = JSON.parse(captured.lines[0] as string) as { message: string };
+    expect(parsed.message).toBe(longMessage);
+    expect(parsed.message).not.toContain("…");
+  });
+
   it("serializes Error-valued event fields to a plain object with a non-empty message", () => {
     const service = new OneShotPresentationService(
       DEFAULT_DISPLAY_CONFIG,

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -227,7 +227,14 @@ export class OneShotPresentationService implements PresentationService {
       handleEvent: (event: StreamEvent) =>
         Effect.sync(() => {
           if (emitEventTypes.has(event.type)) {
-            process.stderr.write(`${JSON.stringify(event, truncateLongStrings)}\n`);
+            // approval_required is exempt from the length scrub: its message/
+            // previewDiff are exactly what a human is being asked to read
+            // before approving, and truncating them defeats the point of
+            // asking — a consumer (e.g. the Telegram bridge) that needs to
+            // bound how much it displays can do so itself, having seen the
+            // whole thing.
+            const replacer = event.type === "approval_required" ? undefined : truncateLongStrings;
+            process.stderr.write(`${JSON.stringify(event, replacer)}\n`);
           }
         }),
       setInterruptHandler: (_handler: (() => void) | null) => Effect.void,

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -227,12 +227,7 @@ export class OneShotPresentationService implements PresentationService {
       handleEvent: (event: StreamEvent) =>
         Effect.sync(() => {
           if (emitEventTypes.has(event.type)) {
-            // approval_required is exempt from the length scrub: its message/
-            // previewDiff are exactly what a human is being asked to read
-            // before approving, and truncating them defeats the point of
-            // asking — a consumer (e.g. the Telegram bridge) that needs to
-            // bound how much it displays can do so itself, having seen the
-            // whole thing.
+            // Don't truncate what a human is being asked to approve.
             const replacer = event.type === "approval_required" ? undefined : truncateLongStrings;
             process.stderr.write(`${JSON.stringify(event, replacer)}\n`);
           }


### PR DESCRIPTION
## What & why
The NDJSON event stream truncates long string fields at 200 characters so a huge tool result can't gush onto stderr — but that same scrub was also cutting off `approval_required`'s `message`/`previewDiff`, which is exactly what a human is being asked to read before tapping Accept. A command longer than ~200 characters showed up truncated mid-sentence in an approval prompt (discovered via the Telegram bot integration), meaning someone could approve a command without ever seeing the whole thing.

## How to verify
- Trigger an `execute_command` approval whose command + description exceeds 200 characters (e.g. via `jazz run --events approval ...` with `--approval-policy read-only` on a long shell command) and confirm the emitted `approval_required` NDJSON line contains the full text, not `…`-truncated.
- Confirm other event types (e.g. `tool_execution_complete`) are still truncated at 200 characters as before.