### PR TITLE
fix(cli): keep one-shot commands off the alternate screen

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -176,7 +176,7 @@ Other providers follow the same `<PROVIDER>_API_KEY` convention — see
 | Variable           | Effect                                                                       |
 | ------------------ | ---------------------------------------------------------------------------- |
 | `JAZZ_NO_TUI`      | `1`: no terminal UI at all, plain output (same as `--no-tui`)                |
-| `JAZZ_FULLSCREEN`  | `0`: keep an interactive interface but not the alternate screen             |
+| `JAZZ_FULLSCREEN`  | `0`: keep an interactive interface but not the alternate screen. One-shot commands (`agent list`, `config show`, …) never enter the alternate screen, so their output stays in scrollback. |
 | `JAZZ_OUTPUT_MODE` | `rendered` \| `hybrid` \| `raw` \| `quiet` (same as `--output`)              |
 | `JAZZ_THEME`       | Colour theme                                                                 |
 | `JAZZ_UI_GLYPHS`   | `unicode` \| `ascii` — override glyph detection for terminals that misreport |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -176,7 +176,7 @@ Other providers follow the same `<PROVIDER>_API_KEY` convention — see
 | Variable           | Effect                                                                       |
 | ------------------ | ---------------------------------------------------------------------------- |
 | `JAZZ_NO_TUI`      | `1`: no terminal UI at all, plain output (same as `--no-tui`)                |
-| `JAZZ_FULLSCREEN`  | `0`: keep an interactive interface but not the alternate screen. One-shot commands (`agent list`, `config show`, …) never enter the alternate screen, so their output stays in scrollback. |
+| `JAZZ_FULLSCREEN`  | `0`: keep an interactive interface but not the alternate screen. Print-and-exit commands never enter it, so their output stays in scrollback. |
 | `JAZZ_OUTPUT_MODE` | `rendered` \| `hybrid` \| `raw` \| `quiet` (same as `--output`)              |
 | `JAZZ_THEME`       | Colour theme                                                                 |
 | `JAZZ_UI_GLYPHS`   | `unicode` \| `ascii` — override glyph detection for terminals that misreport |

--- a/src/app-layer.test.ts
+++ b/src/app-layer.test.ts
@@ -1,17 +1,61 @@
 import { describe, expect, test } from "bun:test";
-import { getPresentationConfig } from "./app-layer";
+import { commandWantsFullscreen, getPresentationConfig } from "./app-layer";
+
+describe("commandWantsFullscreen", () => {
+  test("only long-lived sessions enter the alternate screen", () => {
+    expect(commandWantsFullscreen("agent chat")).toBe(true);
+    expect(commandWantsFullscreen("agent create")).toBe(true);
+    expect(commandWantsFullscreen("agent edit")).toBe(true);
+    expect(commandWantsFullscreen("persona create")).toBe(true);
+    expect(commandWantsFullscreen("persona edit")).toBe(true);
+    expect(commandWantsFullscreen("workflow run")).toBe(true);
+    expect(commandWantsFullscreen("workflow catchup")).toBe(true);
+    expect(commandWantsFullscreen("jazz")).toBe(true);
+  });
+
+  test("one-shot commands stay on the main screen so their output survives exit", () => {
+    expect(commandWantsFullscreen("agent list")).toBe(false);
+    expect(commandWantsFullscreen("agent show")).toBe(false);
+    expect(commandWantsFullscreen("agent delete")).toBe(false);
+    expect(commandWantsFullscreen("config show")).toBe(false);
+    expect(commandWantsFullscreen("persona list")).toBe(false);
+    expect(commandWantsFullscreen("mcp list")).toBe(false);
+    expect(commandWantsFullscreen("workflow list")).toBe(false);
+    expect(commandWantsFullscreen("runs list")).toBe(false);
+    expect(commandWantsFullscreen("update")).toBe(false);
+    expect(commandWantsFullscreen(undefined)).toBe(false);
+  });
+});
 
 describe("getPresentationConfig", () => {
   const terminalEnvironment = { TERM: "xterm-256color" };
   const terminalOutput = { isTTY: true, columns: 100, rows: 24 };
   const terminalInput = { isTTY: true };
 
-  test("capable TTY uses the interactive presentation", () => {
-    const config = getPresentationConfig(terminalEnvironment, terminalOutput, terminalInput);
+  test("capable TTY uses the interactive presentation for a session command", () => {
+    const config = getPresentationConfig(
+      terminalEnvironment,
+      terminalOutput,
+      terminalInput,
+      "agent chat",
+    );
     expect(config.isQuiet).toBe(false);
     expect(config.usePlainTerminal).toBe(false);
     expect(config.useCLIPresentation).toBe(false);
     expect(config.useFullscreen).toBe(true);
+  });
+
+  test("one-shot commands keep Ink on the main screen so output stays in scrollback", () => {
+    const config = getPresentationConfig(
+      terminalEnvironment,
+      terminalOutput,
+      terminalInput,
+      "agent list",
+    );
+    expect(config.isQuiet).toBe(false);
+    expect(config.usePlainTerminal).toBe(false);
+    expect(config.useCLIPresentation).toBe(false);
+    expect(config.useFullscreen).toBe(false);
   });
 
   // `jazz run` and `jazz workflow --json` set JAZZ_NO_TUI to keep stdout clean

--- a/src/app-layer.test.ts
+++ b/src/app-layer.test.ts
@@ -1,57 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { commandWantsFullscreen, getPresentationConfig } from "./app-layer";
-
-describe("commandWantsFullscreen", () => {
-  test("only long-lived sessions enter the alternate screen", () => {
-    expect(commandWantsFullscreen("agent chat")).toBe(true);
-    expect(commandWantsFullscreen("agent create")).toBe(true);
-    expect(commandWantsFullscreen("agent edit")).toBe(true);
-    expect(commandWantsFullscreen("persona create")).toBe(true);
-    expect(commandWantsFullscreen("persona edit")).toBe(true);
-    expect(commandWantsFullscreen("workflow run")).toBe(true);
-    expect(commandWantsFullscreen("workflow catchup")).toBe(true);
-    expect(commandWantsFullscreen("jazz")).toBe(true);
-  });
-
-  test("one-shot commands stay on the main screen so their output survives exit", () => {
-    expect(commandWantsFullscreen("agent list")).toBe(false);
-    expect(commandWantsFullscreen("agent show")).toBe(false);
-    expect(commandWantsFullscreen("agent delete")).toBe(false);
-    expect(commandWantsFullscreen("config show")).toBe(false);
-    expect(commandWantsFullscreen("persona list")).toBe(false);
-    expect(commandWantsFullscreen("mcp list")).toBe(false);
-    expect(commandWantsFullscreen("workflow list")).toBe(false);
-    expect(commandWantsFullscreen("runs list")).toBe(false);
-    expect(commandWantsFullscreen("update")).toBe(false);
-    expect(commandWantsFullscreen(undefined)).toBe(false);
-  });
-});
+import { getPresentationConfig } from "./app-layer";
 
 describe("getPresentationConfig", () => {
   const terminalEnvironment = { TERM: "xterm-256color" };
   const terminalOutput = { isTTY: true, columns: 100, rows: 24 };
   const terminalInput = { isTTY: true };
 
-  test("capable TTY uses the interactive presentation for a session command", () => {
-    const config = getPresentationConfig(
-      terminalEnvironment,
-      terminalOutput,
-      terminalInput,
-      "agent chat",
-    );
+  test("a session on a capable TTY uses the alternate screen", () => {
+    const config = getPresentationConfig(terminalEnvironment, terminalOutput, terminalInput, true);
     expect(config.isQuiet).toBe(false);
     expect(config.usePlainTerminal).toBe(false);
     expect(config.useCLIPresentation).toBe(false);
     expect(config.useFullscreen).toBe(true);
   });
 
-  test("one-shot commands keep Ink on the main screen so output stays in scrollback", () => {
-    const config = getPresentationConfig(
-      terminalEnvironment,
-      terminalOutput,
-      terminalInput,
-      "agent list",
-    );
+  test("print-and-exit keeps Ink on the main screen so output stays in scrollback", () => {
+    const config = getPresentationConfig(terminalEnvironment, terminalOutput, terminalInput);
     expect(config.isQuiet).toBe(false);
     expect(config.usePlainTerminal).toBe(false);
     expect(config.useCLIPresentation).toBe(false);
@@ -66,6 +30,7 @@ describe("getPresentationConfig", () => {
       { ...terminalEnvironment, JAZZ_NO_TUI: "1" },
       terminalOutput,
       terminalInput,
+      true,
     );
     expect(config.isQuiet).toBe(false);
     expect(config.usePlainTerminal).toBe(true);
@@ -86,7 +51,12 @@ describe("getPresentationConfig", () => {
   });
 
   test("non-TTY uses plain terminal and CLI presentation", () => {
-    const config = getPresentationConfig(terminalEnvironment, { isTTY: false }, terminalInput);
+    const config = getPresentationConfig(
+      terminalEnvironment,
+      { isTTY: false },
+      terminalInput,
+      true,
+    );
     expect(config.isQuiet).toBe(false);
     expect(config.usePlainTerminal).toBe(true);
     expect(config.useCLIPresentation).toBe(true);
@@ -98,11 +68,13 @@ describe("getPresentationConfig", () => {
       terminalEnvironment,
       { ...terminalOutput, rows: 11 },
       terminalInput,
+      true,
     );
     const narrow = getPresentationConfig(
       terminalEnvironment,
       { ...terminalOutput, columns: 59 },
       terminalInput,
+      true,
     );
     expect(short.usePlainTerminal).toBe(true);
     expect(short.useCLIPresentation).toBe(true);
@@ -120,7 +92,7 @@ describe("getPresentationConfig", () => {
       { ...terminalEnvironment, JAZZ_A11Y: "1" },
     ];
     for (const environment of environments) {
-      const config = getPresentationConfig(environment, terminalOutput, terminalInput);
+      const config = getPresentationConfig(environment, terminalOutput, terminalInput, true);
       expect(config.usePlainTerminal).toBe(true);
       expect(config.useCLIPresentation).toBe(true);
       expect(config.useFullscreen).toBe(false);
@@ -133,7 +105,7 @@ describe("getPresentationConfig", () => {
       { ...terminalEnvironment, JAZZ_FULLSCREEN: "false" },
     ];
     for (const environment of environments) {
-      const config = getPresentationConfig(environment, terminalOutput, terminalInput);
+      const config = getPresentationConfig(environment, terminalOutput, terminalInput, true);
       expect(config.usePlainTerminal).toBe(false);
       expect(config.useCLIPresentation).toBe(false);
       expect(config.useFullscreen).toBe(false);
@@ -152,7 +124,12 @@ describe("getPresentationConfig", () => {
   });
 
   test("non-TTY stdin uses plain output even when stdout is a TTY", () => {
-    const config = getPresentationConfig(terminalEnvironment, terminalOutput, { isTTY: false });
+    const config = getPresentationConfig(
+      terminalEnvironment,
+      terminalOutput,
+      { isTTY: false },
+      true,
+    );
     expect(config.usePlainTerminal).toBe(true);
     expect(config.useCLIPresentation).toBe(true);
     expect(config.useFullscreen).toBe(false);

--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -65,29 +65,13 @@ interface EnvShape extends FullscreenEnvironment {
   readonly JAZZ_FULLSCREEN?: string;
 }
 
-// The alternate screen is discarded when the process exits, so a command that
-// prints and returns would flash then vanish. Only long-lived sessions enter it.
-const FULLSCREEN_SESSION_COMMANDS: ReadonlySet<string> = new Set([
-  "jazz",
-  "agent chat",
-  "agent create",
-  "agent edit",
-  "persona create",
-  "persona edit",
-  "workflow run",
-  "workflow catchup",
-]);
-
-/** Whether this command should take over the alternate screen, given a capable TTY. */
-export function commandWantsFullscreen(commandName: string | undefined): boolean {
-  return commandName !== undefined && FULLSCREEN_SESSION_COMMANDS.has(commandName);
-}
-
 export function getPresentationConfig(
   env: EnvShape = process.env,
   stdout: TerminalOutputCapabilities = process.stdout,
   stdin: TerminalInputCapabilities = process.stdin,
-  commandName: string | undefined = getCurrentCommandName(),
+  // Alternate screen is discarded on exit. Only a command that stays until the
+  // user leaves should ask for it; print-and-return is the default.
+  session = false,
 ): PresentationConfig {
   const isQuiet = env.JAZZ_OUTPUT_MODE === "quiet";
   const rawOutput = env.JAZZ_OUTPUT_MODE === "raw";
@@ -110,8 +94,7 @@ export function getPresentationConfig(
     isQuiet,
     usePlainTerminal: isQuiet || rawOutput || requestNoTui || capabilityBlocked,
     useCLIPresentation: !isQuiet && (rawOutput || requestNoTui || capabilityBlocked),
-    useFullscreen:
-      decision.fullscreen && !isQuiet && !rawOutput && commandWantsFullscreen(commandName),
+    useFullscreen: decision.fullscreen && !isQuiet && !rawOutput && session,
   };
 }
 
@@ -147,7 +130,10 @@ export interface AppLayerConfig {
  *
  */
 
-export function createAppLayer(config: AppLayerConfig = {}) {
+export function createAppLayer(
+  config: AppLayerConfig = {},
+  options: { readonly session?: boolean } = {},
+) {
   const { debug, configPath } = config;
   const fileSystemLayer = NodeFileSystem.layer;
   const configLayer = createConfigLayer(debug, configPath).pipe(Layer.provide(fileSystemLayer));
@@ -165,7 +151,12 @@ export function createAppLayer(config: AppLayerConfig = {}) {
     }),
   ).pipe(Layer.provide(configLayer));
 
-  const presentationConfig = getPresentationConfig(process.env, process.stdout, process.stdin);
+  const presentationConfig = getPresentationConfig(
+    process.env,
+    process.stdout,
+    process.stdin,
+    options.session === true,
+  );
 
   const terminalLayer = presentationConfig.usePlainTerminal
     ? createPlainTerminalServiceLayer()
@@ -312,6 +303,12 @@ export function runCliEffect<R, E extends JazzError | Error>(
      * box would otherwise corrupt the clean stdout payload.
      */
     readonly skipUpdateCheck?: boolean | undefined;
+    /**
+     * This command lives until the user leaves (chat, wizard, editor).
+     * Print-and-exit commands must not set this — the alternate screen would
+     * restore the previous buffer and the output would vanish.
+     */
+    readonly session?: boolean | undefined;
   } = {},
 ): void {
   const cliOptionsLayer = Layer.succeed(CLIOptionsTag, {
@@ -464,7 +461,12 @@ export function runCliEffect<R, E extends JazzError | Error>(
   });
 
   const managedEffect = program.pipe(
-    Effect.provide(Layer.mergeAll(createAppLayer(config), cliOptionsLayer)),
+    Effect.provide(
+      Layer.mergeAll(
+        createAppLayer(config, { session: options.session === true }),
+        cliOptionsLayer,
+      ),
+    ),
     Effect.scoped,
   ) as Effect.Effect<void, never, never>;
 

--- a/src/app-layer.ts
+++ b/src/app-layer.ts
@@ -65,10 +65,29 @@ interface EnvShape extends FullscreenEnvironment {
   readonly JAZZ_FULLSCREEN?: string;
 }
 
+// The alternate screen is discarded when the process exits, so a command that
+// prints and returns would flash then vanish. Only long-lived sessions enter it.
+const FULLSCREEN_SESSION_COMMANDS: ReadonlySet<string> = new Set([
+  "jazz",
+  "agent chat",
+  "agent create",
+  "agent edit",
+  "persona create",
+  "persona edit",
+  "workflow run",
+  "workflow catchup",
+]);
+
+/** Whether this command should take over the alternate screen, given a capable TTY. */
+export function commandWantsFullscreen(commandName: string | undefined): boolean {
+  return commandName !== undefined && FULLSCREEN_SESSION_COMMANDS.has(commandName);
+}
+
 export function getPresentationConfig(
   env: EnvShape = process.env,
   stdout: TerminalOutputCapabilities = process.stdout,
   stdin: TerminalInputCapabilities = process.stdin,
+  commandName: string | undefined = getCurrentCommandName(),
 ): PresentationConfig {
   const isQuiet = env.JAZZ_OUTPUT_MODE === "quiet";
   const rawOutput = env.JAZZ_OUTPUT_MODE === "raw";
@@ -91,7 +110,8 @@ export function getPresentationConfig(
     isQuiet,
     usePlainTerminal: isQuiet || rawOutput || requestNoTui || capabilityBlocked,
     useCLIPresentation: !isQuiet && (rawOutput || requestNoTui || capabilityBlocked),
-    useFullscreen: decision.fullscreen && !isQuiet && !rawOutput,
+    useFullscreen:
+      decision.fullscreen && !isQuiet && !rawOutput && commandWantsFullscreen(commandName),
   };
 }
 

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -1,12 +1,12 @@
 import { Command } from "commander";
 import packageJson from "../../package.json";
-import { setCurrentCommandName } from "../core/utils/current-command";
 import {
   isApprovalPolicyFlag,
   isReasoningEffortFlag,
   parseEventCategories,
 } from "./commands/run/flags";
 import { parsePositiveInt } from "./utils/option-parsers";
+import { setCurrentCommandName } from "../core/utils/current-command";
 
 /**
  * CLI Application setup and command registration
@@ -32,6 +32,8 @@ interface CliRuntimeOptions {
 interface CliRunOptions {
   readonly skipCatchUp?: boolean;
   readonly skipUpdateCheck?: boolean;
+  /** Live until the user leaves. Print-and-exit commands omit this. */
+  readonly session?: boolean;
 }
 
 type AppLayerModule = typeof import("../app-layer");
@@ -307,6 +309,7 @@ function registerAgentCommands(program: Command): void {
       runCliAction(
         () => import("./commands/create-agent").then((mod) => mod.createAgentCommand()),
         cliRuntimeOptions(program),
+        { session: true },
       ),
     );
 
@@ -327,6 +330,7 @@ function registerAgentCommands(program: Command): void {
       runCliAction(
         () => import("./commands/edit-agent").then((mod) => mod.editAgentCommand(agentId)),
         cliRuntimeOptions(program),
+        { session: true },
       ),
     );
 
@@ -387,6 +391,7 @@ function registerAgentCommands(program: Command): void {
               }),
             ),
           cliRuntimeOptions(program),
+          { session: true },
         );
       },
     );
@@ -478,15 +483,20 @@ function registerMCPCommands(program: Command): void {
 function registerPersonaCommands(program: Command): void {
   const personaCommand = program.command("persona").description("Manage personas");
 
-  function run(loadEffect: () => Promise<CliCommandEffect>): Promise<void> {
-    return runCliAction(loadEffect, cliRuntimeOptions(program));
+  function run(
+    loadEffect: () => Promise<CliCommandEffect>,
+    options?: CliRunOptions,
+  ): Promise<void> {
+    return runCliAction(loadEffect, cliRuntimeOptions(program), options);
   }
 
   personaCommand
     .command("create")
     .description("Create a new custom persona (interactive)")
     .action(() =>
-      run(() => import("./commands/persona").then((mod) => mod.createPersonaCommand())),
+      run(() => import("./commands/persona").then((mod) => mod.createPersonaCommand()), {
+        session: true,
+      }),
     );
 
   personaCommand
@@ -506,7 +516,9 @@ function registerPersonaCommands(program: Command): void {
     .command("edit <identifier>")
     .description("Edit an existing custom persona")
     .action((identifier: string) =>
-      run(() => import("./commands/persona").then((mod) => mod.editPersonaCommand(identifier))),
+      run(() => import("./commands/persona").then((mod) => mod.editPersonaCommand(identifier)), {
+        session: true,
+      }),
     );
 
   personaCommand
@@ -744,7 +756,7 @@ function registerWorkflowCommands(program: Command): void {
               }),
             ),
           cliRuntimeOptions(program),
-          { skipCatchUp: isWorkflowRunCommand, skipUpdateCheck: json },
+          { skipCatchUp: isWorkflowRunCommand, skipUpdateCheck: json, session: true },
         );
       },
     );
@@ -786,6 +798,7 @@ function registerWorkflowCommands(program: Command): void {
       runCliAction(
         () => import("./commands/workflow").then((mod) => mod.catchupWorkflowCommand()),
         cliRuntimeOptions(program),
+        { session: true },
       ),
     );
 
@@ -854,6 +867,7 @@ export function createCLIApp(): Command {
       runCliAction(
         () => import("./commands/wizard").then((mod) => mod.wizardCommand()),
         cliRuntimeOptions(program),
+        { session: true },
       ),
     );
   }


### PR DESCRIPTION
## What & why
`jazz agent list` (and other print-and-exit commands) opened the fullscreen TUI, then restored the previous terminal buffer on exit — so the table flashed and vanished. Only long-lived sessions now enter the alternate screen; one-shot output stays in scrollback.

## How to verify
- Run `bun run cli agent list` in a real TTY. The table should still be on screen after the command returns.
- Run `bun run cli agent show <id>` and `bun run cli config show`. Same: no fullscreen flash, output remains.
- Run `bun run cli agent chat <name>` and confirm chat still takes over the screen.
- Pipe `bun run cli agent list` to a file and confirm it still prints.
