### PR TITLE
feat(ui): delay-arm approvals and keep follow-ups queued

### DIFF
--- a/src/cli/ui/fullscreen/App.tsx
+++ b/src/cli/ui/fullscreen/App.tsx
@@ -445,16 +445,19 @@ function AppView({ view, onAction, onKey, onPaste, overrideContent }: AppProps):
     () => ({ ...view.input, disabled: view.input.disabled || overlayOpen }),
     [view.input, overlayOpen],
   );
+  const overlayKind = view.overlay?.kind;
+  const overlayArmed = view.overlay?.kind === "approval" ? view.overlay.armed : true;
   const footerHints = useMemo(
     () =>
       hintsFor(
         focus,
         view.runActive === true,
         view.input.queueing === true,
-        view.overlay?.kind,
+        overlayKind,
         view.input.commands !== undefined,
+        overlayArmed,
       ),
-    [focus, view.runActive, view.input.queueing, view.overlay?.kind, view.input.commands],
+    [focus, view.runActive, view.input.queueing, overlayKind, view.input.commands, overlayArmed],
   );
   const footer = useMemo(
     () => ({

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -23,7 +23,7 @@ import packageJson from "../../../../package.json";
 import { hydrateTranscriptFromHistory } from "../hydrate-transcript";
 import { store } from "../store";
 import { THEME } from "../theme";
-import { FullscreenBridge } from "./bridge";
+import { APPROVAL_ARM_MS, flushPendingTerminalKeys, FullscreenBridge } from "./bridge";
 
 /**
  * Settles a state update dispatched from a keyboard event.
@@ -373,6 +373,8 @@ describe("fullscreen bridge", () => {
     store.setPrompt(null);
 
     expect(typed).toContain("/");
+    expect(typed).not.toContain("all conversations");
+    expect(typed).not.toContain("this conversation");
     expect(opened).toContain("all conversations");
   });
 
@@ -465,6 +467,7 @@ describe("fullscreen bridge", () => {
     await settleKeypress(rendered.flush, 100);
     expect(rendered.captureCharFrame()).toContain("1 queued");
     expect(rendered.captureCharFrame()).toContain("follow up");
+    expect(rendered.captureCharFrame()).toContain("enter to queue");
     expect(store.getMessageQueueSnapshot()).toEqual(["follow up"]);
 
     await rendered.mockInput.pressKey("ARROW_UP");
@@ -481,6 +484,33 @@ describe("fullscreen bridge", () => {
 
     rendered.renderer.destroy();
     store.setChatBusy(false);
+    store.setPrompt(null);
+  });
+
+  it("keeps the composer enabled after the chat prompt resolves while a queue is shown", async () => {
+    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
+    await rendered.renderOnce();
+    store.setPrompt({ type: "chat", message: "", resolve: () => undefined });
+    await rendered.flush();
+    store.setChatBusy(true);
+    store.setPrompt(null);
+    await rendered.flush();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await rendered.flush();
+
+    await typeInto(rendered.mockInput, rendered.flush, "already waiting");
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush, 100);
+    expect(rendered.captureCharFrame()).toContain("1 queued");
+    expect(rendered.captureCharFrame()).toContain("enter to queue");
+
+    await typeInto(rendered.mockInput, rendered.flush, "second thought");
+    expect(rendered.captureCharFrame()).toContain("second thought");
+    expect(rendered.captureCharFrame()).toContain("1 queued");
+
+    rendered.renderer.destroy();
+    store.setChatBusy(false);
+    store.clearQueue();
     store.setPrompt(null);
   });
 
@@ -1350,6 +1380,95 @@ describe("fullscreen bridge", () => {
     store.setPrompt(null);
     expect(pasted).toContain("pasted-while-scrolled");
     expect(pasted).toContain("enter to send");
+  });
+
+  it("drains buffered stdin so a pending Enter cannot land on a new card", () => {
+    const leftover: Array<string | Buffer> = ["\r", "a"];
+    const stdin = {
+      readable: true,
+      read: () => leftover.shift() ?? null,
+    } as unknown as NodeJS.ReadStream;
+    flushPendingTerminalKeys(stdin);
+    expect(leftover).toEqual([]);
+  });
+
+  it("does not resolve a producer approval from queued Enter or a during the deny-only window", async () => {
+    let settled: { approved: boolean } | undefined;
+    const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
+    await rendered.renderOnce();
+    const pending = Effect.runPromise(
+      presentationProducer().requestApproval({
+        toolCallId: "call-cal",
+        toolName: "calendar_create",
+        executeToolName: "calendar_create",
+        message: "This invitation will be sent immediately.",
+        executeArgs: {
+          account: "user@example.com",
+          title: "Planning",
+          field1: "one",
+          field2: "two",
+          field3: "three",
+          field4: "four",
+          field5: "five",
+          field6: "six",
+          field7: "seven",
+          field8: "eight",
+          field9: "nine",
+        },
+      }),
+    );
+    void pending.then((outcome) => {
+      settled = outcome;
+    });
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("field9");
+    expect(rendered.captureCharFrame()).toContain("esc to reject");
+    expect(rendered.captureCharFrame()).not.toContain("enter to accept");
+
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush);
+    await rendered.mockInput.pressKey("a");
+    await settleKeypress(rendered.flush);
+    expect(settled).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, APPROVAL_ARM_MS + 50));
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("enter to accept");
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush);
+    expect(await pending).toEqual({ approved: true });
+
+    rendered.renderer.destroy();
+  });
+
+  it("keeps reject available from a producer while accept is still inert", async () => {
+    let settled: { approved: boolean } | undefined;
+    const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
+    await rendered.renderOnce();
+    const pending = Effect.runPromise(
+      presentationProducer().requestApproval({
+        toolCallId: "call-mail",
+        toolName: "email_send",
+        executeToolName: "email_send",
+        message: "This message will leave the machine.",
+        executeArgs: { account: "user@example.com", to: "other@example.com" },
+      }),
+    );
+    void pending.then((outcome) => {
+      settled = outcome;
+    });
+    await rendered.flush();
+
+    await rendered.mockInput.pressKey("ESCAPE");
+    await settleKeypress(rendered.flush, 100);
+    expect(settled).toBeUndefined();
+    expect(rendered.captureCharFrame().toLowerCase()).toContain("instead");
+
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush, 100);
+    expect(await pending).toEqual({ approved: false });
+
+    rendered.renderer.destroy();
   });
 
   it("accepts only denial until an approval has armed", async () => {

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -97,7 +97,15 @@ const WAITING_ROTATE_MS = 4_000;
 
 /** How long the band holds its height after the last tool finishes. */
 const SETTLE_MS = 800;
-const APPROVAL_ARM_MS = 250;
+export const APPROVAL_ARM_MS = 250;
+
+/** Discard keystrokes already sitting on stdin before the card can see them. */
+export function flushPendingTerminalKeys(stdin: NodeJS.ReadStream = process.stdin): void {
+  if (stdin.readable !== true || typeof stdin.read !== "function") return;
+  while (stdin.read() !== null) {
+    // Buffered Enter / always-allow must not land on a card that just appeared.
+  }
+}
 
 interface PromptEditorState {
   readonly value: string;
@@ -1089,6 +1097,7 @@ export function FullscreenBridge(): React.ReactNode {
   }, [prompt, updatePromptControls]);
 
   useEffect(() => {
+    if (approval !== null) flushPendingTerminalKeys();
     setApprovalArmedState(false);
     setApprovalFieldOffset(0);
   }, [approval, setApprovalArmedState]);
@@ -2039,8 +2048,8 @@ export function FullscreenBridge(): React.ReactNode {
       anchor: draftAnchor,
       placeholder: busy ? "Type to queue for next turn" : "Ask anything",
       queued: queue,
-      queueing: busy,
-      disabled: overlay !== undefined || (!busy && prompt?.type !== "chat"),
+      queueing: busy || queue.length > 0,
+      disabled: overlay !== undefined || (!busy && queue.length === 0 && prompt?.type !== "chat"),
       ...(commands === undefined ? {} : { commands }),
     };
   }, [draft, draftCaret, draftAnchor, busy, queue, overlay, prompt, commandQuery, commandIndex]);

--- a/src/cli/ui/fullscreen/keymap.test.ts
+++ b/src/cli/ui/fullscreen/keymap.test.ts
@@ -321,9 +321,10 @@ describe("footer hints", () => {
       "^f to search",
       "^r for reasoning",
     ]);
-    expect(hintsFor("input", false, false, "approval")).toEqual([
+    expect(hintsFor("input", false, false, "approval", false, false)).toEqual(["esc to reject"]);
+    expect(hintsFor("input", false, false, "approval", false, true)).toEqual([
       "enter to accept",
-      "esc to cancel",
+      "esc to reject",
     ]);
     expect(hintsFor("input", false, false, "text")).toEqual(["enter to confirm", "esc to go back"]);
     expect(hintsFor("input", true, false, "search")).toEqual([
@@ -348,7 +349,8 @@ describe("footer hints", () => {
       ...hintsFor("input", false),
       ...hintsFor("input", true),
       ...hintsFor("transcript", false),
-      ...hintsFor("input", false, false, "approval"),
+      ...hintsFor("input", false, false, "approval", false, false),
+      ...hintsFor("input", false, false, "approval", false, true),
     ].join(" ");
     expect(advertised).not.toMatch(/\bcopy\b/);
     expect(advertised).not.toContain("palette");

--- a/src/cli/ui/fullscreen/keymap.ts
+++ b/src/cli/ui/fullscreen/keymap.ts
@@ -431,8 +431,11 @@ export function hintsFor(
   queueing = false,
   overlay?: "approval" | "search" | "question" | "text" | "filepicker",
   commandsOpen = false,
+  overlayArmed = true,
 ): readonly string[] {
-  if (overlay === "approval") return ["enter to accept", "esc to cancel"];
+  if (overlay === "approval") {
+    return overlayArmed ? ["enter to accept", "esc to reject"] : ["esc to reject"];
+  }
   if (overlay === "search") return ["enter to insert", "tab to scope", "esc to close"];
   if (overlay === "text") return ["enter to confirm", "esc to go back"];
   if (overlay === "question" || overlay === "filepicker") {


### PR DESCRIPTION
## What & why
A leftover Enter or `a` could accept an approval the instant the card appeared, and the footer advertised accept before that was true. New cards now discard pending keystrokes and stay deny-only for 250ms; Esc still rejects. While a run is on screen, the composer keeps taking queued follow-ups after the chat prompt clears, and the footer only advertises keys that currently work.

## How to verify
- Trigger a calendar or email approval and mash Enter or `a` immediately — the tool must not run until the deny-only window ends. Esc still rejects.
- Approve a tool with nine or more argument fields and confirm the ninth is on the card or reachable with up/down.
- During a busy turn, type a follow-up after the chat prompt disappears and confirm it queues; on an idle composer, type `/` and confirm slash commands list instead of history search.
- Confirm the footer says `esc to reject` before arming and `enter to accept` only after.
- `bun test src/cli/ui/fullscreen/bridge.test.tsx src/cli/ui/fullscreen/keymap.test.ts`
