### PR TITLE
chore(errors): drop the task error family nothing throws

### DIFF
--- a/src/core/presentation/error-handler.ts
+++ b/src/core/presentation/error-handler.ts
@@ -83,63 +83,6 @@ function generateSuggestions(error: JazzError): ErrorDisplay {
       };
     }
 
-    case "TaskNotFoundError": {
-      return {
-        title: "Task Not Found",
-        message: `Task with ID "${error.taskId}" not found`,
-        suggestion: error.suggestion || "Check if the task ID is correct",
-        recovery: [
-          "List all tasks: `jazz task list`",
-          "Check task ID spelling and case sensitivity",
-          "Create a new task: `jazz task create`",
-        ],
-        relatedCommands: ["jazz task list", "jazz task create"],
-      };
-    }
-
-    case "TaskExecutionError": {
-      return {
-        title: "Task Execution Failed",
-        message: `Task "${error.taskId}" failed: ${error.reason}`,
-        suggestion: error.suggestion || "Check the task configuration and dependencies",
-        recovery: [
-          "Check task configuration: `jazz task get <task-id>`",
-          "Run with debug mode: `jazz task run <task-id> --debug`",
-          "Check task dependencies: `jazz task deps <task-id>`",
-        ],
-        relatedCommands: ["jazz task get", "jazz task run --debug"],
-      };
-    }
-
-    case "TaskTimeoutError": {
-      return {
-        title: "Task Timeout",
-        message: `Task "${error.taskId}" timed out after ${error.timeout}ms`,
-        suggestion: error.suggestion || "Increase the timeout or optimize the task",
-        recovery: [
-          "Increase task timeout in configuration",
-          "Optimize task performance",
-          "Check for resource constraints",
-          "Run with longer timeout: `jazz task run <task-id> --timeout 60000`",
-        ],
-        relatedCommands: ["jazz task run --timeout", "jazz agent config"],
-      };
-    }
-
-    case "TaskDependencyError": {
-      return {
-        title: "Task Dependency Error",
-        message: `Task "${error.taskId}" has dependency issue with "${error.dependencyId}": ${error.reason}`,
-        suggestion: error.suggestion || "Resolve the dependency issue",
-        recovery: [
-          "Check dependency task status: `jazz task get <dependency-id>`",
-          "Run dependency task first: `jazz task run <dependency-id>`",
-          "Update task dependencies: `jazz task update <task-id>`",
-        ],
-        relatedCommands: ["jazz task get", "jazz task run"],
-      };
-    }
-
     case "ConfigurationError": {
       return {
         title: "Configuration Error",

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -44,33 +44,6 @@ export class ToolNotFoundError extends Data.TaggedError("ToolNotFoundError")<{
   }
 }
 
-// Task Errors
-export class TaskNotFoundError extends Data.TaggedError("TaskNotFoundError")<{
-  readonly taskId: string;
-  readonly suggestion?: string;
-}> {}
-
-export class TaskExecutionError extends Data.TaggedError("TaskExecutionError")<{
-  readonly taskId: string;
-  readonly reason: string;
-  readonly exitCode?: number;
-  readonly output?: string;
-  readonly suggestion?: string;
-}> {}
-
-export class TaskTimeoutError extends Data.TaggedError("TaskTimeoutError")<{
-  readonly taskId: string;
-  readonly timeout: number;
-  readonly suggestion?: string;
-}> {}
-
-export class TaskDependencyError extends Data.TaggedError("TaskDependencyError")<{
-  readonly taskId: string;
-  readonly dependencyId: string;
-  readonly reason: string;
-  readonly suggestion?: string;
-}> {}
-
 // Automation Errors
 export class AutomationNotFoundError extends Data.TaggedError("AutomationNotFoundError")<{
   readonly automationId: string;
@@ -335,10 +308,6 @@ export type JazzError =
   | AgentAlreadyExistsError
   | AgentExecutionError
   | AgentConfigurationError
-  | TaskNotFoundError
-  | TaskExecutionError
-  | TaskTimeoutError
-  | TaskDependencyError
   | AutomationNotFoundError
   | AutomationExecutionError
   | TriggerError


### PR DESCRIPTION
## What & why

Removes four error classes that are never thrown. Their only trace was four unreachable branches in the error handler, which told users to run `jazz task list`, `jazz task run` and `jazz task deps` — commands that do not exist. Leftovers from a workflow-DAG design that was never built.

Clearing them also frees the name *Task*, which currently means four different things in jazz; the emptiest of the four goes first.

## How to verify
- `bun test` and `bun run typecheck` — nothing referenced these outside their own definitions.
- Trigger any real error (e.g. `jazz run --agent nope "hi"`) and confirm the handler still formats it with a title, suggestion and recovery steps.