### PR TITLE
feat(llm): let models that generate media be chosen, and keep what they produce

### DIFF
--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -841,6 +841,10 @@ function runIteration(
       ...state.response,
       content: visibleContent,
       ...(completion.reasoning ? { reasoning: completion.reasoning } : {}),
+      // Media the model itself returned, joining anything tools produced earlier in the run.
+      ...(completion.artifacts && completion.artifacts.length > 0
+        ? { artifacts: [...(state.response.artifacts ?? []), ...completion.artifacts] }
+        : {}),
     };
 
     // Internal runs (compaction, other sub-agents) return content to the

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -1,4 +1,5 @@
 import type { ProviderName } from "@/core/constants/models";
+import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { ChatMessage, StoredReasoningPart } from "./message";
 import type { ToolCall, ToolDefinition } from "./tools";
 
@@ -16,6 +17,14 @@ export interface ChatCompletionResponse {
   /** Structured reasoning blocks with provider payloads, for replay in conversation history. */
   reasoningParts?: ReadonlyArray<StoredReasoningPart>;
   toolCalls?: ToolCall[];
+  /**
+   * Media the model returned alongside its text, already written to disk.
+   *
+   * Populated only by models whose output modalities include image/audio/video — the agent's own
+   * model, not a separate one, since generating media is a model capability rather than a tool
+   * jazz provides.
+   */
+  artifacts?: readonly GeneratedArtifact[];
   usage?: {
     promptTokens: number;
     completionTokens: number;

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -83,6 +83,7 @@ import { formatProviderDisplayName } from "@/core/utils/provider-model";
 import { sanitize } from "@/core/utils/string";
 import { LLM_PROVIDER_ENV_VARS } from "@/services/secrets/registry";
 import { resolveAttachments, type ResolvedAttachments } from "./attachment-resolver";
+import { saveModelGeneratedFiles } from "./generated-files";
 import {
   createModelFetcher,
   fetchModelsDevModels,
@@ -1471,6 +1472,9 @@ class AISDKService implements LLMService {
 
         const responseModel = options.model;
         const content = result.text ?? "";
+        // Files the model itself produced. Empty for every text-only model, so this costs
+        // nothing on the common path.
+        const generatedArtifacts = await saveModelGeneratedFiles(result.files ?? [], responseModel);
         let toolCalls: ChatCompletionResponse["toolCalls"] = undefined;
         let usage: ChatCompletionResponse["usage"] = undefined;
 
@@ -1550,6 +1554,7 @@ class AISDKService implements LLMService {
           ...(toolCalls ? { toolCalls } : {}),
           ...(usage ? { usage } : {}),
           ...(toolsDisabled ? { toolsDisabled } : {}),
+          ...(generatedArtifacts.length > 0 ? { artifacts: generatedArtifacts } : {}),
           ...(prepared
             ? {
                 toolDefinitionChars: prepared.toolDefinitionChars,
@@ -1747,8 +1752,20 @@ class AISDKService implements LLMService {
                 // Process the stream and get final response
                 const finalResponse = await processor.process(result);
 
+                // `files` resolves once the stream finishes, so media a model emitted mid-answer
+                // is saved after the text has already been rendered. Awaited here rather than in
+                // the processor so streaming stays purely about text deltas.
+                const streamedArtifacts = await saveModelGeneratedFiles(
+                  await result.files,
+                  options.model,
+                );
+
                 // Resolve deferred for consumers who just await response
-                responseDeferred.resolve(finalResponse);
+                responseDeferred.resolve(
+                  streamedArtifacts.length > 0
+                    ? { ...finalResponse, artifacts: streamedArtifacts }
+                    : finalResponse,
+                );
 
                 // Close the stream
                 processor.close();

--- a/src/services/llm/generated-files.test.ts
+++ b/src/services/llm/generated-files.test.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "bun:test";
+import {
+  artifactKindForMediaType,
+  extensionForMediaType,
+  saveModelGeneratedFiles,
+} from "./generated-files";
+
+describe("artifactKindForMediaType", () => {
+  it("maps on the top-level type, so unfamiliar subtypes still work", () => {
+    // A model may return any image subtype; rejecting image/avif for not being on a list would
+    // lose a file the user can open perfectly well.
+    expect(artifactKindForMediaType("image/png")).toBe("image");
+    expect(artifactKindForMediaType("image/avif")).toBe("image");
+    expect(artifactKindForMediaType("audio/wav")).toBe("audio");
+    expect(artifactKindForMediaType("video/mp4")).toBe("video");
+  });
+
+  it("recognizes PDF, which has no media top-level type", () => {
+    expect(artifactKindForMediaType("application/pdf")).toBe("pdf");
+  });
+
+  it("returns null for anything jazz cannot present as a file", () => {
+    expect(artifactKindForMediaType("text/plain")).toBeNull();
+    expect(artifactKindForMediaType("application/json")).toBeNull();
+  });
+});
+
+describe("extensionForMediaType", () => {
+  it("uses the subtype", () => {
+    expect(extensionForMediaType("image/png")).toBe("png");
+    expect(extensionForMediaType("audio/wav")).toBe("wav");
+  });
+
+  it("prefers the conventional extension over the subtype", () => {
+    // "shot.jpeg" and "clip.mpeg" open fine but are not what anyone expects to see.
+    expect(extensionForMediaType("image/jpeg")).toBe("jpg");
+    expect(extensionForMediaType("audio/mpeg")).toBe("mp3");
+  });
+
+  it("strips parameters and vendor suffixes", () => {
+    expect(extensionForMediaType("image/svg+xml; charset=utf-8")).toBe("svg");
+  });
+
+  it("falls back rather than emitting a nonsense extension", () => {
+    expect(extensionForMediaType("application/octet-stream")).toBe("bin");
+    expect(extensionForMediaType("garbage")).toBe("bin");
+  });
+});
+
+describe("saveModelGeneratedFiles", () => {
+  const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]);
+
+  it("is empty for a text-only response, the common path", async () => {
+    expect(await saveModelGeneratedFiles([], "gemini-3-pro-image")).toEqual([]);
+  });
+
+  it("writes the bytes and reports where", async () => {
+    const artifacts = await saveModelGeneratedFiles(
+      [{ mediaType: "image/png", uint8Array: pngBytes }],
+      "gemini-3-pro-image",
+    );
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.path.endsWith(".png")).toBe(true);
+    expect(new Uint8Array(await readFile(artifacts[0]!.path))).toEqual(pngBytes);
+  });
+
+  it("marks the artifact as model output, not rendered", async () => {
+    // The distinction the whole artifact type exists for: these pixels were painted by a model,
+    // unlike a chart screenshotted from HTML.
+    const [artifact] = await saveModelGeneratedFiles(
+      [{ mediaType: "image/png", uint8Array: pngBytes }],
+      "gemini-3-pro-image",
+    );
+    expect(artifact?.source).toBe("model");
+    expect(artifact?.tool).toBe("gemini-3-pro-image");
+  });
+
+  it("skips media types it cannot present, keeping the rest", async () => {
+    const artifacts = await saveModelGeneratedFiles(
+      [
+        { mediaType: "text/plain", uint8Array: new Uint8Array([1]) },
+        { mediaType: "image/png", uint8Array: pngBytes },
+      ],
+      "some-model",
+    );
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.kind).toBe("image");
+  });
+
+  it("gives each file its own path", async () => {
+    const artifacts = await saveModelGeneratedFiles(
+      [
+        { mediaType: "image/png", uint8Array: pngBytes },
+        { mediaType: "image/png", uint8Array: pngBytes },
+      ],
+      "some-model",
+    );
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0]?.path).not.toBe(artifacts[1]?.path);
+  });
+});

--- a/src/services/llm/generated-files.ts
+++ b/src/services/llm/generated-files.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Saving media a model produced as part of its response
+ *
+ * Some chat models return files alongside their text — `gemini-3-pro-image` answers and attaches
+ * an image in the same turn. The AI SDK surfaces these on `result.files`, as bytes in memory.
+ *
+ * Jazz's contract for produced files is a path (see `core/types/artifact`), so these are written
+ * to disk here and reported as artifacts. Everything downstream — the printed path, the `--json`
+ * envelope, chat bridges — then treats them the same as a rendered PDF, with one difference that
+ * matters: `source: "model"`, because pixels a model painted are not the same kind of thing as a
+ * chart rendered from HTML the model wrote.
+ *
+ * These land in jazz's own data directory rather than the working directory, unlike `create_pdf`.
+ * A PDF is the thing the user asked for; an image that arrives mid-conversation was not requested
+ * by path, and scattering files into whatever directory an agent happens to be in would be a
+ * surprise. The path is printed either way.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import shortUUID from "short-uuid";
+import type { ArtifactKind, GeneratedArtifact } from "@/core/types/artifact";
+import { getUserDataDirectory } from "@/core/utils/paths";
+
+/** The subset of the AI SDK's `GeneratedFile` this needs. */
+export interface ModelGeneratedFile {
+  readonly mediaType: string;
+  readonly uint8Array: Uint8Array;
+}
+
+function generatedFilesDirectory(): string {
+  return join(getUserDataDirectory(), "generated");
+}
+
+/**
+ * Map an IANA media type onto an artifact kind, or null when it is not media jazz can present.
+ *
+ * Matching on the top-level segment rather than a fixed list: a model may return any image or
+ * audio subtype, and rejecting `image/avif` because it is not on a list would lose a file the
+ * user can perfectly well open.
+ */
+export function artifactKindForMediaType(mediaType: string): ArtifactKind | null {
+  const topLevel = mediaType.split("/")[0]?.toLowerCase();
+  if (topLevel === "image") return "image";
+  if (topLevel === "audio") return "audio";
+  if (topLevel === "video") return "video";
+  if (mediaType.toLowerCase() === "application/pdf") return "pdf";
+  return null;
+}
+
+/** File extension for a media type, for a filename that opens in the right application. */
+export function extensionForMediaType(mediaType: string): string {
+  const subtype = mediaType.split("/")[1]?.toLowerCase() ?? "";
+  // Strip parameters and vendor prefixes: "image/svg+xml; charset=utf-8" → "svg".
+  const cleaned = subtype.split(";")[0]?.split("+")[0]?.trim() ?? "";
+  if (cleaned === "jpeg") return "jpg";
+  if (cleaned === "mpeg") return "mp3";
+  return cleaned.length > 0 && /^[a-z0-9]{1,6}$/.test(cleaned) ? cleaned : "bin";
+}
+
+/**
+ * Write the files a model returned and describe them as artifacts.
+ *
+ * Never throws: a model that produced an image and a disk that would not take it should still
+ * yield the model's text answer. A file that cannot be written is skipped, and the caller decides
+ * whether the absence is worth mentioning.
+ */
+export async function saveModelGeneratedFiles(
+  files: readonly ModelGeneratedFile[],
+  modelId: string,
+): Promise<GeneratedArtifact[]> {
+  if (files.length === 0) return [];
+
+  const directory = generatedFilesDirectory();
+  try {
+    await mkdir(directory, { recursive: true });
+  } catch {
+    return [];
+  }
+
+  const artifacts: GeneratedArtifact[] = [];
+  for (const file of files) {
+    const kind = artifactKindForMediaType(file.mediaType);
+    if (kind === null) continue;
+
+    const path = join(
+      directory,
+      `${shortUUID.generate()}.${extensionForMediaType(file.mediaType)}`,
+    );
+    try {
+      await writeFile(path, file.uint8Array);
+    } catch {
+      continue;
+    }
+
+    artifacts.push({
+      kind,
+      path,
+      mediaType: file.mediaType,
+      tool: modelId,
+      source: "model",
+    });
+  }
+  return artifacts;
+}

--- a/src/services/llm/model-fetcher.test.ts
+++ b/src/services/llm/model-fetcher.test.ts
@@ -671,19 +671,44 @@ describe("ModelFetcher", () => {
       expect(ids).not.toContain("old-model");
     });
 
-    it("drops non-text-chat models (embeddings, tts, image/video generation)", async () => {
+    it("drops anything you cannot hold a conversation with", async () => {
+      // Text in and text out is the whole test, and it covers every case this filter exists for.
       modelsDevProviderModels = [
         modelsDevEntry({ id: "chat-model" }),
         modelsDevEntry({ id: "embedding-model", outputModalities: [] }),
+        // TTS: takes text, returns only audio.
         modelsDevEntry({ id: "tts-model", outputModalities: ["audio"] }),
-        modelsDevEntry({ id: "image-gen-model", outputModalities: ["text", "image"] }),
-        modelsDevEntry({ id: "realtime-model", outputModalities: ["text", "audio"] }),
+        // Transcription (whisper-class): takes only audio, returns text.
+        modelsDevEntry({
+          id: "transcription-model",
+          inputModalities: ["audio"],
+          outputModalities: ["text"],
+        }),
+        // A pure generator (gpt-image-1): prompt in, image out, nothing to talk to.
+        modelsDevEntry({ id: "pure-image-generator", outputModalities: ["image"] }),
         modelsDevEntry({ id: "vision-only-input", inputModalities: ["image"] }),
       ];
 
       const ids = (await fetchModelsDevModels("openai")).map((model) => model.id);
 
       expect(ids).toEqual(["chat-model"]);
+    });
+
+    it("keeps a chat model that also emits media", async () => {
+      // The reason the blanket media-output exclusion was removed. gemini-3-pro-image and
+      // gpt-image-1.5 converse normally and can also return an image; hiding them made it
+      // impossible to run an agent on a model that generates images, which is the only way jazz
+      // offers image generation — it is a model capability, not a tool.
+      modelsDevProviderModels = [
+        modelsDevEntry({ id: "image-chat-model", outputModalities: ["text", "image"] }),
+        modelsDevEntry({ id: "audio-chat-model", outputModalities: ["text", "audio"] }),
+      ];
+
+      const ids = (await fetchModelsDevModels("google")).map((model) => model.id);
+
+      // Order-independent: the listing sorts by release date then id, which is unrelated to
+      // what this test is about.
+      expect(ids.toSorted()).toEqual(["audio-chat-model", "image-chat-model"]);
     });
 
     it("drops dated snapshot duplicates only when the undated base id exists", async () => {

--- a/src/services/llm/model-fetcher.ts
+++ b/src/services/llm/model-fetcher.ts
@@ -77,18 +77,20 @@ function resolveToModelInfo(
 /** Dated snapshot suffixes like "-20251001" or "-2024-05-13" (kept only when no undated base id exists). */
 const DATED_SNAPSHOT_SUFFIX = /-(\d{8}|\d{4}-\d{2}-\d{2})$/;
 
-const MEDIA_OUTPUT_MODALITIES = ["image", "audio", "video"] as const;
-
 /**
- * Keep only text-in/text-out chat models: drops embedding, TTS, transcription,
- * image/video generation, and realtime-audio entries from the catalog.
+ * Keep models a person can actually hold a conversation with: text in, text out.
+ *
+ * That pair is the whole test, and it already excludes what this filter exists to exclude —
+ * embeddings and TTS produce no text, transcription models like `whisper-large-v3` accept no
+ * text, and a pure generator like `gpt-image-1` outputs only an image.
+ *
+ * It deliberately does *not* exclude a model that emits text **and** media. `gemini-3-pro-image`
+ * and `gpt-image-1.5` converse normally and can also return an image, and generating media is a
+ * capability of the model rather than a tool jazz provides — so the way to get an image is to
+ * run an agent on a model that makes them. Hiding those models here made that impossible.
  */
 function isTextChatModel(entry: ModelsDevModelEntry): boolean {
-  return (
-    entry.inputModalities.includes("text") &&
-    entry.outputModalities.includes("text") &&
-    !MEDIA_OUTPUT_MODALITIES.some((modality) => entry.outputModalities.includes(modality))
-  );
+  return entry.inputModalities.includes("text") && entry.outputModalities.includes("text");
 }
 
 /**


### PR DESCRIPTION
## The problem

Some models can generate an image as part of a normal reply — `gemini-3-pro-image` answers you and attaches a picture in the same turn. You could not use any of them in Jazz, because the model picker hid every single one.

`isTextChatModel` excluded any model whose output modalities include image, audio or video. The filter exists for a good reason: it keeps embeddings, TTS and transcription models out of the picker, where they would be noise. But it also excluded `gemini-3-pro-image`, `gemini-3.1-flash-image` and `gpt-image-1.5`, which hold an ordinary conversation and happen to be able to return an image too.

## What changes for you

Those models are now selectable, and what they produce is kept:

- **Google**: 6 image-capable models appear (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-2.5-flash-image`, …)
- **OpenAI**: 3 (`gpt-image-1.5`, `gpt-image-1-mini`, `chatgpt-image-latest`)
- **Anthropic**: none, because it has no media output at all

Point an agent at one and any image it returns is written to disk and reported like any other produced file — path printed under the answer, and in the `--json` envelope as an artifact tagged `source: "model"`.

Still correctly unselectable: whisper (takes no text), TTS (returns no text), embeddings, and pure generators like `gpt-image-1` that return an image and nothing else. Text in and text out turned out to be the whole test, so this is a deletion rather than a new rule.

## The design decision behind it

Generating media is treated as **a capability of the model you chose**, not a tool any agent can call.

The alternative was a `generate_image` tool that quietly called a separate image model behind the scenes. It would have worked on any provider, Anthropic included, and it was rejected because it ships your prompt to a provider you never chose, inside a tool call you never see, to paper over a capability your model does not have. It also creates a spend channel invisible to cost accounting, which would then need its own metering and caps.

Keeping generation on the agent's own model means you always know who is being paid and who is receiving your data, and the tokens flow through the usual usage accounting with no special handling.

The cost is friction: wanting an image mid-conversation means switching to an agent on a model that makes them. That is the deliberate trade.

## Where the files go

Model-generated media lands in Jazz's data directory, not your working directory — unlike `create_pdf`. A PDF is the thing you asked for by name; an image arriving mid-conversation was not requested by path, and scattering files into whatever directory an agent happens to be in would be a surprise. The path is printed either way.

## How to verify

- Open the model picker for Google or OpenAI — image-capable models should now be listed; whisper and TTS models should not.
- Create an agent on `gemini-3-pro-image`, ask for an illustration. The image should be saved and its path reported, tagged `source: "model"` in `--json`.
- Confirm an ordinary text agent is unaffected: no artifacts, no behaviour change.
- Anthropic's model list should be unchanged.

**Not verified live:** `result.files` actually populating. That needs a Gemini-family API key, which this environment does not have, so the save-and-report path is covered by unit tests only. The filter change *was* checked against the real models.dev catalog. Worth exercising the generation path against a real key before relying on it.
