### PR TITLE
feat(ui): publish wizard and workflow menus as data

### DIFF
--- a/src/cli/commands/config-wizard.ts
+++ b/src/cli/commands/config-wizard.ts
@@ -1,5 +1,4 @@
 import { Effect } from "effect";
-import React from "react";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { AVAILABLE_PROVIDERS, type ProviderName } from "@/core/constants/models";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
@@ -10,7 +9,7 @@ import type { ColorProfile, OutputMode } from "@/core/types/output";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
 import { sortProvidersForPicker } from "@/core/utils/provider-picker";
 import { store } from "../ui/store";
-import { WizardHome, type WizardMenuOption } from "../ui/WizardHome";
+import type { WizardMenuOption } from "../ui/WizardHome";
 
 /**
  * Menu actions for the config wizard
@@ -71,29 +70,18 @@ function showConfigMenu(
   options: WizardMenuOption[],
 ): Effect.Effect<ConfigMenuAction, never, never> {
   return Effect.async<ConfigMenuAction>((resume) => {
-    let resumed = false;
-    const safeResume = (action: ConfigMenuAction): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(action));
-    };
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "menu",
         title: "Configuration",
-        onSelect: (value: string) => safeResume(value as ConfigMenuAction),
-        onExit: () => safeResume("back"),
-      }),
+        options,
+      },
+      (result) => {
+        resume(
+          Effect.succeed(result.kind === "exit" ? "back" : (result.value as ConfigMenuAction)),
+        );
+      },
     );
-    store.setActiveMenu({
-      kind: "menu",
-      options,
-      onSelect: (value: string) => safeResume(value as ConfigMenuAction),
-      onExit: () => safeResume("back"),
-    });
   });
 }
 

--- a/src/cli/commands/wizard-list-agents.test.ts
+++ b/src/cli/commands/wizard-list-agents.test.ts
@@ -27,7 +27,6 @@ function agent(partial: {
 describe("showAgentList", () => {
   it("publishes every agent to the fullscreen menu instead of an empty list", async () => {
     store.setActiveMenu(null);
-    store.setCustomView(null);
 
     const agents = [
       agent({ id: "a2", name: "qwen-coder", model: "qwen2.5-coder" }),
@@ -46,6 +45,8 @@ describe("showAgentList", () => {
     if (menu?.kind !== "agents") {
       throw new Error("expected an agents menu");
     }
+    expect(menu).not.toHaveProperty("onSelect");
+    expect(menu).not.toHaveProperty("onExit");
     expect(menu.title).toBe("agents");
     expect(menu.action).toBe("back");
     expect(menu.browse).toBe(true);
@@ -64,7 +65,7 @@ describe("showAgentList", () => {
       model: "qwen2.5-coder",
     });
 
-    menu.onExit();
+    store.completePrompt({ kind: "exit" });
     await listed;
     expect(store.getActiveMenuSnapshot()).toBe(null);
   });
@@ -79,7 +80,8 @@ describe("showAgentList", () => {
     }
     expect(menu.agents).toEqual([]);
     expect(menu.browse).toBe(true);
-    menu.onExit();
+    expect(menu).not.toHaveProperty("onSelect");
+    store.completePrompt({ kind: "exit" });
     await listed;
     expect(store.getActiveMenuSnapshot()).toBe(null);
   });

--- a/src/cli/commands/wizard.ts
+++ b/src/cli/commands/wizard.ts
@@ -1,5 +1,4 @@
 import { Effect } from "effect";
-import React from "react";
 import { sortAgents } from "@/core/agent/agent-sort";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentServiceTag } from "@/core/interfaces/agent-service";
@@ -15,7 +14,7 @@ import { createAgentCommand } from "./create-agent";
 import { editAgentCommand } from "./edit-agent";
 import { homeRequirements } from "../ui/fullscreen/home-readiness";
 import { store, type ActiveAgentChoice } from "../ui/store";
-import { TIPS, WizardHome, type WizardMenuOption } from "../ui/WizardHome";
+import { TIPS, type WizardMenuOption } from "../ui/WizardHome";
 
 /**
  * Wizard menu option identifiers
@@ -293,33 +292,18 @@ function showWizardMenu(
   requirements: ReturnType<typeof homeRequirements>,
 ): Effect.Effect<MenuAction, never, never> {
   return Effect.async<MenuAction>((resume) => {
-    let resumed = false;
-
-    const safeResume = (action: MenuAction) => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(action));
-    };
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
-        onSelect: (value: string) => safeResume(value as MenuAction),
-        onExit: () => safeResume("exit"),
-      }),
-    );
-
     const tip = TIPS[Math.floor(Math.random() * TIPS.length)] ?? TIPS[0] ?? "";
-    store.setActiveMenu({
-      kind: "menu",
-      options,
-      requirements,
-      tip,
-      onSelect: (value: string) => safeResume(value as MenuAction),
-      onExit: () => safeResume("exit"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options,
+        requirements,
+        tip,
+      },
+      (result) => {
+        resume(Effect.succeed(result.kind === "exit" ? "exit" : (result.value as MenuAction)));
+      },
+    );
   });
 }
 
@@ -343,36 +327,19 @@ export function showAgentList(
   lastUsedAgentId: string | null | undefined,
 ): Effect.Effect<void, never, never> {
   return Effect.async<void>((resume) => {
-    let resumed = false;
-    const dismiss = (): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(undefined));
-    };
-
     const sorted = sortAgents(agents, lastUsedAgentId);
-    const options = sorted.map((agent) => ({ label: agent.name, value: agent.id }));
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "agents",
         title: "agents",
-        onSelect: () => dismiss(),
-        onExit: () => dismiss(),
-      }),
+        action: "back",
+        browse: true,
+        agents: agentChoicesFor(sorted, lastUsedAgentId),
+      },
+      () => {
+        resume(Effect.succeed(undefined));
+      },
     );
-
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: agentChoicesFor(sorted, lastUsedAgentId),
-      onSelect: () => dismiss(),
-      onExit: () => dismiss(),
-    });
   });
 }
 
@@ -386,35 +353,24 @@ function selectAgent(
   action: string,
 ): Effect.Effect<Agent | null, never, never> {
   return Effect.async<Agent | null>((resume) => {
-    let resumed = false;
-    const safeResume = (agentId: string | null): void => {
-      if (resumed) return;
-      resumed = true;
-      store.setCustomView(null);
-      store.setActiveMenu(null);
-      resume(Effect.succeed(agents.find((agent) => agent.id === agentId) ?? null));
-    };
-
     const sorted = sortAgents(agents, lastUsedAgentId);
-    const options = sorted.map((agent) => ({ label: agent.name, value: agent.id }));
-
-    store.setCustomView(
-      React.createElement(WizardHome, {
-        options,
+    store.setActiveMenu(
+      {
+        kind: "agents",
         title,
-        onSelect: (value: string) => safeResume(value),
-        onExit: () => safeResume(null),
-      }),
+        action,
+        agents: agentChoicesFor(sorted, lastUsedAgentId),
+      },
+      (result) => {
+        resume(
+          Effect.succeed(
+            result.kind === "exit"
+              ? null
+              : (agents.find((agent) => agent.id === result.value) ?? null),
+          ),
+        );
+      },
     );
-
-    store.setActiveMenu({
-      kind: "agents",
-      title,
-      action,
-      agents: agentChoicesFor(sorted, lastUsedAgentId),
-      onSelect: (value: string) => safeResume(value),
-      onExit: () => safeResume(null),
-    });
   });
 }
 

--- a/src/cli/commands/workflow-select-agent.test.ts
+++ b/src/cli/commands/workflow-select-agent.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { Agent } from "@/core/types/index";
+import { selectAgentForWorkflow } from "./workflow";
+import { store } from "../ui/store";
+
+function agent(partial: {
+  readonly id: string;
+  readonly name: string;
+  readonly model: string;
+}): Agent {
+  return {
+    id: partial.id,
+    name: partial.name,
+    model: `anthropic/${partial.model}`,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    config: {
+      llmProvider: "anthropic",
+      llmModel: partial.model,
+    },
+  };
+}
+
+describe("selectAgentForWorkflow", () => {
+  it("publishes a data-only agent menu instead of an Ink tree", async () => {
+    store.setActiveMenu(null);
+    const agents = [
+      agent({ id: "a1", name: "reviewer", model: "claude-sonnet-4" }),
+      agent({ id: "a2", name: "coder", model: "qwen2.5-coder" }),
+    ];
+
+    const selected = Effect.runPromise(
+      selectAgentForWorkflow(agents, "Select an agent to run this workflow:"),
+    );
+    const menu = store.getActiveMenuSnapshot();
+
+    expect(menu?.kind).toBe("agents");
+    if (menu?.kind !== "agents") {
+      throw new Error("expected an agents menu");
+    }
+    expect(menu).not.toHaveProperty("onSelect");
+    expect(menu).not.toHaveProperty("onExit");
+    expect(menu.title).toBe("Select an agent to run this workflow:");
+    expect(menu.action).toBe("run");
+    expect(menu.agents.map((choice) => choice.id)).toEqual(["a1", "a2"]);
+
+    store.completePrompt({ kind: "select", value: "a2" });
+    await expect(selected).resolves.toMatchObject({ id: "a2", name: "coder" });
+    expect(store.getActiveMenuSnapshot()).toBe(null);
+  });
+
+  it("returns null when the picker is dismissed", async () => {
+    store.setActiveMenu(null);
+    const selected = Effect.runPromise(
+      selectAgentForWorkflow(
+        [agent({ id: "a1", name: "reviewer", model: "claude-sonnet-4" })],
+        "Select an agent to run this scheduled workflow:",
+      ),
+    );
+
+    store.completePrompt({ kind: "exit" });
+    await expect(selected).resolves.toBe(null);
+    expect(store.getActiveMenuSnapshot()).toBe(null);
+  });
+});

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,9 +1,5 @@
 import { Duration, Effect } from "effect";
-import { Box, Text } from "ink";
-import React from "react";
-import { SearchSelect } from "@/cli/ui/components/SearchSelect";
 import { store } from "@/cli/ui/store";
-import { THEME } from "@/cli/ui/theme";
 import { separatorLine } from "@/cli/utils/string-utils";
 import { AgentRunner } from "@/core/agent/agent-runner";
 import { getAgentByIdentifier, listAllAgents } from "@/core/agent/agent-service";
@@ -835,39 +831,32 @@ function runCostFields(result: {
 /**
  * Helper to prompt user to select an agent for workflow execution.
  */
-function selectAgentForWorkflow(
+export function selectAgentForWorkflow(
   agents: readonly Agent[],
   prompt: string,
 ): Effect.Effect<Agent | null, never> {
   return Effect.async<Agent | null, never>((resume) => {
-    const options = agents.map((agent) => ({
-      label: `${agent.name} (${agent.config.llmModel})`,
-      value: agent.id,
-    }));
-
-    store.setCustomView(
-      React.createElement(
-        Box,
-        { flexDirection: "column", padding: 1 },
-        React.createElement(Text, { bold: true, color: THEME.primary }, prompt),
-        React.createElement(
-          Box,
-          { marginTop: 1 },
-          React.createElement(SearchSelect<string>, {
-            options,
-            pageSize: 10,
-            placeholder: "Type to filter agents…",
-            onSelect: (value: string) => {
-              store.setCustomView(null);
-              resume(Effect.succeed(agents.find((a) => a.id === value) ?? null));
-            },
-            onCancel: () => {
-              store.setCustomView(null);
-              resume(Effect.succeed(null));
-            },
-          }),
-        ),
-      ),
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: prompt,
+        action: "run",
+        agents: agents.map((agent) => ({
+          id: agent.id,
+          name: agent.name,
+          model: agent.config.llmModel,
+          ...(agent.description !== undefined && agent.description !== agent.name
+            ? { description: agent.description }
+            : {}),
+        })),
+      },
+      (result) => {
+        if (result.kind === "exit") {
+          resume(Effect.succeed(null));
+          return;
+        }
+        resume(Effect.succeed(agents.find((agent) => agent.id === result.value) ?? null));
+      },
     );
   });
 }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -13,9 +13,10 @@ import { Prompt } from "./Prompt";
 import { QueueInput } from "./QueueInput";
 import { RAIL_WIDTH, railStreamLines } from "./rail";
 import StatusFooter from "./StatusFooter";
-import { store, useOutputSlice, usePromptSlice, useSessionSlice } from "./store";
+import { store, useOutputSlice, usePromptSlice, useSessionSlice, type ActiveMenu } from "./store";
 import { PADDING, PADDING_BUDGET, THEME } from "./theme";
 import type { OutputEntryWithId } from "./types";
+import { WizardHome } from "./WizardHome";
 import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
 import { InputPriority, InputResults } from "../services/input-service";
 
@@ -155,8 +156,35 @@ const OutputIsland = React.memo(OutputIslandComponent);
 // Main App Component
 // ============================================================================
 
+function ActiveMenuView({ menu }: { readonly menu: ActiveMenu }): React.ReactElement {
+  const options =
+    menu.kind === "agents"
+      ? menu.agents.map((agent) => ({
+          label: `${agent.name} (${agent.model})`,
+          value: agent.id,
+        }))
+      : menu.options;
+  const title = menu.title;
+  const browse = menu.kind === "agents" && menu.browse === true;
+
+  return (
+    <WizardHome
+      options={options}
+      {...(title === undefined ? {} : { title })}
+      onSelect={(value) => {
+        if (browse) {
+          store.completePrompt({ kind: "exit" });
+          return;
+        }
+        store.completePrompt({ kind: "select", value });
+      }}
+      onExit={() => store.completePrompt({ kind: "exit" })}
+    />
+  );
+}
+
 export function App(): React.ReactElement {
-  const { customView, interruptHandler, modeToast } = useSessionSlice();
+  const { activeMenu: menu, interruptHandler, modeToast } = useSessionSlice();
   const interruptHandlerRef = useRef(interruptHandler);
   interruptHandlerRef.current = interruptHandler;
   const modeToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -298,10 +326,10 @@ export function App(): React.ReactElement {
 
   return (
     <ErrorBoundary>
-      {customView}
+      {menu !== null && <ActiveMenuView menu={menu} />}
       <Box
         flexDirection="column"
-        display={customView ? "none" : "flex"}
+        display={menu !== null ? "none" : "flex"}
       >
         <Box
           flexDirection="column"

--- a/src/cli/ui/WizardHome.tsx
+++ b/src/cli/ui/WizardHome.tsx
@@ -137,6 +137,7 @@ export function WizardHome({
 
         <SelectInput
           items={items}
+          limit={10}
           onSelect={(item) => onSelect(item.value)}
           indicatorComponent={IndicatorComponent}
           itemComponent={ItemComponent}

--- a/src/cli/ui/WizardHome.tsx
+++ b/src/cli/ui/WizardHome.tsx
@@ -16,7 +16,7 @@ export interface WizardMenuOption {
 }
 
 interface WizardHomeProps {
-  options: WizardMenuOption[];
+  options: readonly WizardMenuOption[];
   onSelect: (value: string) => void;
   onExit: () => void;
   title?: string;

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -104,7 +104,6 @@ function resetStoreSlices(): void {
   store.setCurrentConversation(null);
   store.clearQueue();
   store.setModeIsYolo(false);
-  store.setCustomView(null);
   store.clearModeToast();
   store.collapseAllEphemeral();
   store.setInterruptHandler(null);
@@ -577,9 +576,9 @@ describe("fullscreen bridge", () => {
   });
 
   it("draws the wizard menu as the home screen", async () => {
-    // The wizard publishes its menu as data alongside the Ink tree, so a
-    // renderer that cannot paint an Ink element can still draw the flow. Without
-    // this the fullscreen interface could not reach a chat session at all.
+    // The wizard publishes its menu as data, so a renderer that cannot paint an
+    // Ink element can still draw the flow. Without this the fullscreen
+    // interface could not reach a chat session at all.
     const text = await frame(() => {
       store.setActiveMenu({
         kind: "menu",
@@ -587,8 +586,6 @@ describe("fullscreen bridge", () => {
           { label: "Start chatting", value: "chat" },
           { label: "Create an agent", value: "create" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("Start chatting");
@@ -609,8 +606,6 @@ describe("fullscreen bridge", () => {
           },
         ],
         options: [{ label: "Create agent", value: "create-agent" }],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("agent");
@@ -629,8 +624,6 @@ describe("fullscreen bridge", () => {
           { id: "a1", name: "Basil", model: "claude-sonnet-4", lastUsed: true },
           { id: "a2", name: "Cass", model: "gpt-5" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("delete an agent");
@@ -644,14 +637,15 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "pick an agent",
-      action: "start",
-      agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4" }],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "pick an agent",
+        action: "start",
+        agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4" }],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ESCAPE");
     await settleKeypress(rendered.flush, 100);
@@ -664,17 +658,18 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "pick an agent",
-      action: "start",
-      agents: [
-        { id: "a1", name: "Basil", model: "claude-sonnet-4" },
-        { id: "a2", name: "Cass", model: "gpt-5" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "pick an agent",
+        action: "start",
+        agents: [
+          { id: "a1", name: "Basil", model: "claude-sonnet-4" },
+          { id: "a2", name: "Cass", model: "gpt-5" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ARROW_DOWN");
     await settleKeypress(rendered.flush, 100);
@@ -696,8 +691,6 @@ describe("fullscreen bridge", () => {
           { id: "a1", name: "doitall", model: "claude-sonnet-4" },
           { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
         ],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("doitall");
@@ -713,18 +706,19 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: [
-        { id: "a1", name: "doitall", model: "claude-sonnet-4" },
-        { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "agents",
+        action: "back",
+        browse: true,
+        agents: [
+          { id: "a1", name: "doitall", model: "claude-sonnet-4" },
+          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     expect(rendered.captureCharFrame()).toContain("doitall");
 
@@ -733,15 +727,16 @@ describe("fullscreen bridge", () => {
     expect(selected).toEqual(["EXIT"]);
 
     selected.length = 0;
-    store.setActiveMenu({
-      kind: "agents",
-      title: "agents",
-      action: "back",
-      browse: true,
-      agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4" }],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "agents",
+        title: "agents",
+        action: "back",
+        browse: true,
+        agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4" }],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
+    );
     await rendered.flush();
     await rendered.mockInput.pressKey("ESCAPE");
     await settleKeypress(rendered.flush, 100);
@@ -758,8 +753,6 @@ describe("fullscreen bridge", () => {
         title: "pick an agent",
         action: "start",
         agents: [],
-        onSelect: () => undefined,
-        onExit: () => undefined,
       });
     });
     expect(text).toContain("No agents yet.");
@@ -769,7 +762,7 @@ describe("fullscreen bridge", () => {
     store.setActiveMenu(null);
   });
 
-  it("hands an Ink-only custom screen to the legacy renderer", async () => {
+  it("keeps a data-only menu fullscreen without falling back", async () => {
     let fallbackRequests = 0;
     const unregisterFallback = store.registerRendererFallbackHandler(() => {
       fallbackRequests += 1;
@@ -777,30 +770,9 @@ describe("fullscreen bridge", () => {
     const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
     await rendered.renderOnce();
 
-    store.setCustomView(React.createElement(React.Fragment, null, "legacy-only"));
-    await rendered.flush();
-    await rendered.flush();
-
-    rendered.renderer.destroy();
-    store.setCustomView(null);
-    unregisterFallback();
-    expect(fallbackRequests).toBe(1);
-  });
-
-  it("keeps a renderer-neutral menu fullscreen when an Ink view is also published", async () => {
-    let fallbackRequests = 0;
-    const unregisterFallback = store.registerRendererFallbackHandler(() => {
-      fallbackRequests += 1;
-    });
-    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
-    await rendered.renderOnce();
-
-    store.setCustomView(React.createElement(React.Fragment, null, "legacy-copy"));
     store.setActiveMenu({
       kind: "menu",
       options: [{ label: "Stay fullscreen", value: "stay" }],
-      onSelect: () => undefined,
-      onExit: () => undefined,
     });
     await rendered.flush();
     await Promise.resolve();
@@ -809,7 +781,6 @@ describe("fullscreen bridge", () => {
     expect(fallbackRequests).toBe(0);
 
     rendered.renderer.destroy();
-    store.setCustomView(null);
     store.setActiveMenu(null);
     unregisterFallback();
   });
@@ -1247,16 +1218,17 @@ describe("fullscreen bridge", () => {
       { width: 100, height: 28 },
     );
     await renderOnce();
-    store.setActiveMenu({
-      kind: "menu",
-      options: [
-        { label: "Start chatting", value: "chat" },
-        { label: "Create an agent", value: "create" },
-        { label: "Exit", value: "exit" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => selected.push("EXIT-CALLED"),
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options: [
+          { label: "Start chatting", value: "chat" },
+          { label: "Create an agent", value: "create" },
+          { label: "Exit", value: "exit" },
+        ],
+      },
+      (result) => selected.push(result.kind === "exit" ? "EXIT-CALLED" : result.value),
+    );
     await flush();
     const before = captureCharFrame();
 
@@ -1278,16 +1250,19 @@ describe("fullscreen bridge", () => {
     const selected: string[] = [];
     const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
     await rendered.renderOnce();
-    store.setActiveMenu({
-      kind: "menu",
-      options: [
-        { label: "Start chatting", value: "chat" },
-        { label: "Create an agent", value: "create" },
-        { label: "Exit", value: "exit" },
-      ],
-      onSelect: (value) => selected.push(value),
-      onExit: () => undefined,
-    });
+    store.setActiveMenu(
+      {
+        kind: "menu",
+        options: [
+          { label: "Start chatting", value: "chat" },
+          { label: "Create an agent", value: "create" },
+          { label: "Exit", value: "exit" },
+        ],
+      },
+      (result) => {
+        if (result.kind === "select") selected.push(result.value);
+      },
+    );
     await rendered.flush();
 
     await rendered.mockInput.pressKey("\x1bOB");
@@ -1648,8 +1623,6 @@ describe("fullscreen bridge", () => {
     store.setActiveMenu({
       kind: "menu",
       options: [{ label: "x", value: "x" }],
-      onSelect: () => undefined,
-      onExit: () => undefined,
     });
     await flush();
 

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -1032,7 +1032,6 @@ export function FullscreenBridge(): React.ReactNode {
     [updateHistory],
   );
   const [commandIndex, commandIndexRef, setCommandIndex] = useSynchronizedState(0);
-  const customView = session.customView;
   const connectors = session.connectors;
   const currentConversation = session.currentConversation;
   const workingDirectory = session.workingDirectory;
@@ -1113,19 +1112,6 @@ export function FullscreenBridge(): React.ReactNode {
     }, APPROVAL_ARM_MS);
     return () => clearTimeout(timer);
   }, [approval, setApprovalArmedState]);
-
-  useEffect(() => {
-    if (customView === null || menu !== null) return;
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (!cancelled && store.getActiveMenuSnapshot() === null) {
-        store.requestRendererFallback();
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [customView, menu]);
 
   useEffect(() => {
     if (prompt?.type !== "filepicker") return;
@@ -1429,19 +1415,21 @@ export function FullscreenBridge(): React.ReactNode {
         if (name === "return" || name === "enter") {
           if (openMenu.kind === "agents") {
             if (openMenu.browse === true) {
-              openMenu.onExit();
+              store.completePrompt({ kind: "exit" });
             } else {
               const choice = openMenu.agents[menuIndexRef.current];
-              if (choice !== undefined) openMenu.onSelect(choice.id);
+              if (choice !== undefined) store.completePrompt({ kind: "select", value: choice.id });
             }
           } else {
             const choice = openMenu.options[menuIndexRef.current];
-            if (choice !== undefined) openMenu.onSelect(choice.value);
+            if (choice !== undefined) {
+              store.completePrompt({ kind: "select", value: choice.value });
+            }
           }
           return true;
         }
         if (name === "escape" || name === "q") {
-          openMenu.onExit();
+          store.completePrompt({ kind: "exit" });
           return true;
         }
         return true;
@@ -2128,10 +2116,6 @@ export function FullscreenBridge(): React.ReactNode {
         }}
         viewport={viewport}
       />
-    ) : customView !== null ? (
-      <box style={{ flexDirection: "column", padding: 1 }}>
-        <text>Switching to the standard interface…</text>
-      </box>
     ) : undefined;
 
   return (

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import type React from "react";
-import { UIStore } from "./store";
+import { UIStore, type ActiveMenu } from "./store";
 import type { OutputEntry } from "./types";
 
 function entry(message = "hello"): OutputEntry {
@@ -146,18 +147,83 @@ describe("UIStore", () => {
       expect(fallbackRequests).toBe(1);
     });
 
-    test("both session subscribers see customView", () => {
+    test("both session subscribers see a data-only menu", () => {
       const s = new UIStore();
-      const ink: Array<React.ReactNode | null> = [];
-      const fullscreen: Array<React.ReactNode | null> = [];
-      s.subscribeSession(() => ink.push(s.getSessionSnapshot().customView));
-      s.subscribeSession(() => fullscreen.push(s.getSessionSnapshot().customView));
+      const ink: Array<ActiveMenu | null> = [];
+      const fullscreen: Array<ActiveMenu | null> = [];
+      const menu: ActiveMenu = {
+        kind: "menu",
+        options: [{ label: "Start chatting", value: "chat" }],
+      };
+      s.subscribeSession(() => ink.push(s.getActiveMenuSnapshot()));
+      s.subscribeSession(() => fullscreen.push(s.getActiveMenuSnapshot()));
 
-      s.setCustomView("Ink-only screen");
-      s.setCustomView(null);
+      s.setActiveMenu(menu);
+      s.setActiveMenu(null);
 
-      expect(ink).toEqual(["Ink-only screen", null]);
-      expect(fullscreen).toEqual(["Ink-only screen", null]);
+      expect(ink).toEqual([menu, null]);
+      expect(fullscreen).toEqual([menu, null]);
+    });
+  });
+
+  describe("completePrompt", () => {
+    test("does not expose setCustomView", () => {
+      const s = new UIStore();
+      expect("setCustomView" in s).toBe(false);
+      expect("registerCustomView" in s).toBe(false);
+    });
+
+    test("no producer or renderer still calls setCustomView", () => {
+      const sources = [
+        join(import.meta.dir, "store.ts"),
+        join(import.meta.dir, "App.tsx"),
+        join(import.meta.dir, "fullscreen/bridge.tsx"),
+        join(import.meta.dir, "../commands/wizard.ts"),
+        join(import.meta.dir, "../commands/config-wizard.ts"),
+        join(import.meta.dir, "../commands/workflow.ts"),
+      ];
+      for (const sourcePath of sources) {
+        const source = readFileSync(sourcePath, "utf8");
+        expect(source.includes("setCustomView")).toBe(false);
+        expect(source.includes("registerCustomView")).toBe(false);
+      }
+    });
+
+    test("keeps the snapshot data-only and runs the continuation once", () => {
+      const s = new UIStore();
+      const results: string[] = [];
+      s.setActiveMenu(
+        {
+          kind: "menu",
+          options: [{ label: "Start chatting", value: "chat" }],
+        },
+        (result) => results.push(result.kind === "exit" ? "exit" : result.value),
+      );
+
+      const snapshot = s.getActiveMenuSnapshot();
+      expect(snapshot).not.toHaveProperty("onSelect");
+      expect(snapshot).not.toHaveProperty("onExit");
+      if (snapshot !== null) {
+        for (const value of Object.values(snapshot)) {
+          expect(typeof value).not.toBe("function");
+        }
+      }
+
+      s.completePrompt({ kind: "select", value: "chat" });
+      s.completePrompt({ kind: "select", value: "again" });
+      expect(results).toEqual(["chat"]);
+      expect(s.getActiveMenuSnapshot()).toBe(null);
+    });
+
+    test("drops a pending continuation when the menu is cleared", () => {
+      const s = new UIStore();
+      let called = 0;
+      s.setActiveMenu({ kind: "menu", options: [{ label: "Go", value: "go" }] }, () => {
+        called += 1;
+      });
+      s.setActiveMenu(null);
+      s.completePrompt({ kind: "exit" });
+      expect(called).toBe(0);
     });
   });
 

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -1,5 +1,4 @@
 import { useSyncExternalStore } from "react";
-import type React from "react";
 import { isActivityEqual, type ActivityState } from "./activity-state";
 import {
   initialScrollbackState,
@@ -58,6 +57,14 @@ export interface CollapseEphemeralSummary {
 
 export type ConnectorStatus = "live" | "renew" | "offline";
 
+/**
+ * A menu the app is waiting on, published as data rather than as a rendered tree.
+ *
+ * Continuations stay on the write side (`completePrompt`). Putting `onSelect` /
+ * `onExit` on the snapshot would smuggle closures through a contract two
+ * renderers share, and the second renderer would still have nothing it can
+ * serialize or replay.
+ */
 export interface ActiveMenuOption {
   readonly label: string;
   readonly value: string;
@@ -84,8 +91,6 @@ export interface ActiveWizardMenu {
   readonly options: readonly ActiveMenuOption[];
   readonly requirements?: readonly ActiveMenuRequirement[];
   readonly tip?: string;
-  readonly onSelect: (value: string) => void;
-  readonly onExit: () => void;
 }
 
 export interface ActiveAgentMenu {
@@ -93,12 +98,17 @@ export interface ActiveAgentMenu {
   readonly title: string;
   readonly action: string;
   readonly agents: readonly ActiveAgentChoice[];
-  readonly onSelect: (value: string) => void;
-  readonly onExit: () => void;
   readonly browse?: boolean;
 }
 
 export type ActiveMenu = ActiveWizardMenu | ActiveAgentMenu;
+
+/** Discriminated surface a renderer paints in place of the chat transcript. */
+export type SurfaceIntent = ActiveMenu;
+
+/** How a renderer answers the surface currently published on the store. */
+export type PromptResult =
+  { readonly kind: "select"; readonly value: string } | { readonly kind: "exit" };
 
 export interface CurrentConversation {
   readonly agentId: string;
@@ -139,7 +149,6 @@ export interface SessionSnapshot {
   readonly interruptHandler: (() => void) | null;
   readonly approvalRequest: PendingApproval | null;
   readonly activeMenu: ActiveMenu | null;
-  readonly customView: React.ReactNode | null;
   readonly modeToast: string | null;
 }
 
@@ -171,7 +180,6 @@ const INITIAL_SESSION: SessionSnapshot = {
   interruptHandler: null,
   approvalRequest: null,
   activeMenu: null,
-  customView: null,
   modeToast: null,
 };
 
@@ -253,6 +261,7 @@ export class UIStore {
   private ephemeralRegions: Map<EphemeralRegionId, EphemeralRegion> = new Map();
   private ephemeralIdCounter = 0;
   private interruptHandlerStack: Array<() => void> = [];
+  private promptContinuation: ((result: PromptResult) => void) | null = null;
   private rendererFallbackHandler: (() => void) | null = null;
 
   subscribeOutput = (listener: () => void): (() => void) => this.output.subscribe(listener);
@@ -367,10 +376,6 @@ export class UIStore {
     }
     if (!changed) return;
     patchSlice(this.session, { runStats: next });
-  };
-
-  setCustomView = (view: React.ReactNode | null): void => {
-    patchSlice(this.session, { customView: view });
   };
 
   setInterruptHandler = (handler: (() => void) | null): void => {
@@ -675,8 +680,24 @@ export class UIStore {
     this.publishScrollback(reduceScrollback(this.scrollback, { type: "clear" }));
   };
 
-  setActiveMenu = (menu: ActiveMenu | null): void => {
+  /** Publish a data-only menu. Pass the continuation here, not on the snapshot. */
+  setActiveMenu = (menu: ActiveMenu | null, onComplete?: (result: PromptResult) => void): void => {
+    this.promptContinuation = menu === null ? null : (onComplete ?? null);
     patchSlice(this.session, { activeMenu: menu });
+  };
+
+  /**
+   * Answer the published surface. Clears the snapshot, then invokes the
+   * write-side continuation once. A second call is a no-op.
+   */
+  completePrompt = (result: PromptResult): void => {
+    if (this.session.getSnapshot().activeMenu === null && this.promptContinuation === null) {
+      return;
+    }
+    const continuation = this.promptContinuation;
+    this.promptContinuation = null;
+    patchSlice(this.session, { activeMenu: null });
+    continuation?.(result);
   };
 
   getActiveMenuSnapshot(): ActiveMenu | null {


### PR DESCRIPTION
## What & why
Wizard, config, and workflow agent pickers used to inject an Ink React tree into the store. Fullscreen cannot paint that, so choosing an agent for `jazz workflow run` (and the same menus in the wizard) ejected into the other renderer. Those pickers now publish a data-only menu; both UIs draw from the same snapshot, and selecting or dismissing goes through the store once.

## How to verify
- Open a wizard or config menu, and the `jazz workflow run` agent picker, in both the standard terminal UI and fullscreen; both should show the same options.
- Select an option and dismiss with Escape; the producer resumes once and the menu clears. Completing again is a no-op.
- Confirm fullscreen stays fullscreen for these menus (no fallback to the other renderer).
- `bun test src/cli/ui/store.test.ts src/cli/commands/wizard-list-agents.test.ts src/cli/commands/workflow-select-agent.test.ts src/cli/ui/fullscreen/bridge.test.tsx`
