### PR TITLE
feat(ui): show queued messages below the composer count

### DIFF
--- a/src/cli/ui/fullscreen/Input.tsx
+++ b/src/cli/ui/fullscreen/Input.tsx
@@ -4,6 +4,8 @@
  * The composer: the one region the user's hands are on.
  *
  *   ▏ 4 more lines                                              2 queued
+ *   ▏ ∙ move the smaller meeting
+ *   ▏ ∙ send the itinerary
  *   » and then check whether anything on Thursday afternoon collides with
  *     the flight, and if it does, move the smaller thing█
  *
@@ -61,6 +63,12 @@ export const INPUT_MAX_ROWS = 6;
 
 /** Same cap as the Ink dropdown: a 20-row list is unscannable. */
 const MAX_VISIBLE_COMMANDS = 8;
+
+/**
+ * Newest queued entries shown under the count. Older ones remain in the
+ * count, so a long queue cannot push the composer off the screen.
+ */
+export const MAX_VISIBLE_QUEUED = 3;
 
 export function wrapCommandIndex(index: number, length: number): number {
   return wrapIndex(index, length);
@@ -142,6 +150,35 @@ function commandSuggestRows(
   return rows;
 }
 
+function previewQueuedEntry(entry: string): string {
+  return entry.replace(/\s+/g, " ").trim();
+}
+
+function queuePreviewRows(
+  entries: readonly string[],
+  width: number,
+  glyphs: GlyphSet,
+  mixedQueue: boolean,
+): InputRow[] {
+  return entries.map((entry, index) => {
+    const oneLine = previewQueuedEntry(entry);
+    // Slash commands only run when they are the whole queue; mixed in they
+    // go to the model as prose, so say so while the entry is still editable.
+    const slashWarning =
+      mixedQueue && oneLine.startsWith("/") ? " (sent as text, not run — queue it alone)" : "";
+    const segments: InputSegment[] = [
+      { text: `${glyphs.rail} `, fg: THEME.border },
+      { text: `${glyphs.bullet} `, fg: THEME.muted },
+      { text: oneLine, fg: THEME.muted },
+      ...(slashWarning.length > 0 ? [{ text: slashWarning, fg: THEME.warning }] : []),
+    ];
+    return {
+      key: `queue:${String(index)}:${oneLine}`,
+      segments: fitTerminalSegments(segments, width),
+    };
+  });
+}
+
 function caret(character: string): InputSegment {
   return { text: character, fg: THEME.canvas, bg: THEME.prompt };
 }
@@ -210,7 +247,7 @@ export function inputRows(
    * default is the unconstrained demand, so standalone callers see the natural
    * size.
    */
-  maxRows: number = INPUT_MAX_ROWS + MAX_VISIBLE_COMMANDS,
+  maxRows: number = INPUT_MAX_ROWS + MAX_VISIBLE_COMMANDS + MAX_VISIBLE_QUEUED,
 ): readonly InputRow[] {
   const width = Math.max(1, viewport.width);
   const contentWidth = Math.max(1, width - GUTTER_CELLS);
@@ -247,17 +284,25 @@ export function inputRows(
   }
   caretLine = Math.min(lines.length - 1, caretLine);
 
-  const queued = Math.max(0, model.queued);
+  const queued = model.queued;
+  const queuedCount = queued.length;
   const budget = Math.max(1, Math.trunc(maxRows));
   const commandItems = model.commands?.items.length ?? 0;
   const wantsCommands = model.commands !== undefined && commandItems > 0;
+  const commandReserve = wantsCommands ? 1 : 0;
+  // Previews yield before the composer or an open command list. The count row
+  // is reserved separately so a squeezed frame can still say how many wait.
+  const queueChrome = queuedCount > 0 ? 1 : 0;
+  const previewRoom = Math.max(0, budget - 1 - commandReserve - queueChrome);
+  const previewCount = Math.min(queuedCount, MAX_VISIBLE_QUEUED, previewRoom);
+  const visibleQueued = previewCount === 0 ? [] : queued.slice(-previewCount);
   // The text always keeps at least one row, and the list keeps at least one
   // whenever it is open — whichever of them has to shrink, neither vanishes.
-  const textBudget = Math.max(1, Math.min(INPUT_MAX_ROWS, budget - (wantsCommands ? 1 : 0)));
+  const textBudget = Math.max(1, Math.min(INPUT_MAX_ROWS, budget - commandReserve - previewCount));
   // The chrome row and the text rows share one budget, so the marker that says
   // "there is more above" can never itself push the composer past the cap.
   const capWithChrome = Math.max(1, textBudget - 1);
-  const capWithoutChrome = queued > 0 ? Math.max(1, textBudget - 1) : textBudget;
+  const capWithoutChrome = queuedCount > 0 ? capWithChrome : textBudget;
   let visible = wrapped;
   let hidden = 0;
   if (lines.length > capWithoutChrome) {
@@ -267,7 +312,7 @@ export function inputRows(
   }
 
   const rows: InputRow[] = [];
-  if (hidden > 0 || queued > 0) {
+  if (hidden > 0 || queuedCount > 0) {
     const left: InputSegment[] = [
       { text: `${glyphs.rail} `, fg: THEME.border },
       ...(hidden > 0
@@ -280,8 +325,11 @@ export function inputRows(
         : []),
     ];
     const right: InputSegment[] =
-      queued > 0 ? [{ text: `${queued} queued`, fg: THEME.secondary }] : [];
+      queuedCount > 0 ? [{ text: `${String(queuedCount)} queued`, fg: THEME.secondary }] : [];
     rows.push(alignRow("chrome", left, right, width));
+  }
+  if (visibleQueued.length > 0) {
+    rows.push(...queuePreviewRows(visibleQueued, width, glyphs, queuedCount > 1));
   }
 
   // The caret's own line may have scrolled out of `visible` — the window

--- a/src/cli/ui/fullscreen/app.test.tsx
+++ b/src/cli/ui/fullscreen/app.test.tsx
@@ -270,7 +270,7 @@ describe("transcript wheel and type-to-input", () => {
           input: {
             value: draft,
             placeholder: "Ask anything",
-            queued: 0,
+            queued: [],
             disabled: false,
           },
         }}
@@ -360,7 +360,7 @@ describe("Ctrl+C", () => {
           view={{
             ...sampleIdleView(),
             runActive: true,
-            input: { value: "hello", placeholder: "Ask anything", queued: 0, disabled: false },
+            input: { value: "hello", placeholder: "Ask anything", queued: [], disabled: false },
           }}
           onAction={(action) => {
             actions.push(action);
@@ -417,7 +417,7 @@ describe("Ctrl+C", () => {
           view={{
             ...sampleIdleView(),
             runActive: true,
-            input: { value: "hello", placeholder: "Ask anything", queued: 0, disabled: false },
+            input: { value: "hello", placeholder: "Ask anything", queued: [], disabled: false },
           }}
           onAction={(action) => {
             actions.push(action);
@@ -492,7 +492,7 @@ function CompletedTurnApp(): React.ReactNode {
         input: {
           value: draft,
           placeholder: "Ask anything",
-          queued: 0,
+          queued: [],
           disabled: false,
         },
       }}

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -457,6 +457,7 @@ describe("fullscreen bridge", () => {
     await rendered.mockInput.pressKey("RETURN");
     await settleKeypress(rendered.flush, 100);
     expect(rendered.captureCharFrame()).toContain("1 queued");
+    expect(rendered.captureCharFrame()).toContain("follow up");
     expect(store.getMessageQueueSnapshot()).toEqual(["follow up"]);
 
     await rendered.mockInput.pressKey("ARROW_UP");

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -1958,7 +1958,7 @@ export function FullscreenBridge(): React.ReactNode {
         caret: draftCaret,
         anchor: draftAnchor,
         placeholder: busy ? "Type to queue for next turn" : "Ask anything",
-        queued: queue.length,
+        queued: queue,
         queueing: busy,
         disabled: overlay !== undefined || (!busy && prompt?.type !== "chat"),
         ...(commands === undefined ? {} : { commands }),

--- a/src/cli/ui/fullscreen/live-input.test.tsx
+++ b/src/cli/ui/fullscreen/live-input.test.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from "bun:test";
 import React from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
-import { Input, inputRows, wrapCells, wrapCommandIndex } from "./Input";
+import { Input, inputRows, MAX_VISIBLE_QUEUED, wrapCells, wrapCommandIndex } from "./Input";
 import { liveRows, LiveZone } from "./LiveZone";
 import { terminalCellWidth } from "./terminal-cells";
 import {
@@ -366,7 +366,7 @@ describe("input", () => {
   const base: InputModel = {
     value: "",
     placeholder: "ask jazz anything",
-    queued: 0,
+    queued: [],
     disabled: false,
   };
 
@@ -467,30 +467,85 @@ describe("input", () => {
     ).toBe(true);
   });
 
-  it("shows the queued count only when there is one", () => {
+  it("lists queued messages below the count", () => {
     const none = inputRows(base, { width: WIDTH, height: HEIGHT });
     expect(none.map((row) => row.segments.map((s) => s.text).join("")).join("")).not.toContain(
       "queued",
     );
 
-    const some = inputRows({ ...base, queued: 3 }, { width: WIDTH, height: HEIGHT });
+    const some = inputRows(
+      { ...base, queued: ["follow up", "send the itinerary"] },
+      { width: WIDTH, height: HEIGHT },
+    );
     const text = some.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
-    expect(text).toContain("3 queued");
-    expect(some).toHaveLength(2);
+    expect(text).toContain("2 queued");
+    expect(text).toContain("follow up");
+    expect(text).toContain("send the itinerary");
+    expect(text.indexOf("2 queued")).toBeLessThan(text.indexOf("follow up"));
+    expect(text.indexOf("follow up")).toBeLessThan(text.indexOf("send the itinerary"));
+    expect(text.indexOf("send the itinerary")).toBeLessThan(text.indexOf("ask jazz"));
+    expect(some).toHaveLength(4);
+  });
+
+  it("keeps the newest queued messages when the queue is longer than the cap", () => {
+    const queued = ["one", "two", "three", "four"];
+    const some = inputRows({ ...base, queued }, { width: WIDTH, height: HEIGHT });
+    const text = some.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
+    expect(text).toContain("4 queued");
+    expect(text).not.toContain(`${glyphs.bullet} one`);
+    expect(text).toContain("two");
+    expect(text).toContain("three");
+    expect(text).toContain("four");
+    expect(some).toHaveLength(2 + MAX_VISIBLE_QUEUED);
+  });
+
+  it("collapses queued newlines and warns when a slash command is mixed in", () => {
+    const some = inputRows(
+      { ...base, queued: ["/clear", "keep going"] },
+      { width: WIDTH, height: HEIGHT },
+    );
+    const text = some.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
+    expect(text).toContain("/clear");
+    expect(text).toContain("sent as text, not run");
+    expect(text).toContain("keep going");
+
+    const wrapped = inputRows(
+      { ...base, queued: ["first line\nsecond line"] },
+      { width: WIDTH, height: HEIGHT },
+    );
+    const wrappedText = wrapped.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
+    expect(wrappedText).toContain("first line second line");
+    expect(wrappedText).not.toContain("first line\nsecond line");
+  });
+
+  it("drops queued previews before the count when the shell is squeezed", () => {
+    const squeezed = inputRows(
+      { ...base, queued: ["follow up", "send the itinerary"] },
+      { width: WIDTH, height: HEIGHT },
+      true,
+      glyphs,
+      2,
+    );
+    const text = squeezed.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
+    expect(text).toContain("2 queued");
+    expect(text).not.toContain("follow up");
+    expect(squeezed).toHaveLength(2);
   });
 
   it("never exceeds the width at the minimum width, caret included", () => {
     const value = "a".repeat(400);
+    const queued = ["one", "two", "three", "four"];
     const models = [
       { ...base, value },
       { ...base, value: "b".repeat(MIN_WIDTH - 2) },
-      { ...base, value, queued: 4 },
+      { ...base, value, queued },
       { ...base, placeholder: "x".repeat(200) },
       { ...base, disabled: true, placeholder: "x".repeat(200) },
     ];
     for (const model of models) {
       const rows = inputRows(model, { width: MIN_WIDTH, height: HEIGHT });
-      expect(rows.length).toBeLessThanOrEqual(INPUT_MAX_ROWS_EXPECTED);
+      const queuedRows = model.queued.length === 0 ? 0 : MAX_VISIBLE_QUEUED;
+      expect(rows.length).toBeLessThanOrEqual(INPUT_MAX_ROWS_EXPECTED + queuedRows);
       for (const row of rows) {
         const width = row.segments.reduce(
           (total, segment) => total + terminalCellWidth(segment.text),

--- a/src/cli/ui/fullscreen/sample.ts
+++ b/src/cli/ui/fullscreen/sample.ts
@@ -177,7 +177,7 @@ export function sampleView(tick = 0): ViewModel {
       // tools churn.
       reservedRows: 3,
     },
-    input: { value: "", placeholder: "Ask anything", queued: 0, disabled: false },
+    input: { value: "", placeholder: "Ask anything", queued: [], disabled: false },
     footer: {
       mode: "chat",
       hints: [],

--- a/src/cli/ui/fullscreen/transcript-window.test.ts
+++ b/src/cli/ui/fullscreen/transcript-window.test.ts
@@ -83,7 +83,7 @@ describe("transcriptVisibleCount", () => {
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
-      queued: 0,
+      queued: [],
       disabled: false,
     };
     expect(
@@ -101,7 +101,7 @@ describe("transcriptVisibleCount", () => {
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
-      queued: 0,
+      queued: [],
       disabled: false,
     };
     const regions = allocateRegions({
@@ -146,13 +146,16 @@ describe("allocateRegions", () => {
     const base: InputModel = {
       value: "",
       placeholder: "Ask anything",
-      queued: 0,
+      queued: [],
       disabled: false,
     };
     // 60x12 is exactly what `decideFullscreen` admits as fullscreen-capable.
     expectFits({ width: 60, height: 12 }, base);
     expectFits({ width: 60, height: 12 }, { ...base, value: "/dep", commands });
-    expectFits({ width: 60, height: 12 }, { ...base, value: "x".repeat(400), queued: 3, commands });
+    expectFits(
+      { width: 60, height: 12 },
+      { ...base, value: "x".repeat(400), queued: ["one", "two", "three"], commands },
+    );
     expectFits({ width: 80, height: 24 }, { ...base, value: "/dep", commands });
   });
 
@@ -160,7 +163,7 @@ describe("allocateRegions", () => {
     const input: InputModel = {
       value: "/dep",
       placeholder: "Ask anything",
-      queued: 0,
+      queued: [],
       disabled: false,
       commands,
     };

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -215,7 +215,8 @@ export interface InputModel {
    */
   readonly anchor?: number;
   readonly placeholder: string;
-  readonly queued: number;
+  /** Messages waiting for the current turn to finish. Empty when idle. */
+  readonly queued: readonly string[];
   /** Busy chat turns queue Enter instead of resolving the active prompt. */
   readonly queueing?: boolean;
   /** Suppressed while a modal overlay owns the keyboard. */


### PR DESCRIPTION
## What & why
While a turn is running, queued follow-ups used to appear only as `1 queued` above the composer. The actual text is now listed under that count, so you can see what will be sent next without recalling the queue.

A long queue still shows the newest three entries; older ones stay in the count. Mixed slash commands keep the existing warning that they will be sent as prose.

## How to verify
- Start a chat turn, type a follow-up while the agent is busy, press Enter. Confirm the composer shows `1 queued` and the message text on the next line.
- Queue a second message and confirm both appear, newest last, under the count.
- Queue four messages and confirm only the newest three are listed, with the count still saying 4.
- Shrink the terminal (or fill the composer) until space is tight: the count should remain after the previews drop.
- Queue `/clear` together with another message and confirm the slash warning appears.