### PR TITLE
feat(ui): copy a highlight on release and confirm it in the footer

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -371,8 +371,10 @@ Turn all of them off and the design is unchanged in structure.
 Wheel scrolling is on in the fullscreen interface so a long transcript can move
 without arrow keys. OpenTUI does not expose wheel-only mouse reporting — scroll
 also replaces the terminal's native click-drag selection with the renderer's own
-selection layer. Shift+drag still reaches native selection on many hosts. Copy
-also works through footer bindings and OSC 52 where the terminal supports it.
+selection layer. Releasing a highlight copies it immediately and the footer says
+`copied` for two seconds; Cmd+C and Ctrl+Shift+C copy whatever is currently
+selected. Shift+drag still reaches native selection on many hosts. Copy also uses
+OSC 52 where the terminal supports it.
 
 ### Headless
 

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -13,7 +13,7 @@ import { deleteAgentCommand } from "./agent-management";
 import { configWizardCommand } from "./config-wizard";
 import { createAgentCommand } from "./create-agent";
 import { editAgentCommand } from "./edit-agent";
-import { configuredProviderNames, homeRequirements } from "../ui/fullscreen/home-readiness";
+import { homeRequirements } from "../ui/fullscreen/home-readiness";
 import { store, type ActiveAgentChoice } from "../ui/store";
 import { TIPS, WizardHome, type WizardMenuOption } from "../ui/WizardHome";
 
@@ -120,19 +120,8 @@ export function wizardCommand() {
 
       menuOptions.push({ label: "Exit", value: "exit" });
 
-      const config = yield* configService.appConfig;
-      const providers = configuredProviderNames(config);
-      const preferred = lastUsedAgent ?? agents[0];
       const requirements = homeRequirements({
-        configuredProviders: providers,
-        ...(preferred === undefined
-          ? {}
-          : {
-              preferredProvider: preferred.config.llmProvider,
-              preferredModel: preferred.config.llmModel,
-            }),
         agentCount: agents.length,
-        connectors: store.getConnectorsSnapshot(),
       });
 
       const selection = yield* showWizardMenu(menuOptions, requirements);

--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -1,9 +1,20 @@
 /** @jsxImportSource @opentui/react */
-import { useKeyboard, usePaste, useRenderer, useTerminalDimensions } from "@opentui/react";
+import {
+  useKeyboard,
+  usePaste,
+  useRenderer,
+  useSelectionHandler,
+  useTerminalDimensions,
+} from "@opentui/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
-import { pasteTextFromEvent, selectedTextFromRenderer, writeClipboard } from "./clipboard";
+import {
+  copyText,
+  pasteTextFromEvent,
+  selectedTextFromRenderer,
+  textFromSelection,
+} from "./clipboard";
 import { selectedText as selectedComposerText } from "./composer-edit";
 import { Footer } from "./Footer";
 import { Header } from "./Header";
@@ -189,6 +200,8 @@ export function App({
   const [newBelow, setNewBelow] = useState<number | undefined>(view.newBelow);
   const seenBlocks = useRef(view.blocks.length);
   const armedAt = useRef<number | undefined>(undefined);
+  const [copyNotice, setCopyNotice] = useState<string | undefined>(undefined);
+  const copyNoticeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const glyphs = getGlyphs();
 
   // `useKeyboard` registers its callback once, so it captures the props and
@@ -242,6 +255,22 @@ export function App({
     },
     [dispatch],
   );
+
+  const announceCopy = useCallback((copied: boolean): void => {
+    if (!copied) return;
+    if (copyNoticeTimer.current !== undefined) clearTimeout(copyNoticeTimer.current);
+    setCopyNotice("copied");
+    copyNoticeTimer.current = setTimeout(() => {
+      setCopyNotice(undefined);
+      copyNoticeTimer.current = undefined;
+    }, 2000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (copyNoticeTimer.current !== undefined) clearTimeout(copyNoticeTimer.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (view.runActive !== true) armedAt.current = undefined;
@@ -303,7 +332,7 @@ export function App({
         composer.length > 0 ? composer : selectedTextFromRenderer(rendererRef.current);
       if (selected.length > 0) {
         consumeKeyEvent(key);
-        void writeClipboard(selected);
+        void copyText(selected, rendererRef.current).then(announceCopy);
       }
       return;
     }
@@ -395,6 +424,14 @@ export function App({
     }
   });
 
+  // Mouse reporting replaces native drag-select, so Cmd+C in the host often
+  // copies nothing. Releasing a highlight writes the clipboard immediately;
+  // Cmd+C / Ctrl+Shift+C still copy whatever is highlighted. The footer says
+  // "copied" for a beat so a silent pasteboard write is not the only signal.
+  useSelectionHandler((selection) => {
+    void copyText(textFromSelection(selection), rendererRef.current).then(announceCopy);
+  });
+
   if (overrideContent !== undefined) {
     return overrideContent;
   }
@@ -430,6 +467,7 @@ export function App({
       view.overlay?.kind,
       view.input.commands !== undefined,
     ),
+    ...(copyNotice === undefined ? {} : { notice: copyNotice }),
   };
 
   return (

--- a/src/cli/ui/fullscreen/Footer.tsx
+++ b/src/cli/ui/fullscreen/Footer.tsx
@@ -36,7 +36,8 @@ export function formatElapsed(elapsedMs: number): string {
 
 /**
  * Fit the row: drop elapsed first, then hints from the end. Everything sits on
- * the neutral ramp except the mode, which takes the one accent.
+ * the neutral ramp except the mode and a transient notice, which take the one
+ * accent.
  */
 export function footerSegments(model: FooterModel, viewport: Viewport): readonly FooterSegment[] {
   const glyphs = getGlyphs();
@@ -53,12 +54,18 @@ export function footerSegments(model: FooterModel, viewport: Viewport): readonly
       ? undefined
       : { text: formatElapsed(model.elapsedMs), fg: THEME.muted };
 
-  let hints = [...model.hints];
+  const notice = model.notice !== undefined && model.notice.length > 0 ? model.notice : undefined;
+  let hints = notice === undefined ? [...model.hints] : [];
   let keepElapsed = elapsed !== undefined;
 
-  const leftWidth = (): number =>
-    terminalSegmentsWidth(mode) +
-    hints.reduce((total, hint) => total + separatorWidth + terminalCellWidth(hint), 0);
+  const leftWidth = (): number => {
+    const noticeWidth = notice === undefined ? 0 : separatorWidth + terminalCellWidth(notice);
+    return (
+      terminalSegmentsWidth(mode) +
+      noticeWidth +
+      hints.reduce((total, hint) => total + separatorWidth + terminalCellWidth(hint), 0)
+    );
+  };
   const rightWidth = (): number => {
     const parts: string[] = [];
     if (cost !== undefined) parts.push(cost.text);
@@ -78,6 +85,10 @@ export function footerSegments(model: FooterModel, viewport: Viewport): readonly
   while (total() > viewport.width && hints.length > 0) hints = hints.slice(0, -1);
 
   const left: FooterSegment[] = [...mode];
+  if (notice !== undefined) {
+    left.push({ text: separator, fg: THEME.muted });
+    left.push({ text: notice, fg: THEME.primary });
+  }
   for (const hint of hints) {
     left.push({ text: separator, fg: THEME.muted });
     left.push({ text: hint, fg: THEME.secondary });

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -593,26 +593,18 @@ describe("fullscreen bridge", () => {
         kind: "menu",
         requirements: [
           {
-            label: "provider",
-            ready: false,
-            detail: "no key yet",
-            remedy: "add a key with jazz config",
-          },
-          {
             label: "agent",
             ready: false,
             detail: "none yet",
             remedy: "create your first one below",
           },
-          { label: "apps", ready: false, detail: "none connected", remedy: "optional, add later" },
         ],
         options: [{ label: "Create agent", value: "create-agent" }],
         onSelect: () => undefined,
         onExit: () => undefined,
       });
     });
-    expect(text).toContain("provider");
-    expect(text).toContain("add a key with jazz config");
+    expect(text).toContain("agent");
     expect(text).toContain("create your first one below");
     expect(text).toContain("Press enter on");
     store.setActiveMenu(null);
@@ -1915,7 +1907,7 @@ describe("fullscreen bridge", () => {
   });
   /** Types a literal string into a live composer, one real keypress each. */
   async function typeInto(
-    mockInput: { pressKey: (key: string, mods?: object) => Promise<void> },
+    mockInput: { pressKey: (key: string, mods?: object) => void },
     flush: () => Promise<void>,
     text: string,
   ): Promise<void> {

--- a/src/cli/ui/fullscreen/clipboard.test.ts
+++ b/src/cli/ui/fullscreen/clipboard.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
   clipboardWriteCommands,
+  copyText,
   flattenPaste,
   normalizePaste,
   pasteTextFromEvent,
   selectedTextFromRenderer,
+  textFromSelection,
 } from "./clipboard";
 
 describe("normalizePaste", () => {
@@ -42,6 +44,32 @@ describe("clipboardWriteCommands", () => {
       { cmd: "xclip", args: ["-selection", "clipboard"] },
       { cmd: "xsel", args: ["--clipboard", "--input"] },
     ]);
+  });
+});
+
+describe("textFromSelection", () => {
+  it("normalises OpenTUI's highlight and ignores a missing one", () => {
+    expect(textFromSelection(undefined)).toBe("");
+    expect(textFromSelection(null)).toBe("");
+    expect(textFromSelection({ getSelectedText: () => "" })).toBe("");
+    expect(textFromSelection({ getSelectedText: () => "\u001b[31mcopied\r\nline\u001b[0m" })).toBe(
+      "copied\nline",
+    );
+  });
+});
+
+describe("copyText", () => {
+  it("does not touch OSC 52 when there is nothing to copy", async () => {
+    const written: string[] = [];
+    expect(
+      await copyText("", {
+        copyToClipboardOSC52: (text) => {
+          written.push(text);
+          return true;
+        },
+      }),
+    ).toBe(false);
+    expect(written).toEqual([]);
   });
 });
 

--- a/src/cli/ui/fullscreen/clipboard.ts
+++ b/src/cli/ui/fullscreen/clipboard.ts
@@ -39,14 +39,34 @@ export function clipboardWriteCommands(
   }
 }
 
+export function textFromSelection(
+  selection: { getSelectedText(): string } | null | undefined,
+): string {
+  if (selection === undefined || selection === null) return "";
+  return normalizePaste(selection.getSelectedText());
+}
+
 export function selectedTextFromRenderer(renderer: {
   readonly hasSelection?: boolean;
   readonly getSelection?: () => { getSelectedText(): string } | null;
 }): string {
   if (renderer.hasSelection !== true) return "";
-  const selection = renderer.getSelection?.();
-  if (selection === undefined || selection === null) return "";
-  return normalizePaste(selection.getSelectedText());
+  return textFromSelection(renderer.getSelection?.());
+}
+
+export interface ClipboardTerminal {
+  readonly copyToClipboardOSC52?: (text: string) => boolean;
+}
+
+/**
+ * Host clipboard and OSC 52 together. Empty text is a no-op so a click
+ * without a highlight cannot wipe the pasteboard. True if either path landed.
+ */
+export async function copyText(text: string, terminal?: ClipboardTerminal): Promise<boolean> {
+  if (text.length === 0) return false;
+  const osc = terminal?.copyToClipboardOSC52?.(text) === true;
+  const host = await writeClipboard(text);
+  return osc || host;
 }
 
 export function normalizePaste(text: string): string {

--- a/src/cli/ui/fullscreen/header-footer.test.tsx
+++ b/src/cli/ui/fullscreen/header-footer.test.tsx
@@ -250,6 +250,21 @@ describe("Footer", () => {
     expect(colorOf(spans, "$0.42")).toBe(THEME.muted.toUpperCase());
   });
 
+  it("replaces hints with a copy confirmation in the live accent", async () => {
+    const { row, spans } = await render(
+      <Footer
+        model={footer({ notice: "copied" })}
+        viewport={{ width: 80, height: 24 }}
+      />,
+      80,
+    );
+
+    expect(row).toContain("copied");
+    expect(row).not.toContain("enter send");
+    expect(row).toContain("plan");
+    expect(colorOf(spans, "copied")).toBe(THEME.primary.toUpperCase());
+  });
+
   it("drops elapsed before it drops a hint", async () => {
     const { row } = await render(
       <Footer

--- a/src/cli/ui/fullscreen/home-readiness.test.ts
+++ b/src/cli/ui/fullscreen/home-readiness.test.ts
@@ -4,53 +4,25 @@ import { configuredProviderNames, homeRequirements } from "./home-readiness";
 describe("homeRequirements", () => {
   it("matches the first-run setup list when nothing is configured", () => {
     const rows = homeRequirements({
-      configuredProviders: [],
       agentCount: 0,
-      connectors: new Map(),
     });
     expect(rows).toEqual([
-      {
-        label: "provider",
-        ready: false,
-        detail: "no key yet",
-        remedy: "add a key with jazz config",
-      },
       { label: "agent", ready: false, detail: "none yet", remedy: "create your first one below" },
-      { label: "apps", ready: false, detail: "none connected", remedy: "optional, add later" },
     ]);
   });
 
-  it("matches the settled setup list when a provider and agents exist", () => {
+  it("matches the settled setup list when agents exist", () => {
     const rows = homeRequirements({
-      configuredProviders: ["anthropic"],
-      preferredProvider: "anthropic",
-      preferredModel: "claude-sonnet-4",
       agentCount: 4,
-      connectors: new Map(),
     });
-    expect(rows).toEqual([
-      { label: "provider", ready: true, detail: "anthropic, claude-sonnet-4" },
-      { label: "agent", ready: true, detail: "4 of them" },
-      { label: "apps", ready: false, detail: "none connected", remedy: "optional, add later" },
-    ]);
+    expect(rows).toEqual([{ label: "agent", ready: true, detail: "4 of them" }]);
   });
 
-  it("counts live connectors and names a partial set", () => {
+  it("names a single agent", () => {
     const rows = homeRequirements({
-      configuredProviders: ["openai"],
       agentCount: 1,
-      connectors: new Map([
-        ["gmail", "live"],
-        ["calendar", "offline"],
-        ["notion", "live"],
-      ]),
     });
-    expect(rows[2]).toEqual({
-      label: "apps",
-      ready: true,
-      detail: "2 of 3 connected",
-    });
-    expect(rows[1]?.detail).toBe("1 of them");
+    expect(rows).toEqual([{ label: "agent", ready: true, detail: "1 of them" }]);
   });
 });
 

--- a/src/cli/ui/fullscreen/home-readiness.ts
+++ b/src/cli/ui/fullscreen/home-readiness.ts
@@ -1,14 +1,9 @@
 import type { AppConfig } from "@/core/types/index";
 import { LLM_PROVIDER_ENV_VARS } from "@/services/secrets/registry";
-import type { ConnectorStatus } from "../store";
 import type { HomeRequirement } from "./screens/Home";
 
 export interface HomeReadinessInput {
-  readonly configuredProviders: readonly string[];
-  readonly preferredProvider?: string;
-  readonly preferredModel?: string;
   readonly agentCount: number;
-  readonly connectors: ReadonlyMap<string, ConnectorStatus>;
 }
 
 export function configuredProviderNames(config: AppConfig): string[] {
@@ -30,27 +25,7 @@ export function configuredProviderNames(config: AppConfig): string[] {
   return names;
 }
 
-function connectorNames(
-  connectors: ReadonlyMap<string, ConnectorStatus>,
-): readonly { readonly name: string; readonly live: boolean }[] {
-  const rows: { readonly name: string; readonly live: boolean }[] = [];
-  for (const [name, status] of connectors) {
-    if (name === undefined) continue;
-    rows.push({ name, live: status === "live" });
-  }
-  return rows;
-}
-
 export function homeRequirements(input: HomeReadinessInput): readonly HomeRequirement[] {
-  const providerName = input.preferredProvider ?? input.configuredProviders[0];
-  const providerReady = providerName !== undefined;
-  const providerDetail =
-    providerName === undefined
-      ? "no key yet"
-      : input.preferredModel === undefined
-        ? providerName
-        : `${providerName}, ${input.preferredModel}`;
-
   const agentReady = input.agentCount > 0;
   const agentDetail =
     input.agentCount === 0
@@ -59,33 +34,12 @@ export function homeRequirements(input: HomeReadinessInput): readonly HomeRequir
         ? "1 of them"
         : `${String(input.agentCount)} of them`;
 
-  const apps = connectorNames(input.connectors);
-  const liveApps = apps.filter((app) => app.live).length;
-  const appsReady = liveApps > 0;
-  const appsDetail = appsReady
-    ? liveApps === apps.length
-      ? `${String(liveApps)} connected`
-      : `${String(liveApps)} of ${String(apps.length)} connected`
-    : "none connected";
-
   return [
-    {
-      label: "provider",
-      ready: providerReady,
-      detail: providerDetail,
-      ...(providerReady ? {} : { remedy: "add a key with jazz config" }),
-    },
     {
       label: "agent",
       ready: agentReady,
       detail: agentDetail,
       ...(agentReady ? {} : { remedy: "create your first one below" }),
-    },
-    {
-      label: "apps",
-      ready: appsReady,
-      detail: appsDetail,
-      ...(appsReady ? {} : { remedy: "optional, add later" }),
     },
   ];
 }

--- a/src/cli/ui/fullscreen/mount.ts
+++ b/src/cli/ui/fullscreen/mount.ts
@@ -124,8 +124,9 @@ export async function mountFullscreen(): Promise<MountedRenderer> {
     maxFps: MAX_FPS,
     // Wheel events only arrive with mouse reporting on. OpenTUI has no
     // wheel-only mode; this also replaces the terminal's native drag-select
-    // with OpenTUI's own selection (text is selectable by default). Scroll
-    // wins that trade. Shift+drag still reaches native selection in many hosts.
+    // with OpenTUI's own selection (text is selectable by default). Releasing
+    // that highlight copies it; Cmd+C does the same when the host forwards it.
+    // Shift+drag still reaches native selection in many hosts.
     useMouse: true,
     // Leave whatever was on the main screen alone; the alternate screen restores
     // it on exit, and clearing it would destroy the user's scrollback.

--- a/src/cli/ui/fullscreen/screens/Home.tsx
+++ b/src/cli/ui/fullscreen/screens/Home.tsx
@@ -4,10 +4,10 @@
  * The home screen.
  *
  * `jazz` with no arguments starts here, which makes this the one screen that has
- * to work when *nothing* is set up — no key, no agent, no connected app. So the
- * design question is not "what is missing" but "what do I do now", and the
- * answer is on screen in three forms: a remedy beside each thing that is not
- * ready, a sentence naming the key to press, and the menu itself.
+ * to work when *nothing* is set up — no agent yet. So the design question is not
+ * "what is missing" but "what do I do now", and the answer is on screen in three
+ * forms: a remedy beside each thing that is not ready, a sentence naming the key
+ * to press, and the menu itself.
  *
  * Four things, in this order, because that is the order a reader needs them:
  *
@@ -54,7 +54,7 @@ const GUIDANCE_MAX_ROWS = 2;
 
 /** One thing jazz needs before it is useful, and the one thing to do about it. */
 export interface HomeRequirement {
-  /** A noun, lowercase: "provider", "agent", "apps". */
+  /** A noun, lowercase: "agent". */
   readonly label: string;
   readonly ready: boolean;
   /** What is true now — "anthropic ∙ claude-sonnet-4", "none yet". */
@@ -195,7 +195,7 @@ function requirementRows(
   );
   return requirements.map((requirement, index) => {
     // The remedy replaces the detail rather than joining it: on a row that is
-    // not ready, "no key yet" and "add one with jazz config" say the same thing
+    // not ready, "none yet" and "create your first one below" say the same thing
     // and only one of them is useful.
     const text = requirement.ready
       ? requirement.detail

--- a/src/cli/ui/fullscreen/screens/screens.test.tsx
+++ b/src/cli/ui/fullscreen/screens/screens.test.tsx
@@ -47,14 +47,7 @@ const FIRST_RUN: HomeModel = {
   version: "0.14.2",
   tagline: "your everyday agentic CLI",
   requirements: [
-    {
-      label: "provider",
-      ready: false,
-      detail: "no key yet",
-      remedy: "add a key with jazz config",
-    },
     { label: "agent", ready: false, detail: "none yet", remedy: "create your first one below" },
-    { label: "apps", ready: false, detail: "none connected", remedy: "optional, add later" },
   ],
   choices: [
     { label: "Create agent", value: "create-agent", hint: "about a minute" },
@@ -68,11 +61,7 @@ const FIRST_RUN: HomeModel = {
 const SETTLED: HomeModel = {
   version: "0.14.2",
   tagline: "your everyday agentic CLI",
-  requirements: [
-    { label: "provider", ready: true, detail: "anthropic, claude-sonnet-4" },
-    { label: "agent", ready: true, detail: "4 of them" },
-    { label: "apps", ready: false, detail: "none connected", remedy: "optional, add later" },
-  ],
+  requirements: [{ label: "agent", ready: true, detail: "4 of them" }],
   choices: [
     { label: "Resume: Basil", value: "continue", hint: "12 minutes ago" },
     { label: "New conversation", value: "new-conversation" },
@@ -231,10 +220,9 @@ describe("home screen", () => {
     expect(drawn.text).toContain("0.14.2");
     expect(drawn.text).toContain("your everyday agentic CLI");
 
-    // Every unmet requirement, named — and each one carries the remedy rather
-    // than only the complaint.
-    expect(drawn.text).toContain("provider");
-    expect(drawn.text).toContain("add a key with jazz config");
+    // The unmet requirement, named — carrying the remedy rather than only the
+    // complaint.
+    expect(drawn.text).toContain("agent");
     expect(drawn.text).toContain("create your first one below");
 
     // And the key to press, naming the thing it is on.
@@ -254,7 +242,7 @@ describe("home screen", () => {
 
     // The one thing on an unconfigured row that you would act on.
     const remedy = allSpans(drawn.frame).find((span) =>
-      span.text.startsWith("add a key with jazz config"),
+      span.text.startsWith("create your first one below"),
     );
     expect(remedy).toBeDefined();
     expect(hexOf(remedy as CapturedSpan)).toBe(THEME.primary.toUpperCase());
@@ -281,8 +269,8 @@ describe("home screen", () => {
       );
       const ready = drawn.rows.filter((row) => row.startsWith(glyphs.active));
       const pending = drawn.rows.filter((row) => row.startsWith(glyphs.pending));
-      expect(ready).toHaveLength(2);
-      expect(pending).toHaveLength(1);
+      expect(ready).toHaveLength(1);
+      expect(pending).toHaveLength(0);
       // The distinction survives a monochrome terminal.
       expect(glyphs.active).not.toBe(glyphs.pending);
       expect(hexOf(spanWithText(drawn.frame, glyphs.active))).toBe(THEME.success.toUpperCase());
@@ -633,7 +621,14 @@ describe("both screens in ascii glyph mode", () => {
     // ASCII spends `*` on the mark, the ready state and the bullet, so readiness
     // is asserted from the side that stays unambiguous: what is NOT ready.
     expect(glyphs.active).not.toBe(glyphs.pending);
-    expect(home.rows.filter((row) => row.startsWith(glyphs.pending))).toHaveLength(1);
+    const firstRun = await draw(
+      <Home
+        model={FIRST_RUN}
+        viewport={WIDE}
+      />,
+      WIDE,
+    );
+    expect(firstRun.rows.filter((row) => row.startsWith(glyphs.pending))).toHaveLength(1);
     expect(home.rows.filter((row) => row.startsWith(glyphs.rail))).toHaveLength(1);
 
     const picker = await draw(

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -225,6 +225,8 @@ export interface InputModel {
 export interface FooterModel {
   readonly mode: Mode;
   readonly hints: readonly string[];
+  /** Replaces hints for a beat — copy confirmation, not a key legend. */
+  readonly notice?: string;
   readonly costUsd?: number;
   readonly elapsedMs?: number;
 }


### PR DESCRIPTION
## What & why
Selecting text in the fullscreen UI now copies it as soon as you release the highlight, and the footer flashes `copied` for two seconds so you know it landed. Mouse reporting owns selection, which means the host's Cmd+C often copies nothing; this makes copy work without that chord, while Cmd+C / Ctrl+Shift+C still copy when the terminal actually forwards them.

Copy also goes out over OSC 52 when the terminal supports it, so a remote session can reach the local pasteboard.

## How to verify
- Drag-select a line in the transcript, release, confirm the footer says `copied`, then paste in another app.
- Click without dragging: the pasteboard should stay unchanged and the footer should not flash.
- Select composer text with Shift+arrows and press Cmd+C (or Ctrl+Shift+C): the same notice should appear if the host forwards the chord.
- Over SSH or a terminal without `pbcopy`, confirm OSC 52 still copies when the host supports it.