### PR TITLE
fix(ui): show tool args and an output snippet on receipts

### DIFF
--- a/src/cli/presentation/activity-reducer.test.ts
+++ b/src/cli/presentation/activity-reducer.test.ts
@@ -196,6 +196,28 @@ describe("activity-reducer", () => {
       expect(result.outputs.length).toBe(1);
       expect(result.outputs[0]!.type).toBe("info");
       expect(String(result.outputs[0]!.message)).toContain("execute_bash");
+      expect(result.outputs[0]!.meta?.["toolStart"]).toBe(true);
+    });
+
+    test("tool_execution_start for view_memory shows root when path is empty", () => {
+      const a = acc();
+      const result = reduceEvent(
+        a,
+        {
+          type: "tool_execution_start",
+          toolName: "view_memory",
+          toolCallId: "mem-1",
+          arguments: { path: "" },
+        },
+        stubInk,
+      );
+
+      expect(a.activeTools.get("mem-1")?.argsPreview).toContain("path: /");
+      expect(String(result.outputs[0]!.message)).toContain("path:");
+      expect(String(result.outputs[0]!.message)).toContain("/");
+      if (result.activity?.phase === "tool-execution") {
+        expect(result.activity.tools[0]?.argsPreview).toContain("path: /");
+      }
     });
 
     test("tool_execution_start for web_search appends provider from metadata", () => {
@@ -239,6 +261,37 @@ describe("activity-reducer", () => {
       expect(result.activity!.phase).toBe("idle");
       expect(result.outputs.length).toBeGreaterThan(0);
       expect(result.outputs[0]!.type).toBe("log");
+    });
+
+    test("tool_execution_complete receipt carries args and an output snippet", () => {
+      const a = acc();
+      a.activeTools.set("mem-1", {
+        toolName: "view_memory",
+        startedAt: Date.now(),
+        argsPreview: "path: /",
+      });
+
+      const result = reduceEvent(
+        a,
+        {
+          type: "tool_execution_complete",
+          toolCallId: "mem-1",
+          result: JSON.stringify({
+            formatted: "Here're the files and directories up to 2 levels deep in /:\n/notes.txt",
+            outcome: { kind: "directory" },
+          }),
+          durationMs: 12,
+          success: true,
+        },
+        stubInk,
+      );
+
+      const receipt = result.outputs[0]?.meta?.["toolReceipt"] as
+        { app?: string; args?: string; summary?: string } | undefined;
+      expect(receipt?.app).toBe("view_memory");
+      expect(receipt?.args).toBe("path: /");
+      expect(receipt?.summary).toContain("Here're the files");
+      expect(receipt?.summary).not.toBe("{");
     });
 
     test("tool_execution_complete keeps tool-execution phase when other tools remain", () => {

--- a/src/cli/presentation/activity-reducer.ts
+++ b/src/cli/presentation/activity-reducer.ts
@@ -15,9 +15,16 @@
 
 import { Box, Text } from "ink";
 import React from "react";
+import { stripAnsiCodes } from "@/cli/utils/string-utils";
 import type { TerminalOutput } from "@/core/interfaces/terminal";
 import type { StreamEvent } from "@/core/types/streaming";
-import { formatToolArguments, formatToolDisplayName, formatToolResult } from "./format-utils";
+import {
+  compactToolArguments,
+  formatToolArguments,
+  formatToolDisplayName,
+  formatToolResult,
+  toolResultSnippet,
+} from "./format-utils";
 import type { ActiveTool, ActivityState } from "../ui/activity-state";
 import { getGlyphs } from "../ui/glyphs";
 import { PADDING, THEME } from "../ui/theme";
@@ -81,6 +88,7 @@ export interface ReducerAccumulator {
       /** Name with backend folded in (e.g. web_search(brave)); falls back to toolName. */
       displayName?: string;
       startedAt: number;
+      argsPreview?: string;
       todoSnapshot?: TodoSnapshotItem[];
     }
   >;
@@ -138,20 +146,15 @@ function buildThinkingOrStreamingActivity(acc: ReducerAccumulator): ActivityStat
 }
 
 function buildToolExecutionActivity(acc: ReducerAccumulator): ActivityState {
-  const tools: ActiveTool[] = Array.from(acc.activeTools.entries()).map(([toolCallId, entry]) =>
-    entry.todoSnapshot
-      ? {
-          toolCallId,
-          toolName: entry.displayName ?? entry.toolName,
-          startedAt: entry.startedAt,
-          todoSnapshot: entry.todoSnapshot,
-        }
-      : {
-          toolCallId,
-          toolName: entry.displayName ?? entry.toolName,
-          startedAt: entry.startedAt,
-        },
-  );
+  const tools: ActiveTool[] = Array.from(acc.activeTools.entries()).map(([toolCallId, entry]) => ({
+    toolCallId,
+    toolName: entry.displayName ?? entry.toolName,
+    startedAt: entry.startedAt,
+    ...(entry.argsPreview !== undefined && entry.argsPreview.length > 0
+      ? { argsPreview: entry.argsPreview }
+      : {}),
+    ...(entry.todoSnapshot ? { todoSnapshot: entry.todoSnapshot } : {}),
+  }));
   const todoSnapshot = findLatestTodoSnapshot(acc.activeTools);
   return todoSnapshot
     ? { phase: "tool-execution", agentName: acc.agentName, tools, todoSnapshot }
@@ -362,26 +365,21 @@ export function reduceEvent(
         event.arguments,
         event.metadata !== undefined ? { metadata: event.metadata } : undefined,
       );
+      const argsPreview = compactToolArguments(event.toolName, event.arguments);
       const displayName = formatToolDisplayName(event.toolName, event.metadata);
-      if (todoSnapshot) {
-        acc.activeTools.set(event.toolCallId, {
-          toolName: event.toolName,
-          ...(displayName !== event.toolName ? { displayName } : {}),
-          startedAt: Date.now(),
-          todoSnapshot,
-        });
-      } else {
-        acc.activeTools.set(event.toolCallId, {
-          toolName: event.toolName,
-          ...(displayName !== event.toolName ? { displayName } : {}),
-          startedAt: Date.now(),
-        });
-      }
+      acc.activeTools.set(event.toolCallId, {
+        toolName: event.toolName,
+        ...(displayName !== event.toolName ? { displayName } : {}),
+        startedAt: Date.now(),
+        ...(argsPreview.length > 0 ? { argsPreview } : {}),
+        ...(todoSnapshot ? { todoSnapshot } : {}),
+      });
 
       outputs.push({
         type: "info",
         message: `${displayName}${args.length > 0 ? ` ${args}` : ""}`,
         timestamp: new Date(),
+        meta: { toolStart: true },
       });
 
       return { activity: buildToolExecutionActivity(acc), outputs };
@@ -419,13 +417,17 @@ export function reduceEvent(
       // structured data so a renderer that lays out its own rows does not have
       // to parse ANSI back into meaning. `meta` keeps it in the output stream,
       // which is what preserves ordering relative to the surrounding turns.
+      const plainBody = stripAnsiCodes(summary ?? "");
+      const snippet = toolResultSnippet(plainBody);
+      const argsPreview = toolEntry?.argsPreview?.trim();
       const receipt = {
         app: toolName ?? "tool",
-        summary: summary && summary.length > 0 ? summary.split("\n")[0] : (toolName ?? "tool"),
+        summary: snippet.length > 0 ? snippet : (toolName ?? "tool"),
         status: failed ? "failed" : "ok",
         durationMs: event.durationMs,
+        ...(argsPreview !== undefined && argsPreview.length > 0 ? { args: argsPreview } : {}),
         ...(failed && event.error ? { reason: event.error.trim() } : {}),
-        ...(summary && summary.includes("\n") ? { detail: summary } : {}),
+        ...(plainBody.length > 0 && plainBody !== snippet ? { detail: summary } : {}),
       };
 
       const displayText = summary && summary.length > 0 ? summary : (toolName ?? "Tool");

--- a/src/cli/presentation/format-utils.ts
+++ b/src/cli/presentation/format-utils.ts
@@ -19,7 +19,11 @@ import {
 import { getGlyphs } from "../ui/glyphs";
 import { CHALK_THEME } from "../ui/theme";
 
-export { formatToolDisplayName } from "@/core/utils/tool-formatter";
+export {
+  compactToolArguments,
+  formatToolDisplayName,
+  toolResultSnippet,
+} from "@/core/utils/tool-formatter";
 
 // ---------------------------------------------------------------------------
 // Tool formatting (delegates to core)

--- a/src/cli/ui/activity-state.ts
+++ b/src/cli/ui/activity-state.ts
@@ -9,6 +9,8 @@ export interface ActiveTool {
   toolCallId: string;
   toolName: string;
   startedAt: number;
+  /** Compact argument preview for the live zone and the settled receipt. */
+  argsPreview?: string;
   todoSnapshot?: TodoSnapshotItem[];
 }
 
@@ -88,7 +90,10 @@ export function isActivityEqual(a: ActivityState, b: ActivityState): boolean {
       if (a.agentName !== (b as typeof a).agentName) return false;
       if (a.tools.length !== bTools.length) return false;
       const sameTools = a.tools.every(
-        (t, i) => t.toolCallId === bTools[i]!.toolCallId && t.toolName === bTools[i]!.toolName,
+        (t, i) =>
+          t.toolCallId === bTools[i]!.toolCallId &&
+          t.toolName === bTools[i]!.toolName &&
+          t.argsPreview === bTools[i]!.argsPreview,
       );
       if (!sameTools) return false;
 

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -888,19 +888,25 @@ function reasoningRows(
 
 /** A settled receipt: what it did and what came back, and nothing else. */
 function receiptSegments(block: ToolReceiptBlock, glyphs: GlyphSet): Segment[] {
+  const args = block.args?.trim();
   if (block.status === "ok") {
-    return [
-      { text: block.app, fg: THEME.muted },
-      { text: `  ${block.summary}`, fg: THEME.muted },
-    ];
+    const segments: Segment[] = [{ text: block.app, fg: THEME.muted }];
+    if (args !== undefined && args.length > 0) {
+      segments.push({ text: `  ${args}`, fg: THEME.secondary });
+    }
+    if (block.summary.length > 0) {
+      segments.push({ text: `  ${block.summary}`, fg: THEME.muted });
+    }
+    return segments;
   }
   // Failure is the one exception that keeps a colour, and it carries the reason
   // and the way out on the same row.
   const tone = block.status === "denied" ? THEME.warning : THEME.error;
-  const segments: Segment[] = [
-    { text: block.app, fg: tone },
-    { text: `  ${block.summary}`, fg: tone },
-  ];
+  const segments: Segment[] = [{ text: block.app, fg: tone }];
+  if (args !== undefined && args.length > 0) {
+    segments.push({ text: `  ${args}`, fg: tone });
+  }
+  segments.push({ text: `  ${block.summary}`, fg: tone });
   if (block.reason !== undefined) {
     segments.push({ text: ` ${glyphs.bullet} ${block.reason}`, fg: THEME.secondary });
   }

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -267,6 +267,25 @@ describe("fullscreen bridge", () => {
     expect(text).toContain("Rank urgent threads");
   });
 
+  it("shows the arguments a running tool was called with", async () => {
+    const text = await frame(() => {
+      store.setActivity({
+        phase: "tool-execution",
+        agentName: "jazz",
+        tools: [
+          {
+            toolCallId: "1",
+            toolName: "view_memory",
+            startedAt: Date.now(),
+            argsPreview: "path: /",
+          },
+        ],
+      });
+    });
+    expect(text).toContain("view");
+    expect(text).toContain("path: /");
+  });
+
   it("ticks turn elapsed time while a run remains active", async () => {
     const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
     await rendered.renderOnce();
@@ -2228,6 +2247,39 @@ describe("fullscreen bridge", () => {
       // anything consults the entry's text.
       expect(text).toContain("gmail");
       expect(text).toContain("4 flagged of 26");
+    });
+
+    it("shows the args used and a snippet of the tool output", async () => {
+      const text = await frame(() => {
+        const accumulator = createAccumulator("cassandra");
+        const result = JSON.stringify({
+          formatted:
+            "Here're the files and directories up to 2 levels deep in /, excluding hidden items:\n/notes.txt\t(1.2KB)",
+          outcome: { kind: "directory", path: "/", entries: [{ name: "notes.txt" }] },
+        });
+        for (const event of [
+          {
+            type: "tool_execution_start" as const,
+            toolName: "view_memory",
+            toolCallId: "call-mem",
+            arguments: { path: "" },
+          },
+          {
+            type: "tool_execution_complete" as const,
+            toolCallId: "call-mem",
+            result,
+            durationMs: 40,
+            success: true,
+          },
+        ]) {
+          const { outputs } = reduceEvent(accumulator, event, ink);
+          for (const entry of outputs) store.printOutput(entry);
+        }
+      });
+      expect(text).toContain("view_memory");
+      expect(text).toContain("path: /");
+      expect(text).toContain("Here're the files");
+      expect(text).not.toMatch(/view_memory\s+\{/);
     });
 
     it("leaves no escape sequence in a frame built from formatted markdown", async () => {

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -526,6 +526,7 @@ interface ToolReceiptMeta {
   readonly app: string;
   readonly summary: string;
   readonly status: "ok" | "failed";
+  readonly args?: string;
   readonly durationMs?: number;
   readonly reason?: string;
   readonly detail?: string;
@@ -541,6 +542,7 @@ function receiptOf(entry: OutputEntry): ToolReceiptMeta | null {
     app: record["app"],
     summary: record["summary"],
     status,
+    ...(typeof record["args"] === "string" ? { args: record["args"] } : {}),
     ...(typeof record["durationMs"] === "number" ? { durationMs: record["durationMs"] } : {}),
     ...(typeof record["reason"] === "string" ? { reason: record["reason"] } : {}),
     ...(typeof record["detail"] === "string" ? { detail: record["detail"] } : {}),
@@ -633,12 +635,15 @@ function blocksFrom(
         app: receipt.app,
         summary: receipt.summary,
         status: receipt.status,
+        ...(receipt.args === undefined ? {} : { args: receipt.args }),
         ...(receipt.reason === undefined ? {} : { reason: receipt.reason }),
         ...(receipt.durationMs === undefined ? {} : { durationMs: receipt.durationMs }),
         ...(receipt.detail === undefined ? {} : { detail: receipt.detail }),
       });
       continue;
     }
+
+    if (entry.meta?.["toolStart"] === true) continue;
 
     const plainText = entry.meta?.["plainText"];
     const text = stripAnsiCodes(typeof plainText === "string" ? plainText : plainOf(entry.message));
@@ -738,9 +743,15 @@ function liveToolsFrom(activity: ActivityState, now: number): LiveTool[] {
   if (activity.phase !== "tool-execution") return [];
   return activity.tools.map((tool, index) => {
     const parts = tool.toolName.split(/[_.-]+/).filter((part) => part.length > 0);
+    const nameRest = parts.length > 1 ? parts.slice(1).join(" ") : "";
+    const args = tool.argsPreview?.trim();
+    let operation = nameRest.length > 0 ? nameRest : tool.toolName;
+    if (args !== undefined && args.length > 0) {
+      operation = nameRest.length > 0 ? `${nameRest} ${args}` : args;
+    }
     return {
       app: parts[0] ?? tool.toolName,
-      operation: parts.length > 1 ? parts.slice(1).join(" ") : tool.toolName,
+      operation,
       elapsedMs: Math.max(0, now - tool.startedAt),
       phase: index,
     };

--- a/src/cli/ui/fullscreen/transcript.test.tsx
+++ b/src/cli/ui/fullscreen/transcript.test.tsx
@@ -474,6 +474,24 @@ describe("tool receipts", () => {
     expect(row).toContain("3.2s");
     expect(colorOf(spans, "thought")).toBe(THEME.muted.toUpperCase());
   });
+
+  it("shows the arguments used and a snippet of what came back", async () => {
+    const blocks: readonly Block[] = [
+      {
+        id: "t",
+        seq: 1,
+        kind: "tool",
+        app: "view_memory",
+        args: "path: /",
+        summary: "Here're the files · /notes.txt",
+        status: "ok",
+      },
+    ];
+    const { rows } = await render(transcript(blocks, WIDE), WIDE);
+    const row = rows.find((line) => line.includes("view_memory")) ?? "";
+    expect(row).toContain("path: /");
+    expect(row).toContain("/notes.txt");
+  });
 });
 
 describe("reasoning is subordinate by geometry", () => {

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -75,14 +75,15 @@ export interface ReasoningBlock extends BlockBase {
 }
 
 /**
- * A settled tool call is a receipt: what it did and what came back. The
- * invocation, arguments, timing and full output live behind an expand key,
- * because once a tool has run those are no longer the interesting part.
+ * A settled tool call is a receipt: the app, the args it used, and a snippet
+ * of what came back. Timing and the full output live behind an expand key.
  */
 export interface ToolReceiptBlock extends BlockBase {
   readonly kind: "tool";
   readonly app: string;
   readonly summary: string;
+  /** Compact argument preview shown next to the app name. */
+  readonly args?: string;
   readonly status: "ok" | "failed" | "denied";
   /** Shown only on failure, with the remedy inline. */
   readonly reason?: string;

--- a/src/core/utils/tool-formatter.test.ts
+++ b/src/core/utils/tool-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatToolArguments, formatToolResult } from "./tool-formatter";
+import { formatToolArguments, formatToolResult, toolResultSnippet } from "./tool-formatter";
 
 describe("formatToolArguments http_request", () => {
   test("merges query params into the displayed URL", () => {
@@ -72,5 +72,88 @@ describe("formatToolResult execute_command", () => {
   test("zero exit without output reports no output", () => {
     const formatted = formatCommand({ exitCode: 0 });
     expect(formatted).toBe("no output");
+  });
+});
+
+describe("formatToolArguments view_memory", () => {
+  test("empty path displays as root", () => {
+    const formatted = formatToolArguments("view_memory", { path: "" }, { style: "plain" });
+    expect(formatted).toContain("path: /");
+  });
+
+  test("missing args still display as root", () => {
+    const formatted = formatToolArguments("view_memory", undefined, { style: "plain" });
+    expect(formatted).toContain("path: /");
+  });
+
+  test("a file path is shown as-is", () => {
+    const formatted = formatToolArguments(
+      "view_memory",
+      { path: "people/alex.md" },
+      { style: "plain" },
+    );
+    expect(formatted).toContain("path: people/alex.md");
+  });
+
+  test("view_range is shown as a line span", () => {
+    const formatted = formatToolArguments(
+      "view_memory",
+      { path: "notes.md", view_range: [1, 40] },
+      { style: "plain" },
+    );
+    expect(formatted).toContain("path: notes.md");
+    expect(formatted).toContain("lines: 1–40");
+  });
+});
+
+describe("formatToolArguments default", () => {
+  test("skips empty string values", () => {
+    const formatted = formatToolArguments(
+      "custom_tool",
+      { path: "", limit: 5 },
+      { style: "plain" },
+    );
+    expect(formatted).not.toContain("path:");
+    expect(formatted).toContain("limit: 5");
+  });
+
+  test("stringifies object values instead of dropping them", () => {
+    const formatted = formatToolArguments(
+      "custom_tool",
+      { filter: { status: "open" } },
+      { style: "plain" },
+    );
+    expect(formatted).toContain('{"status":"open"}');
+  });
+});
+
+describe("formatToolResult generic objects", () => {
+  test("prefers a formatted string over pretty-printed JSON", () => {
+    const formatted = formatToolResult(
+      "view_memory",
+      JSON.stringify({
+        formatted: "Here're the files and directories up to 2 levels deep in /:\n/notes.txt",
+        outcome: { kind: "directory", path: "/", entries: [] },
+      }),
+    );
+    expect(formatted).toContain("Here're the files and directories");
+    expect(formatted).toContain("/notes.txt");
+    expect(formatted.trimStart().startsWith("{")).toBe(false);
+  });
+});
+
+describe("toolResultSnippet", () => {
+  test("skips brace-only JSON lines", () => {
+    expect(toolResultSnippet('{\n  "ok": true\n}')).toBe('"ok": true');
+  });
+
+  test("joins the first two content lines", () => {
+    expect(toolResultSnippet("Here're the files\n/notes.txt\n/people")).toBe(
+      "Here're the files · /notes.txt",
+    );
+  });
+
+  test("returns empty for braces only", () => {
+    expect(toolResultSnippet("{\n}")).toBe("");
   });
 });

--- a/src/core/utils/tool-formatter.ts
+++ b/src/core/utils/tool-formatter.ts
@@ -52,6 +52,25 @@ export function formatToolDisplayName(
   return provider ? `${toolName}(${provider})` : toolName;
 }
 
+const MAX_ARG_VALUE_LENGTH = 120;
+
+function formatArgValue(value: unknown, maxLength: number = MAX_ARG_VALUE_LENGTH): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return "";
+    return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    const json = JSON.stringify(value);
+    if (json === undefined || json === "{}" || json === "[]") return "";
+    return json.length > maxLength ? `${json.slice(0, maxLength)}…` : json;
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Format tool arguments for display
  * Shows relevant parameters for each tool type
@@ -68,7 +87,7 @@ export function formatToolArguments(
   const style = options.style ?? "colored";
   const usePlain = style === "plain";
 
-  if (!args || Object.keys(args).length === 0) {
+  if ((!args || Object.keys(args).length === 0) && toolName !== "view_memory") {
     return "";
   }
 
@@ -89,11 +108,28 @@ export function formatToolArguments(
     return parts.join("");
   }
 
+  const toolArgs = args ?? {};
+
   // Format arguments based on tool type
   switch (toolName) {
+    case "view_memory": {
+      const path = safeString(toolArgs["path"]);
+      const displayPath = path.trim().length === 0 || path === "/" ? "/" : path;
+      const parts: string[] = [formatKeyValue("path", displayPath)];
+      const range = toolArgs["view_range"];
+      if (Array.isArray(range) && range.length === 2) {
+        const start = formatArgValue(range[0]);
+        const end = formatArgValue(range[1]);
+        if (start.length > 0 && end.length > 0) {
+          const span = `${start}–${end}`;
+          parts.push(usePlain ? `lines: ${span}` : ` ${chalk.dim(`lines: ${span}`)}`);
+        }
+      }
+      return formatParts(parts);
+    }
     case "read_file": {
       const parts: string[] = [];
-      const path = safeString(args["path"] || args["filePath"]);
+      const path = safeString(toolArgs["path"] || toolArgs["filePath"]);
       if (path) {
         if (usePlain) {
           parts.push(`file: ${path}`);
@@ -101,8 +137,8 @@ export function formatToolArguments(
           parts.push(formatKeyValue("file", path));
         }
       }
-      const startLine = args["startLine"];
-      const endLine = args["endLine"];
+      const startLine = toolArgs["startLine"];
+      const endLine = toolArgs["endLine"];
       if (typeof startLine === "number" || typeof endLine === "number") {
         const start = typeof startLine === "number" ? startLine : undefined;
         const end = typeof endLine === "number" ? endLine : undefined;
@@ -120,7 +156,7 @@ export function formatToolArguments(
     }
     case "grep": {
       const parts: string[] = [];
-      const pattern = safeString(args["pattern"]);
+      const pattern = safeString(toolArgs["pattern"]);
       if (pattern) {
         if (usePlain) {
           parts.push(`pattern: ${pattern}`);
@@ -128,7 +164,7 @@ export function formatToolArguments(
           parts.push(formatKeyValue("pattern", pattern));
         }
       }
-      const path = safeString(args["path"]);
+      const path = safeString(toolArgs["path"]);
       if (path) {
         if (usePlain) {
           parts.push(`in: ${path}`);
@@ -137,25 +173,25 @@ export function formatToolArguments(
         }
       }
       const flags: string[] = [];
-      if (args["recursive"] === true) flags.push("--recursive");
-      if (args["ignoreCase"] === true) flags.push("--ignore-case");
-      const rawPattern = args["pattern"];
+      if (toolArgs["recursive"] === true) flags.push("--recursive");
+      if (toolArgs["ignoreCase"] === true) flags.push("--ignore-case");
+      const rawPattern = toolArgs["pattern"];
       if (
-        args["regex"] === true ||
+        toolArgs["regex"] === true ||
         (typeof rawPattern === "string" && rawPattern.startsWith("re:"))
       ) {
         flags.push("--regex");
       }
-      if (args["filePattern"]) {
-        const filePattern = safeString(args["filePattern"]);
+      if (toolArgs["filePattern"]) {
+        const filePattern = safeString(toolArgs["filePattern"]);
         if (filePattern) flags.push(`--include=${filePattern}`);
       }
-      if (args["exclude"]) {
-        const exclude = safeString(args["exclude"]);
+      if (toolArgs["exclude"]) {
+        const exclude = safeString(toolArgs["exclude"]);
         if (exclude) flags.push(`--exclude=${exclude}`);
       }
-      if (args["excludeDir"]) {
-        const excludeDir = safeString(args["excludeDir"]);
+      if (toolArgs["excludeDir"]) {
+        const excludeDir = safeString(toolArgs["excludeDir"]);
         if (excludeDir) flags.push(`--exclude-dir=${excludeDir}`);
       }
       if (flags.length > 0) {
@@ -163,15 +199,15 @@ export function formatToolArguments(
           usePlain ? `flags: ${flags.join(" ")}` : ` ${chalk.dim(`flags: ${flags.join(" ")}`)}`,
         );
       }
-      if (args["maxResults"]) {
-        const maxResults = safeString(args["maxResults"]);
+      if (toolArgs["maxResults"]) {
+        const maxResults = safeString(toolArgs["maxResults"]);
         if (maxResults) {
           parts.push(usePlain ? `max: ${maxResults}` : ` ${chalk.dim(`max: ${maxResults}`)}`);
         }
       }
 
-      if (args["contextLines"]) {
-        const contextLines = safeString(args["contextLines"]);
+      if (toolArgs["contextLines"]) {
+        const contextLines = safeString(toolArgs["contextLines"]);
         if (contextLines) {
           parts.push(
             usePlain ? `context: ${contextLines}` : ` ${chalk.dim(`context: ${contextLines}`)}`,
@@ -184,18 +220,18 @@ export function formatToolArguments(
     case "execute_write_file":
     case "edit_file":
     case "execute_edit_file": {
-      const path = safeString(args["path"] || args["filePath"]);
+      const path = safeString(toolArgs["path"] || toolArgs["filePath"]);
       if (!path) return "";
       return usePlain ? `{ file: ${path} }` : formatKeyValue("file", path);
     }
     case "cd": {
-      const to = safeString(args["path"] || args["directory"]);
+      const to = safeString(toolArgs["path"] || toolArgs["directory"]);
       if (!to) return "";
       return usePlain ? `{ path: ${to} }` : ` ${chalk.dim("→")} ${chalk.cyan(to)}`;
     }
     case "ls": {
       const parts: string[] = [];
-      const dir = safeString(args["path"]);
+      const dir = safeString(toolArgs["path"]);
       if (dir) {
         if (usePlain) {
           parts.push(`dir: ${dir}`);
@@ -203,13 +239,13 @@ export function formatToolArguments(
           parts.push(formatKeyValue("dir", dir));
         }
       }
-      if (args["all"] === true) parts.push(usePlain ? "--all" : ` ${chalk.dim("--all")}`);
-      if (args["long"] === true) parts.push(usePlain ? "--long" : ` ${chalk.dim("--long")}`);
+      if (toolArgs["all"] === true) parts.push(usePlain ? "--all" : ` ${chalk.dim("--all")}`);
+      if (toolArgs["long"] === true) parts.push(usePlain ? "--long" : ` ${chalk.dim("--long")}`);
       return formatParts(parts);
     }
     case "find": {
       const parts: string[] = [];
-      const searchPath = safeString(args["path"]);
+      const searchPath = safeString(toolArgs["path"]);
       if (searchPath) {
         if (usePlain) {
           parts.push(`path: ${searchPath}`);
@@ -217,7 +253,7 @@ export function formatToolArguments(
           parts.push(formatKeyValue("path", searchPath));
         }
       }
-      const name = safeString(args["name"]);
+      const name = safeString(toolArgs["name"]);
       if (name) {
         if (usePlain) {
           parts.push(`name: ${name}`);
@@ -225,7 +261,7 @@ export function formatToolArguments(
           parts.push(formatKeyValue("name", name));
         }
       }
-      const type = safeString(args["type"]);
+      const type = safeString(toolArgs["type"]);
       if (type) {
         if (usePlain) {
           parts.push(`type: ${type}`);
@@ -237,7 +273,7 @@ export function formatToolArguments(
     }
     case "execute_command":
     case "execute_execute_command": {
-      const command = safeString(args["command"]);
+      const command = safeString(toolArgs["command"]);
       if (!command) return "";
       return usePlain
         ? `{ command: "${command}" }`
@@ -245,15 +281,15 @@ export function formatToolArguments(
     }
     case "http_request": {
       const parts: string[] = [];
-      const method = safeString(args["method"] || "GET");
+      const method = safeString(toolArgs["method"] || "GET");
       if (usePlain) {
         parts.push(`method: ${method}`);
       } else {
         parts.push(` ${chalk.dim(`${method}:`)}`);
       }
-      const url = safeString(args["url"]);
+      const url = safeString(toolArgs["url"]);
       if (url) {
-        const resolvedUrl = appendQueryParams(url, args["query"]);
+        const resolvedUrl = appendQueryParams(url, toolArgs["query"]);
         if (usePlain) {
           parts.push(`url: ${resolvedUrl}`);
         } else {
@@ -265,17 +301,17 @@ export function formatToolArguments(
     case "web_search": {
       // Check common query argument names across providers. The provider
       // itself renders inside the tool name via formatToolDisplayName.
-      const query = safeString(args["query"] || args["search_query"] || args["q"]);
+      const query = safeString(toolArgs["query"] || toolArgs["search_query"] || toolArgs["q"]);
       if (!query) return "";
       return usePlain ? `{ query: "${query}" }` : formatKeyValue("query", query);
     }
     case "mkdir": {
-      const dirPath = safeString(args["path"]);
+      const dirPath = safeString(toolArgs["path"]);
       if (!dirPath) return "";
       return usePlain ? `{ path: ${dirPath} }` : formatKeyValue("path", dirPath);
     }
     case "manage_todos": {
-      const todos = args["todos"];
+      const todos = toolArgs["todos"];
       if (!Array.isArray(todos)) return "";
       const total = todos.length;
       let completed = 0;
@@ -290,23 +326,32 @@ export function formatToolArguments(
       return usePlain ? `{ todos: ${value} }` : formatKeyValue("todos", value);
     }
     default: {
-      // For unknown tools, show first few arguments (truncate long values)
-      const MAX_VALUE_LENGTH = 120;
-      const keys = Object.keys(args).slice(0, usePlain ? 3 : 2);
-      if (keys.length === 0) return "";
-      const parts = keys.map((key) => {
-        let valueStr = safeString(args[key]);
-        if (valueStr.length > MAX_VALUE_LENGTH) {
-          valueStr = valueStr.slice(0, MAX_VALUE_LENGTH) + "…";
-        }
-        if (usePlain) {
-          return `${key}: ${valueStr}`;
-        }
-        return `${chalk.dim(`${key}:`)} ${chalk.cyan(valueStr)}`;
-      });
+      const keys = Object.keys(toolArgs).slice(0, usePlain ? 3 : 2);
+      const parts: string[] = [];
+      for (const key of keys) {
+        const valueStr = formatArgValue(toolArgs[key]);
+        if (valueStr.length === 0) continue;
+        parts.push(
+          usePlain ? `${key}: ${valueStr}` : `${chalk.dim(`${key}:`)} ${chalk.cyan(valueStr)}`,
+        );
+      }
+      if (parts.length === 0) return "";
       return usePlain ? `{ ${parts.join(", ")} }` : ` ${parts.join(", ")}`;
     }
   }
+}
+
+/**
+ * Arguments for a live tool row or a settled receipt: the same fields
+ * `formatToolArguments` would show, without the wrapping braces plain style
+ * adds around a list.
+ */
+export function compactToolArguments(toolName: string, args?: Record<string, unknown>): string {
+  const formatted = formatToolArguments(toolName, args, { style: "plain" }).trim();
+  if (formatted.startsWith("{") && formatted.endsWith("}")) {
+    return formatted.slice(1, -1).trim();
+  }
+  return formatted;
 }
 
 /**
@@ -478,6 +523,29 @@ export function formatToolResult(toolName: string, result: string): string {
   }
 
   function formatGenericObject(parsedResult: Record<string, unknown>): string {
+    const formatted = parsedResult["formatted"];
+    if (typeof formatted === "string" && formatted.trim().length > 0) {
+      return formatted;
+    }
+    const content = parsedResult["content"];
+    if (typeof content === "string" && content.trim().length > 0) {
+      return content;
+    }
+    const message = parsedResult["message"];
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+    const scalars: string[] = [];
+    for (const [key, value] of Object.entries(parsedResult)) {
+      if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+        continue;
+      }
+      const text = typeof value === "string" ? value.trim() : String(value);
+      if (text.length === 0) continue;
+      scalars.push(`${key}: ${text}`);
+      if (scalars.length >= 3) break;
+    }
+    if (scalars.length > 0) return scalars.join(" · ");
     return JSON.stringify(parsedResult, null, 2);
   }
 
@@ -596,4 +664,28 @@ export function formatToolResult(toolName: string, result: string): string {
   } catch {
     return truncateDisplayText(result);
   }
+}
+
+const SNIPPET_MAX_CHARS = 88;
+const SNIPPET_MAX_LINES = 2;
+
+function isStructuralJsonLine(line: string): boolean {
+  return line === "{" || line === "}" || line === "[" || line === "]" || line === "{},";
+}
+
+/**
+ * One or two content lines from a formatted tool result, for a receipt row.
+ * Skips brace-only JSON so a pretty-printed object cannot collapse to `{`.
+ */
+export function toolResultSnippet(text: string): string {
+  const lines: string[] = [];
+  for (const raw of text.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || isStructuralJsonLine(trimmed)) continue;
+    lines.push(trimmed.replace(/\s+/g, " "));
+    if (lines.length >= SNIPPET_MAX_LINES) break;
+  }
+  const joined = lines.join(" · ");
+  if (joined.length <= SNIPPET_MAX_CHARS) return joined;
+  return `${joined.slice(0, SNIPPET_MAX_CHARS - 1)}…`;
 }


### PR DESCRIPTION
## What & why
Tool calls in the fullscreen conversation were showing empty arguments and a lone `{` instead of the result — `view_memory` with no path rendered as `view_memory  path:` then `view_memory  {`. Receipts now include the args that were actually used (empty memory path as `/`) and a short snippet of what came back.

While a tool is running, the live zone shows those args too. The leftover start line is no longer duplicated into the transcript.

## How to verify
- Start a chat so the agent calls `view_memory` with no path. The live row should show `path: /`, and the settled receipt should show that path plus a snippet of the listing — not `{`.
- Call `view_memory` with a file path (e.g. `people/alex.md`) and confirm the path and a snippet of the file appear on the receipt.
- Confirm a `gmail_search` (or similar) still packs as a compact receipt with its query visible, and that a failed tool still shows the reason on the same row.