### PR TITLE
feat(cli): show which agents can generate media, and how to make one

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -18,6 +18,7 @@ import {
   enableMcpServerCommand,
   disableMcpServerCommand,
 } from "./commands/mcp";
+import { isMediaCapability, MEDIA_CAPABILITIES } from "./commands/media-agents";
 import {
   createPersonaCommand,
   listPersonasCommand,
@@ -264,9 +265,21 @@ function registerAgentCommands(program: Command): void {
     .command("list")
     .alias("ls")
     .description("List all agents")
-    .action(() => {
+    .option(
+      "--can <media>",
+      "Only agents whose model can generate this: image, audio, or video. Shows how to get one when none can.",
+    )
+    .action((commandOptions: { can?: string }) => {
       const opts = program.opts<CliOptions>();
-      runCliEffect(listAgentsCommand(), {
+      const requested = commandOptions.can;
+      if (requested !== undefined && !isMediaCapability(requested)) {
+        console.error(
+          `Unknown capability "${requested}". Use one of: ${MEDIA_CAPABILITIES.join(", ")}`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      runCliEffect(listAgentsCommand(requested ? { can: requested } : {}), {
         verbose: opts.verbose,
         debug: opts.debug,
         configPath: opts.config,

--- a/src/cli/commands/agent-management.ts
+++ b/src/cli/commands/agent-management.ts
@@ -15,8 +15,14 @@ import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-serv
 import { CLIOptionsTag, type CLIOptions } from "@/core/interfaces/cli-options";
 import { JazzStateServiceTag, type JazzStateService } from "@/core/interfaces/jazz-state";
 import { ink, TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
+import type { Agent } from "@/core/types/agent";
 import { CLIError, StorageError, StorageNotFoundError } from "@/core/types/errors";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
+import {
+  findAgentsWithCapability,
+  type MediaCapability,
+  suggestModelsForCapability,
+} from "./media-agents";
 import { AgentDetailsCard } from "../ui/AgentDetailsCard";
 import { AgentsList } from "../ui/AgentsList";
 
@@ -149,6 +155,62 @@ function formatAgentsListBlock(
  */
 
 /**
+ * Show the agents that can produce a given kind of media, or how to get one.
+ *
+ * Jazz cannot generate media on a model that does not do it — there is no tool to fall back on —
+ * so "none of your agents can" has to come with the next step attached, or it is a dead end.
+ */
+function listAgentsWithCapability(
+  agents: readonly Agent[],
+  capability: MediaCapability,
+  terminal: TerminalService,
+): Effect.Effect<void, never, never> {
+  return Effect.gen(function* () {
+    const capable = yield* Effect.tryPromise({
+      try: () => findAgentsWithCapability(agents, capability),
+      catch: (error) => error,
+    }).pipe(Effect.catchAll(() => Effect.succeed([])));
+
+    if (capable.length > 0) {
+      yield* terminal.log(`Agents that can generate ${capability}:\n`);
+      for (const { agent, supportsTools } of capable) {
+        // Naming the tool gap matters: most media models cannot call tools at all, so an agent
+        // that draws may be unable to read a file or search the web.
+        const toolNote = supportsTools ? "" : "  (this model has no tools — generation only)";
+        yield* terminal.log(`  ${agent.name}  ${agent.model}${toolNote}`);
+      }
+      yield* terminal.log(`\nStart one with: jazz agent chat <name>`);
+      return;
+    }
+
+    yield* terminal.log(`None of your agents can generate ${capability}.\n`);
+
+    const providers = [...new Set(agents.map((agent) => agent.model.split("/")[0] ?? ""))].filter(
+      (provider) => provider.length > 0,
+    );
+    const suggestions = yield* Effect.tryPromise({
+      try: () => suggestModelsForCapability(capability, providers),
+      catch: (error) => error,
+    }).pipe(Effect.catchAll(() => Effect.succeed([])));
+
+    if (suggestions.length === 0) {
+      yield* terminal.log(
+        `No model from your configured providers generates ${capability}. Gemini models are the ` +
+          `most common source; add that provider with: jazz config set llm.gemini.api_key <key>`,
+      );
+      return;
+    }
+
+    yield* terminal.log("Models that can, from providers you already use:\n");
+    for (const suggestion of suggestions) {
+      const toolNote = suggestion.supportsTools ? "  (also supports tools)" : "";
+      yield* terminal.log(`  ${suggestion.provider}/${suggestion.id}${toolNote}`);
+    }
+    yield* terminal.log(`\nCreate an agent on one with: jazz agent create`);
+  });
+}
+
+/**
  * List all agents via CLI command
  *
  * Retrieves and displays all available agents in a formatted table showing
@@ -159,7 +221,9 @@ function formatAgentsListBlock(
  * @throws {StorageError} When there's an error accessing storage
  *
  */
-export function listAgentsCommand(): Effect.Effect<
+export function listAgentsCommand(
+  options: { readonly can?: MediaCapability } = {},
+): Effect.Effect<
   void,
   StorageError,
   AgentService | TerminalService | CLIOptions | JazzStateService
@@ -171,6 +235,11 @@ export function listAgentsCommand(): Effect.Effect<
 
     if (agentsUnsorted.length === 0) {
       yield* terminal.info("No agents found. Create your first agent with: jazz agent create");
+      return;
+    }
+
+    if (options.can !== undefined) {
+      yield* listAgentsWithCapability(agentsUnsorted, options.can, terminal);
       return;
     }
 

--- a/src/cli/commands/media-agents.test.ts
+++ b/src/cli/commands/media-agents.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Agent } from "@/core/types/agent";
+import type { ModelsDevMetadata } from "@/core/utils/models-dev";
+
+const metadataByModel = new Map<string, ModelsDevMetadata>();
+const providerEntries = new Map<string, unknown[]>();
+
+mock.module("@/core/utils/models-dev", () => ({
+  getModelsDevMetadata: (model: string) => Promise.resolve(metadataByModel.get(model)),
+  getModelsDevProviderModels: (provider: string) =>
+    Promise.resolve(providerEntries.get(provider) ?? []),
+}));
+
+const { findAgentsWithCapability, isMediaCapability, suggestModelsForCapability } =
+  await import("./media-agents");
+
+function metadata(overrides: Partial<ModelsDevMetadata> = {}): ModelsDevMetadata {
+  return {
+    contextWindow: 128_000,
+    supportsTools: false,
+    isReasoningModel: false,
+    supportsVision: false,
+    supportsPdf: false,
+    supportsAudio: false,
+    supportsVideo: false,
+    generatesImage: false,
+    generatesAudio: false,
+    generatesVideo: false,
+    supportsTemperature: true,
+    ...overrides,
+  };
+}
+
+function agent(name: string, model: string): Agent {
+  return {
+    id: name,
+    name,
+    model: model as Agent["model"],
+    config: { persona: "default", llmProvider: "x", llmModel: "y" },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as Agent;
+}
+
+describe("isMediaCapability", () => {
+  it("accepts the three media kinds and nothing else", () => {
+    expect(isMediaCapability("image")).toBe(true);
+    expect(isMediaCapability("audio")).toBe(true);
+    expect(isMediaCapability("video")).toBe(true);
+    expect(isMediaCapability("spreadsheet")).toBe(false);
+  });
+});
+
+describe("findAgentsWithCapability", () => {
+  it("keeps only agents whose model produces that media", async () => {
+    metadataByModel.set("gpt-image-1.5", metadata({ generatesImage: true }));
+    metadataByModel.set("claude-sonnet-5", metadata());
+
+    const found = await findAgentsWithCapability(
+      [agent("artist", "openai/gpt-image-1.5"), agent("writer", "anthropic/claude-sonnet-5")],
+      "image",
+    );
+
+    expect(found.map((entry) => entry.agent.name)).toEqual(["artist"]);
+  });
+
+  it("reports whether the agent can also use tools", async () => {
+    // The difference between an agent that draws and works, and one that only draws — most
+    // image models report tool_call: false.
+    metadataByModel.set("draw-only", metadata({ generatesImage: true }));
+    metadataByModel.set("draw-and-work", metadata({ generatesImage: true, supportsTools: true }));
+
+    const found = await findAgentsWithCapability(
+      [agent("a", "gemini/draw-only"), agent("b", "gemini/draw-and-work")],
+      "image",
+    );
+
+    expect(found.find((entry) => entry.agent.name === "a")?.supportsTools).toBe(false);
+    expect(found.find((entry) => entry.agent.name === "b")?.supportsTools).toBe(true);
+  });
+
+  it("does not confuse one modality for another", async () => {
+    metadataByModel.set("speaker", metadata({ generatesAudio: true }));
+    expect(await findAgentsWithCapability([agent("s", "gemini/speaker")], "image")).toEqual([]);
+    expect(await findAgentsWithCapability([agent("s", "gemini/speaker")], "audio")).toHaveLength(1);
+  });
+
+  it("skips agents whose model id cannot be parsed or is unknown", async () => {
+    // An unknown model reads the same as "cannot", which is the safe direction: claiming an
+    // agent can generate when it cannot sends the user down a dead end.
+    expect(await findAgentsWithCapability([agent("weird", "not-a-model-id")], "image")).toEqual([]);
+    expect(
+      await findAgentsWithCapability([agent("x", "openai/never-heard-of-it")], "image"),
+    ).toEqual([]);
+  });
+});
+
+describe("suggestModelsForCapability", () => {
+  function entry(id: string, meta: ModelsDevMetadata) {
+    return {
+      id,
+      displayName: id,
+      inputModalities: ["text"],
+      outputModalities: ["text", "image"],
+      metadata: meta,
+    };
+  }
+
+  it("ranks tool-capable models first", async () => {
+    // An agent that can only generate is much narrower than one that can also do the work.
+    providerEntries.set("openai", [
+      entry("no-tools", metadata({ generatesImage: true })),
+      entry("with-tools", metadata({ generatesImage: true, supportsTools: true })),
+    ]);
+
+    const suggestions = await suggestModelsForCapability("image", ["openai"]);
+    expect(suggestions[0]?.id).toBe("with-tools");
+  });
+
+  it("skips OpenRouter routers, which only might reach a capable model", async () => {
+    providerEntries.set("openrouter", [
+      entry("openrouter/auto", metadata({ generatesImage: true, supportsTools: true })),
+      entry("google/gemini-3-pro-image", metadata({ generatesImage: true })),
+    ]);
+
+    const ids = (await suggestModelsForCapability("image", ["openrouter"])).map((s) => s.id);
+    expect(ids).not.toContain("openrouter/auto");
+    expect(ids).toContain("google/gemini-3-pro-image");
+  });
+
+  it("skips models jazz would not let you select as an agent", async () => {
+    // A pure generator returns no text, so it cannot be an agent however well it draws.
+    providerEntries.set("openai", [
+      {
+        id: "pure-generator",
+        displayName: "pure",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+        metadata: metadata({ generatesImage: true }),
+      },
+    ]);
+
+    expect(await suggestModelsForCapability("image", ["openai"])).toEqual([]);
+  });
+
+  it("is empty when a provider has nothing for that capability", async () => {
+    providerEntries.set("anthropic", [entry("claude", metadata())]);
+    expect(await suggestModelsForCapability("image", ["anthropic"])).toEqual([]);
+  });
+});

--- a/src/cli/commands/media-agents.ts
+++ b/src/cli/commands/media-agents.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Finding which of your agents can generate media
+ *
+ * Jazz has no image-generation tool on purpose: producing media is a capability of the model an
+ * agent runs on, not something jazz can hand to any agent (see the media-generation decision).
+ * The cost of that choice is discoverability — "use a model that can" is useless advice if you
+ * cannot see which of your agents qualify, or which model to pick when none do.
+ *
+ * This answers both questions: the agents that can, and, when there are none, a concrete model
+ * to create one with.
+ */
+
+import { OPENROUTER_GATEWAY_MODELS } from "@/core/constants/models";
+import type { Agent } from "@/core/types/agent";
+import {
+  getModelsDevMetadata,
+  getModelsDevProviderModels,
+  type ModelsDevMetadata,
+  type ModelsDevModelEntry,
+} from "@/core/utils/models-dev";
+import { parseProviderModel } from "@/core/utils/provider-model";
+
+/** The media an agent can be asked to produce. */
+export type MediaCapability = "image" | "audio" | "video";
+
+export const MEDIA_CAPABILITIES: readonly MediaCapability[] = ["image", "audio", "video"];
+
+export function isMediaCapability(value: string): value is MediaCapability {
+  return (MEDIA_CAPABILITIES as readonly string[]).includes(value);
+}
+
+function metadataHasCapability(
+  metadata: ModelsDevMetadata | undefined,
+  capability: MediaCapability,
+): boolean {
+  if (metadata === undefined) return false;
+  if (capability === "image") return metadata.generatesImage;
+  if (capability === "audio") return metadata.generatesAudio;
+  return metadata.generatesVideo;
+}
+
+export interface CapableAgent {
+  readonly agent: Agent;
+  /** True when the agent can also call tools, which most media models cannot. */
+  readonly supportsTools: boolean;
+}
+
+/**
+ * The agents whose model produces `capability`.
+ *
+ * `supportsTools` rides along because it is the difference between an agent that can draw *and*
+ * work, and one that can only draw — most image models report `tool_call: false`, so an agent on
+ * `gemini-3-pro-image` cannot read a file or search the web. Someone choosing between two image
+ * agents needs to know that before they pick.
+ */
+export async function findAgentsWithCapability(
+  agents: readonly Agent[],
+  capability: MediaCapability,
+): Promise<CapableAgent[]> {
+  const capable: CapableAgent[] = [];
+  for (const agent of agents) {
+    const parsed = parseProviderModel(agent.model);
+    if (parsed === null) continue;
+
+    let metadata: ModelsDevMetadata | undefined;
+    try {
+      metadata = await getModelsDevMetadata(parsed.model, parsed.provider);
+    } catch {
+      // An unreachable catalog should not make every agent look incapable, but there is nothing
+      // better to say about this one than "unknown", which reads the same as "no".
+      continue;
+    }
+    if (metadataHasCapability(metadata, capability)) {
+      capable.push({ agent, supportsTools: metadata?.supportsTools === true });
+    }
+  }
+  return capable;
+}
+
+/**
+ * Models that could back a new agent for this capability, best first.
+ *
+ * Tool-capable models are ranked first because an agent that can only produce media is a much
+ * narrower thing than one that can also do the work around it.
+ */
+export async function suggestModelsForCapability(
+  capability: MediaCapability,
+  providers: readonly string[],
+  limit = 4,
+): Promise<{ id: string; provider: string; supportsTools: boolean }[]> {
+  const suggestions: { id: string; provider: string; supportsTools: boolean }[] = [];
+
+  for (const provider of providers) {
+    let entries: readonly ModelsDevModelEntry[];
+    try {
+      entries = await getModelsDevProviderModels(provider);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.status === "deprecated") continue;
+      // A router advertises what it might reach. Recommending it for image generation would send
+      // someone to a model that may or may not be able to do the thing they asked for.
+      if (OPENROUTER_GATEWAY_MODELS.has(entry.id)) continue;
+      if (!metadataHasCapability(entry.metadata, capability)) continue;
+      // Only models jazz will let you select: it must hold a conversation.
+      if (!entry.inputModalities.includes("text") || !entry.outputModalities.includes("text")) {
+        continue;
+      }
+      suggestions.push({
+        id: entry.id,
+        provider,
+        supportsTools: entry.metadata.supportsTools,
+      });
+    }
+  }
+
+  suggestions.sort((left, right) => Number(right.supportsTools) - Number(left.supportsTools));
+  return suggestions.slice(0, limit);
+}

--- a/src/core/agent/agent-prompt-instructions.test.ts
+++ b/src/core/agent/agent-prompt-instructions.test.ts
@@ -105,3 +105,27 @@ describe("system prompt cache keys off the toolset", () => {
     expect(withoutQuestions).not.toContain("# Asking the user questions");
   });
 });
+
+describe("media generation guidance", () => {
+  test("a model that cannot generate media is told how to redirect the user", () => {
+    // Without this the agent answers "I can't generate images" and stops, which is true and a
+    // dead end — jazz has no generation tool, so the only route is another agent.
+    const prompt = build("default", { canGenerateMedia: false });
+    expect(prompt).toContain("jazz agent list --can image");
+  });
+
+  test("a model that can generate media is not given it", () => {
+    const prompt = build("default", { canGenerateMedia: true });
+    expect(prompt).not.toContain("jazz agent list --can image");
+  });
+
+  test("nothing is added when the capability is unknown", () => {
+    // Absent metadata should not put instructions in every prompt; the guidance is opt-in on a
+    // definite "cannot".
+    expect(build("default")).not.toContain("jazz agent list --can image");
+  });
+
+  test("the summarizer never gets it — no user to advise", () => {
+    expect(build("summarizer", { canGenerateMedia: false })).not.toContain("jazz agent list");
+  });
+});

--- a/src/core/agent/agent-prompt.ts
+++ b/src/core/agent/agent-prompt.ts
@@ -9,6 +9,7 @@ import {
   COMPLETION_INSTRUCTIONS,
   ENVIRONMENT_TEMPLATE,
   INTERACTIVE_QUESTIONS_GUIDELINES,
+  MEDIA_GENERATION_UNAVAILABLE,
   MEMORY_INSTRUCTIONS,
   SKILLS_INSTRUCTIONS,
   TASK_STATE_INSTRUCTIONS,
@@ -130,6 +131,11 @@ export interface AgentPromptOptions {
   readonly supportedAttachmentKinds?: readonly AttachmentKind[];
   /** Whether the target model runs locally, which relaxes attachment size limits. */
   readonly attachmentsAreLocal?: boolean;
+  /**
+   * Whether this model can produce media itself. When it cannot, the prompt gains a line telling
+   * the agent how to point the user at an agent that can, instead of dead-ending on "I can't".
+   */
+  readonly canGenerateMedia?: boolean;
 }
 
 /**
@@ -348,6 +354,12 @@ export class AgentPromptBuilder {
           systemPrompt = fillEnvironment(systemPrompt);
         } else if (personaName !== "summarizer") {
           systemPrompt = `${systemPrompt}\n${fillEnvironment(ENVIRONMENT_TEMPLATE)}`;
+        }
+
+        // Only for models that cannot generate media, and never for the summarizer, which has no
+        // user to advise.
+        if (personaName !== "summarizer" && options.canGenerateMedia === false) {
+          systemPrompt = `${systemPrompt}\n${MEDIA_GENERATION_UNAVAILABLE}`;
         }
 
         // Every acting persona gets the completion contract. The summarizer is

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -71,6 +71,29 @@ import { normalizeToolConfig } from "./utils/tool-config";
  * text-only. The known cost is locally-served models: ollama and llama.cpp are largely absent
  * from the catalog, so a capable local VLM reads as text-only here.
  */
+/**
+ * Whether this agent's model produces media of any kind.
+ *
+ * Unknown models count as "cannot", matching every other capability check here: the consequence
+ * of guessing wrong is an agent that promises an image it cannot make.
+ */
+function resolveCanGenerateMedia(
+  agent: AgentRunnerOptions["agent"],
+): Effect.Effect<boolean, never> {
+  return Effect.gen(function* () {
+    const parsed = parseProviderModel(agent.model);
+    if (parsed === null) return false;
+
+    const metadata = yield* Effect.tryPromise({
+      try: () => getModelsDevMetadata(parsed.model, parsed.provider),
+      catch: (error) => error,
+    }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+    if (metadata === undefined) return false;
+
+    return metadata.generatesImage || metadata.generatesAudio || metadata.generatesVideo;
+  });
+}
+
 function resolveSupportedAttachmentKinds(
   agent: AgentRunnerOptions["agent"],
 ): Effect.Effect<readonly AttachmentKind[], never> {
@@ -354,6 +377,9 @@ function initializeAgentRun(
     const supportedAttachmentKinds = ingestsAttachments
       ? yield* resolveSupportedAttachmentKinds(agent)
       : [];
+    // Whether this model can produce media itself. Drives one line of prompt guidance so a
+    // text-only agent can point the user at one that can, instead of dead-ending.
+    const canGenerateMedia = yield* resolveCanGenerateMedia(agent);
     const attachmentsAreLocal = isLocalServerProvider(
       parseProviderModel(agent.model)?.provider ?? "",
     );
@@ -375,6 +401,7 @@ function initializeAgentRun(
         }),
         supportedAttachmentKinds,
         attachmentsAreLocal,
+        canGenerateMedia,
         ...(triggeredSkillNames.length > 0 && { triggeredSkillNames }),
         ...(projectInstructions.length > 0 && { projectInstructions }),
       },

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -17,6 +17,22 @@ export const ENVIRONMENT_TEMPLATE = `# Environment
 - TTY: {tty}
 `;
 
+/**
+ * Added only for models that cannot generate media themselves.
+ *
+ * Jazz has no image-generation tool — producing media is a capability of the model an agent runs
+ * on. Without this line the agent answers "I can't generate images" and stops, which is true but
+ * a dead end: the user has no way to discover that another of their agents might be able to, or
+ * which model to create one with. Two sentences buys them the next step.
+ */
+export const MEDIA_GENERATION_UNAVAILABLE = `
+You cannot generate images, audio or video — your model produces text only, and there is no tool
+for it. If asked for one, say so plainly and tell the user to run \`jazz agent list --can image\`
+(or \`--can audio\` / \`--can video\`), which lists the agents that can and suggests a model to
+create one with when none do. Do not offer ASCII art or a description as a substitute unless they
+ask for that instead.
+`;
+
 export const SKILLS_INSTRUCTIONS = `
 Skills:
 1. If a request matches a skill in the index, load it with load_skill. Use find_skills when the index is not enough to decide.

--- a/src/core/constants/models.ts
+++ b/src/core/constants/models.ts
@@ -45,3 +45,16 @@ export const AVAILABLE_PROVIDERS = [
 ] as const;
 
 export type ProviderName = (typeof AVAILABLE_PROVIDERS)[number];
+
+/**
+ * OpenRouter meta-models that route to some other model rather than being one.
+ *
+ * Their advertised capabilities describe what they *might* reach, not what they are, so they get
+ * the benefit of the doubt when deciding whether tools work — and must be left out when
+ * recommending a model for a specific capability, where "it might route somewhere that can" is
+ * not an answer.
+ */
+export const OPENROUTER_GATEWAY_MODELS: ReadonlySet<string> = new Set([
+  "openrouter/free",
+  "openrouter/auto",
+]);

--- a/src/core/utils/models-dev.ts
+++ b/src/core/utils/models-dev.ts
@@ -44,6 +44,16 @@ export interface ModelsDevMetadata {
   readonly supportsAudio: boolean;
   /** Whether the model accepts video input. Derived from modalities.input containing "video". */
   readonly supportsVideo: boolean;
+  /**
+   * Whether the model *produces* media, from `modalities.output`.
+   *
+   * Distinct from the `supports*` fields above, which are about what it accepts. Jazz has no
+   * generation tool — producing an image means running an agent on a model that does it — so
+   * these are what tells a user which of their agents can, and which model to pick when none can.
+   */
+  readonly generatesImage: boolean;
+  readonly generatesAudio: boolean;
+  readonly generatesVideo: boolean;
   /** Whether the model accepts a custom temperature (from models.dev `temperature`). Defaults to true when absent. */
   readonly supportsTemperature: boolean;
   /** Input price in USD per 1M tokens (from models.dev cost.input). */
@@ -136,6 +146,7 @@ function toMetadata(spec: ModelsDevModelSpec): ModelsDevMetadata {
       : undefined;
 
   const inputModalities = Array.isArray(spec.modalities?.input) ? spec.modalities.input : [];
+  const outputModalities = Array.isArray(spec.modalities?.output) ? spec.modalities.output : [];
 
   return {
     contextWindow,
@@ -145,6 +156,9 @@ function toMetadata(spec: ModelsDevModelSpec): ModelsDevMetadata {
     supportsPdf: inputModalities.includes("pdf"),
     supportsAudio: inputModalities.includes("audio"),
     supportsVideo: inputModalities.includes("video"),
+    generatesImage: outputModalities.includes("image"),
+    generatesAudio: outputModalities.includes("audio"),
+    generatesVideo: outputModalities.includes("video"),
     supportsTemperature: spec.temperature !== false,
     ...(inputPrice !== undefined && { inputPricePerMillion: inputPrice }),
     ...(outputPrice !== undefined && { outputPricePerMillion: outputPrice }),

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -49,7 +49,7 @@ import { minimax } from "vercel-minimax-ai-provider";
 import { createZhipu, zhipu } from "zhipu-ai-provider";
 import { z } from "zod";
 import { AI_SDK_MAX_RETRIES, AI_SDK_MAX_STEPS } from "@/core/constants/agent";
-import type { ProviderName } from "@/core/constants/models";
+import { OPENROUTER_GATEWAY_MODELS, type ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
@@ -447,12 +447,6 @@ export function toCoreMessages(
 type ModelName = string;
 type ProviderOptions = NonNullable<Parameters<typeof generateText>[0]["providerOptions"]>;
 type AISDKToolChoice = Parameters<typeof generateText>[0]["toolChoice"];
-
-/**
- * OpenRouter gateway models that are meta-models routing to various underlying models.
- * These should always assume tool support since the underlying models may support them.
- */
-const OPENROUTER_GATEWAY_MODELS = new Set(["openrouter/free", "openrouter/auto"]);
 
 /**
  * Get provider-native web search tool if supported by the provider


### PR DESCRIPTION
## The problem

Jazz generates images by running an agent on a model that generates images — there is no tool for it, deliberately. That leaves a gap: **"use a model that can" is useless advice if you cannot see which of your agents qualify.**

Ask a Claude agent for a picture today and it says "I can't generate images." True, and a dead end. You are not told that another of your agents might be able to, or which model to create one with.

## What changes

**A command that answers it:**

```
$ jazz agent list --can image

None of your agents can generate image.

Models that can, from providers you already use:

  openrouter/google/gemini-3-pro-image  (also supports tools)
  openai/gpt-image-1.5
  openai/gpt-image-1-mini
  openai/chatgpt-image-latest

Create an agent on one with: jazz agent create
```

Once you have one:

```
$ jazz agent list --can image

Agents that can generate image:

  artist  openai/gpt-image-1.5  (this model has no tools — generation only)

Start one with: jazz agent chat <name>
```

Also `--can audio` and `--can video`.

**And the agent tells you, so you don't have to already know the command exists:**

> I can't generate images. If you want, you can run:
> ```bash
> jazz agent list --can image
> ```
> That will show which agents on your machine can create it, and suggest a model to use.

## Two details worth knowing

**The tool gap is surfaced, not hidden.** Most image models report `tool_call: false` — an agent on `gemini-3-pro-image` can draw and nothing else: no file reading, no web search, no `create_pdf`. Every listing says so, and suggestions rank tool-capable models first, because an agent that can only generate is a much narrower thing than one that can also do the work around it.

**Routers are excluded from suggestions.** `openrouter/auto` advertises image output because it *might* route somewhere that has it. Recommending it would point you at a model that may or may not do what you asked.

## Cost

One line of system prompt, and only for models that definitely cannot generate media. A model with unknown capability gets nothing, so this is not weight every agent pays.

## How to verify

- `jazz agent list --can image` with no capable agent — should suggest real models from your providers and say how to create one.
- Create an agent on `gpt-image-1.5`, run it again — should list the agent and flag that the model has no tools.
- `--can spreadsheet` — should be rejected with the valid options.
- Ask a text-only agent to draw something — it should name the command rather than just refusing.
- Ask an image-capable agent to draw — it should not mention the command at all.
