### PR TITLE
feat(agent): produce PDFs, and give produced files a real channel

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -15,7 +15,7 @@ and [Security](../../SECURITY.md) for the threat model.
 
 |                                                                         | Count  |
 | ----------------------------------------------------------------------- | ------ |
-| **Agent-facing tools**                                                  | **34** |
+| **Agent-facing tools**                                                  | **35** |
 | Hidden `execute_*` counterparts (the second half of each approval pair) | 7      |
 | Total registered                                                        | 41     |
 | `read-only`                                                             | 20     |
@@ -159,6 +159,7 @@ Opt-in per agent via `tools`. Used by chat bridges that can render a Mini App or
 | Tool             | Risk       | Approval pair | What it does                                                                                                                           |
 | ---------------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `create_web_app` | `low-risk` | —             | Create an interactive UI — a chart, form, dashboard, small game, or any other webpage — for delivery as a static image or a live page. |
+| `create_pdf`     | `low-risk` | —             | Render a PDF from HTML the agent writes, saved to the working directory or an explicit path. Text and numbers are exact — a renderer, not an image generator. |
 
 ---
 
@@ -196,6 +197,7 @@ That keeps the tier low while letting the one command through. Matching is on a 
 - **`http_request` is `read-only`** by risk classification even though it can issue POSTs. It reaches whatever URL the agent targets; network policy belongs at the firewall, not the tier. Treat it accordingly on surfaces that accept untrusted input.
 - **Timeouts** — 3 minutes by default per tool. `ask_user_question` and `ask_file_picker` are `longRunning` and never time out, because waiting for a human is not a hang.
 - **Concurrency** — up to 10 tools execute in parallel per iteration.
+- **`create_pdf` needs a browser too** — same `puppeteer-core` path as `create_web_app`'s static mode, rendering through `page.pdf()`. It writes to the agent's working directory by default (an explicit `path` overrides), unlike `create_web_app`, whose output lands in Jazz's own data directory because only a bridge ever reads it.
 - **`create_web_app` needs a browser for `mode: "static"`** — it screenshots the page through `puppeteer-core`, which deliberately ships no bundled Chrome so that installing Jazz never downloads one. It uses `PUPPETEER_EXECUTABLE_PATH` if set, otherwise an installed Google Chrome; with neither it fails and says so. `mode: "interactive"` needs no browser.
 
 ---

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -4,6 +4,7 @@ import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { buildWorkStatePreamble } from "@/core/agent/context/work-state-preamble";
 import { CommonSuggestions, getErrorMessage } from "@/core/presentation/error-handler";
 import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
+import { describeArtifact, type GeneratedArtifact } from "@/core/types/artifact";
 import { AgentNotFoundError } from "@/core/types/errors";
 import type { ChatMessage } from "@/core/types/message";
 import type { StreamEvent } from "@/core/types/streaming";
@@ -65,6 +66,15 @@ export interface OneShotSuccess {
   readonly tokenUsage: OneShotTokenUsage;
   readonly toolCalls: readonly OneShotToolCall[];
   readonly webApp?: OneShotWebApp;
+  /**
+   * Files this run produced, in the order they were made.
+   *
+   * Supersedes `webApp` for anything that only needs "a file appeared, here is where and what
+   * kind" — a script or bridge reads this instead of learning each producing tool by name.
+   * `webApp` stays because its interactive mode carries a URL-bearing shape no generic artifact
+   * can express.
+   */
+  readonly artifacts?: readonly GeneratedArtifact[];
   /**
    * Full message transcript for this run, included only for `--ephemeral`
    * calls. Since ephemeral runs never load/save `--conversation` history on
@@ -141,7 +151,15 @@ export interface OneShotOutputOptions {
  */
 export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutputOptions): string {
   if (!options.json) {
-    return `${result.answer.trim()}\n`;
+    const answer = result.answer.trim();
+    const artifacts = result.artifacts ?? [];
+    if (artifacts.length === 0) return `${answer}\n`;
+
+    // Paths go below the answer whether or not the model mentioned them. A run that writes a
+    // file and does not say where is a run the user has to go hunting after, and models are
+    // inconsistent about repeating a path they already saw in a tool result.
+    const lines = artifacts.map((artifact) => `  ${describeArtifact(artifact)}`).join("\n");
+    return `${answer}\n\n${lines}\n`;
   }
 
   return `${JSON.stringify({
@@ -151,6 +169,7 @@ export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutp
     tokenUsage: result.tokenUsage,
     toolCalls: result.toolCalls,
     ...(result.webApp ? { webApp: result.webApp } : {}),
+    ...(result.artifacts && result.artifacts.length > 0 ? { artifacts: result.artifacts } : {}),
     ...(result.messages ? { messages: result.messages } : {}),
   })}\n`;
 }
@@ -502,6 +521,7 @@ export function runAgentOnceCommand(
       arguments: toolCall.function?.arguments ?? "",
     }));
     const webApp = extractWebAppResult(runResult.toolResults);
+    const artifacts = runResult.artifacts ?? [];
 
     yield* writeStdout(
       formatOneShotResult(
@@ -518,6 +538,7 @@ export function runAgentOnceCommand(
           },
           toolCalls,
           ...(webApp ? { webApp } : {}),
+          ...(artifacts.length > 0 ? { artifacts } : {}),
           ...(ephemeral ? { messages: runResult.messages ?? [] } : {}),
         },
         outputOptions,

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -6,6 +6,7 @@ import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { PresentationService, StreamingRenderer } from "@/core/interfaces/presentation";
 import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { ChatMessage, ConversationMessages } from "@/core/types";
+import { parseGeneratedArtifacts } from "@/core/types/artifact";
 import {
   type AttachmentKind,
   describeAttachment,
@@ -526,6 +527,14 @@ function handleToolPhase(
       pendingAttachments.length = 0;
     }
 
+    // Accumulated across the whole run, unlike toolResults, which keeps only the last call per
+    // tool name — two create_pdf calls have to produce two files, not one.
+    const producedArtifacts = toolResults.flatMap((toolResult) =>
+      parseGeneratedArtifacts(
+        (toolResult.result as { artifacts?: unknown } | undefined)?.artifacts,
+      ),
+    );
+
     state.response = {
       ...state.response,
       toolCalls: [...(state.response.toolCalls ?? []), ...toolCalls],
@@ -533,6 +542,9 @@ function handleToolPhase(
         ...state.response.toolResults,
         ...Object.fromEntries(toolResults.map((r) => [r.name, r.result])),
       },
+      ...(producedArtifacts.length > 0
+        ? { artifacts: [...(state.response.artifacts ?? []), ...producedArtifacts] }
+        : {}),
     };
 
     const queuedMessage = options.checkQueuedMessage?.();

--- a/src/core/agent/tools/pdf-tools.test.ts
+++ b/src/core/agent/tools/pdf-tools.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { pdfFilenameFromTitle, resolvePdfOutputPath } from "./pdf-tools";
+
+describe("pdfFilenameFromTitle", () => {
+  it("slugifies a title", () => {
+    expect(pdfFilenameFromTitle("Q3 Revenue Report")).toBe("q3-revenue-report.pdf");
+  });
+
+  it("collapses punctuation rather than emitting it into a filename", () => {
+    expect(pdfFilenameFromTitle("Notes: 2026 — draft!")).toBe("notes-2026-draft.pdf");
+  });
+
+  it("falls back for a title with nothing usable in it", () => {
+    // "???.pdf" would slug to an empty name and produce a dotfile.
+    expect(pdfFilenameFromTitle("???")).toBe("document.pdf");
+  });
+
+  it("bounds the length", () => {
+    expect(pdfFilenameFromTitle("word ".repeat(60)).length).toBeLessThanOrEqual(84);
+  });
+});
+
+describe("resolvePdfOutputPath", () => {
+  it("defaults to the working directory, not jazz's own data directory", () => {
+    // The whole reason this tool differs from create_web_app: someone running `jazz run` in a
+    // terminal wants the file where they are, not buried in ~/.jazz.
+    const resolved = resolvePdfOutputPath({ title: "My Report" }, "/work/project");
+    expect(resolved).toBe("/work/project/my-report.pdf");
+  });
+
+  it("resolves an explicit relative path against the working directory", () => {
+    const resolved = resolvePdfOutputPath(
+      { title: "ignored", path: "out/report.pdf" },
+      "/work/project",
+    );
+    expect(resolved).toBe("/work/project/out/report.pdf");
+  });
+
+  it("honours an absolute path verbatim", () => {
+    const resolved = resolvePdfOutputPath({ title: "ignored", path: "/tmp/x.pdf" }, "/work");
+    expect(resolved).toBe("/tmp/x.pdf");
+  });
+});

--- a/src/core/agent/tools/pdf-tools.ts
+++ b/src/core/agent/tools/pdf-tools.ts
@@ -1,0 +1,209 @@
+/**
+ * @fileoverview Rendering a PDF from HTML the agent wrote
+ *
+ * Deliberately not a model capability. Three models in the whole models.dev catalog claim PDF
+ * output, while every provider can write HTML — and the same Chromium jazz already needs for
+ * `create_web_app`'s static mode turns that HTML into a PDF via `page.pdf()`. That makes PDF the
+ * only generated format that is exact, reproducible, free, and works offline on every provider
+ * including local models.
+ *
+ * Unlike `create_web_app`, the output lands in the user's working directory by default. That
+ * tool writes into jazz's own home because only a bridge ever read its path; a person running
+ * `jazz run "turn these notes into a PDF"` in a terminal wants the file where they are, not
+ * buried in `~/.jazz`.
+ */
+
+import { isAbsolute, resolve as resolvePath } from "node:path";
+import { FileSystem } from "@effect/platform";
+import { Effect } from "effect";
+import puppeteer from "puppeteer-core";
+import { z } from "zod";
+import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
+import type { Tool } from "@/core/interfaces/tool-registry";
+import type { GeneratedArtifact } from "@/core/types/artifact";
+import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types/tools";
+import { defineTool, makeZodValidator } from "./base-tool";
+import { buildKeyFromContext } from "./context-utils";
+import {
+  type BrowserExecutableLookup,
+  createSystemBrowserLookup,
+  resolveBrowserExecutablePath,
+} from "./web-app-tools";
+
+export const MISSING_BROWSER_FOR_PDF_ERROR =
+  "create_pdf needs a Chrome or Chromium install to render the page, and none was found. " +
+  "Install Google Chrome or Chromium, or point PUPPETEER_EXECUTABLE_PATH at an existing browser " +
+  "binary.";
+
+const createPdfParameters = z
+  .object({
+    html: z
+      .string()
+      .min(1)
+      .describe("Complete HTML document to render. Inline any CSS; @page rules control margins."),
+    title: z.string().min(1).describe("Short title, used for the filename when path is omitted."),
+    path: z
+      .string()
+      .optional()
+      .describe(
+        "Where to write the PDF. Relative paths resolve against the working directory. Defaults to <title>.pdf in the working directory.",
+      ),
+    landscape: z.boolean().optional().describe("Landscape orientation (default: portrait)."),
+    format: z
+      .enum(["A4", "Letter", "Legal", "A3", "A5"])
+      .optional()
+      .describe("Page size (default: A4)."),
+  })
+  .strict();
+
+type CreatePdfArgs = z.infer<typeof createPdfParameters>;
+
+/**
+ * Filename from a title: lowercase, punctuation collapsed to hyphens.
+ *
+ * Only used when the caller gave no path. Falls back to a fixed name rather than an empty one
+ * for a title that is entirely punctuation.
+ */
+export function pdfFilenameFromTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return `${slug.length > 0 ? slug : "document"}.pdf`;
+}
+
+/** Absolute destination for the PDF, honouring an explicit path over the derived filename. */
+export function resolvePdfOutputPath(
+  args: Pick<CreatePdfArgs, "path" | "title">,
+  workingDirectory: string,
+): string {
+  const requested = args.path ?? pdfFilenameFromTitle(args.title);
+  return isAbsolute(requested) ? requested : resolvePath(workingDirectory, requested);
+}
+
+async function renderPdf(
+  htmlPath: string,
+  pdfPath: string,
+  executablePath: string,
+  options: { landscape: boolean; format: NonNullable<CreatePdfArgs["format"]> },
+): Promise<void> {
+  const browser = await puppeteer.launch({
+    browser: "chrome",
+    executablePath,
+    headless: true,
+    // Same reason as the screenshot path: Chromium's sandbox needs kernel privileges most
+    // containers do not grant.
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`file://${htmlPath}`, { waitUntil: "networkidle0" });
+    await page.pdf({
+      path: pdfPath,
+      format: options.format,
+      landscape: options.landscape,
+      // Backgrounds are off by default in print, which silently strips every styled header and
+      // table stripe the model wrote.
+      printBackground: true,
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+export function createPdfTool(
+  browserLookup: () => BrowserExecutableLookup = createSystemBrowserLookup,
+): Tool<FileSystem.FileSystem | FileSystemContextService> {
+  return defineTool<FileSystem.FileSystem | FileSystemContextService, CreatePdfArgs>({
+    name: "create_pdf",
+    description:
+      "Render a PDF from HTML you write, saved to the user's working directory (or an explicit path). " +
+      "Use for reports, summaries, invoices, or anything the person will keep, print, or send on. " +
+      "The text and numbers are exactly what you write — this is a renderer, not an image generator. " +
+      "Needs Chrome or Chromium installed (or PUPPETEER_EXECUTABLE_PATH set).",
+    tags: ["document", "pdf"],
+    parameters: createPdfParameters,
+    riskLevel: "low-risk",
+    validate: makeZodValidator(createPdfParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+
+        const executablePath = yield* Effect.tryPromise({
+          try: () => resolveBrowserExecutablePath(browserLookup()),
+          catch: () => new Error(MISSING_BROWSER_FOR_PDF_ERROR),
+        });
+        if (executablePath === null) {
+          return yield* Effect.fail(new Error(MISSING_BROWSER_FOR_PDF_ERROR));
+        }
+
+        const workingDirectory = yield* resolveWorkingDirectory(context);
+        const pdfPath = resolvePdfOutputPath(args, workingDirectory);
+
+        // Chromium loads the source over file://, so the HTML has to exist on disk. It goes next
+        // to the PDF rather than in a temp dir so a broken render leaves something inspectable.
+        const htmlPath = `${pdfPath}.source.html`;
+        yield* fs.writeFileString(htmlPath, args.html);
+
+        yield* Effect.tryPromise({
+          try: () =>
+            renderPdf(htmlPath, pdfPath, executablePath, {
+              landscape: args.landscape ?? false,
+              format: args.format ?? "A4",
+            }),
+          catch: (error) =>
+            new Error(
+              `Failed to render PDF: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        });
+        yield* fs.remove(htmlPath).pipe(Effect.catchAll(() => Effect.void));
+
+        const artifact: GeneratedArtifact = {
+          kind: "pdf",
+          path: pdfPath,
+          mediaType: "application/pdf",
+          title: args.title,
+          tool: "create_pdf",
+          source: "rendered",
+        };
+
+        return {
+          success: true,
+          result: { path: pdfPath, title: args.title, artifacts: [artifact] },
+          artifacts: [artifact],
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { path: string };
+      return `Wrote ${data.path}`;
+    },
+  });
+}
+
+/**
+ * The agent's tracked working directory, falling back to the process cwd.
+ *
+ * The agent can `cd` mid-session, so a relative output path has to resolve against where the
+ * agent believes it is, not where jazz was launched.
+ */
+function resolveWorkingDirectory(
+  context: ToolExecutionContext,
+): Effect.Effect<string, never, FileSystemContextService> {
+  return Effect.gen(function* () {
+    const shell = yield* FileSystemContextServiceTag;
+    const cwd = yield* shell
+      .getCwd(buildKeyFromContext(context))
+      .pipe(Effect.catchAll(() => Effect.succeed(process.cwd())));
+    return typeof cwd === "string" && cwd.length > 0 ? cwd : process.cwd();
+  });
+}

--- a/src/core/agent/tools/register-tools.ts
+++ b/src/core/agent/tools/register-tools.ts
@@ -5,6 +5,7 @@ import { createContextInfoTool, createGetTimeTool } from "./context-tools";
 import { fs } from "./fs";
 import { createHttpRequestTool } from "./http-tools";
 import { createManageMemoryTool, createViewMemoryTool } from "./memory-tools";
+import { createPdfTool } from "./pdf-tools";
 import {
   createAddReminderTool,
   createCancelReminderTool,
@@ -199,6 +200,8 @@ export function registerWebAppTools(): Effect.Effect<void, Error, ToolRegistry> 
     const registerTool = registry.registerForCategory(WEB_APP_CATEGORY);
 
     yield* registerTool(createWebAppTool());
+    // Same category: both turn HTML the agent wrote into a file, and both need Chromium.
+    yield* registerTool(createPdfTool());
   });
 }
 

--- a/src/core/agent/tools/web-app-tools.ts
+++ b/src/core/agent/tools/web-app-tools.ts
@@ -4,6 +4,7 @@ import puppeteer, { type ChromeReleaseChannel } from "puppeteer-core";
 import shortuuid from "short-uuid";
 import { z } from "zod";
 import type { Tool } from "@/core/interfaces/tool-registry";
+import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { ToolExecutionResult } from "@/core/types/tools";
 import { getUserDataDirectory } from "@/core/utils/paths";
 import { defineTool, makeZodValidator } from "./base-tool";
@@ -210,6 +211,18 @@ export function createWebAppTool(
             ),
         });
 
+        // `source: "rendered"`, emphatically: this PNG is a screenshot of HTML the model wrote,
+        // so its numbers and labels are exact. Labelling it alongside AI-generated imagery would
+        // tell the reader not to trust figures they can trust.
+        const artifact: GeneratedArtifact = {
+          kind: "image",
+          path: pngPath,
+          mediaType: "image/png",
+          title: args.title,
+          tool: "create_web_app",
+          source: "rendered",
+        };
+
         return {
           success: true,
           result: {
@@ -218,7 +231,9 @@ export function createWebAppTool(
             title: args.title,
             htmlPath,
             imagePath: pngPath,
+            artifacts: [artifact],
           },
+          artifacts: [artifact],
         } satisfies ToolExecutionResult;
       }).pipe(
         Effect.catchAll((error) =>

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -1,5 +1,6 @@
 import type { Effect } from "effect";
 import type { ProviderName } from "@/core/constants/models";
+import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import type { DisplayConfig } from "@/core/types/output";
 import type {
@@ -178,6 +179,14 @@ export interface AgentResponse {
    *
    */
   readonly toolResults?: Record<string, unknown>;
+  /**
+   * Files produced during this run, in the order they were made.
+   *
+   * A list rather than a map because `toolResults` is keyed by tool name and keeps only the last
+   * call — fine for inspecting what a tool returned, lossy for artifacts, where calling
+   * `create_pdf` twice must yield two files.
+   */
+  readonly artifacts?: readonly GeneratedArtifact[];
   /**
    * Indicates tools were provided but disabled for the selected model.
    */

--- a/src/core/types/artifact.test.ts
+++ b/src/core/types/artifact.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+  describeArtifact,
+  type GeneratedArtifact,
+  parseGeneratedArtifact,
+  parseGeneratedArtifacts,
+} from "./artifact";
+
+function artifact(overrides: Partial<GeneratedArtifact> = {}): GeneratedArtifact {
+  return {
+    kind: "pdf",
+    path: "/tmp/report.pdf",
+    mediaType: "application/pdf",
+    tool: "create_pdf",
+    source: "rendered",
+    ...overrides,
+  };
+}
+
+describe("parseGeneratedArtifact", () => {
+  it("accepts a well-formed artifact", () => {
+    expect(parseGeneratedArtifact(artifact())).toEqual(artifact());
+  });
+
+  it("keeps an optional title and omits an empty one", () => {
+    expect(parseGeneratedArtifact(artifact({ title: "Q3 report" }))?.title).toBe("Q3 report");
+    expect(parseGeneratedArtifact({ ...artifact(), title: "" })?.title).toBeUndefined();
+  });
+
+  it("rejects an unknown kind rather than passing it through", () => {
+    // Custom and MCP tools can return anything, and this value ends up in the JSON envelope
+    // that scripts and bridges consume.
+    expect(parseGeneratedArtifact({ ...artifact(), kind: "spreadsheet" })).toBeNull();
+  });
+
+  it("rejects an unknown source", () => {
+    // Provenance drives what the user is told about the file, so a bogus value must not survive.
+    expect(parseGeneratedArtifact({ ...artifact(), source: "somewhere" })).toBeNull();
+  });
+
+  it("rejects missing or empty required fields", () => {
+    expect(parseGeneratedArtifact({ ...artifact(), path: "" })).toBeNull();
+    expect(parseGeneratedArtifact({ ...artifact(), mediaType: undefined })).toBeNull();
+    expect(parseGeneratedArtifact({ ...artifact(), tool: "" })).toBeNull();
+  });
+
+  it("rejects non-objects", () => {
+    for (const value of [null, undefined, "pdf", 42, []]) {
+      expect(parseGeneratedArtifact(value)).toBeNull();
+    }
+  });
+});
+
+describe("parseGeneratedArtifacts", () => {
+  it("keeps the valid entries and drops the rest", () => {
+    // One malformed artifact should not cost the user the files that did work.
+    const parsed = parseGeneratedArtifacts([artifact(), { kind: "nope" }, artifact()]);
+    expect(parsed).toHaveLength(2);
+  });
+
+  it("is empty for anything that is not an array", () => {
+    expect(parseGeneratedArtifacts(undefined)).toEqual([]);
+    expect(parseGeneratedArtifacts({ kind: "pdf" })).toEqual([]);
+  });
+});
+
+describe("describeArtifact", () => {
+  it("always shows the path", () => {
+    expect(describeArtifact(artifact())).toContain("/tmp/report.pdf");
+  });
+
+  it("marks model output as AI-generated", () => {
+    const described = describeArtifact(
+      artifact({ kind: "image", source: "model", tool: "generate_image" }),
+    );
+    expect(described).toContain("AI-generated");
+  });
+
+  it("does not mark a rendered chart as AI-generated", () => {
+    // The point of tracking provenance: a chart screenshotted from HTML has exact numbers, and
+    // calling it AI-generated would tell the reader not to trust figures they can trust.
+    const described = describeArtifact(
+      artifact({ kind: "image", tool: "create_web_app", source: "rendered", title: "Spending" }),
+    );
+    expect(described).not.toContain("AI-generated");
+    expect(described).toContain("Spending");
+  });
+});

--- a/src/core/types/artifact.ts
+++ b/src/core/types/artifact.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Files an agent produced during a run
+ *
+ * The counterpart to `MessageAttachment`, which carries files *into* a run. Both hold a path
+ * rather than bytes, for the same reason: the file already exists on disk and copying it into a
+ * message or a JSON envelope only makes both larger.
+ *
+ * Every producer declares its artifacts rather than a consumer recognizing them by tool name.
+ * The alternative — what jazz did before this — was `extractWebAppResult` looking up
+ * `toolResults["create_web_app"]` and validating its exact shape, which meant every new producer
+ * needed a branch in the runner, in the JSON envelope, and in every bridge.
+ */
+
+/** What kind of file this is, which is all a consumer needs to decide how to present it. */
+export type ArtifactKind = "image" | "audio" | "video" | "pdf" | "html";
+
+/**
+ * How an artifact came to exist.
+ *
+ * This is a user-facing distinction, not an implementation detail. A chart rendered from HTML the
+ * model wrote has exact numbers and reproduces byte-for-byte; an image from a generative model
+ * has neither property and will happily invent an axis label. Presenting them identically tells
+ * someone the numbers in a chart came from a model's imagination when they did not — or the
+ * reverse, which is worse.
+ *
+ * Carried explicitly rather than inferred from `tool`, so no consumer has to maintain a list of
+ * which tool names are which.
+ */
+export type ArtifactSource = "rendered" | "model";
+
+export interface GeneratedArtifact {
+  readonly kind: ArtifactKind;
+  /** Absolute path on disk. */
+  readonly path: string;
+  /** Full IANA media type, e.g. "application/pdf". */
+  readonly mediaType: string;
+  /** Human-readable label, used when a surface wants a caption or filename. */
+  readonly title?: string;
+  /** Tool that produced it, for display and debugging. */
+  readonly tool: string;
+  readonly source: ArtifactSource;
+}
+
+const ARTIFACT_KINDS: ReadonlySet<string> = new Set<ArtifactKind>([
+  "image",
+  "audio",
+  "video",
+  "pdf",
+  "html",
+]);
+
+const ARTIFACT_SOURCES: ReadonlySet<string> = new Set<ArtifactSource>(["rendered", "model"]);
+
+/**
+ * Validate a value a tool returned as an artifact.
+ *
+ * Tool results are typed `unknown` and custom/MCP tools can return anything, so this is the
+ * boundary where a malformed artifact is dropped rather than propagated into the JSON envelope
+ * that scripts and bridges consume.
+ */
+export function parseGeneratedArtifact(value: unknown): GeneratedArtifact | null {
+  if (value === null || typeof value !== "object") return null;
+  const candidate = value as Record<string, unknown>;
+
+  const { kind, path, mediaType, tool, source, title } = candidate;
+  if (typeof kind !== "string" || !ARTIFACT_KINDS.has(kind)) return null;
+  if (typeof source !== "string" || !ARTIFACT_SOURCES.has(source)) return null;
+  if (typeof path !== "string" || path.length === 0) return null;
+  if (typeof mediaType !== "string" || mediaType.length === 0) return null;
+  if (typeof tool !== "string" || tool.length === 0) return null;
+
+  return {
+    kind: kind as ArtifactKind,
+    path,
+    mediaType,
+    tool,
+    source: source as ArtifactSource,
+    ...(typeof title === "string" && title.length > 0 ? { title } : {}),
+  };
+}
+
+/** Collect the valid artifacts out of whatever a tool returned, dropping malformed entries. */
+export function parseGeneratedArtifacts(value: unknown): GeneratedArtifact[] {
+  if (!Array.isArray(value)) return [];
+  const artifacts: GeneratedArtifact[] = [];
+  for (const entry of value) {
+    const parsed = parseGeneratedArtifact(entry);
+    if (parsed !== null) artifacts.push(parsed);
+  }
+  return artifacts;
+}
+
+/**
+ * One-line description for the terminal.
+ *
+ * Names the provenance for anything a model produced, because "generated" is the word that tells
+ * the reader not to trust the pixels the way they would trust a rendered chart. Rendered output
+ * needs no such warning, so it stays quiet.
+ */
+export function describeArtifact(artifact: GeneratedArtifact): string {
+  const label = artifact.title ?? artifact.kind;
+  const provenance = artifact.source === "model" ? " (AI-generated)" : "";
+  return `${label}${provenance}: ${artifact.path}`;
+}

--- a/src/core/types/tools.ts
+++ b/src/core/types/tools.ts
@@ -2,6 +2,7 @@ import type { Effect } from "effect";
 import type z from "zod";
 import type { ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types/agent";
+import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { AttachmentKind, MessageAttachment } from "@/core/types/attachment";
 import type { ChatMessage } from "@/core/types/message";
 import type { StreamEvent } from "@/core/types/streaming";
@@ -97,6 +98,13 @@ export interface ToolExecutionResult {
   readonly success: boolean;
   readonly result: unknown;
   readonly error?: string;
+  /**
+   * Files this call produced, for the runner to surface to whoever is watching.
+   *
+   * Declared by the producer rather than recognized by tool name downstream, so adding a
+   * producer does not mean editing the runner, the JSON envelope and every bridge.
+   */
+  readonly artifacts?: readonly GeneratedArtifact[];
 }
 
 /**


### PR DESCRIPTION
## The problem

Jazz can read a PDF you hand it and cannot write one back. Ask an agent for a report, an invoice, or a summary you can keep, and the best it can do is print text into your terminal.

There was also no way for it to learn. The path from "a tool made a file" to "the user gets the file" was hardcoded to one tool — `extractWebAppResult` looks up `toolResults["create_web_app"]` by name and validates its exact shape — so every new producer would need its own branch in the runner, in the JSON envelope, and in every bridge.

## What this changes for you

```
$ jazz run "turn these notes into a one-page PDF called Coffee Budget"

Created a one-page PDF with the table and a total row.

  Coffee Budget: /Users/you/work/coffee-budget.pdf
```

The file lands **where you are working**, and the path is printed whether or not the model thought to mention it. Under `--json` it also arrives as a structured artifact, so a script or a bridge can pick it up without parsing prose.

`create_web_app` writes into `~/.jazz/` because only a chat bridge ever read its output. That is the wrong default for someone at a terminal, so `create_pdf` defaults to the working directory, with an explicit `path` to override.

## Why a renderer, not a model

PDF generation goes through the same Chromium `create_web_app` already needs, using `page.pdf()` on HTML the model writes. Three models in the entire models.dev catalog claim PDF output; every provider can write HTML.

Going through the renderer means the document is **exact** — the numbers in the table are the numbers the model wrote, not an approximation — and it is free, reproducible, offline, and identical on every provider including local ones.

## Provenance, before it is needed

Every artifact carries `source: "rendered" | "model"`. Nothing generates images yet, but this distinction has to exist before anything does.

A chart screenshotted from HTML has exact figures. An image from a generative model does not, and will happily invent an axis label. Presenting both as "here's an image" tells someone the numbers in a chart came from a model's imagination when they did not. It is carried explicitly rather than inferred from the tool name, so no consumer has to keep a list of which tools mean which.

## Scope

First of the output-modality work: PDF plus the channel everything later reuses. Image generation and speech build on this same `artifacts` list and add no new delivery code. `create_web_app` becomes its first other producer rather than a special case; its existing `webApp` envelope field is untouched, since interactive mode carries a URL-bearing shape no generic artifact expresses.

## How to verify

- `jazz run "make me a PDF titled X with a table of ..."` from any directory — the PDF should appear **in that directory**, and the path should print under the answer.
- Open it: the numbers should be exactly what you asked for, with table borders intact.
- Ask for an explicit path (`save it as out/report.pdf`) — it should land there, relative to the agent's working directory.
- Add `--json` — the run should carry an `artifacts` array with `kind`, `path`, `mediaType`, `tool` and `source: "rendered"`.
- Ask for two PDFs in one run — you should get two files and two artifacts, which the old tool-name-keyed map could not represent.
- With no Chrome or Chromium installed, it should fail with the same guidance `create_web_app` gives.
