### PR TITLE
fix(cost): fail closed after unpriced capped runs

### DIFF
--- a/docs/surfaces/chat-platforms.md
+++ b/docs/surfaces/chat-platforms.md
@@ -83,7 +83,7 @@ What the Telegram bridge demonstrates — worth reading before you write your ow
 | **Live progress**   | `--events` NDJSON on stderr drives a status bubble that updates with thinking, tool calls, and sub-agents, then closes with a `✅ Done · 7 tools · 12k tokens · $0.03` summary. |
 | **Cancellation**    | A ⏹ button kills the child process mid-run.                                                                                                                                    |
 | **Reminders**       | `/remind 30m …`, persisted to disk so they survive restarts and fire late if the bridge was down.                                                                              |
-| **Spend cap**       | `JAZZ_DAILY_COST_CAP_USD` — the envelope's `costUSD` is accumulated per day.                                                                                                   |
+| **Spend cap**       | `JAZZ_DAILY_COST_CAP_USD` — known `costUSD` is accumulated per day; after an unpriced run, further requests pause until the next UTC day.                                      |
 | **Local-only mode** | Point `JAZZ_TELEGRAM_PROVIDER=ollama` at a local model: no keys, no cloud, no per-message cost.                                                                                |
 | **Allowlist**       | Only `TELEGRAM_ALLOWED_CHAT_IDS` are answered; everyone else is silently ignored.                                                                                              |
 
@@ -186,7 +186,7 @@ flowchart LR
 - **Default to `low-risk`.** At `high-risk`, a message — or a prompt injection inside a web page the agent fetched — can run arbitrary commands on the host. That is the documented behavior of that tier, not a bug.
 - **Trim the toolset.** An agent config that doesn't include `execute_command` cannot run shell commands regardless of policy. This is the strongest control available.
 - **Treat the history volume as sensitive.** Transcripts are plaintext JSON under `~/.jazz/history/`.
-- **Cap spend.** Use the envelope's `costUSD` to enforce a daily ceiling.
+- **Cap spend.** Use `costKnown` as well as `costUSD`. The bridges pause subsequent requests after an unpriced run; no dollar cap can guarantee the cost of that first unpriced request.
 
 Full model: [Security](../../SECURITY.md).
 

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -68,6 +68,7 @@ stdout is exactly one single-line object. Always one line, always one object —
   "ok": true,
   "answer": "4",
   "costUSD": 0.000182,
+  "costKnown": true,
   "tokenUsage": { "promptTokens": 1204, "completionTokens": 6, "totalTokens": 1210 },
   "toolCalls": [{ "id": "call_1", "name": "read_file", "arguments": "{\"path\":\"…\"}" }]
 }
@@ -80,6 +81,10 @@ stdout is exactly one single-line object. Always one line, always one object —
 
 Note that the failure envelope still reports `costUSD` — a run that timed out still
 spent money, and an unattended deployment needs to account for it.
+
+Successful envelopes also include `costKnown`. When pricing metadata is unavailable,
+`costUSD` remains `0` for compatibility and `costKnown` is `false`; consumers must not
+interpret that fallback as a free run.
 
 ---
 
@@ -220,6 +225,7 @@ interface JazzResult {
   answer?: string;
   error?: string;
   costUSD: number;
+  costKnown?: boolean;
 }
 
 export function askJazz(chatId: string, message: string): Promise<JazzResult> {

--- a/integrations/discord-bot/README.md
+++ b/integrations/discord-bot/README.md
@@ -139,7 +139,9 @@ While a message is processing, the progress message carries a **⏹ Cancel**
 button that kills the run. Each answer gets follow-up buttons (`🔍 Go deeper`,
 `✂️ Shorter`, …) that upgrade to contextual ones a beat later; set
 `JAZZ_DISCORD_DYNAMIC_CTA=0` to keep only the static ones.
-Set `JAZZ_DAILY_COST_CAP_USD` to cap total spend per day (0 = no cap).
+Set `JAZZ_DAILY_COST_CAP_USD` to cap known spend per UTC day (0 = no cap).
+If a completed run has no pricing metadata, its exact cost cannot be capped;
+the bot records it as unpriced and pauses later requests until the next UTC day.
 
 **Servers vs DMs.** In a server the bot only answers when mentioned, when you
 reply to it, or in a thread it already joined (`DISCORD_REQUIRE_MENTION=1`,
@@ -180,7 +182,7 @@ _that_ conversation. `JAZZ_DISCORD_PROVIDER` / `JAZZ_DISCORD_MODEL` /
 | `JAZZ_APPROVAL_POLICY` | `low-risk` | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`. |
 | `JAZZ_AUTO_APPROVE_TOOLS` | — | Comma-separated tool names to auto-approve regardless of policy. Tools needing approval that aren't in this list are sent to the channel as an accept/reject prompt instead of being declined. |
 | `JAZZ_RUN_TIMEOUT_MS` | `300000` | Per-message agent timeout. |
-| `JAZZ_DAILY_COST_CAP_USD` | `0` | Daily spend ceiling across all conversations; `0` disables the cap. |
+| `JAZZ_DAILY_COST_CAP_USD` | `0` | Daily known-spend ceiling across all conversations; an unpriced run pauses later requests for the UTC day; `0` disables the cap. |
 | `DISCORD_PUBLIC_BASE_URL` | unset | Public HTTPS origin used to link `create_web_app`'s interactive pages. Unset disables interactive mode (static/image mode always works). |
 | `PUPPETEER_EXECUTABLE_PATH` | `/usr/bin/chromium` | Browser used to screenshot `create_web_app`'s "static" mode. |
 

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -75,7 +75,7 @@ import { neutralizeBroadcastMentions, splitForDiscord, threadNameFromPrompt } fr
 import { startReminderSweep } from "./reminders";
 import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
-import { recordUsage, todayUsage } from "./usage";
+import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
 
 const PROGRESS_MIN_INTERVAL_MS = 2_000;
 const PROGRESS_MAX_TOOLS_SHOWN = 8;
@@ -129,6 +129,7 @@ interface JazzSuccessEnvelope {
   readonly ok: true;
   readonly answer: string;
   readonly costUSD: number;
+  readonly costKnown?: boolean;
   readonly tokenUsage?: {
     readonly totalTokens?: number;
     readonly promptTokens?: number;
@@ -590,7 +591,18 @@ async function handleMessage(
 ): Promise<void> {
   ensureChatAgent(config.jazzHome, channelId, config.baseAgentId);
 
-  if (config.dailyCostCapUsd > 0 && todayUsage(config.jazzHome).costUSD >= config.dailyCostCapUsd) {
+  const usage = todayUsage(config.jazzHome);
+  const capBlockReason = dailyCostCapBlockReason(usage, config.dailyCostCapUsd);
+  if (capBlockReason === "unpriced") {
+    await sendReply(
+      config,
+      channelId,
+      "⚠️ Daily cost cap paused: pricing was unavailable for an earlier run today, so spend cannot be verified. Try again tomorrow, disable the cap, or select a priced model.",
+    );
+    return;
+  }
+
+  if (capBlockReason === "reached") {
     await sendReply(
       config,
       channelId,
@@ -635,12 +647,20 @@ async function handleMessage(
     }
 
     if (envelope.ok) {
-      recordUsage(config.jazzHome, envelope.costUSD, envelope.tokenUsage?.totalTokens ?? 0);
+      const costKnown = envelope.costKnown !== false;
+      recordUsage(
+        config.jazzHome,
+        envelope.costUSD,
+        envelope.tokenUsage?.totalTokens ?? 0,
+        costKnown,
+      );
       const used = reporter?.toolsUsed() ?? [];
       const parts = ["✅ **Done**"];
       if (used.length > 0) parts.push(used.map((tool) => `\`${tool}\``).join(" "));
       if (envelope.costUSD > 0) {
         parts.push(envelope.costUSD >= 0.0001 ? `$${envelope.costUSD.toFixed(4)}` : "<$0.0001");
+      } else if (!costKnown) {
+        parts.push("price unavailable");
       }
       const usageLines = formatUsageLines(envelope.tokenUsage);
       await reporter?.finish(
@@ -1065,7 +1085,7 @@ async function handleCommand(
         : []),
       `Model: \`${agent.config.llmProvider}/${agent.config.llmModel}\` (reasoning: ${agent.config.reasoningEffort})`,
       `Timezone: \`${tzForChat(config.jazzHome, channelId)}\`${hasChatTz(config.jazzHome, channelId) ? "" : " (default)"}`,
-      `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}`,
+      `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}${(day.unpricedRuns ?? 0) > 0 ? ` · ${day.unpricedRuns} unpriced` : ""}`,
       `Daily cap: ${cap > 0 ? `$${cap.toFixed(2)}` : "none"}`,
       `Uptime: ${formatUptime(Date.now() - BRIDGE_STARTED_AT)}`,
     ];

--- a/integrations/discord-bot/usage.test.ts
+++ b/integrations/discord-bot/usage.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true });
+});
+
+function temporaryJazzHome(): string {
+  const directory = mkdtempSync(join(tmpdir(), "jazz-dc-usage-"));
+  directories.push(directory);
+  return directory;
+}
+
+describe("Discord daily usage", () => {
+  it("persists unpriced runs separately from known cost", () => {
+    const jazzHome = temporaryJazzHome();
+
+    recordUsage(jazzHome, 0.02, 12, true);
+    recordUsage(jazzHome, 0, 8, false);
+
+    expect(todayUsage(jazzHome)).toEqual({
+      costUSD: 0.02,
+      tokens: 20,
+      runs: 2,
+      unpricedRuns: 1,
+    });
+  });
+
+  it("keeps the numeric threshold behavior for priced runs", () => {
+    const usage = { costUSD: 0.5, tokens: 20, runs: 1 };
+
+    expect(dailyCostCapBlockReason(usage, 0.5)).toBe("reached");
+    expect(dailyCostCapBlockReason(usage, 0.51)).toBeUndefined();
+  });
+});

--- a/integrations/discord-bot/usage.ts
+++ b/integrations/discord-bot/usage.ts
@@ -10,6 +10,7 @@ export interface DailyUsage {
   costUSD: number;
   tokens: number;
   runs: number;
+  unpricedRuns?: number;
 }
 
 function usagePath(dataDir: string): string {
@@ -38,7 +39,21 @@ export function todayUsage(dataDir: string): DailyUsage {
   return readUsage(dataDir)[todayKey()] ?? { costUSD: 0, tokens: 0, runs: 0 };
 }
 
-export function recordUsage(dataDir: string, costUSD: number, tokens: number): void {
+export function dailyCostCapBlockReason(
+  usage: DailyUsage,
+  capUSD: number,
+): "unpriced" | "reached" | undefined {
+  if (capUSD <= 0) return undefined;
+  if ((usage.unpricedRuns ?? 0) > 0) return "unpriced";
+  return usage.costUSD >= capUSD ? "reached" : undefined;
+}
+
+export function recordUsage(
+  dataDir: string,
+  costUSD: number,
+  tokens: number,
+  costKnown = true,
+): void {
   const usage = readUsage(dataDir);
   const key = todayKey();
   const day = usage[key] ?? { costUSD: 0, tokens: 0, runs: 0 };
@@ -46,6 +61,7 @@ export function recordUsage(dataDir: string, costUSD: number, tokens: number): v
     costUSD: day.costUSD + costUSD,
     tokens: day.tokens + tokens,
     runs: day.runs + 1,
+    unpricedRuns: (day.unpricedRuns ?? 0) + (costKnown ? 0 : 1),
   };
   const cutoff = new Date(Date.now() - 30 * 86_400_000).toISOString().slice(0, 10);
   for (const date of Object.keys(usage)) {

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -85,7 +85,9 @@ the nearest pharmacy" → "🧭 Directions", "🕒 Opening hours", "🔍 Go deep
 one sends it as your next message. Answers appear instantly with static
 `🔍 Go deeper` / `✂️ Shorter` buttons that upgrade to the contextual set a beat
 later; set `JAZZ_TELEGRAM_DYNAMIC_CTA=0` to keep only the static ones.
-Set `JAZZ_DAILY_COST_CAP_USD` to cap total spend per day (0 = no cap).
+Set `JAZZ_DAILY_COST_CAP_USD` to cap known spend per UTC day (0 = no cap).
+If a completed run has no pricing metadata, its exact cost cannot be capped;
+the bot records it as unpriced and pauses later requests until the next UTC day.
 
 **Location.** Share a location (📎 → Location) and the bot reverse-geocodes it
 (OpenStreetMap Nominatim) and hands the agent the coordinates + address, so you

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -37,7 +37,7 @@ import { startReminderSweep } from "./reminders";
 import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
 import { escapeHtml, markdownToTelegramHtml, splitForTelegram } from "./telegram-html";
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
-import { recordUsage, todayUsage } from "./usage";
+import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const GETUPDATES_TIMEOUT_SECONDS = 30;
@@ -116,6 +116,7 @@ interface JazzSuccessEnvelope {
   readonly ok: true;
   readonly answer: string;
   readonly costUSD: number;
+  readonly costKnown?: boolean;
   readonly tokenUsage?: {
     readonly totalTokens?: number;
     readonly promptTokens?: number;
@@ -850,7 +851,18 @@ async function deliverWebApp(
 async function handleMessage(config: BridgeConfig, chatId: number, text: string): Promise<void> {
   ensureChatAgent(config.jazzHome, chatId, config.baseAgentId);
 
-  if (config.dailyCostCapUsd > 0 && todayUsage(config.jazzHome).costUSD >= config.dailyCostCapUsd) {
+  const usage = todayUsage(config.jazzHome);
+  const capBlockReason = dailyCostCapBlockReason(usage, config.dailyCostCapUsd);
+  if (capBlockReason === "unpriced") {
+    await sendReply(
+      config,
+      chatId,
+      "⚠️ Daily cost cap paused: pricing was unavailable for an earlier run today, so spend cannot be verified. Try again tomorrow, disable the cap, or select a priced model.",
+    );
+    return;
+  }
+
+  if (capBlockReason === "reached") {
     await sendReply(
       config,
       chatId,
@@ -892,7 +904,13 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
     }
 
     if (envelope.ok) {
-      recordUsage(config.jazzHome, envelope.costUSD, envelope.tokenUsage?.totalTokens ?? 0);
+      const costKnown = envelope.costKnown !== false;
+      recordUsage(
+        config.jazzHome,
+        envelope.costUSD,
+        envelope.tokenUsage?.totalTokens ?? 0,
+        costKnown,
+      );
       const used = reporter?.toolsUsed() ?? [];
       const parts = ["✅ <b>Done</b>"];
       if (used.length > 0) {
@@ -900,6 +918,8 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       }
       if (envelope.costUSD > 0) {
         parts.push(envelope.costUSD >= 0.0001 ? `$${envelope.costUSD.toFixed(4)}` : "<$0.0001");
+      } else if (!costKnown) {
+        parts.push("price unavailable");
       }
       const usageLines = formatUsageLines(envelope.tokenUsage);
       await reporter?.finish(
@@ -1329,7 +1349,7 @@ async function handleCommand(
         : []),
       `Model: <code>${escapeHtml(agent.config.llmProvider)}/${escapeHtml(agent.config.llmModel)}</code> (reasoning: ${escapeHtml(agent.config.reasoningEffort)})`,
       `Timezone: <code>${escapeHtml(tzForChat(config.jazzHome, chatId))}</code>${hasChatTz(config.jazzHome, chatId) ? "" : " (default)"}`,
-      `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}`,
+      `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}${(day.unpricedRuns ?? 0) > 0 ? ` · ${day.unpricedRuns} unpriced` : ""}`,
       `Daily cap: ${cap > 0 ? `$${cap.toFixed(2)}` : "none"}`,
       `Uptime: ${formatUptime(Date.now() - BRIDGE_STARTED_AT)}`,
     ];

--- a/integrations/telegram-bot/usage.test.ts
+++ b/integrations/telegram-bot/usage.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true });
+});
+
+function temporaryJazzHome(): string {
+  const directory = mkdtempSync(join(tmpdir(), "jazz-tg-usage-"));
+  directories.push(directory);
+  return directory;
+}
+
+describe("Telegram daily usage", () => {
+  it("distinguishes an unavailable price from a zero-cost priced run", () => {
+    const jazzHome = temporaryJazzHome();
+
+    recordUsage(jazzHome, 0, 12, true);
+    recordUsage(jazzHome, 0, 8, false);
+
+    expect(todayUsage(jazzHome)).toEqual({
+      costUSD: 0,
+      tokens: 20,
+      runs: 2,
+      unpricedRuns: 1,
+    });
+  });
+
+  it("reads usage files written before unpriced tracking was added", () => {
+    const jazzHome = temporaryJazzHome();
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      join(jazzHome, "tg-usage.json"),
+      JSON.stringify({ [today]: { costUSD: 0.25, tokens: 40, runs: 1 } }),
+    );
+
+    recordUsage(jazzHome, 0.1, 10, false);
+
+    expect(todayUsage(jazzHome).unpricedRuns).toBe(1);
+    expect(readFileSync(join(jazzHome, "tg-usage.json"), "utf8")).toContain('"unpricedRuns": 1');
+  });
+
+  it("fails closed after an unpriced run only when a cap is enabled", () => {
+    const usage = { costUSD: 0, tokens: 20, runs: 1, unpricedRuns: 1 };
+
+    expect(dailyCostCapBlockReason(usage, 1)).toBe("unpriced");
+    expect(dailyCostCapBlockReason(usage, 0)).toBeUndefined();
+  });
+});

--- a/integrations/telegram-bot/usage.ts
+++ b/integrations/telegram-bot/usage.ts
@@ -10,6 +10,7 @@ export interface DailyUsage {
   costUSD: number;
   tokens: number;
   runs: number;
+  unpricedRuns?: number;
 }
 
 function usagePath(dataDir: string): string {
@@ -38,7 +39,21 @@ export function todayUsage(dataDir: string): DailyUsage {
   return readUsage(dataDir)[todayKey()] ?? { costUSD: 0, tokens: 0, runs: 0 };
 }
 
-export function recordUsage(dataDir: string, costUSD: number, tokens: number): void {
+export function dailyCostCapBlockReason(
+  usage: DailyUsage,
+  capUSD: number,
+): "unpriced" | "reached" | undefined {
+  if (capUSD <= 0) return undefined;
+  if ((usage.unpricedRuns ?? 0) > 0) return "unpriced";
+  return usage.costUSD >= capUSD ? "reached" : undefined;
+}
+
+export function recordUsage(
+  dataDir: string,
+  costUSD: number,
+  tokens: number,
+  costKnown = true,
+): void {
   const usage = readUsage(dataDir);
   const key = todayKey();
   const day = usage[key] ?? { costUSD: 0, tokens: 0, runs: 0 };
@@ -46,6 +61,7 @@ export function recordUsage(dataDir: string, costUSD: number, tokens: number): v
     costUSD: day.costUSD + costUSD,
     tokens: day.tokens + tokens,
     runs: day.runs + 1,
+    unpricedRuns: (day.unpricedRuns ?? 0) + (costKnown ? 0 : 1),
   };
   // Keep the file bounded — drop entries older than 30 days.
   const cutoff = new Date(Date.now() - 30 * 86_400_000).toISOString().slice(0, 10);

--- a/src/cli/commands/run-agent.test.ts
+++ b/src/cli/commands/run-agent.test.ts
@@ -15,6 +15,7 @@ import {
   formatOneShotError,
   formatOneShotResult,
   isApprovalPolicyFlag,
+  isRunCostKnown,
   isReasoningEffortFlag,
   type OneShotSuccess,
   parseEventCategories,
@@ -24,6 +25,7 @@ import {
 const baseResult: OneShotSuccess = {
   answer: "Hello from the agent",
   costUSD: 0.0012,
+  costKnown: true,
   tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
   toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
 };
@@ -49,6 +51,7 @@ describe("formatOneShotResult", () => {
       ok: true,
       answer: "Hello from the agent",
       costUSD: 0.0012,
+      costKnown: true,
       tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
       toolCalls: [{ id: "call_1", name: "web_search", arguments: '{"q":"x"}' }],
     });
@@ -84,6 +87,23 @@ describe("formatOneShotError", () => {
 
   it("json mode defaults costUSD to 0", () => {
     expect(JSON.parse(formatOneShotError("boom", { json: true })).costUSD).toBe(0);
+  });
+});
+
+describe("isRunCostKnown", () => {
+  it("accepts provider pricing, including a real zero", () => {
+    expect(isRunCostKnown(0, "openai", "free-model")).toBe(true);
+    expect(isRunCostKnown(0.01, "openai", "priced-model")).toBe(true);
+  });
+
+  it("recognizes local servers as zero-cost without misclassifying Ollama Cloud", () => {
+    expect(isRunCostKnown(undefined, "llamacpp", "local.gguf")).toBe(true);
+    expect(isRunCostKnown(undefined, "ollama", "qwen3:8b")).toBe(true);
+    expect(isRunCostKnown(undefined, "ollama", "kimi-k3:cloud")).toBe(false);
+  });
+
+  it("marks missing remote pricing as unknown", () => {
+    expect(isRunCostKnown(undefined, "openai", "unlisted-model")).toBe(false);
   });
 });
 
@@ -318,12 +338,13 @@ describe("--conversation persistence", () => {
     expect(second?.startedAt).toBe(first?.startedAt ?? "");
   });
 
-  it("json envelope shape is unchanged by conversation runs", () => {
+  it("conversation runs use the current JSON envelope shape", () => {
     const output = formatOneShotResult(baseResult, { json: true });
     expect(Object.keys(JSON.parse(output))).toEqual([
       "ok",
       "answer",
       "costUSD",
+      "costKnown",
       "tokenUsage",
       "toolCalls",
     ]);

--- a/src/cli/commands/run-agent.ts
+++ b/src/cli/commands/run-agent.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { buildWorkStatePreamble } from "@/core/agent/context/work-state-preamble";
+import { isOllamaCloudModel } from "@/core/constants/ollama";
 import { CommonSuggestions, getErrorMessage } from "@/core/presentation/error-handler";
 import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
 import { describeArtifact, type GeneratedArtifact } from "@/core/types/artifact";
@@ -63,6 +64,8 @@ export interface OneShotWebApp {
 export interface OneShotSuccess {
   readonly answer: string;
   readonly costUSD: number;
+  /** Whether costUSD is based on pricing metadata rather than an unknown-price fallback. */
+  readonly costKnown: boolean;
   readonly tokenUsage: OneShotTokenUsage;
   readonly toolCalls: readonly OneShotToolCall[];
   readonly webApp?: OneShotWebApp;
@@ -85,6 +88,17 @@ export interface OneShotSuccess {
    * disk.
    */
   readonly messages?: readonly ChatMessage[];
+}
+
+/** Distinguish unavailable remote pricing from providers that run on the user's machine. */
+export function isRunCostKnown(
+  costUSD: number | undefined,
+  provider: string,
+  modelId: string,
+): boolean {
+  if (costUSD !== undefined) return true;
+  if (provider === "llamacpp") return true;
+  return provider === "ollama" && !isOllamaCloudModel(modelId);
 }
 
 /**
@@ -166,6 +180,7 @@ export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutp
     ok: true,
     answer: result.answer,
     costUSD: result.costUSD,
+    costKnown: result.costKnown,
     tokenUsage: result.tokenUsage,
     toolCalls: result.toolCalls,
     ...(result.webApp ? { webApp: result.webApp } : {}),
@@ -528,6 +543,11 @@ export function runAgentOnceCommand(
         {
           answer: runResult.content,
           costUSD: runResult.costUSD ?? 0,
+          costKnown: isRunCostKnown(
+            runResult.costUSD,
+            agentForRun.config.llmProvider,
+            agentForRun.config.llmModel,
+          ),
           tokenUsage: {
             promptTokens,
             completionTokens,

--- a/src/cli/commands/workflow.test.ts
+++ b/src/cli/commands/workflow.test.ts
@@ -26,7 +26,18 @@ import { runWorkflowCommand } from "./workflow";
  * and restored after each test.
  */
 
-const mockAgent = { id: "agent-1", name: "ci-reviewer" } as Agent;
+const mockAgent: Agent = {
+  id: "agent-1",
+  name: "ci-reviewer",
+  model: "openai/gpt-4o-mini",
+  config: {
+    persona: "default",
+    llmProvider: "openai",
+    llmModel: "gpt-4o-mini",
+  },
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
 
 const mockWorkflow: WorkflowContent = {
   metadata: {

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -29,7 +29,7 @@ import {
 import { SchedulerServiceTag } from "@/core/workflows/scheduler-service";
 import { WorkflowServiceTag, type WorkflowMetadata } from "@/core/workflows/workflow-service";
 import { formatWorkflow, groupWorkflows } from "@/core/workflows/workflow-utils";
-import { formatOneShotError, formatOneShotResult } from "./run-agent";
+import { formatOneShotError, formatOneShotResult, isRunCostKnown } from "./run-agent";
 
 /**
  * CLI commands for managing and running workflows.
@@ -439,6 +439,11 @@ export function runWorkflowCommand(
             {
               answer: runResult.content,
               costUSD: runResult.costUSD ?? 0,
+              costKnown: isRunCostKnown(
+                runResult.costUSD,
+                agent.config.llmProvider,
+                agent.config.llmModel,
+              ),
               tokenUsage: {
                 promptTokens,
                 completionTokens,


### PR DESCRIPTION
Closes #380.

## What changed

- add `costKnown` to successful `jazz run --json` and workflow JSON envelopes while retaining numeric `costUSD`
- classify provider-priced runs and local llama.cpp/non-cloud Ollama runs as known; preserve Ollama Cloud and other missing remote prices as unknown
- persist `unpricedRuns` in the Telegram and Discord daily usage ledgers with backward-compatible reads
- when `JAZZ_DAILY_COST_CAP_USD` is enabled, pause subsequent requests after an unpriced run instead of continuing to count it as `$0`
- show unpriced state in completion/status output and document the first-unpriced-request limitation

## Why this design

I considered making `costUSD` nullable/optional, adding an explicit known-state field, and falling back to a request-count cap. I chose the explicit field because it keeps the existing numeric envelope compatible for consumers while removing the false equivalence between unavailable pricing and a real zero. A request-count fallback was rejected because it is not a dollar ceiling.

The first unpriced request necessarily completes before its unknown cost is visible. This change records that uncertainty and fails closed for later requests that UTC day; it does not claim an exact provider-invoice guarantee.

## Verification

- `bun test`: 2,726 passed; 9 existing live skips; 10 existing TODOs; 0 failed
- `bun run typecheck`
- `bun run test:typecheck`
- `bun run lint` plus integration-file ESLint
- `bun run build`
- `bun run docs:check-links`: all 72 Markdown files resolve
- repository pre-commit Prettier and ESLint hooks

Developed and verified with AI assistance under the `fablgen-agent` account; the issue, design tradeoffs, code, tests, and documentation are public for maintainer review.