### PR TITLE
perf(ui): keep transcript blocks stable across tick and draft

### DIFF
--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -6,7 +6,7 @@ import {
   useSelectionHandler,
   useTerminalDimensions,
 } from "@opentui/react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
 import {
@@ -40,7 +40,14 @@ import { Search } from "./overlays/Search";
 import { TextPrompt } from "./overlays/TextPrompt";
 import { Transcript, type TranscriptHandle } from "./Transcript";
 import { allocateRegions, wheelScrollDelta } from "./transcript-window";
-import { MIN_HEIGHT, MIN_WIDTH, type Focus, type Overlay, type ViewModel } from "./types";
+import {
+  MIN_HEIGHT,
+  MIN_WIDTH,
+  type Focus,
+  type Overlay,
+  type ViewModel,
+  type Viewport,
+} from "./types";
 
 /**
  * The shell: five stacked regions and a floating overlay layer.
@@ -181,6 +188,11 @@ function renderOverlay(
         />
       );
   }
+}
+
+export function reuseViewport(width: number, height: number, previous: Viewport): Viewport {
+  if (previous.width === width && previous.height === height) return previous;
+  return { width, height };
 }
 
 export function App({
@@ -432,6 +444,33 @@ export function App({
     void copyText(textFromSelection(selection), rendererRef.current).then(announceCopy);
   });
 
+  const viewportRef = useRef<Viewport>({ width, height });
+  viewportRef.current = reuseViewport(width, height, viewportRef.current);
+  const viewport = viewportRef.current;
+  const inputModel = useMemo(
+    () => ({ ...view.input, disabled: view.input.disabled || overlayOpen }),
+    [view.input, overlayOpen],
+  );
+  const footerHints = useMemo(
+    () =>
+      hintsFor(
+        focus,
+        view.runActive === true,
+        view.input.queueing === true,
+        view.overlay?.kind,
+        view.input.commands !== undefined,
+      ),
+    [focus, view.runActive, view.input.queueing, view.overlay?.kind, view.input.commands],
+  );
+  const footer = useMemo(
+    () => ({
+      ...view.footer,
+      hints: footerHints,
+      ...(copyNotice === undefined ? {} : { notice: copyNotice }),
+    }),
+    [view.footer, footerHints, copyNotice],
+  );
+
   if (overrideContent !== undefined) {
     return overrideContent;
   }
@@ -445,9 +484,7 @@ export function App({
     );
   }
 
-  const viewport = { width, height };
   const inputFocused = focus === "input" && !overlayOpen;
-  const inputModel = { ...view.input, disabled: view.input.disabled || overlayOpen };
   // One allocation, shared by all three regions. Computing the transcript's
   // share here and letting the other two size themselves independently is how
   // the rows stopped adding up to more than the terminal has.
@@ -458,17 +495,6 @@ export function App({
     inputFocused,
   });
   const visibleCount = regions.transcript;
-  const footer = {
-    ...view.footer,
-    hints: hintsFor(
-      focus,
-      view.runActive === true,
-      view.input.queueing === true,
-      view.overlay?.kind,
-      view.input.commands !== undefined,
-    ),
-    ...(copyNotice === undefined ? {} : { notice: copyNotice }),
-  };
 
   return (
     <box

--- a/src/cli/ui/fullscreen/Footer.tsx
+++ b/src/cli/ui/fullscreen/Footer.tsx
@@ -12,7 +12,7 @@
  * stop.
  */
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
 import { fitTerminalSegments, terminalCellWidth, terminalSegmentsWidth } from "./terminal-cells";
@@ -113,7 +113,7 @@ export function footerSegments(model: FooterModel, viewport: Viewport): readonly
   return [...fittedLeft, ...padding, ...right];
 }
 
-export function Footer({ model, viewport }: { model: FooterModel; viewport: Viewport }): ReactNode {
+function FooterView({ model, viewport }: { model: FooterModel; viewport: Viewport }): ReactNode {
   const segments = footerSegments(model, viewport);
   return (
     <box style={{ width: viewport.width, height: 1, flexShrink: 0 }}>
@@ -130,3 +130,5 @@ export function Footer({ model, viewport }: { model: FooterModel; viewport: View
     </box>
   );
 }
+
+export const Footer = memo(FooterView);

--- a/src/cli/ui/fullscreen/Header.tsx
+++ b/src/cli/ui/fullscreen/Header.tsx
@@ -11,7 +11,7 @@
  * connector needs something from you.
  */
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { getGlyphs, type GlyphSet } from "../glyphs";
 import { THEME } from "../theme";
 import { fitTerminalSegments, terminalCellWidth, terminalSegmentsWidth } from "./terminal-cells";
@@ -143,7 +143,7 @@ export function headerSegments(model: HeaderModel, viewport: Viewport): readonly
   return [...left, ...padding, ...right];
 }
 
-export function Header({ model, viewport }: { model: HeaderModel; viewport: Viewport }): ReactNode {
+function HeaderView({ model, viewport }: { model: HeaderModel; viewport: Viewport }): ReactNode {
   const segments = headerSegments(model, viewport);
   return (
     <box style={{ width: viewport.width, height: 1, flexShrink: 0 }}>
@@ -160,3 +160,5 @@ export function Header({ model, viewport }: { model: HeaderModel; viewport: View
     </box>
   );
 }
+
+export const Header = memo(HeaderView);

--- a/src/cli/ui/fullscreen/Input.tsx
+++ b/src/cli/ui/fullscreen/Input.tsx
@@ -40,7 +40,7 @@
  * region paints both without changing shape.
  */
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { getGlyphs, type GlyphSet } from "../glyphs";
 import { carouselWindow, wrapIndex } from "../picker-window";
 import { THEME } from "../theme";
@@ -395,7 +395,7 @@ export function inputRows(
   return [...commandSuggestRows(model.commands, width, glyphs, listSize), ...rows];
 }
 
-export function Input({ model, viewport, focused, maxRows }: InputProps): ReactNode {
+function InputView({ model, viewport, focused, maxRows }: InputProps): ReactNode {
   const rows = inputRows(model, viewport, focused ?? !model.disabled, undefined, maxRows);
 
   return (
@@ -430,3 +430,5 @@ export function Input({ model, viewport, focused, maxRows }: InputProps): ReactN
     </box>
   );
 }
+
+export const Input = memo(InputView);

--- a/src/cli/ui/fullscreen/LiveZone.tsx
+++ b/src/cli/ui/fullscreen/LiveZone.tsx
@@ -288,7 +288,15 @@ export function liveRows(
 
   const rows: LiveRow[] = [];
   if (showWaiting && model.waiting !== undefined) {
-    rows.push(waitingRow(model.waiting, model.elapsedMs, model.tick, glyphs, width));
+    rows.push(
+      waitingRow(
+        model.waiting,
+        model.reasoningElapsedMs ?? model.elapsedMs,
+        model.tick,
+        glyphs,
+        width,
+      ),
+    );
   }
   if (showStep && model.step !== undefined) {
     rows.push(

--- a/src/cli/ui/fullscreen/LiveZone.tsx
+++ b/src/cli/ui/fullscreen/LiveZone.tsx
@@ -33,7 +33,7 @@
  * running rather than one thing blinking three times.
  */
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { highlightCodeLine } from "./syntax-spans";
 import { getGlyphs, laneFrame, type GlyphSet } from "../glyphs";
 import { THEME } from "../theme";
@@ -307,7 +307,7 @@ export function liveRows(
   return rows;
 }
 
-export function LiveZone({ model, viewport, streaming, maxRows }: LiveZoneProps): ReactNode {
+function LiveZoneView({ model, viewport, streaming, maxRows }: LiveZoneProps): ReactNode {
   const height = reservedHeight(model, maxRows);
   const rows = liveRows(model, viewport, streaming ?? false, undefined, maxRows);
 
@@ -347,3 +347,5 @@ export function LiveZone({ model, viewport, streaming, maxRows }: LiveZoneProps)
     </box>
   );
 }
+
+export const LiveZone = memo(LiveZoneView);

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -94,13 +94,13 @@ interface InlineMarks {
   readonly strikethrough?: boolean;
 }
 
-function sameInlineStyle(left: Segment, right: Segment): boolean {
+function sameInlineStyle(previous: Segment, current: Segment): boolean {
   return (
-    left.fg === right.fg &&
-    left.bold === right.bold &&
-    left.italic === right.italic &&
-    left.underline === right.underline &&
-    left.strikethrough === right.strikethrough
+    previous.fg === current.fg &&
+    previous.bold === current.bold &&
+    previous.italic === current.italic &&
+    previous.underline === current.underline &&
+    previous.strikethrough === current.strikethrough
   );
 }
 

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -34,7 +34,15 @@
  */
 
 import { TextAttributes } from "@opentui/core";
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  forwardRef,
+  memo,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { isFileMutationTool } from "@/core/utils/tool-formatter";
 import {
   highlightCodeLine,
@@ -1288,7 +1296,7 @@ export interface TranscriptHandle {
   scrollBy(delta: number, unit?: "line" | "page" | "end"): void;
 }
 
-export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function Transcript(
+const TranscriptView = forwardRef<TranscriptHandle, TranscriptProps>(function Transcript(
   { blocks, viewport, focus, newBelow, followLive = true, visibleCount },
   ref,
 ): ReactNode {
@@ -1296,10 +1304,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function
   // shell re-renders on each streaming delta, each keystroke and a ~6Hz tick,
   // so without this the cost of a frame grows with the length of the whole
   // conversation rather than with what changed.
-  const rows = useMemo(
-    () => transcriptRows(blocks, viewport),
-    [blocks, viewport.width, viewport.height],
-  );
+  const rows = useMemo(() => transcriptRows(blocks, viewport), [blocks, viewport.width]);
   const page = pageWidth(viewport);
   const windowHeight =
     visibleCount === undefined ? Math.max(1, viewport.height) : Math.max(0, visibleCount);
@@ -1404,3 +1409,5 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function
     </box>
   );
 });
+
+export const Transcript = memo(TranscriptView);

--- a/src/cli/ui/fullscreen/app.test.tsx
+++ b/src/cli/ui/fullscreen/app.test.tsx
@@ -16,7 +16,7 @@ import { describe, expect, it } from "bun:test";
 import React, { useState } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
-import { App } from "./App";
+import { App, reuseViewport } from "./App";
 import { isPrintableSequence } from "./keymap";
 import {
   sampleApprovalView,
@@ -505,6 +505,17 @@ function CompletedTurnApp(): React.ReactNode {
     />
   );
 }
+
+describe("stable viewport identity", () => {
+  it("reuses the previous object when width and height are unchanged", () => {
+    const first = reuseViewport(120, 34, { width: 0, height: 0 });
+    const same = reuseViewport(120, 34, first);
+    const resized = reuseViewport(80, 34, same);
+    expect(same).toBe(first);
+    expect(resized).not.toBe(first);
+    expect(resized).toEqual({ width: 80, height: 34 });
+  });
+});
 
 describe("composer after a completed turn", () => {
   it("stays on screen and shows the next typed character", async () => {

--- a/src/cli/ui/fullscreen/bridge-blocks.test.ts
+++ b/src/cli/ui/fullscreen/bridge-blocks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import type { EphemeralRegion } from "../store";
+import type { OutputEntry } from "../types";
+import { blocksFrom, shareUnchangedBlocks, transcriptBlocks } from "./bridge";
+
+const USER: OutputEntry = {
+  id: "u1",
+  type: "user",
+  message: "what is on Thursday",
+  timestamp: new Date("2026-08-23T12:00:00.000Z"),
+};
+
+const AGENT: OutputEntry = {
+  id: "a1",
+  type: "streamContent",
+  message: "Thursday is free after 3.",
+  timestamp: new Date("2026-08-23T12:00:01.000Z"),
+};
+
+const EMPTY_REGIONS: readonly EphemeralRegion[] = [];
+
+describe("transcript block identity", () => {
+  it("incrementing tick or editing draft does not change blocks referential identity", () => {
+    const sources = { outputs: [USER, AGENT], streaming: "", regions: EMPTY_REGIONS };
+    const first = { tick: 1, draft: "", blocks: transcriptBlocks(sources) };
+    const afterTick = {
+      tick: first.tick + 1,
+      draft: first.draft,
+      blocks: transcriptBlocks(sources, first.blocks),
+    };
+    const afterDraft = {
+      tick: afterTick.tick,
+      draft: `${first.draft}hello`,
+      blocks: transcriptBlocks(sources, afterTick.blocks),
+    };
+    expect(afterTick.tick).not.toBe(first.tick);
+    expect(afterDraft.draft).not.toBe(first.draft);
+    expect(afterTick.blocks).toBe(first.blocks);
+    expect(afterDraft.blocks).toBe(first.blocks);
+    expect(afterDraft.blocks[0]).toBe(first.blocks[0]);
+    expect(afterDraft.blocks[1]).toBe(first.blocks[1]);
+  });
+
+  it("reuses unchanged Block objects when streaming grows", () => {
+    const settled = transcriptBlocks({
+      outputs: [USER, AGENT],
+      streaming: "",
+      regions: EMPTY_REGIONS,
+    });
+    const streaming = transcriptBlocks(
+      { outputs: [USER, AGENT], streaming: " and Friday too.", regions: EMPTY_REGIONS },
+      settled,
+    );
+    expect(streaming).not.toBe(settled);
+    expect(streaming[0]).toBe(settled[0]);
+    expect(streaming[1]).toBe(settled[1]);
+    expect(streaming.at(-1)?.kind).toBe("agent");
+    expect(streaming.at(-1)).not.toBe(settled.at(-1));
+  });
+
+  it("does not write live reasoning duration onto a Block", () => {
+    const regions: readonly EphemeralRegion[] = [
+      {
+        id: "r-live",
+        kind: "reasoning",
+        label: "Reasoning",
+        startedAt: Date.now() - 4_000,
+        tail: ["weighing the two calendars"],
+        maxLines: 8,
+      },
+    ];
+    const first = transcriptBlocks({ outputs: [], streaming: "", regions });
+    const later = transcriptBlocks({ outputs: [], streaming: "", regions }, first);
+    expect(later).toBe(first);
+    const reasoning = later.find((block) => block.kind === "reasoning");
+    expect(reasoning).toBeDefined();
+    expect(reasoning?.kind === "reasoning" ? reasoning.durationMs : "missing").toBeUndefined();
+    expect(reasoning?.kind === "reasoning" ? reasoning.text : "").toBe(
+      "weighing the two calendars",
+    );
+  });
+
+  it("shareUnchangedBlocks returns the previous array when every block is reused", () => {
+    const next = blocksFrom([USER], "", EMPTY_REGIONS);
+    const previous = shareUnchangedBlocks([], next);
+    expect(shareUnchangedBlocks(previous, blocksFrom([USER], "", EMPTY_REGIONS))).toBe(previous);
+  });
+});

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -79,6 +79,10 @@ import {
   LIVE_ZONE_MAX_ROWS,
   type ApprovalOverlay,
   type Block,
+  type FooterModel,
+  type HeaderModel,
+  type InputModel,
+  type LiveModel,
   type LiveTool,
   type Overlay,
   type StepLine,
@@ -614,11 +618,10 @@ function plainOf(message: unknown): string {
  * rather than one block each: the model emits prose in pieces, and a block per
  * piece would make the transcript unscrollable and the markdown unparseable.
  */
-function blocksFrom(
+export function blocksFrom(
   entries: readonly OutputEntry[],
   streaming: string,
   regions: readonly EphemeralRegion[],
-  now: number,
 ): Block[] {
   const blocks: Block[] = [];
   let seq = 0;
@@ -746,7 +749,6 @@ function blocksFrom(
         kind: "reasoning",
         text: region.tail.join("\n"),
         collapsed: false,
-        durationMs: Math.max(0, now - region.startedAt),
       });
       continue;
     }
@@ -765,6 +767,100 @@ function blocksFrom(
     });
   }
   return blocks;
+}
+
+function sameBlock(left: Block | undefined, right: Block): boolean {
+  if (left === undefined || left.kind !== right.kind) return false;
+  if (left.id !== right.id || left.seq !== right.seq) return false;
+  switch (left.kind) {
+    case "user":
+      return right.kind === "user" && left.text === right.text && left.at === right.at;
+    case "agent":
+      return (
+        right.kind === "agent" &&
+        left.markdown === right.markdown &&
+        left.streaming === right.streaming
+      );
+    case "reasoning":
+      return (
+        right.kind === "reasoning" &&
+        left.text === right.text &&
+        left.collapsed === right.collapsed &&
+        left.steps === right.steps &&
+        left.durationMs === right.durationMs &&
+        left.tokens === right.tokens
+      );
+    case "tool":
+      return (
+        right.kind === "tool" &&
+        left.app === right.app &&
+        left.summary === right.summary &&
+        left.args === right.args &&
+        left.status === right.status &&
+        left.reason === right.reason &&
+        left.remedyKey === right.remedyKey &&
+        left.durationMs === right.durationMs &&
+        left.detail === right.detail &&
+        left.expanded === right.expanded &&
+        left.classifiedRisk === right.classifiedRisk
+      );
+    case "notice":
+      return right.kind === "notice" && left.text === right.text && left.tone === right.tone;
+    case "divider":
+      return right.kind === "divider" && left.label === right.label;
+    case "lane":
+      return (
+        right.kind === "lane" &&
+        left.name === right.name &&
+        left.ask === right.ask &&
+        left.lane === right.lane &&
+        left.state === right.state &&
+        left.result === right.result &&
+        left.steps === right.steps
+      );
+  }
+}
+
+export function shareUnchangedBlocks(
+  previous: readonly Block[],
+  next: readonly Block[],
+): readonly Block[] {
+  if (previous.length === 0) return next;
+  let changed = previous.length !== next.length;
+  const shared = next.map((block, index) => {
+    const prior = previous[index];
+    if (prior !== undefined && sameBlock(prior, block)) return prior;
+    changed = true;
+    return block;
+  });
+  return changed ? shared : previous;
+}
+
+export interface TranscriptBlockSources {
+  readonly outputs: readonly OutputEntry[];
+  readonly streaming: string;
+  readonly regions: readonly EphemeralRegion[];
+}
+
+export function transcriptBlocks(
+  sources: TranscriptBlockSources,
+  previous: readonly Block[] = [],
+): readonly Block[] {
+  return shareUnchangedBlocks(
+    previous,
+    blocksFrom(sources.outputs, sources.streaming, sources.regions),
+  );
+}
+
+function liveReasoningElapsedMs(
+  regions: readonly EphemeralRegion[],
+  now: number,
+): number | undefined {
+  let startedAt: number | undefined;
+  for (const region of regions) {
+    if (region.kind === "reasoning") startedAt = region.startedAt;
+  }
+  return startedAt === undefined ? undefined : Math.max(0, now - startedAt);
 }
 
 function liveToolsFrom(activity: ActivityState, now: number): LiveTool[] {
@@ -1961,13 +2057,32 @@ export function FullscreenBridge(): React.ReactNode {
     [approval, prompt, commitComposer],
   );
 
-  const view = useMemo<ViewModel>(() => {
+  const previousBlocks = useRef<readonly Block[]>([]);
+  const blocks = useMemo(() => {
+    const next = transcriptBlocks({ outputs, streaming, regions }, previousBlocks.current);
+    previousBlocks.current = next;
+    return next;
+  }, [outputs, streaming, regions]);
+
+  const header = useMemo<HeaderModel>(
+    () => ({
+      version: packageJson.version,
+      cwd: compactWorkingDirectory(workingDirectory),
+      model: stats.model ?? "no model",
+      connectors: [...connectors].map(([name, status]) => ({ name, status })),
+      contextUsed: stats.tokensInContext ?? 0,
+      contextMax: stats.maxContextTokens ?? 0,
+    }),
+    [workingDirectory, stats.model, stats.tokensInContext, stats.maxContextTokens, connectors],
+  );
+
+  const overlay = useMemo<Overlay | undefined>(() => {
     // An approval outranks search: it is a decision the agent is blocked on, and
     // it arrived because the user asked for something.
     const promptOverlay = overlayFromPrompt(prompt, promptControls);
-    let overlay: Overlay | undefined = promptOverlay;
+    let next: Overlay | undefined = promptOverlay;
     if (searchQuery !== null) {
-      overlay = {
+      next = {
         kind: "search",
         query: searchQuery,
         scope: searchScope,
@@ -1978,9 +2093,22 @@ export function FullscreenBridge(): React.ReactNode {
       };
     }
     if (approval !== null) {
-      overlay = approvalFrom(approval, approvalArmed, approvalFieldOffset);
+      next = approvalFrom(approval, approvalArmed, approvalFieldOffset);
     }
+    return next;
+  }, [
+    prompt,
+    promptControls,
+    searchQuery,
+    searchScope,
+    searchHits,
+    searchIndex,
+    approval,
+    approvalArmed,
+    approvalFieldOffset,
+  ]);
 
+  const input = useMemo<InputModel>(() => {
     const commandItems = commandQuery === null ? [] : filterCommandsByPrefix(commandQuery);
     const commands =
       commandItems.length === 0
@@ -1989,81 +2117,55 @@ export function FullscreenBridge(): React.ReactNode {
             items: commandItems,
             selected: wrapCommandIndex(commandIndex, commandItems.length),
           };
-
     return {
-      header: {
-        version: packageJson.version,
-        cwd: compactWorkingDirectory(workingDirectory),
-        model: stats.model ?? "no model",
-        connectors: [...connectors].map(([name, status]) => ({ name, status })),
-        contextUsed: stats.tokensInContext ?? 0,
-        contextMax: stats.maxContextTokens ?? 0,
-      },
-      blocks: blocksFrom(outputs, streaming, regions, Date.now()),
+      value: draft,
+      caret: draftCaret,
+      anchor: draftAnchor,
+      placeholder: busy ? "Type to queue for next turn" : "Ask anything",
+      queued: queue,
+      queueing: busy,
+      disabled: overlay !== undefined || (!busy && prompt?.type !== "chat"),
+      ...(commands === undefined ? {} : { commands }),
+    };
+  }, [draft, draftCaret, draftAnchor, busy, queue, overlay, prompt, commandQuery, commandIndex]);
+
+  const footer = useMemo<FooterModel>(
+    () => ({
+      mode: isYolo ? "yolo" : "safe",
+      hints: [],
+      ...(stats.costUSD === undefined ? {} : { costUsd: stats.costUSD }),
+      ...(elapsedMs === undefined ? {} : { elapsedMs }),
+    }),
+    [isYolo, stats.costUSD, elapsedMs],
+  );
+
+  const live = useMemo<LiveModel>(() => {
+    const reasoningElapsedMs = liveReasoningElapsedMs(regions, Date.now());
+    return {
+      tools,
+      hiddenTools: [],
+      ...(step === undefined ? {} : { step }),
+      ...(waitingNow ? { waiting: WAITING[Math.floor(tick / 24) % WAITING.length] as string } : {}),
+      tick,
+      ...(elapsedMs === undefined ? {} : { elapsedMs }),
+      reservedRows,
+      ...(reasoningElapsedMs === undefined ? {} : { reasoningElapsedMs }),
+    };
+  }, [tools, step, waitingNow, tick, elapsedMs, reservedRows, regions]);
+
+  const view = useMemo<ViewModel>(
+    () => ({
+      header,
+      blocks,
       runActive,
-      live: {
-        tools,
-        hiddenTools: [],
-        ...(step === undefined ? {} : { step }),
-        ...(waitingNow
-          ? { waiting: WAITING[Math.floor(tick / 24) % WAITING.length] as string }
-          : {}),
-        tick,
-        ...(elapsedMs === undefined ? {} : { elapsedMs }),
-        reservedRows,
-      },
-      input: {
-        value: draft,
-        caret: draftCaret,
-        anchor: draftAnchor,
-        placeholder: busy ? "Type to queue for next turn" : "Ask anything",
-        queued: queue,
-        queueing: busy,
-        disabled: overlay !== undefined || (!busy && prompt?.type !== "chat"),
-        ...(commands === undefined ? {} : { commands }),
-      },
-      footer: {
-        mode: isYolo ? "yolo" : "safe",
-        hints: [],
-        ...(stats.costUSD === undefined ? {} : { costUsd: stats.costUSD }),
-        ...(elapsedMs === undefined ? {} : { elapsedMs }),
-      },
+      live,
+      input,
+      footer,
       ...(overlay === undefined ? {} : { overlay }),
       focus: "input",
-    };
-  }, [
-    outputs,
-    streaming,
-    activity,
-    stats,
-    queue,
-    busy,
-    regions,
-    tick,
-    draft,
-    draftCaret,
-    draftAnchor,
-    commandQuery,
-    commandIndex,
-    prompt,
-    promptControls,
-    approval,
-    approvalArmed,
-    approvalFieldOffset,
-    connectors,
-    workingDirectory,
-    searchQuery,
-    searchHits,
-    searchIndex,
-    searchScope,
-    runActive,
-    isYolo,
-    elapsedMs,
-    tools,
-    step,
-    waitingNow,
-    reservedRows,
-  ]);
+    }),
+    [header, blocks, runActive, live, input, footer, overlay],
+  );
 
   // A menu the app is waiting on gets the real screen. The wizard publishes it
   // as data precisely so a renderer that cannot paint an Ink tree can still draw

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -769,54 +769,62 @@ export function blocksFrom(
   return blocks;
 }
 
-function sameBlock(left: Block | undefined, right: Block): boolean {
-  if (left === undefined || left.kind !== right.kind) return false;
-  if (left.id !== right.id || left.seq !== right.seq) return false;
-  switch (left.kind) {
+// `previous` is undefined on the first block or a missing cache slot; still
+// compare so sharing can no-op without a null check at every call site.
+function sameBlock(previous: Block | undefined, current: Block): previous is Block {
+  if (previous === undefined || previous.kind !== current.kind) return false;
+  if (previous.id !== current.id || previous.seq !== current.seq) return false;
+  switch (previous.kind) {
     case "user":
-      return right.kind === "user" && left.text === right.text && left.at === right.at;
+      return (
+        current.kind === "user" && previous.text === current.text && previous.at === current.at
+      );
     case "agent":
       return (
-        right.kind === "agent" &&
-        left.markdown === right.markdown &&
-        left.streaming === right.streaming
+        current.kind === "agent" &&
+        previous.markdown === current.markdown &&
+        previous.streaming === current.streaming
       );
     case "reasoning":
       return (
-        right.kind === "reasoning" &&
-        left.text === right.text &&
-        left.collapsed === right.collapsed &&
-        left.steps === right.steps &&
-        left.durationMs === right.durationMs &&
-        left.tokens === right.tokens
+        current.kind === "reasoning" &&
+        previous.text === current.text &&
+        previous.collapsed === current.collapsed &&
+        previous.steps === current.steps &&
+        previous.durationMs === current.durationMs &&
+        previous.tokens === current.tokens
       );
     case "tool":
       return (
-        right.kind === "tool" &&
-        left.app === right.app &&
-        left.summary === right.summary &&
-        left.args === right.args &&
-        left.status === right.status &&
-        left.reason === right.reason &&
-        left.remedyKey === right.remedyKey &&
-        left.durationMs === right.durationMs &&
-        left.detail === right.detail &&
-        left.expanded === right.expanded &&
-        left.classifiedRisk === right.classifiedRisk
+        current.kind === "tool" &&
+        previous.app === current.app &&
+        previous.summary === current.summary &&
+        previous.args === current.args &&
+        previous.status === current.status &&
+        previous.reason === current.reason &&
+        previous.remedyKey === current.remedyKey &&
+        previous.durationMs === current.durationMs &&
+        previous.detail === current.detail &&
+        previous.expanded === current.expanded &&
+        previous.classifiedRisk === current.classifiedRisk
       );
     case "notice":
-      return right.kind === "notice" && left.text === right.text && left.tone === right.tone;
+      return (
+        current.kind === "notice" &&
+        previous.text === current.text &&
+        previous.tone === current.tone
+      );
     case "divider":
-      return right.kind === "divider" && left.label === right.label;
+      return current.kind === "divider" && previous.label === current.label;
     case "lane":
       return (
-        right.kind === "lane" &&
-        left.name === right.name &&
-        left.ask === right.ask &&
-        left.lane === right.lane &&
-        left.state === right.state &&
-        left.result === right.result &&
-        left.steps === right.steps
+        current.kind === "lane" &&
+        previous.name === current.name &&
+        previous.ask === current.ask &&
+        previous.lane === current.lane &&
+        previous.state === current.state &&
+        previous.result === current.result &&
+        previous.steps === current.steps
       );
   }
 }
@@ -827,11 +835,11 @@ export function shareUnchangedBlocks(
 ): readonly Block[] {
   if (previous.length === 0) return next;
   let changed = previous.length !== next.length;
-  const shared = next.map((block, index) => {
-    const prior = previous[index];
-    if (prior !== undefined && sameBlock(prior, block)) return prior;
+  const shared = next.map((current, index) => {
+    const cached = previous[index];
+    if (sameBlock(cached, current)) return cached;
     changed = true;
-    return block;
+    return current;
   });
   return changed ? shared : previous;
 }

--- a/src/cli/ui/fullscreen/live-input.test.tsx
+++ b/src/cli/ui/fullscreen/live-input.test.tsx
@@ -307,6 +307,18 @@ describe("live zone", () => {
     expect(cleared).toHaveLength(0);
   });
 
+  it("shows the reasoning clock on the waiting row while a reasoning region is open", () => {
+    const model = live({
+      waiting: "thinking it through",
+      elapsedMs: 45_000,
+      reasoningElapsedMs: 7_000,
+    });
+    const [row] = liveRows(model, { width: WIDTH, height: HEIGHT });
+    const text = row?.segments.map((segment) => segment.text).join("") ?? "";
+    expect(text).toContain("7s");
+    expect(text).not.toContain("45s");
+  });
+
   it("paints the live indicator in the accent, not in whatever the terminal defaults to", async () => {
     const { renderer, renderOnce, captureSpans } = await testRender(
       <LiveZone

--- a/src/cli/ui/fullscreen/transcript.test.tsx
+++ b/src/cli/ui/fullscreen/transcript.test.tsx
@@ -953,3 +953,11 @@ describe("inline emphasis", () => {
     expect(content.find((segment) => segment.text.includes("jazz"))?.fg).toBe(THEME.syntaxValue);
   });
 });
+
+describe("wrap depends on width, not height", () => {
+  it("produces the same rows when only viewport height changes", () => {
+    const tall = transcriptRows(SESSION, { width: 120, height: 34 });
+    const short = transcriptRows(SESSION, { width: 120, height: 8 });
+    expect(short).toEqual(tall);
+  });
+});

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -176,6 +176,12 @@ export interface LiveModel {
   /** Monotonic tick driving the indicator. */
   readonly tick: number;
   /**
+   * Elapsed time for the open reasoning region, if one is running.
+   * Lives here rather than on a transcript Block so a live tick cannot
+   * rewrite block identity and defeat wrap memoization.
+   */
+  readonly reasoningElapsedMs?: number;
+  /**
    * Rows the band occupies, as a high-water mark for the turn.
    *
    * Tools churn several times a second, and a band that shrank the moment one


### PR DESCRIPTION
## What & why
The fullscreen transcript rebuilt on every spinner tick and every composer keystroke, so the conversation rewrapped while you typed. Unchanged rows now keep their identity, and live reasoning elapsed time lives on the live band instead of rewriting a transcript block.

## How to verify
- Start a turn and type in the composer while the spinner moves: the transcript should stay put.
- Stream a reply: new tokens appear; settled rows above should not flicker.
- Resize width: wrap recomputes. Resize height only: wrap stays the same.
- `bun test src/cli/ui/fullscreen/bridge-blocks.test.ts src/cli/ui/fullscreen/transcript.test.tsx src/cli/ui/fullscreen/app.test.tsx`