### PR TITLE
feat(ui): delay-arm approvals and keep fullscreen prompts live

### DIFF
--- a/src/cli/commands/config-wizard.ts
+++ b/src/cli/commands/config-wizard.ts
@@ -1,5 +1,4 @@
 import { Effect } from "effect";
-import React from "react";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { AVAILABLE_PROVIDERS, type ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
@@ -10,7 +9,7 @@ import type { ColorProfile, OutputMode } from "@/core/types/output";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
 import { sortProvidersForPicker } from "@/core/utils/provider-picker";
 import { store } from "../ui/store";
-import { WizardHome, type WizardMenuOption } from "../ui/WizardHome";
+import type { WizardMenuOption } from "../ui/WizardHome";
 
 /**
  * Menu actions for the config wizard
@@ -71,29 +70,18 @@ function showConfigMenu(
   options: WizardMenuOption[],
 ): Effect.Effect<ConfigMenuAction, never, never> {
   return Effect.async<ConfigMenuAction>((resume) => {
-    let resumed = false;
-    const safeResume = (action: ConfigMenuAction): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(action));
-    };
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "menu",
         title: "Configuration",
-        onSelect: (value: string) => safeResume(value as ConfigMenuAction),
-        onExit: () => safeResume("back"),
-      }),
+        options,
+      },
+      (result) => {
+        resume(
+          Effect.succeed(result.kind === "exit" ? "back" : (result.value as ConfigMenuAction)),
+        );
+      },
     );
-    store.setActiveMenu({
-      kind: "menu",
-      options,
-      onSelect: (value: string) => safeResume(value as ConfigMenuAction),
-      onExit: () => safeResume("back"),
-    });
   });
 }
 

--- a/src/cli/commands/wizard-list-agents.test.ts
+++ b/src/cli/commands/wizard-list-agents.test.ts
@@ -27,7 +27,6 @@ function agent(partial: {
 describe("showAgentList", () => {
   it("publishes every agent to the fullscreen menu instead of an empty list", async () => {
     store.setActiveMenu(null);
-    store.setCustomView(null);
 
     const agents = [
       agent({ id: "a2", name: "qwen-coder", model: "qwen2.5-coder" }),
@@ -46,6 +45,8 @@ describe("showAgentList", () => {
     if (menu?.kind !== "agents") {
       throw new Error("expected an agents menu");
     }
+    expect(menu).not.toHaveProperty("onSelect");
+    expect(menu).not.toHaveProperty("onExit");
     expect(menu.title).toBe("agents");
     expect(menu.action).toBe("back");
     expect(menu.browse).toBe(true);
@@ -64,7 +65,7 @@ describe("showAgentList", () => {
       model: "qwen2.5-coder",
     });
 
-    menu.onExit();
+    store.completePrompt({ kind: "exit" });
     await listed;
     expect(store.getActiveMenuSnapshot()).toBe(null);
   });
@@ -79,7 +80,8 @@ describe("showAgentList", () => {
     }
     expect(menu.agents).toEqual([]);
     expect(menu.browse).toBe(true);
-    menu.onExit();
+    expect(menu).not.toHaveProperty("onSelect");
+    store.completePrompt({ kind: "exit" });
     await listed;
     expect(store.getActiveMenuSnapshot()).toBe(null);
   });

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -1,5 +1,4 @@
 import { Effect } from "effect";
-import React from "react";
 import { sortAgents } from "@/core/agent/agent-sort";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag } from "@/core/interfaces/agent-service";
@@ -15,7 +14,7 @@ import { createAgentCommand } from "./create-agent";
 import { editAgentCommand } from "./edit-agent";
 import { homeRequirements } from "../ui/fullscreen/home-readiness";
 import { store, type ActiveAgentChoice } from "../ui/store";
-import { TIPS, WizardHome, type WizardMenuOption } from "../ui/WizardHome";
+import { TIPS, type WizardMenuOption } from "../ui/WizardHome";
 
 /**
  * Wizard menu option identifiers
@@ -293,33 +292,18 @@ function showWizardMenu(
   requirements: ReturnType<typeof homeRequirements>,
 ): Effect.Effect<MenuAction, never, never> {
   return Effect.async<MenuAction>((resume) => {
-    let resumed = false;
-
-    const safeResume = (action: MenuAction) => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(action));
-    };
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
-        onSelect: (value: string) => safeResume(value as MenuAction),
-        onExit: () => safeResume("exit"),
-      }),
-    );
-
     const tip = TIPS[Math.floor(Math.random() * TIPS.length)] ?? TIPS[0] ?? "";
-    store.setActiveMenu({
-      kind: "menu",
-      options,
-      requirements,
-      tip,
-      onSelect: (value: string) => safeResume(value as MenuAction),
-      onExit: () => safeResume("exit"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options,
+        requirements,
+        tip,
+      },
+      (result) => {
+        resume(Effect.succeed(result.kind === "exit" ? "exit" : (result.value as MenuAction)));
+      },
+    );
   });
 }
 
@@ -343,36 +327,19 @@ export function showAgentList(
   lastUsedAgentId: string | null | undefined,
 ): Effect.Effect<void, never, never> {
   return Effect.async<void>((resume) => {
-    let resumed = false;
-    const dismiss = (): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(undefined));
-    };
-
     const sorted = sortAgents(agents, lastUsedAgentId);
-    const options = sorted.map((agent) => ({ label: agent.name, value: agent.id }));
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "agents",
         title: "agents",
-        onSelect: () => dismiss(),
-        onExit: () => dismiss(),
-      }),
+        action: "back",
+        browse: true,
+        agents: agentChoicesFor(sorted, lastUsedAgentId),
+      },
+      () => {
+        resume(Effect.succeed(undefined));
+      },
     );
-
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: agentChoicesFor(sorted, lastUsedAgentId),
-      onSelect: () => dismiss(),
-      onExit: () => dismiss(),
-    });
   });
 }
 
@@ -386,35 +353,24 @@ function selectAgent(
   action: string,
 ): Effect.Effect<Agent | null, never, never> {
   return Effect.async<Agent | null>((resume) => {
-    let resumed = false;
-    const safeResume = (agentId: string | null): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(agents.find((agent) => agent.id === agentId) ?? null));
-    };
-
     const sorted = sortAgents(agents, lastUsedAgentId);
-    const options = sorted.map((agent) => ({ label: agent.name, value: agent.id }));
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "agents",
         title,
-        onSelect: (value: string) => safeResume(value),
-        onExit: () => safeResume(null),
-      }),
+        action,
+        agents: agentChoicesFor(sorted, lastUsedAgentId),
+      },
+      (result) => {
+        resume(
+          Effect.succeed(
+            result.kind === "exit"
+              ? null
+              : (agents.find((agent) => agent.id === result.value) ?? null),
+          ),
+        );
+      },
     );
-
-    store.setActiveMenu({
-      kind: "agents",
-      title,
-      action,
-      agents: agentChoicesFor(sorted, lastUsedAgentId),
-      onSelect: (value: string) => safeResume(value),
-      onExit: () => safeResume(null),
-    });
   });
 }
 

--- a/src/cli/commands/workflow-select-agent.test.ts
+++ b/src/cli/commands/workflow-select-agent.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { Agent } from "@/core/types/index";
+import { selectAgentForWorkflow } from "./workflow";
+import { store } from "../ui/store";
+
+function agent(partial: {
+  readonly id: string;
+  readonly name: string;
+  readonly model: string;
+}): Agent {
+  return {
+    id: partial.id,
+    name: partial.name,
+    model: `anthropic/${partial.model}`,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    config: {
+      llmProvider: "anthropic",
+      llmModel: partial.model,
+    },
+  };
+}
+
+describe("selectAgentForWorkflow", () => {
+  it("publishes a data-only agent menu instead of an Ink tree", async () => {
+    store.setActiveMenu(null);
+    const agents = [
+      agent({ id: "a1", name: "reviewer", model: "claude-sonnet-4" }),
+      agent({ id: "a2", name: "coder", model: "qwen2.5-coder" }),
+    ];
+
+    const selected = Effect.runPromise(
+      selectAgentForWorkflow(agents, "Select an agent to run this workflow:"),
+    );
+    const menu = store.getActiveMenuSnapshot();
+
+    expect(menu?.kind).toBe("agents");
+    if (menu?.kind !== "agents") {
+      throw new Error("expected an agents menu");
+    }
+    expect(menu).not.toHaveProperty("onSelect");
+    expect(menu).not.toHaveProperty("onExit");
+    expect(menu.title).toBe("Select an agent to run this workflow:");
+    expect(menu.action).toBe("run");
+    expect(menu.agents.map((choice) => choice.id)).toEqual(["a1", "a2"]);
+
+    store.completePrompt({ kind: "select", value: "a2" });
+    await expect(selected).resolves.toMatchObject({ id: "a2", name: "coder" });
+    expect(store.getActiveMenuSnapshot()).toBe(null);
+  });
+
+  it("returns null when the picker is dismissed", async () => {
+    store.setActiveMenu(null);
+    const selected = Effect.runPromise(
+      selectAgentForWorkflow(
+        [agent({ id: "a1", name: "reviewer", model: "claude-sonnet-4" })],
+        "Select an agent to run this scheduled workflow:",
+      ),
+    );
+
+    store.completePrompt({ kind: "exit" });
+    await expect(selected).resolves.toBe(null);
+    expect(store.getActiveMenuSnapshot()).toBe(null);
+  });
+});

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,9 +1,5 @@
 import { Duration, Effect } from "effect";
-import { Box, Text } from "ink";
-import React from "react";
-import { SearchSelect } from "@/cli/ui/components/SearchSelect";
 import { store } from "@/cli/ui/store";
-import { THEME } from "@/cli/ui/theme";
 import { separatorLine } from "@/cli/utils/string-utils";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
@@ -835,39 +831,32 @@ function runCostFields(result: {
 /**
  * Helper to prompt user to select an agent for workflow execution.
  */
-function selectAgentForWorkflow(
+export function selectAgentForWorkflow(
   agents: readonly Agent[],
   prompt: string,
 ): Effect.Effect<Agent | null, never> {
   return Effect.async<Agent | null, never>((resume) => {
-    const options = agents.map((agent) => ({
-      label: `${agent.name} (${agent.config.llmModel})`,
-      value: agent.id,
-    }));
-
-    store.setCustomView(
-      React.createElement(
-        Box,
-        { flexDirection: "column", padding: 1 },
-        React.createElement(Text, { bold: true, color: THEME.primary }, prompt),
-        React.createElement(
-          Box,
-          { marginTop: 1 },
-          React.createElement(SearchSelect<string>, {
-            options,
-            pageSize: 10,
-            placeholder: "Type to filter agents…",
-            onSelect: (value: string) => {
-              store.setCustomView(null);
-              resume(Effect.succeed(agents.find((a) => a.id === value) ?? null));
-            },
-            onCancel: () => {
-              store.setCustomView(null);
-              resume(Effect.succeed(null));
-            },
-          }),
-        ),
-      ),
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: prompt,
+        action: "run",
+        agents: agents.map((agent) => ({
+          id: agent.id,
+          name: agent.name,
+          model: agent.config.llmModel,
+          ...(agent.description !== undefined && agent.description !== agent.name
+            ? { description: agent.description }
+            : {}),
+        })),
+      },
+      (result) => {
+        if (result.kind === "exit") {
+          resume(Effect.succeed(null));
+          return;
+        }
+        resume(Effect.succeed(agents.find((agent) => agent.id === result.value) ?? null));
+      },
     );
   });
 }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -8,17 +8,18 @@ import { PreWrappedText } from "./components/PreWrappedText";
 import { useTerminalDimensions } from "./contexts/TerminalDimensionsContext";
 import { EphemeralPanelIsland } from "./EphemeralPanelIsland";
 import ErrorBoundary from "./ErrorBoundary";
-import { formatMarkdown, wrapToWidth } from "../presentation/markdown-formatter";
 import { useInputHandler } from "./hooks/use-input-service";
 import { OutputEntryView } from "./OutputEntryView";
 import { Prompt } from "./Prompt";
 import { QueueInput } from "./QueueInput";
 import { RAIL_WIDTH, railStreamLines } from "./rail";
 import StatusFooter from "./StatusFooter";
-import { store, type RunStats } from "./store";
+import { store, type ActiveMenu, type RunStats } from "./store";
 import { PADDING, PADDING_BUDGET, THEME } from "./theme";
 import type { OutputEntryWithId, PromptState } from "./types";
+import { WizardHome } from "./WizardHome";
 import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
+import { formatMarkdown, wrapToWidth } from "../presentation/markdown-formatter";
 import { InputPriority, InputResults } from "../services/input-service";
 
 // ============================================================================
@@ -253,17 +254,43 @@ const OutputIsland = React.memo(OutputIslandComponent);
 // Main App Component
 // ============================================================================
 
+function ActiveMenuView({ menu }: { readonly menu: ActiveMenu }): React.ReactElement {
+  const options =
+    menu.kind === "agents"
+      ? menu.agents.map((agent) => ({
+          label: `${agent.name} (${agent.model})`,
+          value: agent.id,
+        }))
+      : menu.options;
+  const title = menu.title;
+  const browse = menu.kind === "agents" && menu.browse === true;
+
+  return (
+    <WizardHome
+      options={options}
+      {...(title === undefined ? {} : { title })}
+      onSelect={(value) => {
+        if (browse) {
+          store.completePrompt({ kind: "exit" });
+          return;
+        }
+        store.completePrompt({ kind: "select", value });
+      }}
+      onExit={() => store.completePrompt({ kind: "exit" })}
+    />
+  );
+}
+
 export function App(): React.ReactElement {
-  const [customView, setCustomView] = useState<React.ReactNode | null>(null);
+  const [menu, setMenu] = useState<ActiveMenu | null>(null);
   const interruptHandlerRef = useRef<(() => void) | null>(null);
   const initializedRef = useRef(false);
-  const unregisterCustomViewRef = useRef<() => void>(() => undefined);
   const [modeToast, setModeToast] = useState<string | null>(null);
   const modeToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Setup store methods synchronously during render
   if (!initializedRef.current) {
-    unregisterCustomViewRef.current = store.registerCustomView(setCustomView);
+    store.registerActiveMenuSetter(setMenu);
     store.registerInterruptHandler((handler) => {
       interruptHandlerRef.current = handler;
     });
@@ -295,7 +322,7 @@ export function App(): React.ReactElement {
   // Cleanup on unmount to prevent stale handler calls
   useEffect(() => {
     return () => {
-      unregisterCustomViewRef.current();
+      store.registerActiveMenuSetter(null);
       store.registerInterruptHandler(null);
     };
   }, []);
@@ -420,10 +447,10 @@ export function App(): React.ReactElement {
 
   return (
     <ErrorBoundary>
-      {customView}
+      {menu !== null && <ActiveMenuView menu={menu} />}
       <Box
         flexDirection="column"
-        display={customView ? "none" : "flex"}
+        display={menu !== null ? "none" : "flex"}
       >
         <Box
           flexDirection="column"

--- a/src/cli/ui/WizardHome.tsx
+++ b/src/cli/ui/WizardHome.tsx
@@ -16,7 +16,7 @@ export interface WizardMenuOption {
 }
 
 interface WizardHomeProps {
-  options: WizardMenuOption[];
+  options: readonly WizardMenuOption[];
   onSelect: (value: string) => void;
   onExit: () => void;
   title?: string;

--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -445,16 +445,19 @@ function AppView({ view, onAction, onKey, onPaste, overrideContent }: AppProps):
     () => ({ ...view.input, disabled: view.input.disabled || overlayOpen }),
     [view.input, overlayOpen],
   );
+  const overlayKind = view.overlay?.kind;
+  const overlayArmed = view.overlay?.kind === "approval" ? view.overlay.armed : true;
   const footerHints = useMemo(
     () =>
       hintsFor(
         focus,
         view.runActive === true,
         view.input.queueing === true,
-        view.overlay?.kind,
+        overlayKind,
         view.input.commands !== undefined,
+        overlayArmed,
       ),
-    [focus, view.runActive, view.input.queueing, view.overlay?.kind, view.input.commands],
+    [focus, view.runActive, view.input.queueing, overlayKind, view.input.commands, overlayArmed],
   );
   const footer = useMemo(
     () => ({

--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -6,7 +6,7 @@ import {
   useSelectionHandler,
   useTerminalDimensions,
 } from "@opentui/react";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
 import {
@@ -195,13 +195,7 @@ export function reuseViewport(width: number, height: number, previous: Viewport)
   return { width, height };
 }
 
-export function App({
-  view,
-  onAction,
-  onKey,
-  onPaste,
-  overrideContent,
-}: AppProps): React.ReactNode {
+function AppView({ view, onAction, onKey, onPaste, overrideContent }: AppProps): React.ReactNode {
   const { width, height } = useTerminalDimensions();
   const renderer = useRenderer();
   const rendererRef = useRef(renderer);
@@ -561,3 +555,5 @@ export function App({
     </box>
   );
 }
+
+export const App = memo(AppView);

--- a/src/cli/ui/fullscreen/LiveZone.tsx
+++ b/src/cli/ui/fullscreen/LiveZone.tsx
@@ -33,10 +33,10 @@
  * running rather than one thing blinking three times.
  */
 
-import { memo, type ReactNode } from "react";
+import { memo, useEffect, useState, type ReactNode } from "react";
 import { highlightCodeLine } from "./syntax-spans";
 import { getGlyphs, laneFrame, type GlyphSet } from "../glyphs";
-import { THEME } from "../theme";
+import { MOTION, THEME } from "../theme";
 import { fitTerminalSegments, terminalSegmentsWidth } from "./terminal-cells";
 import {
   LIVE_ZONE_MAX_ROWS,
@@ -256,6 +256,7 @@ export function liveRows(
   streaming = false,
   glyphs: GlyphSet = getGlyphs(),
   maxRows = LIVE_ZONE_MAX_ROWS,
+  tick = 0,
 ): readonly LiveRow[] {
   const width = Math.max(1, viewport.width);
   const capacity = reservedHeight(model, maxRows);
@@ -288,7 +289,7 @@ export function liveRows(
 
   const rows: LiveRow[] = [];
   if (showWaiting && model.waiting !== undefined) {
-    rows.push(waitingRow(model.waiting, model.elapsedMs, model.tick, glyphs, width));
+    rows.push(waitingRow(model.waiting, model.elapsedMs, tick, glyphs, width));
   }
   if (showStep && model.step !== undefined) {
     rows.push(
@@ -301,15 +302,33 @@ export function liveRows(
       ),
     );
   }
-  for (const tool of shown) rows.push(toolRow(tool, model.tick, glyphs, width));
+  for (const tool of shown) rows.push(toolRow(tool, tick, glyphs, width));
   if (hiddenNames.length > 0) rows.push(overflowRow(hiddenNames, glyphs, width));
 
   return rows;
 }
 
+function liveBandAnimates(model: LiveModel, streaming: boolean, maxRows?: number): boolean {
+  if (reservedHeight(model, maxRows) === 0) return false;
+  if (model.tools.length > 0) return true;
+  return model.waiting !== undefined && !streaming;
+}
+
 function LiveZoneView({ model, viewport, streaming, maxRows }: LiveZoneProps): ReactNode {
+  const [tick, setTick] = useState(0);
+  const streamingNow = streaming ?? false;
+  const animate = liveBandAnimates(model, streamingNow, maxRows);
+
+  useEffect(() => {
+    if (!animate) return;
+    const timer = setInterval(() => {
+      setTick((value) => value + 1);
+    }, MOTION.indicator);
+    return () => clearInterval(timer);
+  }, [animate]);
+
   const height = reservedHeight(model, maxRows);
-  const rows = liveRows(model, viewport, streaming ?? false, undefined, maxRows);
+  const rows = liveRows(model, viewport, streamingNow, undefined, maxRows, tick);
 
   // The run has settled: the whole band goes away and the transcript takes the
   // rows back. Note this is keyed on the reservation rather than on the rows,

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -1486,9 +1486,9 @@ const TranscriptView = forwardRef<TranscriptHandle, TranscriptProps>(function Tr
   ref,
 ): ReactNode {
   // Deriving rows re-parses every block's markdown, tables and fences. The
-  // shell re-renders on each streaming delta, each keystroke and a ~6Hz tick,
-  // so without this the cost of a frame grows with the length of the whole
-  // conversation rather than with what changed.
+  // shell re-renders on each streaming delta and each keystroke, so without
+  // this the cost of a frame grows with the length of the whole conversation
+  // rather than with what changed.
   const rows = useMemo(() => transcriptRows(blocks, viewport), [blocks, viewport.width]);
   const page = pageWidth(viewport);
   const windowHeight =

--- a/src/cli/ui/fullscreen/app.test.tsx
+++ b/src/cli/ui/fullscreen/app.test.tsx
@@ -474,7 +474,7 @@ function completedTurnView(): ViewModel {
   const base = sampleView();
   return {
     ...base,
-    live: { tools: [], hiddenTools: [], tick: 0, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     runActive: false,
     footer: {
       mode: base.footer.mode,

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -23,7 +23,7 @@ import packageJson from "../../../../package.json";
 import { hydrateTranscriptFromHistory } from "../hydrate-transcript";
 import { store } from "../store";
 import { THEME } from "../theme";
-import { FullscreenBridge } from "./bridge";
+import { APPROVAL_ARM_MS, flushPendingTerminalKeys, FullscreenBridge } from "./bridge";
 
 /**
  * Settles a state update dispatched from a keyboard event.
@@ -385,6 +385,8 @@ describe("fullscreen bridge", () => {
     store.setPrompt(null);
 
     expect(typed).toContain("/");
+    expect(typed).not.toContain("all conversations");
+    expect(typed).not.toContain("this conversation");
     expect(opened).toContain("all conversations");
   });
 
@@ -477,6 +479,7 @@ describe("fullscreen bridge", () => {
     await settleKeypress(rendered.flush, 100);
     expect(rendered.captureCharFrame()).toContain("1 queued");
     expect(rendered.captureCharFrame()).toContain("follow up");
+    expect(rendered.captureCharFrame()).toContain("enter to queue");
     expect(store.getMessageQueueSnapshot()).toEqual(["follow up"]);
 
     await rendered.mockInput.pressKey("ARROW_UP");
@@ -493,6 +496,33 @@ describe("fullscreen bridge", () => {
 
     rendered.renderer.destroy();
     store.setChatBusy(false);
+    store.setPrompt(null);
+  });
+
+  it("keeps the composer enabled after the chat prompt resolves while a queue is shown", async () => {
+    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
+    await rendered.renderOnce();
+    store.setPrompt({ type: "chat", message: "", resolve: () => undefined });
+    await rendered.flush();
+    store.setChatBusy(true);
+    store.setPrompt(null);
+    await rendered.flush();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await rendered.flush();
+
+    await typeInto(rendered.mockInput, rendered.flush, "already waiting");
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush, 100);
+    expect(rendered.captureCharFrame()).toContain("1 queued");
+    expect(rendered.captureCharFrame()).toContain("enter to queue");
+
+    await typeInto(rendered.mockInput, rendered.flush, "second thought");
+    expect(rendered.captureCharFrame()).toContain("second thought");
+    expect(rendered.captureCharFrame()).toContain("1 queued");
+
+    rendered.renderer.destroy();
+    store.setChatBusy(false);
+    store.clearQueue();
     store.setPrompt(null);
   });
 
@@ -1362,6 +1392,95 @@ describe("fullscreen bridge", () => {
     store.setPrompt(null);
     expect(pasted).toContain("pasted-while-scrolled");
     expect(pasted).toContain("enter to send");
+  });
+
+  it("drains buffered stdin so a pending Enter cannot land on a new card", () => {
+    const leftover: Array<string | Buffer> = ["\r", "a"];
+    const stdin = {
+      readable: true,
+      read: () => leftover.shift() ?? null,
+    } as unknown as NodeJS.ReadStream;
+    flushPendingTerminalKeys(stdin);
+    expect(leftover).toEqual([]);
+  });
+
+  it("does not resolve a producer approval from queued Enter or a during the deny-only window", async () => {
+    let settled: { approved: boolean } | undefined;
+    const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
+    await rendered.renderOnce();
+    const pending = Effect.runPromise(
+      presentationProducer().requestApproval({
+        toolCallId: "call-cal",
+        toolName: "calendar_create",
+        executeToolName: "calendar_create",
+        message: "This invitation will be sent immediately.",
+        executeArgs: {
+          account: "user@example.com",
+          title: "Planning",
+          field1: "one",
+          field2: "two",
+          field3: "three",
+          field4: "four",
+          field5: "five",
+          field6: "six",
+          field7: "seven",
+          field8: "eight",
+          field9: "nine",
+        },
+      }),
+    );
+    void pending.then((outcome) => {
+      settled = outcome;
+    });
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("field9");
+    expect(rendered.captureCharFrame()).toContain("esc to reject");
+    expect(rendered.captureCharFrame()).not.toContain("enter to accept");
+
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush);
+    await rendered.mockInput.pressKey("a");
+    await settleKeypress(rendered.flush);
+    expect(settled).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, APPROVAL_ARM_MS + 50));
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("enter to accept");
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush);
+    expect(await pending).toEqual({ approved: true });
+
+    rendered.renderer.destroy();
+  });
+
+  it("keeps reject available from a producer while accept is still inert", async () => {
+    let settled: { approved: boolean } | undefined;
+    const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
+    await rendered.renderOnce();
+    const pending = Effect.runPromise(
+      presentationProducer().requestApproval({
+        toolCallId: "call-mail",
+        toolName: "email_send",
+        executeToolName: "email_send",
+        message: "This message will leave the machine.",
+        executeArgs: { account: "user@example.com", to: "other@example.com" },
+      }),
+    );
+    void pending.then((outcome) => {
+      settled = outcome;
+    });
+    await rendered.flush();
+
+    await rendered.mockInput.pressKey("ESCAPE");
+    await settleKeypress(rendered.flush, 100);
+    expect(settled).toBeUndefined();
+    expect(rendered.captureCharFrame().toLowerCase()).toContain("instead");
+
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush, 100);
+    expect(await pending).toEqual({ approved: false });
+
+    rendered.renderer.destroy();
   });
 
   it("accepts only denial until an approval has armed", async () => {

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -588,9 +588,9 @@ describe("fullscreen bridge", () => {
   });
 
   it("draws the wizard menu as the home screen", async () => {
-    // The wizard publishes its menu as data alongside the Ink tree, so a
-    // renderer that cannot paint an Ink element can still draw the flow. Without
-    // this the fullscreen interface could not reach a chat session at all.
+    // The wizard publishes its menu as data, so a renderer that cannot paint an
+    // Ink element can still draw the flow. Without this the fullscreen
+    // interface could not reach a chat session at all.
     const text = await frame(() => {
       store.setActiveMenu({
         kind: "menu",
@@ -598,8 +598,6 @@ describe("fullscreen bridge", () => {
           { label: "Start chatting", value: "chat" },
           { label: "Create an agent", value: "create" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("Start chatting");
@@ -620,8 +618,6 @@ describe("fullscreen bridge", () => {
           },
         ],
         options: [{ label: "Create agent", value: "create-agent" }],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("agent");
@@ -640,8 +636,6 @@ describe("fullscreen bridge", () => {
           { id: "a1", name: "Basil", model: "claude-sonnet-4", lastUsed: true },
           { id: "a2", name: "Cass", model: "gpt-5" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("delete an agent");
@@ -655,14 +649,15 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "pick an agent",
-      action: "start",
-      agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4" }],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "pick an agent",
+        action: "start",
+        agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4" }],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ESCAPE");
     await settleKeypress(rendered.flush, 100);
@@ -675,17 +670,18 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "pick an agent",
-      action: "start",
-      agents: [
-        { id: "a1", name: "Basil", model: "claude-sonnet-4" },
-        { id: "a2", name: "Cass", model: "gpt-5" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "pick an agent",
+        action: "start",
+        agents: [
+          { id: "a1", name: "Basil", model: "claude-sonnet-4" },
+          { id: "a2", name: "Cass", model: "gpt-5" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ARROW_DOWN");
     await settleKeypress(rendered.flush, 100);
@@ -707,8 +703,6 @@ describe("fullscreen bridge", () => {
           { id: "a1", name: "doitall", model: "claude-sonnet-4" },
           { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("doitall");
@@ -724,18 +718,19 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: [
-        { id: "a1", name: "doitall", model: "claude-sonnet-4" },
-        { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "agents",
+        action: "back",
+        browse: true,
+        agents: [
+          { id: "a1", name: "doitall", model: "claude-sonnet-4" },
+          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     expect(rendered.captureCharFrame()).toContain("doitall");
 
@@ -744,15 +739,16 @@ describe("fullscreen bridge", () => {
     expect(selected).toEqual(["EXIT"]);
 
     selected.length = 0;
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4" }],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "agents",
+        action: "back",
+        browse: true,
+        agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4" }],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ESCAPE");
     await settleKeypress(rendered.flush, 100);
@@ -769,8 +765,6 @@ describe("fullscreen bridge", () => {
         title: "pick an agent",
         action: "start",
         agents: [],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("No agents yet.");
@@ -780,7 +774,7 @@ describe("fullscreen bridge", () => {
     store.setActiveMenu(null);
   });
 
-  it("hands an Ink-only custom screen to the legacy renderer", async () => {
+  it("keeps a data-only menu fullscreen without falling back", async () => {
     let fallbackRequests = 0;
     const unregisterFallback = store.registerRendererFallbackHandler(() => {
       fallbackRequests += 1;
@@ -788,30 +782,9 @@ describe("fullscreen bridge", () => {
     const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
     await rendered.renderOnce();
 
-    store.setCustomView(React.createElement(React.Fragment, null, "legacy-only"));
-    await rendered.flush();
-    await rendered.flush();
-
-    rendered.renderer.destroy();
-    store.setCustomView(null);
-    unregisterFallback();
-    expect(fallbackRequests).toBe(1);
-  });
-
-  it("keeps a renderer-neutral menu fullscreen when an Ink view is also published", async () => {
-    let fallbackRequests = 0;
-    const unregisterFallback = store.registerRendererFallbackHandler(() => {
-      fallbackRequests += 1;
-    });
-    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
-    await rendered.renderOnce();
-
-    store.setCustomView(React.createElement(React.Fragment, null, "legacy-copy"));
     store.setActiveMenu({
       kind: "menu",
       options: [{ label: "Stay fullscreen", value: "stay" }],
-      onSelect: () => undefined,
-      onExit: () => undefined,
     });
     await rendered.flush();
     await Promise.resolve();
@@ -820,7 +793,6 @@ describe("fullscreen bridge", () => {
     expect(fallbackRequests).toBe(0);
 
     rendered.renderer.destroy();
-    store.setCustomView(null);
     store.setActiveMenu(null);
     unregisterFallback();
   });
@@ -1258,16 +1230,17 @@ describe("fullscreen bridge", () => {
       { width: 100, height: 28 },
     );
     await renderOnce();
-    store.setActiveMenu({
-      kind: "menu",
-      options: [
-        { label: "Start chatting", value: "chat" },
-        { label: "Create an agent", value: "create" },
-        { label: "Exit", value: "exit" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT-CALLED"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options: [
+          { label: "Start chatting", value: "chat" },
+          { label: "Create an agent", value: "create" },
+          { label: "Exit", value: "exit" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT-CALLED" : result.value),
+    );
     await flush();
     const before = captureCharFrame();
 
@@ -1289,16 +1262,19 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "menu",
-      options: [
-        { label: "Start chatting", value: "chat" },
-        { label: "Create an agent", value: "create" },
-        { label: "Exit", value: "exit" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => undefined,
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options: [
+          { label: "Start chatting", value: "chat" },
+          { label: "Create an agent", value: "create" },
+          { label: "Exit", value: "exit" },
+        ],
+      },
+      (result) => {
+        if (result.kind === "select") selected.push(result.value);
+      },
+    );
     await rendered.flush();
 
     await rendered.mockInput.pressKey("\x1bOB");
@@ -1659,8 +1635,6 @@ describe("fullscreen bridge", () => {
     store.setActiveMenu({
       kind: "menu",
       options: [{ label: "x", value: "x" }],
-      onSelect: () => undefined,
-      onExit: () => undefined,
     });
     await flush();
 

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -1030,7 +1030,6 @@ export function FullscreenBridge(): React.ReactNode {
     [updateHistory],
   );
   const [commandIndex, commandIndexRef, setCommandIndex] = useSynchronizedState(0);
-  const [customView, setCustomView] = useState<React.ReactNode | null>(null);
   const [connectors, setConnectors] = useState<ReadonlyMap<string, ConnectorStatus>>(new Map());
   const [currentConversation, setCurrentConversation] = useState(
     store.getCurrentConversationSnapshot(),
@@ -1145,7 +1144,6 @@ export function FullscreenBridge(): React.ReactNode {
       setApprovalFieldOffset(0);
       setApproval(next);
     });
-    const unregisterCustomView = store.registerCustomView(setCustomView);
     store.registerConnectorsSetter(setConnectors);
     store.registerCurrentConversationSetter(setCurrentConversation);
     store.registerWorkingDirectorySetter(setWorkingDirectory);
@@ -1167,7 +1165,6 @@ export function FullscreenBridge(): React.ReactNode {
     if (pending.length > 0) setOutputs((previous) => [...previous, ...pending]);
 
     return () => {
-      unregisterCustomView();
       store.registerPrintOutput(null);
       store.registerUpdateOutput(null);
       store.registerClearOutputs(null);
@@ -1195,19 +1192,6 @@ export function FullscreenBridge(): React.ReactNode {
     }, APPROVAL_ARM_MS);
     return () => clearTimeout(timer);
   }, [approval, setApprovalArmedState]);
-
-  useEffect(() => {
-    if (customView === null || menu !== null) return;
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (!cancelled && store.getActiveMenuSnapshot() === null) {
-        store.requestRendererFallback();
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [customView, menu]);
 
   useEffect(() => {
     if (prompt?.type !== "filepicker") return;
@@ -1511,19 +1495,21 @@ export function FullscreenBridge(): React.ReactNode {
         if (name === "return" || name === "enter") {
           if (openMenu.kind === "agents") {
             if (openMenu.browse === true) {
-              openMenu.onExit();
+              store.completePrompt({ kind: "exit" });
             } else {
               const choice = openMenu.agents[menuIndexRef.current];
-              if (choice !== undefined) openMenu.onSelect(choice.id);
+              if (choice !== undefined) store.completePrompt({ kind: "select", value: choice.id });
             }
           } else {
             const choice = openMenu.options[menuIndexRef.current];
-            if (choice !== undefined) openMenu.onSelect(choice.value);
+            if (choice !== undefined) {
+              store.completePrompt({ kind: "select", value: choice.value });
+            }
           }
           return true;
         }
         if (name === "escape" || name === "q") {
-          openMenu.onExit();
+          store.completePrompt({ kind: "exit" });
           return true;
         }
         return true;
@@ -2210,10 +2196,6 @@ export function FullscreenBridge(): React.ReactNode {
         }}
         viewport={viewport}
       />
-    ) : customView !== null ? (
-      <box style={{ flexDirection: "column", padding: 1 }}>
-        <text>Switching to the standard interface…</text>
-      </box>
     ) : undefined;
 
   return (

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -98,7 +98,15 @@ const WAITING_ROTATE_MS = 4_000;
 
 /** How long the band holds its height after the last tool finishes. */
 const SETTLE_MS = 800;
-const APPROVAL_ARM_MS = 250;
+export const APPROVAL_ARM_MS = 250;
+
+/** Discard keystrokes already sitting on stdin before the card can see them. */
+export function flushPendingTerminalKeys(stdin: NodeJS.ReadStream = process.stdin): void {
+  if (stdin.readable !== true || typeof stdin.read !== "function") return;
+  while (stdin.read() !== null) {
+    // Buffered Enter / always-allow must not land on a card that just appeared.
+  }
+}
 
 interface PromptEditorState {
   readonly value: string;
@@ -1140,6 +1148,7 @@ export function FullscreenBridge(): React.ReactNode {
     store.registerEphemeralRegionsSetter(setRegions);
     store.registerPromptSetter(setPromptState);
     store.registerApprovalRequestSetter((next) => {
+      if (next !== null) flushPendingTerminalKeys();
       setApprovalArmedState(false);
       setApprovalFieldOffset(0);
       setApproval(next);
@@ -2119,8 +2128,8 @@ export function FullscreenBridge(): React.ReactNode {
       anchor: draftAnchor,
       placeholder: busy ? "Type to queue for next turn" : "Ask anything",
       queued: queue,
-      queueing: busy,
-      disabled: overlay !== undefined || (!busy && prompt?.type !== "chat"),
+      queueing: busy || queue.length > 0,
+      disabled: overlay !== undefined || (!busy && queue.length === 0 && prompt?.type !== "chat"),
       ...(commands === undefined ? {} : { commands }),
     };
   }, [draft, draftCaret, draftAnchor, busy, queue, overlay, prompt, commandQuery, commandIndex]);

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -92,6 +92,10 @@ import {
 /** Waiting copy, house voice: idiomatic, never jokey. */
 const WAITING = ["comping behind you", "turning it over", "two horns out", "digging the crates"];
 
+/** Footer and live elapsed digits update once a second, not on the indicator. */
+const FOOTER_ELAPSED_MS = 1000;
+const WAITING_ROTATE_MS = 4_000;
+
 /** How long the band holds its height after the last tool finishes. */
 const SETTLE_MS = 800;
 const APPROVAL_ARM_MS = 250;
@@ -1040,7 +1044,6 @@ export function FullscreenBridge(): React.ReactNode {
   const [searchIndex, searchIndexRef, setSearchIndex] = useSynchronizedState(0);
   const [menu, menuRef, setMenu] = useSynchronizedState<ActiveMenu | null>(null);
   const [menuIndex, menuIndexRef, setMenuIndex] = useSynchronizedState(0);
-  const [tick, setTick] = useState(0);
   const [elapsedMs, setElapsedMs] = useState<number | undefined>();
   const [reservedRows, setReservedRows] = useState(0);
   const runStartedAt = useRef<number | null>(null);
@@ -1252,15 +1255,14 @@ export function FullscreenBridge(): React.ReactNode {
     }
     if (runStartedAt.current === null) runStartedAt.current = Date.now();
     const update = (): void => {
-      setTick((value) => value + 1);
       setElapsedMs(Math.max(0, Date.now() - (runStartedAt.current ?? Date.now())));
     };
     update();
-    const timer = setInterval(update, 170);
+    const timer = setInterval(update, FOOTER_ELAPSED_MS);
     return () => clearInterval(timer);
   }, [runActive]);
 
-  const tools = useMemo(() => liveToolsFrom(activity, Date.now()), [activity, tick]);
+  const tools = useMemo(() => liveToolsFrom(activity, Date.now()), [activity, elapsedMs]);
   const step = useMemo(() => stepFrom(activity), [activity]);
   const waitingNow = activity.phase === "awaiting" || activity.phase === "thinking";
   const neededRows = Math.min(
@@ -2153,13 +2155,18 @@ export function FullscreenBridge(): React.ReactNode {
       tools,
       hiddenTools: [],
       ...(step === undefined ? {} : { step }),
-      ...(waitingNow ? { waiting: WAITING[Math.floor(tick / 24) % WAITING.length] as string } : {}),
-      tick,
+      ...(waitingNow
+        ? {
+            waiting: WAITING[
+              Math.floor((elapsedMs ?? 0) / WAITING_ROTATE_MS) % WAITING.length
+            ] as string,
+          }
+        : {}),
       ...(elapsedMs === undefined ? {} : { elapsedMs }),
       reservedRows,
       ...(reasoningElapsedMs === undefined ? {} : { reasoningElapsedMs }),
     };
-  }, [tools, step, waitingNow, tick, elapsedMs, reservedRows, regions]);
+  }, [tools, step, waitingNow, elapsedMs, reservedRows, regions]);
 
   const view = useMemo<ViewModel>(
     () => ({

--- a/src/cli/ui/fullscreen/keymap.test.ts
+++ b/src/cli/ui/fullscreen/keymap.test.ts
@@ -321,9 +321,10 @@ describe("footer hints", () => {
       "^f to search",
       "^r for reasoning",
     ]);
-    expect(hintsFor("input", false, false, "approval")).toEqual([
+    expect(hintsFor("input", false, false, "approval", false, false)).toEqual(["esc to reject"]);
+    expect(hintsFor("input", false, false, "approval", false, true)).toEqual([
       "enter to accept",
-      "esc to cancel",
+      "esc to reject",
     ]);
     expect(hintsFor("input", false, false, "text")).toEqual(["enter to confirm", "esc to go back"]);
     expect(hintsFor("input", true, false, "search")).toEqual([
@@ -348,7 +349,8 @@ describe("footer hints", () => {
       ...hintsFor("input", false),
       ...hintsFor("input", true),
       ...hintsFor("transcript", false),
-      ...hintsFor("input", false, false, "approval"),
+      ...hintsFor("input", false, false, "approval", false, false),
+      ...hintsFor("input", false, false, "approval", false, true),
     ].join(" ");
     expect(advertised).not.toMatch(/\bcopy\b/);
     expect(advertised).not.toContain("palette");

--- a/src/cli/ui/fullscreen/keymap.ts
+++ b/src/cli/ui/fullscreen/keymap.ts
@@ -431,8 +431,11 @@ export function hintsFor(
   queueing = false,
   overlay?: "approval" | "search" | "question" | "text" | "filepicker",
   commandsOpen = false,
+  overlayArmed = true,
 ): readonly string[] {
-  if (overlay === "approval") return ["enter to accept", "esc to cancel"];
+  if (overlay === "approval") {
+    return overlayArmed ? ["enter to accept", "esc to reject"] : ["esc to reject"];
+  }
   if (overlay === "search") return ["enter to insert", "tab to scope", "esc to close"];
   if (overlay === "text") return ["enter to confirm", "esc to go back"];
   if (overlay === "question" || overlay === "filepicker") {

--- a/src/cli/ui/fullscreen/live-input.test.tsx
+++ b/src/cli/ui/fullscreen/live-input.test.tsx
@@ -68,7 +68,7 @@ function tool(app: string, operation: string, phase: number, elapsedMs = 1000): 
  * mark set `reservedRows` explicitly, because that is the property under test.
  */
 function live(overrides: Partial<LiveModel> = {}): LiveModel {
-  const model: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 0, ...overrides };
+  const model: LiveModel = { tools: [], hiddenTools: [], reservedRows: 0, ...overrides };
   if (overrides.reservedRows !== undefined) return model;
   const needed =
     model.tools.length +
@@ -257,7 +257,6 @@ describe("live zone", () => {
   it("gives two tools at different phases different indicator cells in one frame", async () => {
     const model = live({
       tools: [tool("gmail", "list threads", 0), tool("calendar", "freebusy", 1)],
-      tick: 0,
     });
     const { frame } = await bandHeight(model);
     const rows = rowsOf(frame);
@@ -269,6 +268,15 @@ describe("live zone", () => {
     // The spinner sits one column past the rail gutter on every tool row.
     const spinnerColumn = [...`${glyphs.rail} `].length;
     expect([...(first as string)][spinnerColumn]).not.toBe([...(second as string)][spinnerColumn]);
+  });
+
+  it("animates from a tick argument without rewriting the LiveModel", () => {
+    const model = live({ tools: [tool("gmail", "list threads", 0)] });
+    const viewport = { width: WIDTH, height: HEIGHT };
+    const atZero = liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 0);
+    const atOne = liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 1);
+    expect(atOne).not.toEqual(atZero);
+    expect(liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 0)).toEqual(atZero);
   });
 
   it("shows the step line as one row while a plan is active, and not otherwise", () => {

--- a/src/cli/ui/fullscreen/live-zone-tick.test.tsx
+++ b/src/cli/ui/fullscreen/live-zone-tick.test.tsx
@@ -1,0 +1,166 @@
+/** @jsxImportSource @opentui/react */
+
+import { testRender } from "@opentui/react/test-utils";
+import { describe, expect, it } from "bun:test";
+import React, { memo, useRef } from "react";
+import { MOTION } from "../theme";
+import { App } from "./App";
+import { Header } from "./Header";
+import { Input } from "./Input";
+import { LiveZone } from "./LiveZone";
+import { sampleView } from "./sample";
+import { transcriptRows } from "./Transcript";
+import type { HeaderModel, InputModel, ViewModel, Viewport } from "./types";
+
+const WIDTH = 120;
+const HEIGHT = 34;
+
+function waitForLiveTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, MOTION.indicator * 2 + 40));
+}
+
+describe("live tick isolation", () => {
+  it("does not commit App when the live indicator advances", async () => {
+    let commits = 0;
+    function CountingApp({ view }: { view: ViewModel }): React.ReactNode {
+      commits += 1;
+      return (
+        <App
+          view={view}
+          onAction={() => undefined}
+        />
+      );
+    }
+
+    const view = sampleView();
+    const { renderer, renderOnce, flush } = await testRender(<CountingApp view={view} />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    const afterMount = commits;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(commits).toBe(afterMount);
+  });
+
+  it("keeps Header and Input props referentially stable across ticks", async () => {
+    const view = sampleView();
+    const viewport: Viewport = { width: WIDTH, height: HEIGHT };
+    const headerModels: HeaderModel[] = [];
+    const inputModels: InputModel[] = [];
+
+    const HeaderProbe = memo(function HeaderProbe({
+      model,
+      viewport: nextViewport,
+    }: {
+      model: HeaderModel;
+      viewport: Viewport;
+    }): React.ReactNode {
+      headerModels.push(model);
+      return (
+        <Header
+          model={model}
+          viewport={nextViewport}
+        />
+      );
+    });
+
+    const InputProbe = memo(function InputProbe({
+      model,
+      viewport: nextViewport,
+    }: {
+      model: InputModel;
+      viewport: Viewport;
+    }): React.ReactNode {
+      inputModels.push(model);
+      return (
+        <Input
+          model={model}
+          viewport={nextViewport}
+          focused
+        />
+      );
+    });
+
+    function Shell(): React.ReactNode {
+      return (
+        <box style={{ width: WIDTH, height: HEIGHT, flexDirection: "column" }}>
+          <HeaderProbe
+            model={view.header}
+            viewport={viewport}
+          />
+          <LiveZone
+            model={view.live}
+            viewport={viewport}
+          />
+          <InputProbe
+            model={view.input}
+            viewport={viewport}
+          />
+        </box>
+      );
+    }
+
+    const { renderer, renderOnce, flush } = await testRender(<Shell />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    expect(headerModels.length).toBeGreaterThan(0);
+    expect(inputModels.length).toBeGreaterThan(0);
+    const headersAfterMount = headerModels.length;
+    const inputsAfterMount = inputModels.length;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(headerModels).toHaveLength(headersAfterMount);
+    expect(inputModels).toHaveLength(inputsAfterMount);
+    expect(headerModels.every((model) => model === view.header)).toBe(true);
+    expect(inputModels.every((model) => model === view.input)).toBe(true);
+  });
+
+  it("does not re-enter transcriptRows when the live indicator advances", async () => {
+    const view = sampleView();
+    const viewport: Viewport = { width: WIDTH, height: HEIGHT };
+    const builds: number[] = [];
+
+    function TranscriptProbe(): React.ReactNode {
+      const countRef = useRef(0);
+      countRef.current += 1;
+      builds.push(countRef.current);
+      transcriptRows(view.blocks, viewport);
+      return <text>probe</text>;
+    }
+
+    function Shell(): React.ReactNode {
+      return (
+        <box style={{ width: WIDTH, height: HEIGHT, flexDirection: "column" }}>
+          <TranscriptProbe />
+          <LiveZone
+            model={view.live}
+            viewport={viewport}
+          />
+        </box>
+      );
+    }
+
+    const { renderer, renderOnce, flush } = await testRender(<Shell />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    const afterMount = builds.length;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(builds).toHaveLength(afterMount);
+  });
+});

--- a/src/cli/ui/fullscreen/sample.ts
+++ b/src/cli/ui/fullscreen/sample.ts
@@ -150,7 +150,7 @@ const SEARCH: SearchOverlay = {
 };
 
 /** The base frame: mid-session, two tools in flight, nothing blocking. */
-export function sampleView(tick = 0): ViewModel {
+export function sampleView(): ViewModel {
   return {
     header: {
       version: packageJson.version,
@@ -174,7 +174,6 @@ export function sampleView(tick = 0): ViewModel {
       hiddenTools: [],
       step: { index: 3, total: 7, label: "rank by urgency" },
       elapsedMs: 11_600,
-      tick,
       // Two tool rows plus the step line. The adapter grows this to fit and
       // only lets it fall once the run settles, so the input holds still while
       // tools churn.
@@ -192,29 +191,29 @@ export function sampleView(tick = 0): ViewModel {
 }
 
 /** The same session with the approval card up. */
-export function sampleApprovalView(tick = 0): ViewModel {
-  const base = sampleView(tick);
+export function sampleApprovalView(): ViewModel {
+  const base = sampleView();
   return {
     ...base,
     // Nothing is running: jazz has stopped and is waiting on a person, and the
     // empty live zone is itself the signal.
-    live: { tools: [], hiddenTools: [], tick, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     overlay: APPROVAL,
   };
 }
 
 /** The same session with history search open across past sessions. */
-export function sampleSearchView(tick = 0): ViewModel {
-  return { ...sampleView(tick), overlay: SEARCH };
+export function sampleSearchView(): ViewModel {
+  return { ...sampleView(), overlay: SEARCH };
 }
 
 /** An idle first-run frame: no work, no plan, nothing to interrupt. */
 export function sampleIdleView(): ViewModel {
-  const base = sampleView(0);
+  const base = sampleView();
   return {
     ...base,
     blocks: [],
-    live: { tools: [], hiddenTools: [], tick: 0, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     footer: {
       mode: base.footer.mode,
       hints: base.footer.hints,
@@ -223,8 +222,8 @@ export function sampleIdleView(): ViewModel {
 }
 
 /** Six tools running, to exercise the live zone's cap and its overflow row. */
-export function sampleBusyView(tick = 0): ViewModel {
-  const base = sampleView(tick);
+export function sampleBusyView(): ViewModel {
+  const base = sampleView();
   return {
     ...base,
     live: {

--- a/src/cli/ui/fullscreen/transcript-window.test.ts
+++ b/src/cli/ui/fullscreen/transcript-window.test.ts
@@ -79,7 +79,7 @@ describe("wheelScrollDelta", () => {
 
 describe("transcriptVisibleCount", () => {
   it("subtracts chrome, the live band, and the composer", () => {
-    const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 2 };
+    const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 2 };
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
@@ -97,7 +97,7 @@ describe("transcriptVisibleCount", () => {
   });
 
   it("keeps a transcript row by taking it from the live band, not from the composer", () => {
-    const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 5 };
+    const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 5 };
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
@@ -119,7 +119,7 @@ describe("transcriptVisibleCount", () => {
 });
 
 describe("allocateRegions", () => {
-  const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 5 };
+  const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 5 };
   const commands = {
     items: Array.from({ length: 12 }, (_, index) => ({
       name: `command-${String(index)}`,

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -173,11 +173,9 @@ export interface LiveModel {
   /** House-voice waiting copy. Shown only before the first token lands. */
   readonly waiting?: string;
   readonly elapsedMs?: number;
-  /** Monotonic tick driving the indicator. */
-  readonly tick: number;
   /**
    * Elapsed time for the open reasoning region, if one is running.
-   * Lives here rather than on a transcript Block so a live tick cannot
+   * Lives here rather than on a transcript Block so a clock update cannot
    * rewrite block identity and defeat wrap memoization.
    */
   readonly reasoningElapsedMs?: number;

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import type React from "react";
-import { UIStore } from "./store";
+import { UIStore, type ActiveMenu } from "./store";
 import type { OutputEntry } from "./types";
 
 function entry(message = "hello"): OutputEntry {
@@ -128,20 +129,83 @@ describe("UIStore", () => {
       expect(fallbackRequests).toBe(1);
     });
 
-    test("carries a custom view across renderer replacement", () => {
+    test("carries a data-only menu across renderer replacement", () => {
       const s = new UIStore();
-      const firstRenderer: Array<React.ReactNode | null> = [];
-      const secondRenderer: Array<React.ReactNode | null> = [];
-      const unregisterFirst = s.registerCustomView((view) => firstRenderer.push(view));
+      const firstRenderer: Array<ActiveMenu | null> = [];
+      const secondRenderer: Array<ActiveMenu | null> = [];
+      const menu: ActiveMenu = {
+        kind: "menu",
+        options: [{ label: "Start chatting", value: "chat" }],
+      };
+      s.registerActiveMenuSetter((next) => firstRenderer.push(next));
 
-      s.setCustomView("Ink-only screen");
-      const unregisterSecond = s.registerCustomView((view) => secondRenderer.push(view));
-      unregisterFirst();
-      s.setCustomView(null);
+      s.setActiveMenu(menu);
+      s.registerActiveMenuSetter((next) => secondRenderer.push(next));
+      s.setActiveMenu(null);
 
-      expect(firstRenderer).toEqual([null, "Ink-only screen"]);
-      expect(secondRenderer).toEqual(["Ink-only screen", null]);
-      unregisterSecond();
+      expect(firstRenderer).toEqual([null, menu]);
+      expect(secondRenderer).toEqual([menu, null]);
+    });
+  });
+
+  describe("completePrompt", () => {
+    test("does not expose setCustomView", () => {
+      const s = new UIStore();
+      expect("setCustomView" in s).toBe(false);
+      expect("registerCustomView" in s).toBe(false);
+    });
+
+    test("no producer or renderer still calls setCustomView", () => {
+      const sources = [
+        join(import.meta.dir, "store.ts"),
+        join(import.meta.dir, "App.tsx"),
+        join(import.meta.dir, "fullscreen/bridge.tsx"),
+        join(import.meta.dir, "../commands/wizard.ts"),
+        join(import.meta.dir, "../commands/config-wizard.ts"),
+        join(import.meta.dir, "../commands/workflow.ts"),
+      ];
+      for (const sourcePath of sources) {
+        const source = readFileSync(sourcePath, "utf8");
+        expect(source.includes("setCustomView")).toBe(false);
+        expect(source.includes("registerCustomView")).toBe(false);
+      }
+    });
+
+    test("keeps the snapshot data-only and runs the continuation once", () => {
+      const s = new UIStore();
+      const results: string[] = [];
+      s.setActiveMenu(
+        {
+          kind: "menu",
+          options: [{ label: "Start chatting", value: "chat" }],
+        },
+        (result) => results.push(result.kind === "exit" ? "exit" : result.value),
+      );
+
+      const snapshot = s.getActiveMenuSnapshot();
+      expect(snapshot).not.toHaveProperty("onSelect");
+      expect(snapshot).not.toHaveProperty("onExit");
+      if (snapshot !== null) {
+        for (const value of Object.values(snapshot)) {
+          expect(typeof value).not.toBe("function");
+        }
+      }
+
+      s.completePrompt({ kind: "select", value: "chat" });
+      s.completePrompt({ kind: "select", value: "again" });
+      expect(results).toEqual(["chat"]);
+      expect(s.getActiveMenuSnapshot()).toBe(null);
+    });
+
+    test("drops a pending continuation when the menu is cleared", () => {
+      const s = new UIStore();
+      let called = 0;
+      s.setActiveMenu({ kind: "menu", options: [{ label: "Go", value: "go" }] }, () => {
+        called += 1;
+      });
+      s.setActiveMenu(null);
+      s.completePrompt({ kind: "exit" });
+      expect(called).toBe(0);
     });
   });
 

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -1,4 +1,3 @@
-import type React from "react";
 import { isActivityEqual, type ActivityState } from "./activity-state";
 import type { StreamKind } from "./adapters/terminal-output-adapter";
 import type { OutputEntry, PromptState } from "./types";
@@ -97,11 +96,10 @@ export type ConnectorStatus = "live" | "renew" | "offline";
 /**
  * A menu the app is waiting on, published as data rather than as a rendered tree.
  *
- * `setCustomView` hands the UI a React element built with Ink components, which
- * only the Ink renderer can paint — so a second renderer sees an opaque node and
- * can do nothing useful with it. Publishing the *intent* instead lets each
- * renderer draw its own version, which is the only way two renderers can share
- * a flow.
+ * Continuations stay on the write side (`completePrompt`). Putting `onSelect` /
+ * `onExit` on the snapshot would smuggle closures through a contract two
+ * renderers share, and the second renderer would still have nothing it can
+ * serialize or replay.
  */
 export interface ActiveMenuOption {
   readonly label: string;
@@ -129,8 +127,6 @@ export interface ActiveWizardMenu {
   readonly options: readonly ActiveMenuOption[];
   readonly requirements?: readonly ActiveMenuRequirement[];
   readonly tip?: string;
-  readonly onSelect: (value: string) => void;
-  readonly onExit: () => void;
 }
 
 export interface ActiveAgentMenu {
@@ -138,12 +134,17 @@ export interface ActiveAgentMenu {
   readonly title: string;
   readonly action: string;
   readonly agents: readonly ActiveAgentChoice[];
-  readonly onSelect: (value: string) => void;
-  readonly onExit: () => void;
   readonly browse?: boolean;
 }
 
 export type ActiveMenu = ActiveWizardMenu | ActiveAgentMenu;
+
+/** Discriminated surface a renderer paints in place of the chat transcript. */
+export type SurfaceIntent = ActiveMenu;
+
+/** How a renderer answers the surface currently published on the store. */
+export type PromptResult =
+  { readonly kind: "select"; readonly value: string } | { readonly kind: "exit" };
 
 /** Identifies the conversation on screen, so history search can be narrowed to it. */
 export interface CurrentConversation {
@@ -220,7 +221,6 @@ export class UIStore {
   private inputHistory: string[] = [];
   private messageQueueSnapshot: readonly string[] = [];
   private chatBusySnapshot: boolean = false;
-  private customViewSnapshot: React.ReactNode | null = null;
 
   // Insertion-ordered map of live ephemeral regions, keyed by id.
   private ephemeralRegions: Map<EphemeralRegionId, EphemeralRegion> = new Map();
@@ -237,7 +237,6 @@ export class UIStore {
   private expandableReasoningSetter: ((value: ExpandableReasoning | null) => void) | null = null;
   private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
   private chatBusySetter: ((busy: boolean) => void) | null = null;
-  private customViewSetter: ((view: React.ReactNode | null) => void) | null = null;
   private modeToastSetter: ((message: string | null) => void) | null = null;
   private modeSetter: ((isYolo: boolean) => void) | null = null;
   private rendererFallbackHandler: (() => void) | null = null;
@@ -374,11 +373,6 @@ export class UIStore {
     if (this.runStatsSetter) {
       this.runStatsSetter(next);
     }
-  };
-
-  setCustomView = (view: React.ReactNode | null): void => {
-    this.customViewSnapshot = view;
-    this.customViewSetter?.(view);
   };
 
   /**
@@ -764,6 +758,7 @@ export class UIStore {
 
   private activeMenuSnapshot: ActiveMenu | null = null;
   private activeMenuSetter: ((menu: ActiveMenu | null) => void) | null = null;
+  private promptContinuation: ((result: PromptResult) => void) | null = null;
   private connectorsSnapshot: ReadonlyMap<string, ConnectorStatus> = new Map();
   private connectorsSetter: ((connectors: ReadonlyMap<string, ConnectorStatus>) => void) | null =
     null;
@@ -820,16 +815,6 @@ export class UIStore {
     }
   }
 
-  registerCustomView(setter: (view: React.ReactNode | null) => void): () => void {
-    this.customViewSetter = setter;
-    setter(this.customViewSnapshot);
-    return () => {
-      if (this.customViewSetter === setter) {
-        this.customViewSetter = null;
-      }
-    };
-  }
-
   registerMessageQueueSetter(setter: ((queue: readonly string[]) => void) | null): void {
     this.messageQueueSetter = setter;
     if (setter) {
@@ -865,10 +850,26 @@ export class UIStore {
     };
   };
 
-  /** The menu currently awaiting a choice, or null. */
-  setActiveMenu = (menu: ActiveMenu | null): void => {
+  /** Publish a data-only menu. Pass the continuation here, not on the snapshot. */
+  setActiveMenu = (menu: ActiveMenu | null, onComplete?: (result: PromptResult) => void): void => {
     this.activeMenuSnapshot = menu;
+    this.promptContinuation = menu === null ? null : (onComplete ?? null);
     if (this.activeMenuSetter) this.activeMenuSetter(menu);
+  };
+
+  /**
+   * Answer the published surface. Clears the snapshot, then invokes the
+   * write-side continuation once. A second call is a no-op.
+   */
+  completePrompt = (result: PromptResult): void => {
+    if (this.activeMenuSnapshot === null && this.promptContinuation === null) {
+      return;
+    }
+    const continuation = this.promptContinuation;
+    this.promptContinuation = null;
+    this.activeMenuSnapshot = null;
+    if (this.activeMenuSetter) this.activeMenuSetter(null);
+    continuation?.(result);
   };
 
   registerActiveMenuSetter(setter: ((menu: ActiveMenu | null) => void) | null): void {


### PR DESCRIPTION
## What & why
Live prompts now work during a fullscreen run, and approval cards start deny-only for 250ms so a buffered Enter cannot accept them. Esc still rejects, every argument field stays reachable, the footer only shows accept after the card arms, and the composer still queues follow-ups. This PR also moves the spinner clock into LiveZone so the rest of the shell does not rebuild several times a second.

## How to verify
- Trigger a calendar or email approval and mash Enter or `a` immediately: the tool must not run until the deny-only window ends; Esc still rejects.
- Approve a tool with nine or more argument fields and confirm the ninth is on the card or reachable with up/down.
- During a busy turn, type a follow-up after the chat prompt disappears and confirm it queues; on an idle composer, type `/` and confirm slash commands list instead of history search.
- Confirm the footer says `esc to reject` before arming and `enter to accept` only after.
- Start a turn: spinner animates; header and composer do not flicker.