### PR TITLE
perf(cli): defer the agent stack until a command runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "One agent. Every surface. Your rules.",
   "license": "MIT",
   "main": "dist/main.js",
-  "types": "dist/main.d.ts",
   "type": "module",
   "bin": {
     "jazz": "./dist/main.js"

--- a/scripts/build.test.ts
+++ b/scripts/build.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import packageJson from "../package.json";
+
+describe("npm package shape", () => {
+  it("does not publish TypeScript declarations", () => {
+    expect("types" in packageJson).toBe(false);
+    expect(packageJson.files.some((entry) => entry.includes(".d.ts"))).toBe(false);
+  });
+
+  it("ships every JS chunk under dist/", () => {
+    const coversChunks = packageJson.files.some(
+      (entry) =>
+        entry === "dist/" || entry === "dist" || entry === "dist/*.js" || entry === "dist/**/*.js",
+    );
+    expect(coversChunks).toBe(true);
+    expect(packageJson.bin.jazz).toBe("./dist/main.js");
+    expect(packageJson.main).toBe("dist/main.js");
+  });
+});

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -104,16 +104,79 @@ function resolveExternals(): string[] {
   return [...EXTERNAL_PACKAGES, ...OPTIONAL_RUNTIME_IMPORTS];
 }
 
+const HELP_PATH_MARKER = "Create and manage autonomous AI agents that execute real-world tasks";
+const APP_LAYER_MARKER = "Force exiting immediately. Some cleanup may be skipped.";
+
+function listDistJsFiles(outdir: string): string[] {
+  return fs
+    .readdirSync(outdir)
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+}
+
+function assertSplitNpmBundle(outdir: string): void {
+  const mainPath = path.join(outdir, "main.js");
+  if (!fs.existsSync(mainPath)) {
+    throw new Error(`Expected ${mainPath} after the npm bundle build.`);
+  }
+
+  const jsFiles = listDistJsFiles(outdir);
+  if (jsFiles.length < 2) {
+    throw new Error(
+      `Code splitting produced only ${jsFiles.length} JS file(s) in ${outdir}. --help would still parse the full bundle.`,
+    );
+  }
+
+  const dtsFiles = [
+    ...new Bun.Glob("**/*.{d.ts,d.ts.map}").scanSync({ cwd: outdir, onlyFiles: true }),
+  ];
+
+  if (dtsFiles.length > 0) {
+    throw new Error(`npm bundle must not emit declaration files, found: ${dtsFiles.join(", ")}`);
+  }
+
+  const mainSource = fs.readFileSync(mainPath, "utf8");
+  if (!mainSource.startsWith("#!/usr/bin/env node")) {
+    throw new Error(`${mainPath} is missing the node shebang.`);
+  }
+
+  const filesWithHelpPath = jsFiles.filter((name) =>
+    fs.readFileSync(path.join(outdir, name), "utf8").includes(HELP_PATH_MARKER),
+  );
+  const filesWithAppLayer = jsFiles.filter((name) =>
+    fs.readFileSync(path.join(outdir, name), "utf8").includes(APP_LAYER_MARKER),
+  );
+
+  if (filesWithHelpPath.length === 0) {
+    throw new Error("Help-path command tree marker was not found in any JS chunk.");
+  }
+  if (filesWithAppLayer.length === 0) {
+    throw new Error("App-layer marker was not found in any JS chunk.");
+  }
+
+  const overlap = filesWithHelpPath.filter((name) => filesWithAppLayer.includes(name));
+  if (overlap.length > 0) {
+    throw new Error(
+      `Help-path and app-layer share chunk(s): ${overlap.join(", ")}. Dynamic import() did not split the agent stack off --help.`,
+    );
+  }
+}
+
 function buildNpmBundle(): void {
   const banner = "#!/usr/bin/env node";
-  const outfile = "dist/main.js";
+  const outdir = "dist";
+  fs.rmSync(outdir, { recursive: true, force: true });
+  fs.mkdirSync(outdir, { recursive: true });
 
   const buildArgs = [
     "bun",
     "build",
     "src/entry.ts",
-    "--outfile",
-    outfile,
+    "--outdir",
+    outdir,
+    "--entry-naming",
+    "main.[ext]",
+    "--splitting",
     "--target",
     "node",
     "--minify",
@@ -132,10 +195,7 @@ function buildNpmBundle(): void {
   if (build.stderr.length > 0) process.stderr.write(build.stderr);
   if (build.exitCode !== 0) throw new Error(`Build failed with exit code ${build.exitCode}`);
 
-  const tsc = run(["bunx", "tsc", "--emitDeclarationOnly", "-p", "tsconfig.app.json"]);
-  if (tsc.stdout.length > 0) process.stdout.write(tsc.stdout);
-  if (tsc.stderr.length > 0) process.stderr.write(tsc.stderr);
-  if (tsc.exitCode !== 0) throw new Error(`TypeScript failed with exit code ${tsc.exitCode}`);
+  assertSplitNpmBundle(outdir);
 }
 
 /**

--- a/src/cli/cli-app.test.ts
+++ b/src/cli/cli-app.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "bun:test";
+import { createCLIApp } from "./cli-app";
+
+const CLI_APP_SOURCE = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "cli-app.ts"),
+  "utf8",
+);
+
+function staticImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importPattern = /^import(?:\s+type)?\s+[\s\S]*?from\s+["']([^"']+)["']/gm;
+  for (const match of source.matchAll(importPattern)) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+describe("createCLIApp help path", () => {
+  it("does not statically import the agent stack", () => {
+    const specifiers = staticImportSpecifiers(CLI_APP_SOURCE);
+    expect(specifiers).not.toContain("../app-layer");
+    expect(specifiers).not.toContain("./commands/run/execute");
+    expect(specifiers).not.toContain("./commands/media-agents");
+    expect(specifiers).not.toContain("./commands/agent-management");
+    expect(specifiers).not.toContain("./commands/chat-agent");
+    expect(specifiers).not.toContain("./commands/wizard");
+    expect(specifiers).not.toContain("./commands/workflow");
+    expect(specifiers).not.toContain("./commands/config");
+    expect(specifiers).not.toContain("./commands/mcp");
+    expect(specifiers).not.toContain("./commands/persona");
+    expect(specifiers).not.toContain("./commands/update");
+    expect(specifiers).not.toContain("./commands/create-agent");
+    expect(specifiers).not.toContain("./commands/edit-agent");
+    expect(specifiers).not.toContain("./commands/run/lifecycle");
+  });
+
+  it("registers the public command families", () => {
+    const program = createCLIApp();
+    const names = program.commands.map((command) => command.name());
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "agent",
+        "run",
+        "config",
+        "mcp",
+        "persona",
+        "update",
+        "runs",
+        "workflow",
+      ]),
+    );
+  });
+});

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -1,57 +1,12 @@
 import { Command } from "commander";
-import { Effect } from "effect";
 import packageJson from "../../package.json";
-import { runCliEffect } from "../app-layer";
-import {
-  deleteAgentCommand,
-  getAgentCommand,
-  listAgentsCommand,
-} from "./commands/agent-management";
-import { chatWithAIAgentCommand } from "./commands/chat-agent";
-import { getConfigCommand, listConfigCommand, setConfigCommand } from "./commands/config";
-import { createAgentCommand } from "./commands/create-agent";
-import { editAgentCommand } from "./commands/edit-agent";
-import {
-  addMcpServerCommand,
-  listMcpServersCommand,
-  removeMcpServerCommand,
-  enableMcpServerCommand,
-  disableMcpServerCommand,
-} from "./commands/mcp";
-import { isMediaCapability, MEDIA_CAPABILITIES } from "./commands/media-agents";
-import {
-  createPersonaCommand,
-  listPersonasCommand,
-  showPersonaCommand,
-  editPersonaCommand,
-  deletePersonaCommand,
-} from "./commands/persona";
-import { runAgentOnceCommand } from "./commands/run/execute";
+import { setCurrentCommandName } from "../core/utils/current-command";
 import {
   isApprovalPolicyFlag,
   isReasoningEffortFlag,
   parseEventCategories,
 } from "./commands/run/flags";
-import {
-  answerRunCommand,
-  cancelRunCommand,
-  listRunsCommand,
-  showRunCommand,
-} from "./commands/run/lifecycle";
-import { updateCommand } from "./commands/update";
-import { wizardCommand } from "./commands/wizard";
-import {
-  listWorkflowsCommand,
-  showWorkflowCommand,
-  runWorkflowCommand,
-  scheduleWorkflowCommand,
-  unscheduleWorkflowCommand,
-  listScheduledWorkflowsCommand,
-  catchupWorkflowCommand,
-  workflowHistoryCommand,
-} from "./commands/workflow";
 import { parsePositiveInt } from "./utils/option-parsers";
-import { setCurrentCommandName } from "../core/utils/current-command";
 
 /**
  * CLI Application setup and command registration
@@ -66,6 +21,51 @@ interface CliOptions {
   config?: string;
   output?: string;
   tui?: boolean;
+}
+
+interface CliRuntimeOptions {
+  readonly verbose?: boolean | undefined;
+  readonly debug?: boolean | undefined;
+  readonly configPath?: string | undefined;
+}
+
+interface CliRunOptions {
+  readonly skipCatchUp?: boolean;
+  readonly skipUpdateCheck?: boolean;
+}
+
+type AppLayerModule = typeof import("../app-layer");
+type CliCommandEffect = Parameters<AppLayerModule["runCliEffect"]>[0];
+
+const MEDIA_CAPABILITIES = ["image", "audio", "video"] as const;
+
+function isMediaCapability(value: string): value is (typeof MEDIA_CAPABILITIES)[number] {
+  return (MEDIA_CAPABILITIES as readonly string[]).includes(value);
+}
+
+function cliRuntimeOptions(program: Command): CliRuntimeOptions {
+  const opts = program.opts<CliOptions>();
+  return {
+    verbose: opts.verbose,
+    debug: opts.debug,
+    configPath: opts.config,
+  };
+}
+
+// Actions load the agent stack only when a command actually runs, so
+// `jazz --help` / `jazz --version` stay on the Commander tree.
+async function runCliAction(
+  loadEffect: () => Promise<CliCommandEffect>,
+  config: CliRuntimeOptions,
+  options?: CliRunOptions,
+): Promise<void> {
+  try {
+    const [{ runCliEffect }, effect] = await Promise.all([import("../app-layer"), loadEffect()]);
+    runCliEffect(effect, config, options);
+  } catch (error) {
+    console.error("Fatal error:", error);
+    throw error;
+  }
 }
 
 /** Build the full command path (`agent list`) by walking up to the root program. */
@@ -163,7 +163,6 @@ function registerRunCommand(program: Command): void {
           park?: boolean;
         },
       ) => {
-        const opts = program.opts<CliOptions>();
         const json = options.json === true;
 
         if (options.approvalPolicy !== undefined && !isApprovalPolicyFlag(options.approvalPolicy)) {
@@ -228,39 +227,41 @@ function registerRunCommand(program: Command): void {
           .map((name) => name.trim())
           .filter((name) => name.length > 0);
 
-        runCliEffect(
-          runAgentOnceCommand(options.agent, prompt, {
-            json,
-            ...(options.approvalPolicy !== undefined && isApprovalPolicyFlag(options.approvalPolicy)
-              ? { approvalPolicy: options.approvalPolicy }
-              : {}),
-            ...(autoApproveTools && autoApproveTools.length > 0
-              ? { autoApprovedTools: autoApproveTools }
-              : {}),
-            ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
-            ...(options.reasoning !== undefined && isReasoningEffortFlag(options.reasoning)
-              ? { reasoningEffort: options.reasoning }
-              : {}),
-            ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
-            ...(options.maxIterations !== undefined
-              ? { maxIterations: options.maxIterations }
-              : {}),
-            ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
-            ...(options.conversation !== undefined ? { conversationId: options.conversation } : {}),
-            ...(options.noStream === true
-              ? { stream: false }
-              : options.stream === true
-                ? { stream: true }
-                : {}),
-            ...(options.ephemeral === true ? { ephemeral: true } : {}),
-            ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
-            ...(options.park === true ? { park: true } : {}),
-          }),
-          {
-            verbose: opts.verbose,
-            debug: opts.debug,
-            configPath: opts.config,
-          },
+        return runCliAction(
+          () =>
+            import("./commands/run/execute").then((mod) =>
+              mod.runAgentOnceCommand(options.agent, prompt, {
+                json,
+                ...(options.approvalPolicy !== undefined &&
+                isApprovalPolicyFlag(options.approvalPolicy)
+                  ? { approvalPolicy: options.approvalPolicy }
+                  : {}),
+                ...(autoApproveTools && autoApproveTools.length > 0
+                  ? { autoApprovedTools: autoApproveTools }
+                  : {}),
+                ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
+                ...(options.reasoning !== undefined && isReasoningEffortFlag(options.reasoning)
+                  ? { reasoningEffort: options.reasoning }
+                  : {}),
+                ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+                ...(options.maxIterations !== undefined
+                  ? { maxIterations: options.maxIterations }
+                  : {}),
+                ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
+                ...(options.conversation !== undefined
+                  ? { conversationId: options.conversation }
+                  : {}),
+                ...(options.noStream === true
+                  ? { stream: false }
+                  : options.stream === true
+                    ? { stream: true }
+                    : {}),
+                ...(options.ephemeral === true ? { ephemeral: true } : {}),
+                ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
+                ...(options.park === true ? { park: true } : {}),
+              }),
+            ),
+          cliRuntimeOptions(program),
           { skipCatchUp: true, skipUpdateCheck: true },
         );
       },
@@ -282,7 +283,6 @@ function registerAgentCommands(program: Command): void {
       "Only agents whose model can generate this: image, audio, or video. Shows how to get one when none can.",
     )
     .action((commandOptions: { can?: string }) => {
-      const opts = program.opts<CliOptions>();
       const requested = commandOptions.can;
       if (requested !== undefined && !isMediaCapability(requested)) {
         console.error(
@@ -291,48 +291,44 @@ function registerAgentCommands(program: Command): void {
         process.exitCode = 1;
         return;
       }
-      runCliEffect(listAgentsCommand(requested ? { can: requested } : {}), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
+      return runCliAction(
+        () =>
+          import("./commands/agent-management").then((mod) =>
+            mod.listAgentsCommand(requested ? { can: requested } : {}),
+          ),
+        cliRuntimeOptions(program),
+      );
     });
 
   agentCommand
     .command("create")
     .description("Create a new agent (interactive mode)")
-    .action(() => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(createAgentCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action(() =>
+      runCliAction(
+        () => import("./commands/create-agent").then((mod) => mod.createAgentCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   agentCommand
     .command("show <agentId>")
     .description("Get an agent details")
-    .action((agentId: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(getAgentCommand(agentId), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((agentId: string) =>
+      runCliAction(
+        () => import("./commands/agent-management").then((mod) => mod.getAgentCommand(agentId)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   agentCommand
     .command("edit <agentId>")
     .description("Edit an existing agent")
-    .action((agentId: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(editAgentCommand(agentId), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((agentId: string) =>
+      runCliAction(
+        () => import("./commands/edit-agent").then((mod) => mod.editAgentCommand(agentId)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   agentCommand
     .command("delete <agentId>")
@@ -341,19 +337,17 @@ function registerAgentCommands(program: Command): void {
     .description("Delete an agent")
     .option("-y, --yes", "Delete without asking for confirmation")
     .option("-f, --force", "Alias for --yes")
-    .action((agentId: string, options: { yes?: boolean; force?: boolean }) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(
-        deleteAgentCommand(agentId, {
-          skipConfirmation: options.yes === true || options.force === true,
-        }),
-        {
-          verbose: opts.verbose,
-          debug: opts.debug,
-          configPath: opts.config,
-        },
-      );
-    });
+    .action((agentId: string, options: { yes?: boolean; force?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/agent-management").then((mod) =>
+            mod.deleteAgentCommand(agentId, {
+              skipConfirmation: options.yes === true || options.force === true,
+            }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   agentCommand
     .command("chat <agentIdentifier>")
@@ -379,22 +373,20 @@ function registerAgentCommands(program: Command): void {
           ephemeral?: boolean;
         },
       ) => {
-        const opts = program.opts<CliOptions>();
         const streamOption =
           options.noStream === true ? false : options.stream === true ? true : undefined;
-        runCliEffect(
-          chatWithAIAgentCommand(agentIdentifier, {
-            ...(streamOption !== undefined ? { stream: streamOption } : {}),
-            ...(options.maxIterations !== undefined
-              ? { maxIterations: options.maxIterations }
-              : {}),
-            ...(options.ephemeral === true ? { ephemeral: true } : {}),
-          }),
-          {
-            verbose: opts.verbose,
-            debug: opts.debug,
-            configPath: opts.config,
-          },
+        return runCliAction(
+          () =>
+            import("./commands/chat-agent").then((mod) =>
+              mod.chatWithAIAgentCommand(agentIdentifier, {
+                ...(streamOption !== undefined ? { stream: streamOption } : {}),
+                ...(options.maxIterations !== undefined
+                  ? { maxIterations: options.maxIterations }
+                  : {}),
+                ...(options.ephemeral === true ? { ephemeral: true } : {}),
+              }),
+            ),
+          cliRuntimeOptions(program),
         );
       },
     );
@@ -409,38 +401,32 @@ function registerConfigCommands(program: Command): void {
   configCommand
     .command("get <key>")
     .description("Get a configuration value")
-    .action((key: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(getConfigCommand(key), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((key: string) =>
+      runCliAction(
+        () => import("./commands/config").then((mod) => mod.getConfigCommand(key)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   configCommand
     .command("set <key> [value]")
     .description("Set a configuration value")
-    .action((key: string, value?: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(setConfigCommand(key, value), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((key: string, value?: string) =>
+      runCliAction(
+        () => import("./commands/config").then((mod) => mod.setConfigCommand(key, value)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   configCommand
     .command("show")
     .description("Show all configuration values")
-    .action(() => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(listConfigCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action(() =>
+      runCliAction(
+        () => import("./commands/config").then((mod) => mod.listConfigCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
 }
 
 /**
@@ -449,44 +435,41 @@ function registerConfigCommands(program: Command): void {
 function registerMCPCommands(program: Command): void {
   const mcpCommand = program.command("mcp").description("Manage MCP servers");
 
-  const run = <R, E extends Error>(effect: Effect.Effect<void, E, R>) => {
-    const opts = program.opts<CliOptions>();
-    runCliEffect(effect, {
-      verbose: opts.verbose,
-      debug: opts.debug,
-      configPath: opts.config,
-    });
-  };
+  function run(loadEffect: () => Promise<CliCommandEffect>): Promise<void> {
+    return runCliAction(loadEffect, cliRuntimeOptions(program));
+  }
 
   mcpCommand
     .command("add [json]")
     .description("Add an MCP server from JSON (inline, --file, or interactive)")
     .option("-f, --file <path>", "Read MCP server JSON from a file")
-    .action((json?: string, options?: { file?: string }) => {
-      run(addMcpServerCommand(json, options?.file));
-    });
+    .action((json?: string, options?: { file?: string }) =>
+      run(() =>
+        import("./commands/mcp").then((mod) => mod.addMcpServerCommand(json, options?.file)),
+      ),
+    );
 
   mcpCommand
     .command("list")
     .alias("ls")
     .description("List all configured MCP servers")
-    .action(() => run(listMcpServersCommand()));
+    .action(() => run(() => import("./commands/mcp").then((mod) => mod.listMcpServersCommand())));
 
   mcpCommand
     .command("remove")
     .alias("rm")
     .description("Remove an MCP server")
-    .action(() => run(removeMcpServerCommand()));
+    .action(() => run(() => import("./commands/mcp").then((mod) => mod.removeMcpServerCommand())));
 
   mcpCommand
     .command("enable")
     .description("Enable a disabled MCP server")
-    .action(() => run(enableMcpServerCommand()));
+    .action(() => run(() => import("./commands/mcp").then((mod) => mod.enableMcpServerCommand())));
 
   mcpCommand
     .command("disable")
     .description("Disable an enabled MCP server")
-    .action(() => run(disableMcpServerCommand()));
+    .action(() => run(() => import("./commands/mcp").then((mod) => mod.disableMcpServerCommand())));
 }
 
 /**
@@ -495,41 +478,44 @@ function registerMCPCommands(program: Command): void {
 function registerPersonaCommands(program: Command): void {
   const personaCommand = program.command("persona").description("Manage personas");
 
-  const run = <R, E extends Error>(effect: Effect.Effect<void, E, R>) => {
-    const opts = program.opts<CliOptions>();
-    runCliEffect(effect, {
-      verbose: opts.verbose,
-      debug: opts.debug,
-      configPath: opts.config,
-    });
-  };
+  function run(loadEffect: () => Promise<CliCommandEffect>): Promise<void> {
+    return runCliAction(loadEffect, cliRuntimeOptions(program));
+  }
 
   personaCommand
     .command("create")
     .description("Create a new custom persona (interactive)")
-    .action(() => run(createPersonaCommand()));
+    .action(() =>
+      run(() => import("./commands/persona").then((mod) => mod.createPersonaCommand())),
+    );
 
   personaCommand
     .command("list")
     .alias("ls")
     .description("List all personas (built-in + custom)")
-    .action(() => run(listPersonasCommand()));
+    .action(() => run(() => import("./commands/persona").then((mod) => mod.listPersonasCommand())));
 
   personaCommand
     .command("show <identifier>")
     .description("Show details of a persona by name or ID")
-    .action((identifier: string) => run(showPersonaCommand(identifier)));
+    .action((identifier: string) =>
+      run(() => import("./commands/persona").then((mod) => mod.showPersonaCommand(identifier))),
+    );
 
   personaCommand
     .command("edit <identifier>")
     .description("Edit an existing custom persona")
-    .action((identifier: string) => run(editPersonaCommand(identifier)));
+    .action((identifier: string) =>
+      run(() => import("./commands/persona").then((mod) => mod.editPersonaCommand(identifier))),
+    );
 
   personaCommand
     .command("delete <identifier>")
     .alias("rm")
     .description("Delete a custom persona")
-    .action((identifier: string) => run(deletePersonaCommand(identifier)));
+    .action((identifier: string) =>
+      run(() => import("./commands/persona").then((mod) => mod.deletePersonaCommand(identifier))),
+    );
 }
 
 /**
@@ -541,14 +527,12 @@ function registerUpdateCommand(program: Command): void {
     .alias("upgrade")
     .description("Update Jazz to the latest version")
     .option("--check", "Check for updates without installing")
-    .action((options: { check?: boolean }) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(updateCommand(options), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((options: { check?: boolean }) =>
+      runCliAction(
+        () => import("./commands/update").then((mod) => mod.updateCommand(options)),
+        cliRuntimeOptions(program),
+      ),
+    );
 }
 
 /**
@@ -558,11 +542,6 @@ function registerRunsCommands(program: Command): void {
   const runsCommand = program
     .command("runs")
     .description("Inspect runs still in flight, and answer the ones waiting on you");
-
-  const cliOptionsOf = () => {
-    const opts = program.opts<CliOptions>();
-    return { verbose: opts.verbose, debug: opts.debug, configPath: opts.config };
-  };
 
   runsCommand
     .command("list")
@@ -575,25 +554,36 @@ function registerRunsCommands(program: Command): void {
       "Include runs that already finished, with what they cost. Records are kept for 7 days.",
     )
     .option("--json", "Emit a single JSON envelope { ok, runs }")
-    .action((options: { agent?: string; conversation?: string; all?: boolean; json?: boolean }) => {
-      runCliEffect(
-        listRunsCommand({
-          json: options.json === true,
-          ...(options.agent !== undefined ? { agentId: options.agent } : {}),
-          ...(options.conversation !== undefined ? { conversationId: options.conversation } : {}),
-          ...(options.all === true ? { all: true } : {}),
-        }),
-        cliOptionsOf(),
-      );
-    });
+    .action((options: { agent?: string; conversation?: string; all?: boolean; json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/run/lifecycle").then((mod) =>
+            mod.listRunsCommand({
+              json: options.json === true,
+              ...(options.agent !== undefined ? { agentId: options.agent } : {}),
+              ...(options.conversation !== undefined
+                ? { conversationId: options.conversation }
+                : {}),
+              ...(options.all === true ? { all: true } : {}),
+            }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   runsCommand
     .command("show <runId>")
     .description("Show one run, including what it is waiting for")
     .option("--json", "Emit a single JSON envelope { ok, run }")
-    .action((runId: string, options: { json?: boolean }) => {
-      runCliEffect(showRunCommand({ runId, json: options.json === true }), cliOptionsOf());
-    });
+    .action((runId: string, options: { json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/run/lifecycle").then((mod) =>
+            mod.showRunCommand({ runId, json: options.json === true }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   runsCommand
     .command("approve <runId>")
@@ -601,12 +591,15 @@ function registerRunsCommands(program: Command): void {
       "Approve what a parked run is waiting for and let it finish (blocks until it does)",
     )
     .option("--json", "Emit a single JSON envelope { ok, runId, answer }")
-    .action((runId: string, options: { json?: boolean }) => {
-      runCliEffect(
-        answerRunCommand({ runId, approved: true, json: options.json === true }),
-        cliOptionsOf(),
-      );
-    });
+    .action((runId: string, options: { json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/run/lifecycle").then((mod) =>
+            mod.answerRunCommand({ runId, approved: true, json: options.json === true }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   runsCommand
     .command("reject <runId>")
@@ -615,25 +608,34 @@ function registerRunsCommands(program: Command): void {
     )
     .option("--note <text>", "Tell the agent why, so it can try something else")
     .option("--json", "Emit a single JSON envelope { ok, runId, answer }")
-    .action((runId: string, options: { note?: string; json?: boolean }) => {
-      runCliEffect(
-        answerRunCommand({
-          runId,
-          approved: false,
-          json: options.json === true,
-          ...(options.note !== undefined ? { note: options.note } : {}),
-        }),
-        cliOptionsOf(),
-      );
-    });
+    .action((runId: string, options: { note?: string; json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/run/lifecycle").then((mod) =>
+            mod.answerRunCommand({
+              runId,
+              approved: false,
+              json: options.json === true,
+              ...(options.note !== undefined ? { note: options.note } : {}),
+            }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   runsCommand
     .command("cancel <runId>")
     .description("Abandon a parked run without answering it")
     .option("--json", "Emit a single JSON envelope { ok, runId }")
-    .action((runId: string, options: { json?: boolean }) => {
-      runCliEffect(cancelRunCommand({ runId, json: options.json === true }), cliOptionsOf());
-    });
+    .action((runId: string, options: { json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/run/lifecycle").then((mod) =>
+            mod.cancelRunCommand({ runId, json: options.json === true }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
 }
 
 /**
@@ -646,26 +648,22 @@ function registerWorkflowCommands(program: Command): void {
     .command("list")
     .alias("ls")
     .description("List all available workflows")
-    .action(() => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(listWorkflowsCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action(() =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.listWorkflowsCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("show <name>")
     .description("Show details of a workflow")
-    .action((name: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(showWorkflowCommand(name), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((name: string) =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.showWorkflowCommand(name)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("run <name>")
@@ -708,7 +706,6 @@ function registerWorkflowCommands(program: Command): void {
         },
         command: Command,
       ) => {
-        const opts = program.opts<CliOptions>();
         const json = options.json === true;
         const isWorkflowRunCommand =
           command.name() === "run" && command.parent?.name() === "workflow";
@@ -737,17 +734,16 @@ function registerWorkflowCommands(program: Command): void {
           process.env["JAZZ_NO_TUI"] = "1";
         }
 
-        runCliEffect(
-          runWorkflowCommand(name, {
-            ...options,
-            ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
-            ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
-          }),
-          {
-            verbose: opts.verbose,
-            debug: opts.debug,
-            configPath: opts.config,
-          },
+        return runCliAction(
+          () =>
+            import("./commands/workflow").then((mod) =>
+              mod.runWorkflowCommand(name, {
+                ...options,
+                ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+                ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
+              }),
+            ),
+          cliRuntimeOptions(program),
           { skipCatchUp: isWorkflowRunCommand, skipUpdateCheck: json },
         );
       },
@@ -756,62 +752,52 @@ function registerWorkflowCommands(program: Command): void {
   workflowCommand
     .command("schedule <name>")
     .description("Enable scheduled execution for a workflow")
-    .action((name: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(scheduleWorkflowCommand(name), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((name: string) =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.scheduleWorkflowCommand(name)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("unschedule <name>")
     .description("Disable scheduled execution for a workflow")
-    .action((name: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(unscheduleWorkflowCommand(name), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((name: string) =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.unscheduleWorkflowCommand(name)),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("scheduled")
     .description("List all scheduled workflows")
-    .action(() => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(listScheduledWorkflowsCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action(() =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.listScheduledWorkflowsCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("catchup")
     .description("List workflows that missed a scheduled run, select which to run, then run them")
-    .action(() => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(catchupWorkflowCommand(), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action(() =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.catchupWorkflowCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
 
   workflowCommand
     .command("history [name]")
     .description("Show workflow run history")
-    .action((name?: string) => {
-      const opts = program.opts<CliOptions>();
-      runCliEffect(workflowHistoryCommand(name), {
-        verbose: opts.verbose,
-        debug: opts.debug,
-        configPath: opts.config,
-      });
-    });
+    .action((name?: string) =>
+      runCliAction(
+        () => import("./commands/workflow").then((mod) => mod.workflowHistoryCommand(name)),
+        cliRuntimeOptions(program),
+      ),
+    );
 }
 
 /**
@@ -822,67 +808,55 @@ function registerWorkflowCommands(program: Command): void {
  * - Configuration management (get, set, show)
  * - MCP server management
  * - Update command
- *
- * @returns An Effect that creates the configured Commander program
  */
-export function createCLIApp(): Effect.Effect<Command, never> {
-  return Effect.sync(() => {
-    const program = new Command();
+export function createCLIApp(): Command {
+  const program = new Command();
 
-    program
-      .name("jazz")
-      .description(
-        "Create and manage autonomous AI agents that execute real-world tasks (email, git, web, shell, and more)",
-      )
-      .version(packageJson.version);
+  program
+    .name("jazz")
+    .description(
+      "Create and manage autonomous AI agents that execute real-world tasks (email, git, web, shell, and more)",
+    )
+    .version(packageJson.version);
 
-    // Global options
-    program
-      .option("-v, --verbose", "Enable verbose logging")
-      .option("--debug", "Enable debug level logging")
-      .option("--config <path>", "Path to configuration file")
-      .option(
-        "--no-tui",
-        "Disable TUI; use plain terminal output (for CI, scripts, small terminals)",
-      )
-      .option(
-        "--output <mode>",
-        "Output mode: rendered, hybrid (default), raw (no formatting), or quiet (suppress output)",
-      );
+  program
+    .option("-v, --verbose", "Enable verbose logging")
+    .option("--debug", "Enable debug level logging")
+    .option("--config <path>", "Path to configuration file")
+    .option("--no-tui", "Disable TUI; use plain terminal output (for CI, scripts, small terminals)")
+    .option(
+      "--output <mode>",
+      "Output mode: rendered, hybrid (default), raw (no formatting), or quiet (suppress output)",
+    );
 
-    // Apply global options before any command runs
-    program.hook("preAction", (thisCommand, actionCommand) => {
-      const opts = thisCommand.optsWithGlobals();
-      if (opts["tui"] === false) {
-        process.env["JAZZ_NO_TUI"] = "1";
-      }
-      if (opts["output"]) {
-        process.env["JAZZ_OUTPUT_MODE"] = opts["output"] as string;
-      }
-      setCurrentCommandName(commandPath(actionCommand));
-    });
-
-    // Register all commands
-    registerRunCommand(program);
-    registerAgentCommands(program);
-    registerPersonaCommands(program);
-    registerConfigCommands(program);
-    registerMCPCommands(program);
-    registerUpdateCommand(program);
-    registerRunsCommands(program);
-    registerWorkflowCommands(program);
-
-    if (process.argv.length <= 2) {
-      program.action(() => {
-        const opts = program.opts<CliOptions>();
-        runCliEffect(wizardCommand(), {
-          verbose: opts.verbose,
-          debug: opts.debug,
-          configPath: opts.config,
-        });
-      });
+  program.hook("preAction", (thisCommand, actionCommand) => {
+    const opts = thisCommand.optsWithGlobals();
+    if (opts["tui"] === false) {
+      process.env["JAZZ_NO_TUI"] = "1";
     }
-
-    return program;
+    if (opts["output"]) {
+      process.env["JAZZ_OUTPUT_MODE"] = opts["output"] as string;
+    }
+    setCurrentCommandName(commandPath(actionCommand));
   });
+
+  registerRunCommand(program);
+  registerAgentCommands(program);
+  registerPersonaCommands(program);
+  registerConfigCommands(program);
+  registerMCPCommands(program);
+  registerUpdateCommand(program);
+  registerRunsCommands(program);
+  registerWorkflowCommands(program);
+
+  if (process.argv.length <= 2) {
+    program.action(() =>
+      runCliAction(
+        () => import("./commands/wizard").then((mod) => mod.wizardCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
+  }
+
+  return program;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import { Effect } from "effect";
 import { createCLIApp } from "./cli/cli-app";
 
 // The `ai` SDK's default warning logger writes its one-time banner via console.info, which is
@@ -17,26 +16,22 @@ globalThis.AI_SDK_LOG_WARNINGS = (options) => {
 /**
  * Main entry point for the Jazz CLI
  */
+async function main(): Promise<void> {
+  // Eval-only, env-gated: install a deterministic fetch record/replay wrapper
+  // before any tool can run. Dynamic import keeps this zero-cost in normal runs.
+  if (process.env["JAZZ_WEB_CASSETTE"]) {
+    const { installWebCassette } = await import("./core/eval/web-cassette");
+    installWebCassette(
+      process.env["JAZZ_WEB_CASSETTE"],
+      process.env["JAZZ_WEB_MODE"] === "record" ? "record" : "replay",
+    );
+  }
 
-function main(): Effect.Effect<void, never> {
-  return Effect.gen(function* () {
-    // Eval-only, env-gated: install a deterministic fetch record/replay wrapper
-    // before any tool can run. Dynamic import keeps this zero-cost in normal runs.
-    if (process.env["JAZZ_WEB_CASSETTE"]) {
-      const { installWebCassette } = yield* Effect.promise(
-        () => import("./core/eval/web-cassette"),
-      );
-      installWebCassette(
-        process.env["JAZZ_WEB_CASSETTE"],
-        process.env["JAZZ_WEB_MODE"] === "record" ? "record" : "replay",
-      );
-    }
-    const program = yield* createCLIApp();
-    program.parse();
-  });
+  const program = createCLIApp();
+  program.parse();
 }
 
-Effect.runPromise(main()).catch((error) => {
+main().catch((error) => {
   console.error("Fatal error:", error);
   throw error;
 });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": ".tsbuild/app",
     "rootDir": "./src",
     "sourceMap": true,
     "declarationMap": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -13,6 +13,7 @@
     "test-preload.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
+    "scripts/**/*.test.ts",
     "evals/**/*.test.ts",
     "integrations/**/*.test.ts"
   ],


### PR DESCRIPTION
## What & why
`jazz --help` / `--version` / `jazz run --help` dropped from ~1s to ~40–50ms because they no longer parse the agent stack. The npm package no longer ships hundreds of unused `.d.ts` files.

## How to verify
- `npm pack --dry-run` (or inspect `dist/` after `bun run build`): JS chunks present, no `.d.ts` / `.d.ts.map`.
- `node dist/main.js --help` and `--version` print correctly and feel instant (~50ms).
- `node dist/main.js run --help` still lists run flags.
- `node dist/main.js` (no args) still launches the wizard/TUI — this path still loads the full stack.
- A real command still works (`jazz --version` is not enough for this bullet — `jazz agent list` or `jazz config show`).
