### PR TITLE
perf(ui): keep the live tick inside LiveZone

### DIFF
--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -6,7 +6,7 @@ import {
   useSelectionHandler,
   useTerminalDimensions,
 } from "@opentui/react";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getGlyphs } from "../glyphs";
 import { THEME } from "../theme";
 import {
@@ -195,13 +195,7 @@ export function reuseViewport(width: number, height: number, previous: Viewport)
   return { width, height };
 }
 
-export function App({
-  view,
-  onAction,
-  onKey,
-  onPaste,
-  overrideContent,
-}: AppProps): React.ReactNode {
+function AppView({ view, onAction, onKey, onPaste, overrideContent }: AppProps): React.ReactNode {
   const { width, height } = useTerminalDimensions();
   const renderer = useRenderer();
   const rendererRef = useRef(renderer);
@@ -561,3 +555,5 @@ export function App({
     </box>
   );
 }
+
+export const App = memo(AppView);

--- a/src/cli/ui/fullscreen/LiveZone.tsx
+++ b/src/cli/ui/fullscreen/LiveZone.tsx
@@ -33,10 +33,10 @@
  * running rather than one thing blinking three times.
  */
 
-import { memo, type ReactNode } from "react";
+import { memo, useEffect, useState, type ReactNode } from "react";
 import { highlightCodeLine } from "./syntax-spans";
 import { getGlyphs, laneFrame, type GlyphSet } from "../glyphs";
-import { THEME } from "../theme";
+import { MOTION, THEME } from "../theme";
 import { fitTerminalSegments, terminalSegmentsWidth } from "./terminal-cells";
 import {
   LIVE_ZONE_MAX_ROWS,
@@ -256,6 +256,7 @@ export function liveRows(
   streaming = false,
   glyphs: GlyphSet = getGlyphs(),
   maxRows = LIVE_ZONE_MAX_ROWS,
+  tick = 0,
 ): readonly LiveRow[] {
   const width = Math.max(1, viewport.width);
   const capacity = reservedHeight(model, maxRows);
@@ -288,7 +289,7 @@ export function liveRows(
 
   const rows: LiveRow[] = [];
   if (showWaiting && model.waiting !== undefined) {
-    rows.push(waitingRow(model.waiting, model.elapsedMs, model.tick, glyphs, width));
+    rows.push(waitingRow(model.waiting, model.elapsedMs, tick, glyphs, width));
   }
   if (showStep && model.step !== undefined) {
     rows.push(
@@ -301,15 +302,33 @@ export function liveRows(
       ),
     );
   }
-  for (const tool of shown) rows.push(toolRow(tool, model.tick, glyphs, width));
+  for (const tool of shown) rows.push(toolRow(tool, tick, glyphs, width));
   if (hiddenNames.length > 0) rows.push(overflowRow(hiddenNames, glyphs, width));
 
   return rows;
 }
 
+function liveBandAnimates(model: LiveModel, streaming: boolean, maxRows?: number): boolean {
+  if (reservedHeight(model, maxRows) === 0) return false;
+  if (model.tools.length > 0) return true;
+  return model.waiting !== undefined && !streaming;
+}
+
 function LiveZoneView({ model, viewport, streaming, maxRows }: LiveZoneProps): ReactNode {
+  const [tick, setTick] = useState(0);
+  const streamingNow = streaming ?? false;
+  const animate = liveBandAnimates(model, streamingNow, maxRows);
+
+  useEffect(() => {
+    if (!animate) return;
+    const timer = setInterval(() => {
+      setTick((value) => value + 1);
+    }, MOTION.indicator);
+    return () => clearInterval(timer);
+  }, [animate]);
+
   const height = reservedHeight(model, maxRows);
-  const rows = liveRows(model, viewport, streaming ?? false, undefined, maxRows);
+  const rows = liveRows(model, viewport, streamingNow, undefined, maxRows, tick);
 
   // The run has settled: the whole band goes away and the transcript takes the
   // rows back. Note this is keyed on the reservation rather than on the rows,

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -1472,9 +1472,9 @@ const TranscriptView = forwardRef<TranscriptHandle, TranscriptProps>(function Tr
   ref,
 ): ReactNode {
   // Deriving rows re-parses every block's markdown, tables and fences. The
-  // shell re-renders on each streaming delta, each keystroke and a ~6Hz tick,
-  // so without this the cost of a frame grows with the length of the whole
-  // conversation rather than with what changed.
+  // shell re-renders on each streaming delta and each keystroke, so without
+  // this the cost of a frame grows with the length of the whole conversation
+  // rather than with what changed.
   const rows = useMemo(() => transcriptRows(blocks, viewport), [blocks, viewport.width]);
   const page = pageWidth(viewport);
   const windowHeight =

--- a/src/cli/ui/fullscreen/app.test.tsx
+++ b/src/cli/ui/fullscreen/app.test.tsx
@@ -474,7 +474,7 @@ function completedTurnView(): ViewModel {
   const base = sampleView();
   return {
     ...base,
-    live: { tools: [], hiddenTools: [], tick: 0, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     runActive: false,
     footer: {
       mode: base.footer.mode,

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -92,6 +92,10 @@ import {
 /** Waiting copy, house voice: idiomatic, never jokey. */
 const WAITING = ["comping behind you", "turning it over", "two horns out", "digging the crates"];
 
+/** Footer and live elapsed digits update once a second, not on the indicator. */
+const FOOTER_ELAPSED_MS = 1000;
+const WAITING_ROTATE_MS = 4_000;
+
 /** How long the band holds its height after the last tool finishes. */
 const SETTLE_MS = 800;
 const APPROVAL_ARM_MS = 250;
@@ -1040,7 +1044,6 @@ export function FullscreenBridge(): React.ReactNode {
   const [searchIndex, searchIndexRef, setSearchIndex] = useSynchronizedState(0);
   const [menu, menuRef, setMenu] = useSynchronizedState<ActiveMenu | null>(null);
   const [menuIndex, menuIndexRef, setMenuIndex] = useSynchronizedState(0);
-  const [tick, setTick] = useState(0);
   const [elapsedMs, setElapsedMs] = useState<number | undefined>();
   const [reservedRows, setReservedRows] = useState(0);
   const runStartedAt = useRef<number | null>(null);
@@ -1252,15 +1255,14 @@ export function FullscreenBridge(): React.ReactNode {
     }
     if (runStartedAt.current === null) runStartedAt.current = Date.now();
     const update = (): void => {
-      setTick((value) => value + 1);
       setElapsedMs(Math.max(0, Date.now() - (runStartedAt.current ?? Date.now())));
     };
     update();
-    const timer = setInterval(update, 170);
+    const timer = setInterval(update, FOOTER_ELAPSED_MS);
     return () => clearInterval(timer);
   }, [runActive]);
 
-  const tools = useMemo(() => liveToolsFrom(activity, Date.now()), [activity, tick]);
+  const tools = useMemo(() => liveToolsFrom(activity, Date.now()), [activity, elapsedMs]);
   const step = useMemo(() => stepFrom(activity), [activity]);
   const waitingNow = activity.phase === "awaiting" || activity.phase === "thinking";
   const neededRows = Math.min(
@@ -2153,13 +2155,18 @@ export function FullscreenBridge(): React.ReactNode {
       tools,
       hiddenTools: [],
       ...(step === undefined ? {} : { step }),
-      ...(waitingNow ? { waiting: WAITING[Math.floor(tick / 24) % WAITING.length] as string } : {}),
-      tick,
+      ...(waitingNow
+        ? {
+            waiting: WAITING[
+              Math.floor((elapsedMs ?? 0) / WAITING_ROTATE_MS) % WAITING.length
+            ] as string,
+          }
+        : {}),
       ...(elapsedMs === undefined ? {} : { elapsedMs }),
       reservedRows,
       ...(reasoningElapsedMs === undefined ? {} : { reasoningElapsedMs }),
     };
-  }, [tools, step, waitingNow, tick, elapsedMs, reservedRows, regions]);
+  }, [tools, step, waitingNow, elapsedMs, reservedRows, regions]);
 
   const view = useMemo<ViewModel>(
     () => ({

--- a/src/cli/ui/fullscreen/live-input.test.tsx
+++ b/src/cli/ui/fullscreen/live-input.test.tsx
@@ -68,7 +68,7 @@ function tool(app: string, operation: string, phase: number, elapsedMs = 1000): 
  * mark set `reservedRows` explicitly, because that is the property under test.
  */
 function live(overrides: Partial<LiveModel> = {}): LiveModel {
-  const model: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 0, ...overrides };
+  const model: LiveModel = { tools: [], hiddenTools: [], reservedRows: 0, ...overrides };
   if (overrides.reservedRows !== undefined) return model;
   const needed =
     model.tools.length +
@@ -257,7 +257,6 @@ describe("live zone", () => {
   it("gives two tools at different phases different indicator cells in one frame", async () => {
     const model = live({
       tools: [tool("gmail", "list threads", 0), tool("calendar", "freebusy", 1)],
-      tick: 0,
     });
     const { frame } = await bandHeight(model);
     const rows = rowsOf(frame);
@@ -269,6 +268,15 @@ describe("live zone", () => {
     // The spinner sits one column past the rail gutter on every tool row.
     const spinnerColumn = [...`${glyphs.rail} `].length;
     expect([...(first as string)][spinnerColumn]).not.toBe([...(second as string)][spinnerColumn]);
+  });
+
+  it("animates from a tick argument without rewriting the LiveModel", () => {
+    const model = live({ tools: [tool("gmail", "list threads", 0)] });
+    const viewport = { width: WIDTH, height: HEIGHT };
+    const atZero = liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 0);
+    const atOne = liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 1);
+    expect(atOne).not.toEqual(atZero);
+    expect(liveRows(model, viewport, false, glyphs, LIVE_ZONE_MAX_ROWS, 0)).toEqual(atZero);
   });
 
   it("shows the step line as one row while a plan is active, and not otherwise", () => {

--- a/src/cli/ui/fullscreen/live-zone-tick.test.tsx
+++ b/src/cli/ui/fullscreen/live-zone-tick.test.tsx
@@ -1,0 +1,166 @@
+/** @jsxImportSource @opentui/react */
+
+import { testRender } from "@opentui/react/test-utils";
+import { describe, expect, it } from "bun:test";
+import React, { memo, useRef } from "react";
+import { MOTION } from "../theme";
+import { App } from "./App";
+import { Header } from "./Header";
+import { Input } from "./Input";
+import { LiveZone } from "./LiveZone";
+import { sampleView } from "./sample";
+import { transcriptRows } from "./Transcript";
+import type { HeaderModel, InputModel, ViewModel, Viewport } from "./types";
+
+const WIDTH = 120;
+const HEIGHT = 34;
+
+function waitForLiveTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, MOTION.indicator * 2 + 40));
+}
+
+describe("live tick isolation", () => {
+  it("does not commit App when the live indicator advances", async () => {
+    let commits = 0;
+    function CountingApp({ view }: { view: ViewModel }): React.ReactNode {
+      commits += 1;
+      return (
+        <App
+          view={view}
+          onAction={() => undefined}
+        />
+      );
+    }
+
+    const view = sampleView();
+    const { renderer, renderOnce, flush } = await testRender(<CountingApp view={view} />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    const afterMount = commits;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(commits).toBe(afterMount);
+  });
+
+  it("keeps Header and Input props referentially stable across ticks", async () => {
+    const view = sampleView();
+    const viewport: Viewport = { width: WIDTH, height: HEIGHT };
+    const headerModels: HeaderModel[] = [];
+    const inputModels: InputModel[] = [];
+
+    const HeaderProbe = memo(function HeaderProbe({
+      model,
+      viewport: nextViewport,
+    }: {
+      model: HeaderModel;
+      viewport: Viewport;
+    }): React.ReactNode {
+      headerModels.push(model);
+      return (
+        <Header
+          model={model}
+          viewport={nextViewport}
+        />
+      );
+    });
+
+    const InputProbe = memo(function InputProbe({
+      model,
+      viewport: nextViewport,
+    }: {
+      model: InputModel;
+      viewport: Viewport;
+    }): React.ReactNode {
+      inputModels.push(model);
+      return (
+        <Input
+          model={model}
+          viewport={nextViewport}
+          focused
+        />
+      );
+    });
+
+    function Shell(): React.ReactNode {
+      return (
+        <box style={{ width: WIDTH, height: HEIGHT, flexDirection: "column" }}>
+          <HeaderProbe
+            model={view.header}
+            viewport={viewport}
+          />
+          <LiveZone
+            model={view.live}
+            viewport={viewport}
+          />
+          <InputProbe
+            model={view.input}
+            viewport={viewport}
+          />
+        </box>
+      );
+    }
+
+    const { renderer, renderOnce, flush } = await testRender(<Shell />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    expect(headerModels.length).toBeGreaterThan(0);
+    expect(inputModels.length).toBeGreaterThan(0);
+    const headersAfterMount = headerModels.length;
+    const inputsAfterMount = inputModels.length;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(headerModels).toHaveLength(headersAfterMount);
+    expect(inputModels).toHaveLength(inputsAfterMount);
+    expect(headerModels.every((model) => model === view.header)).toBe(true);
+    expect(inputModels.every((model) => model === view.input)).toBe(true);
+  });
+
+  it("does not re-enter transcriptRows when the live indicator advances", async () => {
+    const view = sampleView();
+    const viewport: Viewport = { width: WIDTH, height: HEIGHT };
+    const builds: number[] = [];
+
+    function TranscriptProbe(): React.ReactNode {
+      const countRef = useRef(0);
+      countRef.current += 1;
+      builds.push(countRef.current);
+      transcriptRows(view.blocks, viewport);
+      return <text>probe</text>;
+    }
+
+    function Shell(): React.ReactNode {
+      return (
+        <box style={{ width: WIDTH, height: HEIGHT, flexDirection: "column" }}>
+          <TranscriptProbe />
+          <LiveZone
+            model={view.live}
+            viewport={viewport}
+          />
+        </box>
+      );
+    }
+
+    const { renderer, renderOnce, flush } = await testRender(<Shell />, {
+      width: WIDTH,
+      height: HEIGHT,
+    });
+    await renderOnce();
+    const afterMount = builds.length;
+
+    await waitForLiveTick();
+    await flush();
+    renderer.destroy();
+
+    expect(builds).toHaveLength(afterMount);
+  });
+});

--- a/src/cli/ui/fullscreen/sample.ts
+++ b/src/cli/ui/fullscreen/sample.ts
@@ -150,7 +150,7 @@ const SEARCH: SearchOverlay = {
 };
 
 /** The base frame: mid-session, two tools in flight, nothing blocking. */
-export function sampleView(tick = 0): ViewModel {
+export function sampleView(): ViewModel {
   return {
     header: {
       version: packageJson.version,
@@ -174,7 +174,6 @@ export function sampleView(tick = 0): ViewModel {
       hiddenTools: [],
       step: { index: 3, total: 7, label: "rank by urgency" },
       elapsedMs: 11_600,
-      tick,
       // Two tool rows plus the step line. The adapter grows this to fit and
       // only lets it fall once the run settles, so the input holds still while
       // tools churn.
@@ -192,29 +191,29 @@ export function sampleView(tick = 0): ViewModel {
 }
 
 /** The same session with the approval card up. */
-export function sampleApprovalView(tick = 0): ViewModel {
-  const base = sampleView(tick);
+export function sampleApprovalView(): ViewModel {
+  const base = sampleView();
   return {
     ...base,
     // Nothing is running: jazz has stopped and is waiting on a person, and the
     // empty live zone is itself the signal.
-    live: { tools: [], hiddenTools: [], tick, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     overlay: APPROVAL,
   };
 }
 
 /** The same session with history search open across past sessions. */
-export function sampleSearchView(tick = 0): ViewModel {
-  return { ...sampleView(tick), overlay: SEARCH };
+export function sampleSearchView(): ViewModel {
+  return { ...sampleView(), overlay: SEARCH };
 }
 
 /** An idle first-run frame: no work, no plan, nothing to interrupt. */
 export function sampleIdleView(): ViewModel {
-  const base = sampleView(0);
+  const base = sampleView();
   return {
     ...base,
     blocks: [],
-    live: { tools: [], hiddenTools: [], tick: 0, reservedRows: 0 },
+    live: { tools: [], hiddenTools: [], reservedRows: 0 },
     footer: {
       mode: base.footer.mode,
       hints: base.footer.hints,
@@ -223,8 +222,8 @@ export function sampleIdleView(): ViewModel {
 }
 
 /** Six tools running, to exercise the live zone's cap and its overflow row. */
-export function sampleBusyView(tick = 0): ViewModel {
-  const base = sampleView(tick);
+export function sampleBusyView(): ViewModel {
+  const base = sampleView();
   return {
     ...base,
     live: {

--- a/src/cli/ui/fullscreen/transcript-window.test.ts
+++ b/src/cli/ui/fullscreen/transcript-window.test.ts
@@ -79,7 +79,7 @@ describe("wheelScrollDelta", () => {
 
 describe("transcriptVisibleCount", () => {
   it("subtracts chrome, the live band, and the composer", () => {
-    const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 2 };
+    const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 2 };
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
@@ -97,7 +97,7 @@ describe("transcriptVisibleCount", () => {
   });
 
   it("keeps a transcript row by taking it from the live band, not from the composer", () => {
-    const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 5 };
+    const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 5 };
     const input: InputModel = {
       value: "",
       placeholder: "Ask anything",
@@ -119,7 +119,7 @@ describe("transcriptVisibleCount", () => {
 });
 
 describe("allocateRegions", () => {
-  const live: LiveModel = { tools: [], hiddenTools: [], tick: 0, reservedRows: 5 };
+  const live: LiveModel = { tools: [], hiddenTools: [], reservedRows: 5 };
   const commands = {
     items: Array.from({ length: 12 }, (_, index) => ({
       name: `command-${String(index)}`,

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -173,11 +173,9 @@ export interface LiveModel {
   /** House-voice waiting copy. Shown only before the first token lands. */
   readonly waiting?: string;
   readonly elapsedMs?: number;
-  /** Monotonic tick driving the indicator. */
-  readonly tick: number;
   /**
    * Elapsed time for the open reasoning region, if one is running.
-   * Lives here rather than on a transcript Block so a live tick cannot
+   * Lives here rather than on a transcript Block so a clock update cannot
    * rewrite block identity and defeat wrap memoization.
    */
   readonly reasoningElapsedMs?: number;


### PR DESCRIPTION
## What & why
The live spinner used to tick on the shared view model, which rebuilt the whole fullscreen shell several times a second. LiveZone now owns that clock, so the transcript, header, and composer stay still while the spinner moves. Footer elapsed still updates once a second.

## How to verify
- Start an interactive turn: the spinner still animates; the header and composer do not flicker or remount.
- Footer elapsed still advances once per second during a run, and clears when idle.
- An idle session has no live band and no animation interval.
- `bun test src/cli/ui/fullscreen/live-zone-tick.test.tsx src/cli/ui/fullscreen/live-input.test.tsx src/cli/ui/fullscreen/app.test.tsx`