### PR TITLE
feat(ui): subscribe store slices with useSyncExternalStore

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,8 +1,6 @@
 import { Box, Static, Text, useInput } from "ink";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { isActivityEqual, type ActivityState } from "./activity-state";
+import React, { useEffect, useRef, useState } from "react";
 import { ActivityView } from "./ActivityView";
-import { useTerminalOutputAdapter } from "./adapters/terminal-output-adapter";
 import type { PendingStream } from "./adapters/terminal-output-adapter";
 import { PreWrappedText } from "./components/PreWrappedText";
 import { useTerminalDimensions } from "./contexts/TerminalDimensionsContext";
@@ -15,9 +13,9 @@ import { Prompt } from "./Prompt";
 import { QueueInput } from "./QueueInput";
 import { RAIL_WIDTH, railStreamLines } from "./rail";
 import StatusFooter from "./StatusFooter";
-import { store, type RunStats } from "./store";
+import { store, useOutputSlice, usePromptSlice, useSessionSlice } from "./store";
 import { PADDING, PADDING_BUDGET, THEME } from "./theme";
-import type { OutputEntryWithId, PromptState } from "./types";
+import type { OutputEntryWithId } from "./types";
 import { dimReasoningMarkdownOutput } from "../presentation/format-utils";
 import { InputPriority, InputResults } from "../services/input-service";
 
@@ -26,24 +24,7 @@ import { InputPriority, InputResults } from "../services/input-service";
 // ============================================================================
 
 function ActivityIslandComponent(): React.ReactElement | null {
-  const [activity, setActivity] = useState<ActivityState>({ phase: "idle" });
-  const initializedRef = useRef(false);
-
-  // Register setter synchronously during render
-  if (!initializedRef.current) {
-    store.registerActivitySetter((next) => {
-      setActivity((prev) => (isActivityEqual(prev, next) ? prev : next));
-    });
-    setActivity(store.getActivitySnapshot());
-    initializedRef.current = true;
-  }
-
-  // Cleanup on unmount to prevent stale setter calls
-  useEffect(() => {
-    return () => {
-      store.registerActivitySetter(null);
-    };
-  }, []);
+  const { activity } = useSessionSlice();
 
   if (activity.phase === "idle" || activity.phase === "complete") return null;
 
@@ -57,34 +38,8 @@ const ActivityIsland = React.memo(ActivityIslandComponent);
 // ============================================================================
 
 function PromptIslandComponent(): React.ReactElement | null {
-  const [prompt, setPrompt] = useState<PromptState | null>(null);
-  const [workingDirectory, setWorkingDirectory] = useState<string | null>(null);
-  const [chatBusy, setChatBusy] = useState(false);
-  const [messageQueue, setMessageQueue] = useState<readonly string[]>([]);
-  const initializedRef = useRef(false);
-
-  // Register setters synchronously during render
-  if (!initializedRef.current) {
-    store.registerPromptSetter(setPrompt);
-    store.registerWorkingDirectorySetter(setWorkingDirectory);
-    store.registerChatBusySetter(setChatBusy);
-    store.registerMessageQueueSetter(setMessageQueue);
-    setPrompt(store.getPromptSnapshot());
-    setWorkingDirectory(store.getWorkingDirectorySnapshot());
-    setChatBusy(store.getChatBusySnapshot());
-    setMessageQueue(store.getMessageQueueSnapshot());
-    initializedRef.current = true;
-  }
-
-  // Cleanup on unmount to prevent stale setter calls
-  useEffect(() => {
-    return () => {
-      store.registerPromptSetter(null);
-      store.registerWorkingDirectorySetter(null);
-      store.registerChatBusySetter(null);
-      store.registerMessageQueueSetter(null);
-    };
-  }, []);
+  const { prompt, messageQueue } = usePromptSlice();
+  const { workingDirectory, chatBusy } = useSessionSlice();
 
   if (prompt) {
     return (
@@ -114,34 +69,14 @@ const PromptIsland = React.memo(PromptIslandComponent);
 // ============================================================================
 
 function StatusFooterIslandComponent(): React.ReactElement | null {
-  // RunStats is the footer's primary content — model · tokens · cost.
-  // The working directory is rendered by the prompt island already, so
-  // we don't duplicate it here (avoids conflicting with the prompt's
-  // single-slot wd setter).
-  const [runStats, setRunStats] = React.useState<RunStats>({});
-  const [modeIsYolo, setModeIsYolo] = React.useState(false);
-  const initializedRef = useRef(false);
-
-  if (!initializedRef.current) {
-    store.registerRunStatsSetter(setRunStats);
-    setRunStats(store.getRunStatsSnapshot());
-    store.registerModeSetter(setModeIsYolo);
-    initializedRef.current = true;
-  }
-
-  useEffect(() => {
-    return () => {
-      store.registerRunStatsSetter(null);
-      store.registerModeSetter(null);
-    };
-  }, []);
+  const { runStats, isYolo } = useSessionSlice();
 
   return (
     <StatusFooter
       status={null}
       workingDirectory={null}
       runStats={runStats}
-      modeIsYolo={modeIsYolo}
+      modeIsYolo={isYolo}
     />
   );
 }
@@ -175,51 +110,18 @@ function renderPendingStream(pending: PendingStream, cols: number): string {
 }
 
 function OutputIslandComponent(): React.ReactElement {
-  const { state, appendStatic, appendStream, finalizeStream, clear } = useTerminalOutputAdapter();
-  // Subscribe to terminal size so the live streaming tail re-wraps when the
-  // window is resized. Ink re-runs Yoga layout on resize but does NOT re-run
-  // React, so a JS-computed wrap width would otherwise stay frozen at its
-  // print-time value until the next stream delta arrives.
+  const output = useOutputSlice();
   const { cols } = useTerminalDimensions();
-  const initializedRef = useRef(false);
-
-  const printOutput = useCallback(
-    (entryOrBatch: Parameters<typeof appendStatic>[0]) => appendStatic(entryOrBatch),
-    [appendStatic],
-  );
-  const clearOutputs = useCallback(() => clear(), [clear]);
-
-  if (!initializedRef.current) {
-    store.registerPrintOutput(printOutput);
-    store.registerClearOutputs(clearOutputs);
-    store.registerStreamingHandler({ appendStream, finalizeStream });
-    if (store.hasPendingClear()) {
-      clearOutputs();
-      store.consumePendingClear();
-    }
-    const queued = store.drainPendingOutputQueue();
-    for (const entry of queued) printOutput(entry);
-    initializedRef.current = true;
-  }
-
-  useEffect(() => {
-    return () => {
-      store.registerPrintOutput(null);
-      store.registerClearOutputs(null);
-      store.registerStreamingHandler(null);
-    };
-  }, []);
-
-  const pending = state.pending;
+  const pending = output.pending;
 
   return (
     <Box flexDirection="column">
       <Static
-        key={state.staticGeneration}
-        items={state.staticEntries}
+        key={output.staticGeneration}
+        items={output.entries as OutputEntryWithId[]}
       >
         {(entry: OutputEntryWithId, index: number) => {
-          const prevEntry = index > 0 ? state.staticEntries[index - 1] : null;
+          const prevEntry = index > 0 ? output.entries[index - 1] : null;
           const isReasoning =
             entry.type === "streamContent" && entry.meta?.["kind"] === "reasoning";
           const prevIsReasoning =
@@ -254,51 +156,27 @@ const OutputIsland = React.memo(OutputIslandComponent);
 // ============================================================================
 
 export function App(): React.ReactElement {
-  const [customView, setCustomView] = useState<React.ReactNode | null>(null);
-  const interruptHandlerRef = useRef<(() => void) | null>(null);
-  const initializedRef = useRef(false);
-  const unregisterCustomViewRef = useRef<() => void>(() => undefined);
-  const [modeToast, setModeToast] = useState<string | null>(null);
+  const { customView, interruptHandler, modeToast } = useSessionSlice();
+  const interruptHandlerRef = useRef(interruptHandler);
+  interruptHandlerRef.current = interruptHandler;
   const modeToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Setup store methods synchronously during render
-  if (!initializedRef.current) {
-    unregisterCustomViewRef.current = store.registerCustomView(setCustomView);
-    store.registerInterruptHandler((handler) => {
-      interruptHandlerRef.current = handler;
-    });
-    initializedRef.current = true;
-  }
-
   useEffect(() => {
-    store.registerModeToastSetter((message) => {
-      if (modeToastTimerRef.current) {
-        clearTimeout(modeToastTimerRef.current);
-      }
-      setModeToast(message);
-      if (message !== null) {
-        modeToastTimerRef.current = setTimeout(() => {
-          setModeToast(null);
-          modeToastTimerRef.current = null;
-        }, 2000);
-      }
-    });
+    if (modeToast === null) return;
+    if (modeToastTimerRef.current) {
+      clearTimeout(modeToastTimerRef.current);
+    }
+    modeToastTimerRef.current = setTimeout(() => {
+      store.clearModeToast();
+      modeToastTimerRef.current = null;
+    }, 2000);
     return () => {
-      store.registerModeToastSetter(null);
       if (modeToastTimerRef.current) {
         clearTimeout(modeToastTimerRef.current);
         modeToastTimerRef.current = null;
       }
     };
-  }, []);
-
-  // Cleanup on unmount to prevent stale handler calls
-  useEffect(() => {
-    return () => {
-      unregisterCustomViewRef.current();
-      store.registerInterruptHandler(null);
-    };
-  }, []);
+  }, [modeToast]);
 
   // Handle Ctrl+C — bridge from Ink raw mode to process SIGINT
   // With exitOnCtrlC: false, Ink forwards Ctrl+C to useInput instead of

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -247,7 +247,7 @@ export function App(): React.ReactElement {
   // expanded view). No-op if no expandable reasoning is available.
   useInput((input, key) => {
     if (key.ctrl && (input === "r" || input === "\x12")) {
-      store.expandLastReasoning();
+      store.expandLastReasoning("append");
     }
   });
 

--- a/src/cli/ui/EphemeralPanelIsland.tsx
+++ b/src/cli/ui/EphemeralPanelIsland.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "ink";
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { EphemeralPanel } from "./EphemeralPanel";
-import { store, type EphemeralRegion } from "./store";
+import { useEphemeralSlice } from "./store";
 
 /** Maximum panels rendered simultaneously; overflow shown as a single hint. */
 export const MAX_VISIBLE_PANELS = 4;
@@ -12,21 +12,7 @@ export const MAX_VISIBLE_PANELS = 4;
  * single dim line summarizing how many more are running.
  */
 function EphemeralPanelIslandComponent(): React.ReactElement | null {
-  const [regions, setRegions] = useState<readonly EphemeralRegion[]>([]);
-  const initializedRef = useRef(false);
-
-  if (!initializedRef.current) {
-    // registerEphemeralRegionsSetter already hydrates the setter with the
-    // current snapshot, so no separate setRegions(snapshot) call is needed.
-    store.registerEphemeralRegionsSetter(setRegions);
-    initializedRef.current = true;
-  }
-
-  useEffect(() => {
-    return () => {
-      store.registerEphemeralRegionsSetter(null);
-    };
-  }, []);
+  const { regions } = useEphemeralSlice();
 
   if (regions.length === 0) return null;
 

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -69,10 +69,9 @@ function presentationProducer(): InkPresentationService {
 /**
  * Mounts the bridge, then feeds the store, then captures.
  *
- * The order matters: the store holds one print handler at a time, so writes have
- * to happen while the bridge under test is the registered one. In production
- * there is exactly one bridge for the life of the process, so this is also the
- * realistic order.
+ * Writes go through the store slices, so a late-mounted bridge still hydrates
+ * from getSnapshot. Feeding after mount matches production, where the bridge
+ * stays subscribed for the life of the process.
  */
 async function frame(feed: () => void = () => undefined): Promise<string> {
   const { renderer, renderOnce, flush, captureCharFrame } = await testRender(<FullscreenBridge />, {
@@ -93,23 +92,22 @@ async function frame(feed: () => void = () => undefined): Promise<string> {
   return text;
 }
 
-function unregisterAllStoreHandlers(): void {
-  store.registerPrintOutput(null);
-  store.registerUpdateOutput(null);
-  store.registerClearOutputs(null);
-  store.registerStreamingHandler(null);
-  store.registerActivitySetter(null);
-  store.registerRunStatsSetter(null);
-  store.registerMessageQueueSetter(null);
-  store.registerChatBusySetter(null);
-  store.registerModeSetter(null);
-  store.registerEphemeralRegionsSetter(null);
-  store.registerPromptSetter(null);
-  store.registerApprovalRequestSetter(null);
-  store.registerConnectorsSetter(null);
-  store.registerActiveMenuSetter(null);
-  store.registerWorkingDirectorySetter(null);
-  store.registerInterruptHandler(null);
+function resetStoreSlices(): void {
+  store.clearOutputs();
+  store.setActivity({ phase: "idle" });
+  store.resetRunStats({});
+  store.setPrompt(null);
+  store.setApprovalRequest(null);
+  store.setActiveMenu(null);
+  store.setChatBusy(false);
+  store.setWorkingDirectory(null);
+  store.setCurrentConversation(null);
+  store.clearQueue();
+  store.setModeIsYolo(false);
+  store.setCustomView(null);
+  store.clearModeToast();
+  store.collapseAllEphemeral();
+  store.setInterruptHandler(null);
 }
 
 describe("fullscreen bridge", () => {
@@ -129,16 +127,7 @@ describe("fullscreen bridge", () => {
   });
 
   beforeEach(() => {
-    unregisterAllStoreHandlers();
-    store.setActivity({ phase: "idle" });
-    store.resetRunStats({});
-    store.setPrompt(null);
-    store.setApprovalRequest(null);
-    store.setActiveMenu(null);
-    store.setChatBusy(false);
-    store.setWorkingDirectory(null);
-    store.clearQueue();
-    store.setModeIsYolo(false);
+    resetStoreSlices();
   });
 
   it("renders a frame at the terminal size before anything has happened", async () => {

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -2,12 +2,10 @@
 /**
  * Drives the fullscreen interface from the live UI store.
  *
- * The store already carries everything the interface needs, through a
- * register-setter / read-snapshot contract that the Ink islands use too. So
- * fullscreen needs no new presentation service: the same service writes to the
- * store, and whoever registered the setters renders. This module is the only
- * place where live state becomes a `ViewModel`, which is what keeps every
- * region a pure function of data.
+ * The store is a process singleton write port. Both this tree and the Ink
+ * islands subscribe to the same Object.is-stable slices via
+ * useSyncExternalStore. This module is the only place where live state becomes
+ * a `ViewModel`, which is what keeps every region a pure function of data.
  *
  * The mapping is deliberately lossy in one direction. The store speaks in
  * output entries and activity phases, which are a log; the interface speaks in
@@ -33,11 +31,12 @@ import {
 import { composeRecalledBuffer, isCursorOnFirstLine, isCursorOnLastLine } from "../queue-recall";
 import {
   store,
-  type ActiveMenu,
-  type ConnectorStatus,
+  useEphemeralSlice,
+  useOutputSlice,
+  usePromptSlice,
+  useSessionSlice,
   type EphemeralRegion,
   type PendingApproval,
-  type RunStats,
 } from "../store";
 import type { Choice, OutputEntry, PromptState } from "../types";
 import { App, type KeyChord } from "./App";
@@ -563,11 +562,6 @@ function receiptOf(entry: OutputEntry): ToolReceiptMeta | null {
   };
 }
 
-/** `Array.isArray` alone widens a readonly array to `any[]`. */
-function isEntryList(value: OutputEntry | readonly OutputEntry[]): value is readonly OutputEntry[] {
-  return Array.isArray(value);
-}
-
 /**
  * `OutputEntry.message` is typed `string | TerminalInkNode` — the second half
  * is an opaque wrapper (`{ _tag: "ink", node: <a React element> }`) that only
@@ -976,19 +970,27 @@ function approvalFrom(
 export function FullscreenBridge(): React.ReactNode {
   const { width, height } = useTerminalDimensions();
   const viewport = { width, height };
-  const [outputs, setOutputs] = useState<readonly OutputEntry[]>([]);
-  const [streaming, setStreaming] = useState("");
-  const [activity, setActivity] = useState<ActivityState>({ phase: "idle" });
-  const [stats, setStats] = useState<RunStats>({});
-  const [queue, setQueue] = useState<readonly string[]>([]);
-  const [busy, busyRef, setBusy] = useSynchronizedState(false);
-  const [isYolo, setIsYolo] = useState(store.getModeIsYolo());
-  const [regions, setRegions] = useState<readonly EphemeralRegion[]>([]);
-  const [prompt, promptRef, updatePrompt] = useSynchronizedState<PromptState | null>(null);
+  const output = useOutputSlice();
+  const session = useSessionSlice();
+  const promptSlice = usePromptSlice();
+  const ephemeral = useEphemeralSlice();
+  const outputs = output.entries;
+  const streaming = stripAnsiCodes(output.streaming);
+  const activity = session.activity;
+  const stats = session.runStats;
+  const queue = promptSlice.messageQueue;
+  const busy = session.chatBusy;
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
+  const isYolo = session.isYolo;
+  const regions = ephemeral.regions;
+  const prompt = promptSlice.prompt;
+  const promptRef = useRef(prompt);
+  promptRef.current = prompt;
   const [promptControls, promptControlsRef, updatePromptControls] =
     useSynchronizedState<PromptControlsState>(EMPTY_PROMPT_CONTROLS);
   const promptFile = promptControls.file;
-  const [approval, setApproval] = useState<PendingApproval | null>(null);
+  const approval = session.approvalRequest;
   const [approvalArmed, setApprovalArmed] = useState(false);
   const [approvalFieldOffset, setApprovalFieldOffset] = useState(0);
   /**
@@ -1030,19 +1032,17 @@ export function FullscreenBridge(): React.ReactNode {
     [updateHistory],
   );
   const [commandIndex, commandIndexRef, setCommandIndex] = useSynchronizedState(0);
-  const [customView, setCustomView] = useState<React.ReactNode | null>(null);
-  const [connectors, setConnectors] = useState<ReadonlyMap<string, ConnectorStatus>>(new Map());
-  const [currentConversation, setCurrentConversation] = useState(
-    store.getCurrentConversationSnapshot(),
-  );
-  const [workingDirectory, setWorkingDirectory] = useState<string | null>(
-    store.getWorkingDirectorySnapshot(),
-  );
+  const customView = session.customView;
+  const connectors = session.connectors;
+  const currentConversation = session.currentConversation;
+  const workingDirectory = session.workingDirectory;
   const [searchQuery, searchQueryRef, setSearchQuery] = useSynchronizedState<string | null>(null);
   const [searchHits, searchHitsRef, setSearchHits] = useSynchronizedState<readonly SearchHit[]>([]);
   const [searchScope, , setSearchScope] = useSynchronizedState<"conversation" | "all">("all");
   const [searchIndex, searchIndexRef, setSearchIndex] = useSynchronizedState(0);
-  const [menu, menuRef, setMenu] = useSynchronizedState<ActiveMenu | null>(null);
+  const menu = session.activeMenu;
+  const menuRef = useRef(menu);
+  menuRef.current = menu;
   const [menuIndex, menuIndexRef, setMenuIndex] = useSynchronizedState(0);
   const [elapsedMs, setElapsedMs] = useState<number | undefined>();
   const [reservedRows, setReservedRows] = useState(0);
@@ -1079,114 +1079,32 @@ export function FullscreenBridge(): React.ReactNode {
     setApprovalArmed(armed);
   }, []);
 
-  const setPromptState = useCallback(
-    (next: PromptState | null): void => {
-      updatePromptControls(initialPromptControls(next));
-      updatePrompt(next);
-    },
-    [updatePrompt, updatePromptControls],
-  );
-
   approvalRef.current = approval;
 
-  const interrupt = useRef<(() => void) | null>(null);
+  const interrupt = useRef(session.interruptHandler);
+  interrupt.current = session.interruptHandler;
   const quitArmed = useRef(false);
 
   useEffect(() => {
-    store.registerPrintOutput((entry) => {
-      const incoming: readonly OutputEntry[] = isEntryList(entry) ? entry : [entry];
-      setOutputs((previous) => [...previous, ...incoming]);
-      return "";
-    });
-    store.registerUpdateOutput((id, patch) => {
-      setOutputs((previous) =>
-        previous.map((entry) => {
-          if (entry.id !== id) return entry;
-          return {
-            ...entry,
-            ...patch,
-            meta: { ...entry.meta, ...patch.meta },
-          };
-        }),
-      );
-    });
-    store.registerClearOutputs(() => {
-      setOutputs([]);
-      setStreaming("");
-    });
-    // Streaming bypasses printOutput entirely, so without this the agent's prose
-    // would never appear.
-    store.registerStreamingHandler({
-      appendStream: (_kind, delta) => setStreaming((previous) => previous + stripAnsiCodes(delta)),
-      finalizeStream: () => {
-        setStreaming((text) => {
-          if (text.trim().length > 0) {
-            setOutputs((previous) => [
-              ...previous,
-              { type: "streamContent", message: text, timestamp: new Date() },
-            ]);
-          }
-          return "";
-        });
-      },
-    });
-    store.registerActivitySetter(setActivity);
-    store.registerRunStatsSetter(setStats);
-    store.registerMessageQueueSetter(setQueue);
-    store.registerChatBusySetter((nextBusy) => {
-      if (!nextBusy) quitArmed.current = false;
-      setBusy(nextBusy);
-    });
-    store.registerModeSetter(setIsYolo);
-    store.registerEphemeralRegionsSetter(setRegions);
-    store.registerPromptSetter(setPromptState);
-    store.registerApprovalRequestSetter((next) => {
-      setApprovalArmedState(false);
-      setApprovalFieldOffset(0);
-      setApproval(next);
-    });
-    const unregisterCustomView = store.registerCustomView(setCustomView);
-    store.registerConnectorsSetter(setConnectors);
-    store.registerCurrentConversationSetter(setCurrentConversation);
-    store.registerWorkingDirectorySetter(setWorkingDirectory);
-    store.registerActiveMenuSetter((next) => {
-      setMenu(next);
-      setMenuIndex(0);
-    });
-    store.registerInterruptHandler((handler) => {
-      if (handler === null) quitArmed.current = false;
-      interrupt.current = handler;
-    });
+    updatePromptControls(initialPromptControls(prompt));
+  }, [prompt, updatePromptControls]);
 
-    // Anything that happened before this mounted.
-    setActivity(store.getActivitySnapshot());
-    setStats(store.getRunStatsSnapshot());
-    setCurrentConversation(store.getCurrentConversationSnapshot());
-    setWorkingDirectory(store.getWorkingDirectorySnapshot());
-    const pending = store.drainPendingOutputQueue();
-    if (pending.length > 0) setOutputs((previous) => [...previous, ...pending]);
+  useEffect(() => {
+    setApprovalArmedState(false);
+    setApprovalFieldOffset(0);
+  }, [approval, setApprovalArmedState]);
 
-    return () => {
-      unregisterCustomView();
-      store.registerPrintOutput(null);
-      store.registerUpdateOutput(null);
-      store.registerClearOutputs(null);
-      store.registerStreamingHandler(null);
-      store.registerActivitySetter(null);
-      store.registerRunStatsSetter(null);
-      store.registerMessageQueueSetter(null);
-      store.registerChatBusySetter(null);
-      store.registerModeSetter(null);
-      store.registerEphemeralRegionsSetter(null);
-      store.registerPromptSetter(null);
-      store.registerApprovalRequestSetter(null);
-      store.registerConnectorsSetter(null);
-      store.registerActiveMenuSetter(null);
-      store.registerCurrentConversationSetter(null);
-      store.registerWorkingDirectorySetter(null);
-      store.registerInterruptHandler(null);
-    };
-  }, [setApprovalArmedState, setPromptState]);
+  useEffect(() => {
+    setMenuIndex(0);
+  }, [menu, setMenuIndex]);
+
+  useEffect(() => {
+    if (!busy) quitArmed.current = false;
+  }, [busy]);
+
+  useEffect(() => {
+    if (session.interruptHandler === null) quitArmed.current = false;
+  }, [session.interruptHandler]);
 
   useEffect(() => {
     if (approval === null) return;

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -1044,6 +1044,10 @@ export function FullscreenBridge(): React.ReactNode {
   const menuRef = useRef(menu);
   menuRef.current = menu;
   const [menuIndex, menuIndexRef, setMenuIndex] = useSynchronizedState(0);
+  // The index reset for a replacement menu runs a frame after the menu lands;
+  // a keypress in that gap must not read the old menu's selection into the new
+  // one, so the index only counts for the menu it was moved on.
+  const menuIndexForRef = useRef<typeof menu>(null);
   const [elapsedMs, setElapsedMs] = useState<number | undefined>();
   const [reservedRows, setReservedRows] = useState(0);
   const runStartedAt = useRef<number | null>(null);
@@ -1053,7 +1057,10 @@ export function FullscreenBridge(): React.ReactNode {
   // prompt makes the handler return before it reads a single keystroke. Refs are
   // correct regardless of the hook's registration semantics.
   const approvalRef = useRef<PendingApproval | null>(null);
-  const approvalArmedRef = useRef(false);
+  // Armed-ness is pinned to the approval it was armed for: the disarm effect
+  // for a replacement card runs a frame after the card lands, and a key-repeat
+  // Enter in that gap must not inherit the old card's armed state.
+  const approvalArmedForRef = useRef<PendingApproval | null>(null);
 
   const updatePromptEditor = useCallback(
     (update: (state: PromptEditorState) => PromptEditorState): void => {
@@ -1075,7 +1082,7 @@ export function FullscreenBridge(): React.ReactNode {
   );
 
   const setApprovalArmedState = useCallback((armed: boolean): void => {
-    approvalArmedRef.current = armed;
+    approvalArmedForRef.current = armed ? approvalRef.current : null;
     setApprovalArmed(armed);
   }, []);
 
@@ -1418,12 +1425,15 @@ export function FullscreenBridge(): React.ReactNode {
       if (openMenu !== null) {
         const itemCount =
           openMenu.kind === "agents" ? openMenu.agents.length : openMenu.options.length;
+        const menuSelection = menuIndexForRef.current === openMenu ? menuIndexRef.current : 0;
         if (name === "up" || name === "k") {
-          setMenuIndex((index) => Math.max(0, index - 1));
+          menuIndexForRef.current = openMenu;
+          setMenuIndex(Math.max(0, menuSelection - 1));
           return true;
         }
         if (name === "down" || name === "j") {
-          setMenuIndex((index) => Math.min(Math.max(0, itemCount - 1), index + 1));
+          menuIndexForRef.current = openMenu;
+          setMenuIndex(Math.min(Math.max(0, itemCount - 1), menuSelection + 1));
           return true;
         }
         if (name === "return" || name === "enter") {
@@ -1431,11 +1441,11 @@ export function FullscreenBridge(): React.ReactNode {
             if (openMenu.browse === true) {
               openMenu.onExit();
             } else {
-              const choice = openMenu.agents[menuIndexRef.current];
+              const choice = openMenu.agents[menuSelection];
               if (choice !== undefined) openMenu.onSelect(choice.id);
             }
           } else {
-            const choice = openMenu.options[menuIndexRef.current];
+            const choice = openMenu.options[menuSelection];
             if (choice !== undefined) openMenu.onSelect(choice.value);
           }
           return true;
@@ -1458,7 +1468,7 @@ export function FullscreenBridge(): React.ReactNode {
           setApprovalFieldOffset((offset) => Math.max(0, offset + delta));
           return true;
         }
-        if (!approvalArmedRef.current) return true;
+        if (approvalArmedForRef.current !== approvalRef.current) return true;
         if (active === null) return true;
         if (name === "return" || name === "enter") {
           active.resolve("yes");

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -415,6 +415,24 @@ describe("UIStore", () => {
       expect(s.getExpandableReasoningSnapshot()).toBeNull();
     });
 
+    test("expandLastReasoning('append') adds a fresh entry so Ink's Static can show it", () => {
+      const s = new UIStore();
+
+      const id = s.openEphemeral("reasoning", "Reasoning", 8);
+      s.collapseEphemeral(id, { durationMs: 1000, fullText: "full reasoning body" });
+
+      expect(s.getOutputSnapshot().entries).toHaveLength(1);
+
+      s.expandLastReasoning("append");
+
+      const printed = s.getOutputSnapshot().entries;
+      expect(printed).toHaveLength(2);
+      expect(printed[0]!.meta?.["collapsed"]).toBe(true);
+      expect(printed[1]!.message).toContain("full reasoning body");
+      expect(printed[1]!.id).not.toBe(printed[0]!.id);
+      expect(s.getExpandableReasoningSnapshot()).toBeNull();
+    });
+
     test("expandLastReasoning expands later blocks without moving them", () => {
       const s = new UIStore();
 

--- a/src/cli/ui/store.test.ts
+++ b/src/cli/ui/store.test.ts
@@ -12,19 +12,20 @@ describe("UIStore", () => {
   // Pending queue — before handler registration
   // -------------------------------------------------------------------------
 
-  describe("pending output queue", () => {
-    test("queues entries when no handler is registered", () => {
+  describe("output slice", () => {
+    test("printOutput lands in the snapshot after the batch flush", async () => {
       const s = new UIStore();
       s.printOutput(entry("a"));
       s.printOutput(entry("b"));
+      expect(s.getOutputSnapshot().entries).toHaveLength(0);
 
-      const drained = s.drainPendingOutputQueue();
-      expect(drained).toHaveLength(2);
-      expect(drained[0]!.message).toBe("a");
-      expect(drained[1]!.message).toBe("b");
+      await Promise.resolve();
+      expect(s.getOutputSnapshot().entries).toHaveLength(2);
+      expect(s.getOutputSnapshot().entries[0]!.message).toBe("a");
+      expect(s.getOutputSnapshot().entries[1]!.message).toBe("b");
     });
 
-    test("assigns unique ids to queued entries", () => {
+    test("assigns unique ids to printed entries", () => {
       const s = new UIStore();
       const id1 = s.printOutput(entry("a"));
       const id2 = s.printOutput(entry("b"));
@@ -34,37 +35,13 @@ describe("UIStore", () => {
       expect(id2).toContain("queued-output-");
     });
 
-    test("preserves caller-provided id", () => {
+    test("preserves caller-provided id", async () => {
       const s = new UIStore();
       const id = s.printOutput({ ...entry(), id: "custom-id" });
 
       expect(id).toBe("custom-id");
-      const drained = s.drainPendingOutputQueue();
-      expect(drained[0]!.id).toBe("custom-id");
-    });
-
-    test("drops entries beyond MAX_PENDING_OUTPUT_QUEUE (2000)", () => {
-      const s = new UIStore();
-      for (let i = 0; i < 2050; i++) {
-        s.printOutput(entry(`msg-${i}`));
-      }
-
-      const drained = s.drainPendingOutputQueue();
-      expect(drained).toHaveLength(2000);
-      // First entry is preserved, overflow entries are dropped
-      expect(drained[0]!.message).toBe("msg-0");
-      expect(drained[1999]!.message).toBe("msg-1999");
-    });
-
-    test("drain empties the queue", () => {
-      const s = new UIStore();
-      s.printOutput(entry("a"));
-
-      const first = s.drainPendingOutputQueue();
-      expect(first).toHaveLength(1);
-
-      const second = s.drainPendingOutputQueue();
-      expect(second).toHaveLength(0);
+      s.flushOutputBatchNow();
+      expect(s.getOutputSnapshot().entries[0]!.id).toBe("custom-id");
     });
   });
 
@@ -72,41 +49,82 @@ describe("UIStore", () => {
   // Handler registration — entries bypass queue
   // -------------------------------------------------------------------------
 
-  describe("handler registration", () => {
-    test("delegates to handler once registered (batched on microtask)", async () => {
+  describe("subscribe slices", () => {
+    test("output subscribe is multicast — both trees see the same snapshot", async () => {
       const s = new UIStore();
-      const received: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        received.push(...arr);
-        return arr[0]?.id ?? "generated";
-      });
+      const ink: OutputEntry[][] = [];
+      const fullscreen: OutputEntry[][] = [];
+      s.subscribeOutput(() => ink.push([...s.getOutputSnapshot().entries]));
+      s.subscribeOutput(() => fullscreen.push([...s.getOutputSnapshot().entries]));
 
-      s.printOutput(entry("direct"));
-      await Promise.resolve(); // Let batch microtask run
-      expect(received).toHaveLength(1);
-      expect(received[0]!.message).toBe("direct");
-      expect(s.drainPendingOutputQueue()).toHaveLength(0);
+      s.printOutput(entry("hello"));
+      await Promise.resolve();
+
+      expect(ink).toHaveLength(1);
+      expect(fullscreen).toHaveLength(1);
+      expect(ink[0]).toEqual(fullscreen[0]);
+      expect(ink[0]![0]!.message).toBe("hello");
+      expect(s.getOutputSnapshot()).toBe(s.getOutputSnapshot());
     });
 
-    test("coalesces rapid calls into single batch", async () => {
+    test("getSnapshot is Object.is-stable across reads and unrelated writes", () => {
       const s = new UIStore();
-      const received: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        received.push(...arr);
-        return arr[0]?.id ?? "generated";
+      const output = s.getOutputSnapshot();
+      const session = s.getSessionSnapshot();
+      const prompt = s.getPromptSlice();
+      const ephemeral = s.getEphemeralSnapshot();
+
+      expect(s.getOutputSnapshot()).toBe(output);
+      expect(s.getSessionSnapshot()).toBe(session);
+      expect(s.getPromptSlice()).toBe(prompt);
+      expect(s.getEphemeralSnapshot()).toBe(ephemeral);
+
+      s.setActivity({ phase: "thinking", agentName: "A" });
+      expect(s.getOutputSnapshot()).toBe(output);
+      expect(s.getPromptSlice()).toBe(prompt);
+      expect(s.getEphemeralSnapshot()).toBe(ephemeral);
+      expect(s.getSessionSnapshot()).not.toBe(session);
+      expect(s.getSessionSnapshot()).toBe(s.getSessionSnapshot());
+    });
+
+    test("session subscribe is multicast", () => {
+      const s = new UIStore();
+      let ink = 0;
+      let fullscreen = 0;
+      s.subscribeSession(() => {
+        ink += 1;
+      });
+      s.subscribeSession(() => {
+        fullscreen += 1;
+      });
+
+      s.setChatBusy(true);
+      expect(ink).toBe(1);
+      expect(fullscreen).toBe(1);
+      s.setChatBusy(true);
+      expect(ink).toBe(1);
+      expect(fullscreen).toBe(1);
+    });
+
+    test("unsubscribing one tree does not silence the other", () => {
+      const s = new UIStore();
+      let ink = 0;
+      let fullscreen = 0;
+      const unsubscribeInk = s.subscribeOutput(() => {
+        ink += 1;
+      });
+      s.subscribeOutput(() => {
+        fullscreen += 1;
       });
 
       s.printOutput(entry("a"));
+      s.flushOutputBatchNow();
+      unsubscribeInk();
       s.printOutput(entry("b"));
-      s.printOutput(entry("c"));
-      expect(received).toHaveLength(0); // Not yet flushed
-      await Promise.resolve();
-      expect(received).toHaveLength(3);
-      expect(received[0]!.message).toBe("a");
-      expect(received[1]!.message).toBe("b");
-      expect(received[2]!.message).toBe("c");
+      s.flushOutputBatchNow();
+
+      expect(ink).toBe(1);
+      expect(fullscreen).toBe(2);
     });
 
     test("stale renderer cleanup does not unregister a newer fallback handler", () => {
@@ -128,20 +146,18 @@ describe("UIStore", () => {
       expect(fallbackRequests).toBe(1);
     });
 
-    test("carries a custom view across renderer replacement", () => {
+    test("both session subscribers see customView", () => {
       const s = new UIStore();
-      const firstRenderer: Array<React.ReactNode | null> = [];
-      const secondRenderer: Array<React.ReactNode | null> = [];
-      const unregisterFirst = s.registerCustomView((view) => firstRenderer.push(view));
+      const ink: Array<React.ReactNode | null> = [];
+      const fullscreen: Array<React.ReactNode | null> = [];
+      s.subscribeSession(() => ink.push(s.getSessionSnapshot().customView));
+      s.subscribeSession(() => fullscreen.push(s.getSessionSnapshot().customView));
 
       s.setCustomView("Ink-only screen");
-      const unregisterSecond = s.registerCustomView((view) => secondRenderer.push(view));
-      unregisterFirst();
       s.setCustomView(null);
 
-      expect(firstRenderer).toEqual([null, "Ink-only screen"]);
-      expect(secondRenderer).toEqual(["Ink-only screen", null]);
-      unregisterSecond();
+      expect(ink).toEqual(["Ink-only screen", null]);
+      expect(fullscreen).toEqual(["Ink-only screen", null]);
     });
   });
 
@@ -150,60 +166,27 @@ describe("UIStore", () => {
   // -------------------------------------------------------------------------
 
   describe("clearOutputs", () => {
-    test("sets pending clear flag and empties queue when no handler", () => {
+    test("clears the output snapshot immediately", () => {
       const s = new UIStore();
       s.printOutput(entry("a"));
       s.printOutput(entry("b"));
+      s.flushOutputBatchNow();
+      expect(s.getOutputSnapshot().entries).toHaveLength(2);
 
       s.clearOutputs();
 
-      expect(s.hasPendingClear()).toBe(true);
-      expect(s.drainPendingOutputQueue()).toHaveLength(0);
-    });
-
-    test("delegates to handler when registered", () => {
-      const s = new UIStore();
-      let cleared = false;
-      s.registerClearOutputs(() => {
-        cleared = true;
-      });
-
-      s.clearOutputs();
-
-      expect(cleared).toBe(true);
-      // No pending clear since handler was called directly
-      expect(s.hasPendingClear()).toBe(false);
-    });
-
-    test("consumePendingClear resets the flag", () => {
-      const s = new UIStore();
-      s.clearOutputs();
-      expect(s.hasPendingClear()).toBe(true);
-
-      s.consumePendingClear();
-      expect(s.hasPendingClear()).toBe(false);
+      expect(s.getOutputSnapshot().entries).toHaveLength(0);
+      expect(s.getOutputSnapshot().streaming).toBe("");
     });
 
     test("discards pending batched outputs to prevent post-clear race", async () => {
       const s = new UIStore();
-      const received: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        received.push(...arr);
-        return arr[0]?.id ?? "generated";
-      });
-      s.registerClearOutputs(() => {
-        received.length = 0;
-      });
-
       s.printOutput(entry("a"));
       s.printOutput(entry("b"));
-      // Before microtask flushes, clear outputs
       s.clearOutputs();
 
-      // Let the microtask run - should NOT flush the discarded batch
       await Promise.resolve();
-      expect(received).toHaveLength(0);
+      expect(s.getOutputSnapshot().entries).toHaveLength(0);
     });
   });
 
@@ -220,10 +203,10 @@ describe("UIStore", () => {
       expect(s.getActivitySnapshot()).toEqual({ phase: "thinking", agentName: "A" });
     });
 
-    test("forwards activity to registered setter", () => {
+    test("notifies session subscribers", () => {
       const s = new UIStore();
       const calls: unknown[] = [];
-      s.registerActivitySetter((a) => calls.push(a));
+      s.subscribeSession(() => calls.push(s.getActivitySnapshot()));
 
       s.setActivity({ phase: "thinking", agentName: "A" });
       expect(calls).toHaveLength(1);
@@ -264,7 +247,7 @@ describe("UIStore", () => {
     test("nested setInterruptHandler restores outer handler when inner pops", () => {
       const s = new UIStore();
       const seen: Array<(() => void) | null> = [];
-      s.registerInterruptHandler((h) => seen.push(h));
+      s.subscribeSession(() => seen.push(s.getSessionSnapshot().interruptHandler));
 
       const outer = (): void => {};
       const inner = (): void => {};
@@ -279,23 +262,18 @@ describe("UIStore", () => {
 
     test("popping below empty is a no-op (over-pop tolerated)", () => {
       const s = new UIStore();
-      s.registerInterruptHandler(() => {});
       expect(() => s.setInterruptHandler(null)).not.toThrow();
     });
 
-    test("registerInterruptHandler(null) detaches the UI setter without dropping the stack", () => {
+    test("unsubscribing does not drop the interrupt stack", () => {
       const s = new UIStore();
-      const seenA: Array<(() => void) | null> = [];
-      s.registerInterruptHandler((h) => seenA.push(h));
+      const unsubscribe = s.subscribeSession(() => undefined);
 
       const handler = (): void => {};
       s.setInterruptHandler(handler);
+      unsubscribe();
 
-      s.registerInterruptHandler(null);
-      // Re-attaching a fresh setter should observe the still-present handler.
-      const seenB: Array<(() => void) | null> = [];
-      s.registerInterruptHandler((h) => seenB.push(h));
-      expect(seenB[0]).toBe(handler);
+      expect(s.getSessionSnapshot().interruptHandler).toBe(handler);
     });
   });
 
@@ -352,12 +330,6 @@ describe("UIStore", () => {
 
     test("collapseEphemeral removes region and emits summary line", () => {
       const s = new UIStore();
-      const received: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        received.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
 
       const id = s.openEphemeral("reasoning", "Reasoning", 8);
       s.collapseEphemeral(id, {
@@ -366,11 +338,8 @@ describe("UIStore", () => {
       });
 
       expect(s.getEphemeralRegionsSnapshot()).toHaveLength(0);
-      // Wait for batch microtask
-      return Promise.resolve().then(() => {
-        expect(received).toHaveLength(1);
-        expect(received[0]!.message).toBe("✓ Reasoning · 12s · 100 tokens");
-      });
+      expect(s.getOutputSnapshot().entries).toHaveLength(1);
+      expect(s.getOutputSnapshot().entries[0]!.message).toBe("✓ Reasoning · 12s · 100 tokens");
     });
 
     test("collapseEphemeral keeps the live tail when fullText is missing", () => {
@@ -411,12 +380,6 @@ describe("UIStore", () => {
 
     test("collapseAllEphemeral removes every open region without emitting summaries", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
 
       s.openEphemeral("reasoning", "R", 8);
       s.openEphemeral("subagent", "S1", 12);
@@ -425,28 +388,11 @@ describe("UIStore", () => {
       s.collapseAllEphemeral();
 
       expect(s.getEphemeralRegionsSnapshot()).toHaveLength(0);
-      return Promise.resolve().then(() => {
-        expect(printed).toHaveLength(0);
-      });
+      expect(s.getOutputSnapshot().entries).toHaveLength(0);
     });
 
     test("expandLastReasoning rewrites the collapsed entry in place", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
-      s.registerUpdateOutput((id, patch) => {
-        const index = printed.findIndex((entry) => entry.id === id);
-        if (index < 0) return;
-        printed[index] = {
-          ...printed[index]!,
-          ...patch,
-          meta: { ...printed[index]!.meta, ...patch.meta },
-        };
-      });
 
       const id = s.openEphemeral("reasoning", "Reasoning", 8);
       s.collapseEphemeral(id, {
@@ -454,12 +400,13 @@ describe("UIStore", () => {
         fullText: "full reasoning body",
       });
 
-      expect(printed).toHaveLength(1);
-      expect(printed[0]!.meta?.["collapsed"]).toBe(true);
+      expect(s.getOutputSnapshot().entries).toHaveLength(1);
+      expect(s.getOutputSnapshot().entries[0]!.meta?.["collapsed"]).toBe(true);
 
       s.expandLastReasoning();
       s.expandLastReasoning(); // second call is no-op
 
+      const printed = s.getOutputSnapshot().entries;
       expect(printed).toHaveLength(1);
       expect(printed[0]!.type).toBe("streamContent");
       expect(printed[0]!.message).toContain("full reasoning body");
@@ -470,21 +417,6 @@ describe("UIStore", () => {
 
     test("expandLastReasoning expands later blocks without moving them", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
-      s.registerUpdateOutput((id, patch) => {
-        const index = printed.findIndex((entry) => entry.id === id);
-        if (index < 0) return;
-        printed[index] = {
-          ...printed[index]!,
-          ...patch,
-          meta: { ...printed[index]!.meta, ...patch.meta },
-        };
-      });
 
       const first = s.openEphemeral("reasoning", "Reasoning", 8);
       s.collapseEphemeral(first, { durationMs: 500, fullText: "first block" });
@@ -495,6 +427,7 @@ describe("UIStore", () => {
       s.expandLastReasoning();
       s.expandLastReasoning(); // stack empty — no-op
 
+      const printed = s.getOutputSnapshot().entries;
       expect(printed).toHaveLength(2);
       expect(printed[0]!.message).toContain("first block");
       expect(printed[1]!.message).toContain("second block");
@@ -503,18 +436,13 @@ describe("UIStore", () => {
 
     test("Ctrl+R during a live panel pins it so collapse stays expanded", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
 
       const id = s.openEphemeral("reasoning", "Reasoning", 8);
       s.appendEphemeral(id, "live thought");
       expect(s.expandLastReasoning()).toBe(true);
       s.collapseEphemeral(id, { durationMs: 400, fullText: "live thought" });
 
+      const printed = s.getOutputSnapshot().entries;
       expect(printed).toHaveLength(1);
       expect(printed[0]!.meta?.["collapsed"]).toBe(false);
       expect(printed[0]!.message).toContain("live thought");
@@ -522,17 +450,12 @@ describe("UIStore", () => {
 
     test("setCollapseReasoning(false) settles reasoning expanded without Ctrl+R", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
       s.setCollapseReasoning(false);
 
       const id = s.openEphemeral("reasoning", "Reasoning", 8);
       s.collapseEphemeral(id, { durationMs: 1500, fullText: "the whole thought" });
 
+      const printed = s.getOutputSnapshot().entries;
       expect(printed).toHaveLength(1);
       expect(printed[0]!.meta?.["collapsed"]).toBe(false);
       expect(printed[0]!.message).toContain("the whole thought");
@@ -542,12 +465,6 @@ describe("UIStore", () => {
 
     test("setCollapseReasoning(false) dumps in-flight reasoning on collapseAllEphemeral", () => {
       const s = new UIStore();
-      const printed: OutputEntry[] = [];
-      s.registerPrintOutput((eOrBatch) => {
-        const arr = Array.isArray(eOrBatch) ? eOrBatch : [eOrBatch];
-        printed.push(...arr);
-        return arr[0]?.id ?? "id";
-      });
       s.setCollapseReasoning(false);
 
       const id = s.openEphemeral("reasoning", "Reasoning", 8);
@@ -555,23 +472,24 @@ describe("UIStore", () => {
       s.collapseAllEphemeral();
 
       expect(s.getEphemeralRegionsSnapshot()).toHaveLength(0);
+      const printed = s.getOutputSnapshot().entries;
       expect(printed).toHaveLength(1);
       expect(printed[0]!.meta?.["collapsed"]).toBe(false);
       expect(printed[0]!.message).toContain("interrupted thought");
       expect(s.getExpandableReasoningSnapshot()).toBeNull();
     });
 
-    test("setter is notified on open, append, and collapse", () => {
+    test("ephemeral subscribers are notified on open, append, and collapse", () => {
       const s = new UIStore();
       const seen: number[] = [];
-      s.registerEphemeralRegionsSetter((regions) => seen.push(regions.length));
-      seen.length = 0;
+      s.subscribeEphemeral(() => seen.push(s.getEphemeralSnapshot().regions.length));
 
       const id = s.openEphemeral("reasoning", "R", 8);
       s.appendEphemeral(id, "x");
       s.collapseEphemeral(id, { durationMs: 1, line: "✓ R" });
 
-      expect(seen).toEqual([1, 1, 0]);
+      expect(seen.slice(0, 3)).toEqual([1, 1, 0]);
+      expect(seen.at(-1)).toBe(0);
     });
   });
 
@@ -628,13 +546,11 @@ describe("UIStore", () => {
       expect(s.getMessageQueueSnapshot()).toEqual([]);
     });
 
-    test("setter receives the array on append, clear, and take", () => {
+    test("prompt subscribers receive the queue on append, clear, and take", () => {
       const s = new UIStore();
-      // Mutable array of immutable snapshots — we accumulate snapshots,
-      // never mutate them in place.
       const seen: (readonly string[])[] = [];
-      s.registerMessageQueueSetter((q) => {
-        seen.push([...q]);
+      s.subscribePrompt(() => {
+        seen.push([...s.getPromptSlice().messageQueue]);
       });
 
       s.appendToQueue("a");
@@ -643,15 +559,13 @@ describe("UIStore", () => {
       s.appendToQueue("c");
       s.clearQueue();
 
-      // First call is the hydration on register (empty array), then each mutation.
-      expect(seen).toEqual([[], ["a"], ["a", "b"], [], ["c"], []]);
+      expect(seen).toEqual([["a"], ["a", "b"], [], ["c"], []]);
     });
 
-    test("clearQueue when already empty does not notify setter", () => {
+    test("clearQueue when already empty does not notify subscribers", () => {
       const s = new UIStore();
       const seen: (readonly string[])[] = [];
-      s.registerMessageQueueSetter((q) => seen.push(q));
-      seen.length = 0; // discard hydration call
+      s.subscribePrompt(() => seen.push(s.getPromptSlice().messageQueue));
 
       s.clearQueue();
       expect(seen).toEqual([]);
@@ -676,11 +590,10 @@ describe("UIStore", () => {
       expect(s.getChatBusySnapshot()).toBe(false);
     });
 
-    test("setter is notified on change but not on no-op", () => {
+    test("session subscribers are notified on change but not on no-op", () => {
       const s = new UIStore();
       const seen: boolean[] = [];
-      s.registerChatBusySetter((b) => seen.push(b));
-      seen.length = 0; // discard hydration
+      s.subscribeSession(() => seen.push(s.getChatBusySnapshot()));
 
       s.setChatBusy(true);
       s.setChatBusy(true); // no-op

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -1,45 +1,33 @@
+import { useSyncExternalStore } from "react";
 import type React from "react";
 import { isActivityEqual, type ActivityState } from "./activity-state";
-import type { StreamKind } from "./adapters/terminal-output-adapter";
-import type { OutputEntry, PromptState } from "./types";
+import {
+  initialScrollbackState,
+  reduceScrollback,
+  type PendingStream,
+  type ScrollbackState,
+  type StreamKind,
+} from "./adapters/terminal-output-adapter";
+import type { OutputEntry, OutputEntryWithId, PromptState } from "./types";
 
-/** Accepts single entry or batch; returns first id when available. */
-type PrintOutputHandler = (entry: OutputEntry | readonly OutputEntry[]) => string;
-
-type UpdateOutputHandler = (id: string, patch: OutputEntry) => void;
-
-type StreamingHandler = {
-  appendStream: (kind: StreamKind, delta: string) => void;
-  finalizeStream: () => void;
-};
-
-/** Handler for mode switch requests (e.g., Shift+Tab toggles safe/yolo) */
 type ModeSwitchHandler = (mode: "safe" | "yolo") => void;
 
-const MAX_PENDING_OUTPUT_QUEUE = 2000;
-
-/** Set when we've logged the queue-full warning once to avoid spam */
-let _hasWarnedQueueFull = false;
+const EMPTY_STREAM = "";
+const EMPTY_OUTPUT_ENTRIES: readonly OutputEntryWithId[] = [];
+const EMPTY_QUEUE: readonly string[] = [];
+const EMPTY_REGIONS: readonly EphemeralRegion[] = [];
+const EMPTY_CONNECTORS: ReadonlyMap<string, ConnectorStatus> = new Map();
+const EMPTY_RUN_STATS: RunStats = {};
 
 interface ExpandableDiffPayload {
   readonly fullDiff: string;
   readonly timestamp: number;
 }
 
-/**
- * Kinds of ephemeral live region. Each kind has its own UI label and default
- * size; "reasoning" is the only kind that supports Ctrl-R expansion.
- */
 export type EphemeralKind = "reasoning" | "subagent";
 
 export type EphemeralRegionId = string;
 
-/**
- * A bounded live region rendered above the prompt while an in-flight activity
- * (the model thinking, a subagent working) is producing output. The region
- * shows only the last N lines of the activity; on completion it is removed
- * and a one-line summary is emitted into scrollback.
- */
 export interface EphemeralRegion {
   readonly id: EphemeralRegionId;
   readonly kind: EphemeralKind;
@@ -49,60 +37,27 @@ export interface EphemeralRegion {
   readonly maxLines: number;
 }
 
-/**
- * Snapshot of a collapsed reasoning block, available for Ctrl-R expansion.
- * Collapsed blocks accumulate in a bounded stack — each Ctrl-R press pops
- * and expands the most recent unexpanded block, so earlier reasoning from
- * a multi-step turn stays recoverable instead of being overwritten.
- */
 export interface ExpandableReasoning {
   readonly fullText: string;
   readonly label: string;
   readonly durationMs: number;
   readonly tokens?: number;
-  /** Output entry to rewrite in place. Missing when the block was never logged. */
   readonly entryId?: string;
 }
 
-/** Upper bound on retained collapsed-reasoning blocks. */
 const MAX_EXPANDABLE_REASONING = 20;
 
-/** Upper bound on recallable sent-message history. */
 const MAX_INPUT_HISTORY = 100;
 
-/** Caller-supplied summary when collapsing a region. */
 export interface CollapseEphemeralSummary {
-  /** One-line static entry to emit into scrollback (omit to skip). */
   readonly line?: string;
-  /** Full text to keep around for Ctrl-R expansion (reasoning only). */
   readonly fullText?: string;
   readonly durationMs: number;
   readonly tokens?: number;
 }
 
-/**
- * Persistent run-level stats surfaced in the status footer.
- *
- * All fields are optional so partial information renders gracefully —
- * the footer simply omits any field that hasn't been populated yet.
- * Most fields are session-totals, updated after each LLM round-trip.
- */
-/**
- * A pending approval, reduced to what an interface needs to render a decision.
- * Deliberately not the full `ApprovalRequest`: the store should not depend on
- * the tools layer, and the resume callback is not the UI's business.
- */
 export type ConnectorStatus = "live" | "renew" | "offline";
 
-/**
- * A menu the app is waiting on, published as data rather than as a rendered tree.
- *
- * `setCustomView` hands the UI a React element built with Ink components, which
- * only the Ink renderer can paint — so a second renderer sees an opaque node and
- * can do nothing useful with it. Publishing the *intent* instead lets each
- * renderer draw its own version, which is the only way two renderers can share
- * a flow.
- */
 export interface ActiveMenuOption {
   readonly label: string;
   readonly value: string;
@@ -145,7 +100,6 @@ export interface ActiveAgentMenu {
 
 export type ActiveMenu = ActiveWizardMenu | ActiveAgentMenu;
 
-/** Identifies the conversation on screen, so history search can be narrowed to it. */
 export interface CurrentConversation {
   readonly agentId: string;
   readonly conversationId: string;
@@ -160,89 +114,164 @@ export interface PendingApproval {
 }
 
 export interface RunStats {
-  /** Display name of the active model (e.g. "claude-sonnet-4-5"). */
   readonly model?: string;
-  /** Provider name (e.g. "anthropic", "openai"). */
   readonly provider?: string;
-  /** Tokens currently in the context window for this conversation. */
   readonly tokensInContext?: number;
-  /** Model's maximum context window in tokens. */
   readonly maxContextTokens?: number;
-  /** Running total cost in USD across this session. */
   readonly costUSD?: number;
 }
 
+export interface OutputSnapshot {
+  readonly entries: readonly OutputEntryWithId[];
+  readonly pending: PendingStream | null;
+  readonly streaming: string;
+  readonly staticGeneration: number;
+}
+
+export interface SessionSnapshot {
+  readonly activity: ActivityState;
+  readonly runStats: RunStats;
+  readonly workingDirectory: string | null;
+  readonly currentConversation: CurrentConversation | null;
+  readonly chatBusy: boolean;
+  readonly isYolo: boolean;
+  readonly connectors: ReadonlyMap<string, ConnectorStatus>;
+  readonly interruptHandler: (() => void) | null;
+  readonly approvalRequest: PendingApproval | null;
+  readonly activeMenu: ActiveMenu | null;
+  readonly customView: React.ReactNode | null;
+  readonly modeToast: string | null;
+}
+
+export interface PromptSnapshot {
+  readonly prompt: PromptState | null;
+  readonly messageQueue: readonly string[];
+}
+
+export interface EphemeralSnapshot {
+  readonly regions: readonly EphemeralRegion[];
+  readonly expandableReasoning: ExpandableReasoning | null;
+}
+
+const INITIAL_OUTPUT: OutputSnapshot = {
+  entries: EMPTY_OUTPUT_ENTRIES,
+  pending: null,
+  streaming: EMPTY_STREAM,
+  staticGeneration: 0,
+};
+
+const INITIAL_SESSION: SessionSnapshot = {
+  activity: { phase: "idle" },
+  runStats: EMPTY_RUN_STATS,
+  workingDirectory: null,
+  currentConversation: null,
+  chatBusy: false,
+  isYolo: false,
+  connectors: EMPTY_CONNECTORS,
+  interruptHandler: null,
+  approvalRequest: null,
+  activeMenu: null,
+  customView: null,
+  modeToast: null,
+};
+
+const INITIAL_PROMPT: PromptSnapshot = {
+  prompt: null,
+  messageQueue: EMPTY_QUEUE,
+};
+
+const INITIAL_EPHEMERAL: EphemeralSnapshot = {
+  regions: EMPTY_REGIONS,
+  expandableReasoning: null,
+};
+
+class StoreSlice<T> {
+  private snapshot: T;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(initial: T) {
+    this.snapshot = initial;
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): T => this.snapshot;
+
+  set(next: T): void {
+    if (Object.is(this.snapshot, next)) return;
+    this.snapshot = next;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+function patchSlice<T extends object>(slice: StoreSlice<T>, patch: Partial<T>): void {
+  const previous = slice.getSnapshot();
+  let changed = false;
+  for (const key of Object.keys(patch) as (keyof T)[]) {
+    if (!Object.is(previous[key], patch[key])) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) return;
+  slice.set({ ...previous, ...patch });
+}
+
+function outputFromScrollback(state: ScrollbackState): OutputSnapshot {
+  return {
+    entries: state.staticEntries,
+    pending: state.pending,
+    streaming: state.pending === null ? EMPTY_STREAM : state.pending.rawTail,
+    staticGeneration: state.staticGeneration,
+  };
+}
+
 export class UIStore {
-  // Output handlers
-  private printOutputHandler: PrintOutputHandler | null = null;
-  private updateOutputHandler: UpdateOutputHandler | null = null;
-  private clearOutputsHandler: (() => void) | null = null;
+  private readonly output = new StoreSlice<OutputSnapshot>(INITIAL_OUTPUT);
+  private readonly session = new StoreSlice<SessionSnapshot>(INITIAL_SESSION);
+  private readonly prompt = new StoreSlice<PromptSnapshot>(INITIAL_PROMPT);
+  private readonly ephemeral = new StoreSlice<EphemeralSnapshot>(INITIAL_EPHEMERAL);
+
+  private scrollback: ScrollbackState = initialScrollbackState();
   private pinnedReasoningIds = new Set<EphemeralRegionId>();
-  /** When false, settled reasoning stays expanded and Ctrl+R is unused. */
   private collapseReasoning = true;
-  private streamingHandler: StreamingHandler | null = null;
-  private pendingOutputQueue: OutputEntry[] = [];
-  private _pendingClear = false;
   private pendingOutputIdCounter = 0;
-
-  /** Coalesce rapid printOutput calls; flush on next microtask */
-  private outputBatch: OutputEntry[] = [];
+  private outputBatch: OutputEntryWithId[] = [];
   private batchFlushScheduled = false;
-
-  // Expandable diff for Ctrl+O expansion
   private expandableDiff: ExpandableDiffPayload | null = null;
-
-  // Mode switch handler (set by chat service)
   private modeSwitchHandler: ModeSwitchHandler | null = null;
-  // Track current mode for toggle behavior (safe = false, yolo = true)
-  private currentModeIsYolo = false;
-
-  // Snapshots (kept in sync so late-registering components can hydrate)
-  private promptSnapshot: PromptState | null = null;
-  private activitySnapshot: ActivityState = { phase: "idle" };
-  private workingDirectorySnapshot: string | null = null;
-  /**
-   * Which conversation the interface is showing.
-   *
-   * Held here because history search needs it to narrow to "this conversation", and the
-   * bridge that runs the search otherwise knows nothing about conversations at all — which
-   * is why that scope silently returned no results.
-   */
-  private currentConversationSnapshot: CurrentConversation | null = null;
-  private runStatsSnapshot: RunStats = {};
-  // Session-wide cumulative cost in USD. Every renderer (main agent and each
-  // sub-agent) adds its own per-turn cost here so the footer total reflects
-  // aggregate spend, not just the orchestrator's. Reset per session.
   private sessionCostUSD = 0;
-  private ephemeralRegionsSnapshot: readonly EphemeralRegion[] = [];
-  private expandableReasoningSnapshot: ExpandableReasoning | null = null;
   private expandableReasoningStack: ExpandableReasoning[] = [];
   private inputHistory: string[] = [];
-  private messageQueueSnapshot: readonly string[] = [];
-  private chatBusySnapshot: boolean = false;
-  private customViewSnapshot: React.ReactNode | null = null;
-
-  // Insertion-ordered map of live ephemeral regions, keyed by id.
   private ephemeralRegions: Map<EphemeralRegionId, EphemeralRegion> = new Map();
   private ephemeralIdCounter = 0;
-
-  // React state setters (registered by island components)
-  private promptSetter: ((prompt: PromptState | null) => void) | null = null;
-  private activitySetter: ((activity: ActivityState) => void) | null = null;
-  private workingDirectorySetter: ((wd: string | null) => void) | null = null;
-  private currentConversationSetter: ((conversation: CurrentConversation | null) => void) | null =
-    null;
-  private runStatsSetter: ((stats: RunStats) => void) | null = null;
-  private ephemeralRegionsSetter: ((regions: readonly EphemeralRegion[]) => void) | null = null;
-  private expandableReasoningSetter: ((value: ExpandableReasoning | null) => void) | null = null;
-  private messageQueueSetter: ((queue: readonly string[]) => void) | null = null;
-  private chatBusySetter: ((busy: boolean) => void) | null = null;
-  private customViewSetter: ((view: React.ReactNode | null) => void) | null = null;
-  private modeToastSetter: ((message: string | null) => void) | null = null;
-  private modeSetter: ((isYolo: boolean) => void) | null = null;
+  private interruptHandlerStack: Array<() => void> = [];
   private rendererFallbackHandler: (() => void) | null = null;
 
-  // ── Public API (called by consumers) ──────────────────────────────
+  subscribeOutput = (listener: () => void): (() => void) => this.output.subscribe(listener);
+  getOutputSnapshot = (): OutputSnapshot => this.output.getSnapshot();
+
+  subscribeSession = (listener: () => void): (() => void) => this.session.subscribe(listener);
+  getSessionSnapshot = (): SessionSnapshot => this.session.getSnapshot();
+
+  subscribePrompt = (listener: () => void): (() => void) => this.prompt.subscribe(listener);
+  getPromptSlice = (): PromptSnapshot => this.prompt.getSnapshot();
+
+  subscribeEphemeral = (listener: () => void): (() => void) => this.ephemeral.subscribe(listener);
+  getEphemeralSnapshot = (): EphemeralSnapshot => this.ephemeral.getSnapshot();
+
+  private publishScrollback(next: ScrollbackState): void {
+    if (Object.is(next, this.scrollback)) return;
+    this.scrollback = next;
+    this.output.set(outputFromScrollback(next));
+  }
 
   private flushOutputBatch = (): void => {
     this.batchFlushScheduled = false;
@@ -250,20 +279,14 @@ export class UIStore {
   };
 
   private doFlushBatch(): void {
-    if (!this.printOutputHandler || this.outputBatch.length === 0) return;
+    if (this.outputBatch.length === 0) return;
     const batch = this.outputBatch;
     this.outputBatch = [];
-    if (batch.length === 1) {
-      this.printOutputHandler(batch[0]!);
-    } else if (batch.length > 1) {
-      this.printOutputHandler(batch);
-    }
+    this.publishScrollback(
+      reduceScrollback(this.scrollback, { type: "appendStatic", entries: batch }),
+    );
   }
 
-  /**
-   * Synchronously flush any pending output batch. Use before setActivity during
-   * streaming so output + activity land in same React tick (reduces flicker).
-   */
   flushOutputBatchNow(): void {
     if (this.batchFlushScheduled) {
       this.batchFlushScheduled = false;
@@ -273,22 +296,9 @@ export class UIStore {
 
   printOutput = (entry: OutputEntry): string => {
     const id = entry.id ?? `queued-output-${++this.pendingOutputIdCounter}`;
-    const entryWithId = entry.id ? entry : { ...entry, id };
-
-    if (!this.printOutputHandler) {
-      if (this.pendingOutputQueue.length < MAX_PENDING_OUTPUT_QUEUE) {
-        this.pendingOutputQueue.push(entryWithId);
-      } else {
-        if (!_hasWarnedQueueFull) {
-          _hasWarnedQueueFull = true;
-          console.warn(
-            `[jazz] Output queue full (${MAX_PENDING_OUTPUT_QUEUE}); some output may be dropped until UI is ready.`,
-          );
-        }
-      }
-      return id;
-    }
-
+    const entryWithId: OutputEntryWithId = entry.id
+      ? (entry as OutputEntryWithId)
+      : { ...entry, id };
     this.outputBatch.push(entryWithId);
     if (!this.batchFlushScheduled) {
       this.batchFlushScheduled = true;
@@ -297,63 +307,48 @@ export class UIStore {
     return id;
   };
 
-  setPrompt = (prompt: PromptState | null): void => {
-    this.promptSnapshot = prompt;
-    // Do NOT eagerly erase Ink's frame here. `Ink.clear()` erases the frame
-    // and then re-syncs log-update to believe those lines are still painted,
-    // so the very next render erases the same line count a second time —
-    // chewing (frameHeight - 1) lines of settled scrollback and overwriting
-    // them with the next entry. Ink's own render already fully erases the
-    // previous frame before repainting, so a shrinking prompt cleans up.
-    if (this.promptSetter) {
-      this.promptSetter(prompt);
-    }
+  private updateOutputEntry(id: string, patch: OutputEntry): void {
+    const previous = this.output.getSnapshot();
+    let found = false;
+    const entries = previous.entries.map((entry) => {
+      if (entry.id !== id) return entry;
+      found = true;
+      return {
+        ...entry,
+        ...patch,
+        id,
+        meta: { ...entry.meta, ...patch.meta },
+      };
+    });
+    if (!found) return;
+    this.scrollback = { ...this.scrollback, staticEntries: entries };
+    this.output.set({ ...previous, entries });
+  }
+
+  setPrompt = (nextPrompt: PromptState | null): void => {
+    patchSlice(this.prompt, { prompt: nextPrompt });
   };
 
   setActivity = (activity: ActivityState): void => {
-    if (isActivityEqual(this.activitySnapshot, activity)) {
+    if (isActivityEqual(this.session.getSnapshot().activity, activity)) {
       return;
     }
-    this.activitySnapshot = activity;
-    if (this.activitySetter) {
-      this.activitySetter(activity);
-    }
+    patchSlice(this.session, { activity });
   };
 
   setCurrentConversation = (conversation: CurrentConversation | null): void => {
-    this.currentConversationSnapshot = conversation;
-    if (this.currentConversationSetter) {
-      this.currentConversationSetter(conversation);
-    }
+    patchSlice(this.session, { currentConversation: conversation });
   };
 
   setWorkingDirectory = (workingDirectory: string | null): void => {
-    this.workingDirectorySnapshot = workingDirectory;
-    if (this.workingDirectorySetter) {
-      this.workingDirectorySetter(workingDirectory);
-    }
+    patchSlice(this.session, { workingDirectory });
   };
 
-  /**
-   * Merge a partial RunStats update into the snapshot. Callers can pass any
-   * subset of fields — anything they omit keeps its prior value. Useful for
-   * incremental updates (e.g. tokens-in-context after every LLM call,
-   * costUSD only after we've resolved pricing).
-   */
-  resetRunStats = (initial: RunStats = {}): void => {
+  resetRunStats = (initial: RunStats = EMPTY_RUN_STATS): void => {
     this.sessionCostUSD = 0;
-    this.runStatsSnapshot = initial;
-    if (this.runStatsSetter) {
-      this.runStatsSetter(initial);
-    }
+    patchSlice(this.session, { runStats: initial });
   };
 
-  /**
-   * Add a run's cost to the session-wide total and publish it to the footer.
-   * Called by every renderer (main agent and sub-agents) as each turn's cost
-   * resolves, so the displayed total aggregates all spend rather than being
-   * clobbered by whichever run completed last.
-   */
   addSessionCostUSD = (deltaUSD: number): void => {
     if (!deltaUSD) return;
     this.sessionCostUSD += deltaUSD;
@@ -361,37 +356,22 @@ export class UIStore {
   };
 
   updateRunStats = (patch: Partial<RunStats>): void => {
-    const next: RunStats = { ...this.runStatsSnapshot, ...patch };
+    const previous = this.session.getSnapshot().runStats;
+    const next: RunStats = { ...previous, ...patch };
     let changed = false;
-    for (const k of Object.keys(patch) as (keyof RunStats)[]) {
-      if (this.runStatsSnapshot[k] !== next[k]) {
+    for (const key of Object.keys(patch) as (keyof RunStats)[]) {
+      if (previous[key] !== next[key]) {
         changed = true;
         break;
       }
     }
     if (!changed) return;
-    this.runStatsSnapshot = next;
-    if (this.runStatsSetter) {
-      this.runStatsSetter(next);
-    }
+    patchSlice(this.session, { runStats: next });
   };
 
   setCustomView = (view: React.ReactNode | null): void => {
-    this.customViewSnapshot = view;
-    this.customViewSetter?.(view);
+    patchSlice(this.session, { customView: view });
   };
-
-  /**
-   * Stack of active interrupt handlers, ordered oldest-first. Each call to
-   * `setInterruptHandler(handler)` with a non-null handler pushes; calling with
-   * null pops. The UI always observes the top of the stack as the active
-   * handler. This lets nested agent runs (a subagent invoked as a tool by a
-   * main agent) each register their own handler without overwriting the
-   * outer scope's: when the inner run finishes and pops, the outer run's
-   * handler is restored automatically.
-   */
-  private interruptHandlerStack: Array<() => void> = [];
-  private interruptHandlerSetter: ((handler: (() => void) | null) => void) | null = null;
 
   setInterruptHandler = (handler: (() => void) | null): void => {
     if (handler === null) {
@@ -400,47 +380,32 @@ export class UIStore {
       this.interruptHandlerStack.push(handler);
     }
     const top = this.interruptHandlerStack[this.interruptHandlerStack.length - 1] ?? null;
-    this.interruptHandlerSetter?.(top);
+    patchSlice(this.session, { interruptHandler: top });
   };
 
-  /**
-   * Append a message to the chat message queue. Each call is one entry —
-   * the UI renders entries stacked, one per line. On flush they're joined
-   * with `\n` and sent to the agent as a single combined turn.
-   */
   appendToQueue = (text: string): void => {
     if (text.length === 0) return;
-    const next = [...this.messageQueueSnapshot, text];
-    this.messageQueueSnapshot = next;
-    this.messageQueueSetter?.(next);
+    const next = [...this.prompt.getSnapshot().messageQueue, text];
+    patchSlice(this.prompt, { messageQueue: next });
   };
 
-  /**
-   * Read the joined queue contents without clearing. Entries are joined with
-   * `\n` so the result is the exact string that would be sent to the agent
-   * if this queue were drained right now.
-   */
-  peekQueue = (): string => this.messageQueueSnapshot.join("\n");
+  peekQueue = (): string => this.prompt.getSnapshot().messageQueue.join("\n");
 
-  /** Read the queue (joined as a single string) and clear it. */
   takeQueue = (): string => {
-    if (this.messageQueueSnapshot.length === 0) return "";
-    const value = this.messageQueueSnapshot.join("\n");
-    this.messageQueueSnapshot = [];
-    this.messageQueueSetter?.([]);
+    const queue = this.prompt.getSnapshot().messageQueue;
+    if (queue.length === 0) return "";
+    const value = queue.join("\n");
+    patchSlice(this.prompt, { messageQueue: EMPTY_QUEUE });
     return value;
   };
 
   clearQueue = (): void => {
-    if (this.messageQueueSnapshot.length === 0) return;
-    this.messageQueueSnapshot = [];
-    this.messageQueueSetter?.([]);
+    if (this.prompt.getSnapshot().messageQueue.length === 0) return;
+    patchSlice(this.prompt, { messageQueue: EMPTY_QUEUE });
   };
 
   setChatBusy = (busy: boolean): void => {
-    if (this.chatBusySnapshot === busy) return;
-    this.chatBusySnapshot = busy;
-    this.chatBusySetter?.(busy);
+    patchSlice(this.session, { chatBusy: busy });
   };
 
   setExpandableDiff = (fullDiff: string): void => {
@@ -455,8 +420,6 @@ export class UIStore {
     this.expandableDiff = null;
   };
 
-  // ── Mode switching ─────────────────────────────────────────────
-
   registerModeSwitchHandler = (handler: ModeSwitchHandler | null): void => {
     this.modeSwitchHandler = handler;
   };
@@ -468,54 +431,35 @@ export class UIStore {
   };
 
   toggleMode = (): void => {
-    const nextMode = this.currentModeIsYolo ? "safe" : "yolo";
-    this.currentModeIsYolo = !this.currentModeIsYolo;
-    this.modeSetter?.(this.currentModeIsYolo);
+    const nextMode = this.session.getSnapshot().isYolo ? "safe" : "yolo";
+    patchSlice(this.session, { isYolo: !this.session.getSnapshot().isYolo });
     this.requestModeSwitch(nextMode);
   };
 
   setModeIsYolo = (isYolo: boolean): void => {
-    this.currentModeIsYolo = isYolo;
-    this.modeSetter?.(isYolo);
+    patchSlice(this.session, { isYolo });
   };
 
-  getModeIsYolo = (): boolean => this.currentModeIsYolo;
-
-  /**
-   * Subscribe the footer (or any island) to approval-mode changes so the
-   * current safe/yolo state stays persistently visible, not just in the
-   * 2-second toast.
-   */
-  registerModeSetter = (setter: ((isYolo: boolean) => void) | null): void => {
-    this.modeSetter = setter;
-    setter?.(this.currentModeIsYolo);
-  };
-
-  registerModeToastSetter = (setter: ((message: string | null) => void) | null): void => {
-    this.modeToastSetter = setter;
-  };
+  getModeIsYolo = (): boolean => this.session.getSnapshot().isYolo;
 
   showModeToast = (message: string): void => {
-    this.modeToastSetter?.(message);
+    patchSlice(this.session, { modeToast: message });
   };
 
-  // ── Ephemeral live regions ────────────────────────────────────────
+  clearModeToast = (): void => {
+    patchSlice(this.session, { modeToast: null });
+  };
 
   private publishEphemeralRegions(): void {
-    this.ephemeralRegionsSnapshot = Array.from(this.ephemeralRegions.values());
-    this.ephemeralRegionsSetter?.(this.ephemeralRegionsSnapshot);
+    const regions =
+      this.ephemeralRegions.size === 0 ? EMPTY_REGIONS : Array.from(this.ephemeralRegions.values());
+    patchSlice(this.ephemeral, { regions });
   }
 
   private setExpandableReasoning(value: ExpandableReasoning | null): void {
-    this.expandableReasoningSnapshot = value;
-    this.expandableReasoningSetter?.(value);
+    patchSlice(this.ephemeral, { expandableReasoning: value });
   }
 
-  /**
-   * Open a new ephemeral live region. Returns the region's id, which the
-   * caller must hold onto for subsequent appendEphemeral / collapseEphemeral
-   * calls. Multiple regions may be open at once (e.g. parallel subagents).
-   */
   openEphemeral = (kind: EphemeralKind, label: string, maxLines: number): EphemeralRegionId => {
     const id = `eph-${++this.ephemeralIdCounter}-${Date.now()}`;
     this.ephemeralRegions.set(id, {
@@ -530,11 +474,6 @@ export class UIStore {
     return id;
   };
 
-  /**
-   * Append text to a live region. Splits incoming text on newlines, merges
-   * the first chunk into the previous line (for delta-style streaming), and
-   * keeps only the last `maxLines` lines.
-   */
   appendEphemeral = (id: EphemeralRegionId, text: string): void => {
     if (text.length === 0) return;
     const region = this.ephemeralRegions.get(id);
@@ -554,16 +493,10 @@ export class UIStore {
     this.publishEphemeralRegions();
   };
 
-  /** When false, settled reasoning stays expanded and Ctrl+R is unused. */
   setCollapseReasoning = (enabled: boolean): void => {
     this.collapseReasoning = enabled;
   };
 
-  /**
-   * Collapse a live region. Emits an optional one-line static entry into
-   * scrollback and removes the region. For reasoning regions, captures the
-   * full text into the expandableReasoning slot so Ctrl-R can re-emit it.
-   */
   collapseEphemeral = (id: EphemeralRegionId, summary: CollapseEphemeralSummary): void => {
     const region = this.ephemeralRegions.get(id);
     if (!region) return;
@@ -612,10 +545,10 @@ export class UIStore {
         message: summary.line,
         timestamp: new Date(),
       });
+      this.flushOutputBatchNow();
     }
   };
 
-  /** Record a sent chat message for ↑/↓ recall. Skips consecutive duplicates. */
   pushInputHistory = (message: string): void => {
     const trimmed = message.trim();
     if (trimmed.length === 0) return;
@@ -636,13 +569,6 @@ export class UIStore {
     this.setExpandableReasoning(value);
   }
 
-  /**
-   * Collapse every open region — used on errors, interrupts, and /clear so
-   * panels don't get stuck. Emits no per-region summary, but open reasoning
-   * regions are preserved into the expandable stack (their visible tail is
-   * the best content available here — the full text lives in the renderer),
-   * so an interrupt doesn't silently destroy in-flight reasoning.
-   */
   collapseAllEphemeral = (): void => {
     if (this.ephemeralRegions.size === 0) return;
     for (const region of this.ephemeralRegions.values()) {
@@ -678,11 +604,6 @@ export class UIStore {
     this.publishEphemeralRegions();
   };
 
-  /**
-   * Keep the live reasoning panel expanded when it settles, so Ctrl+R during
-   * a run does not wait for the turn to finish and then dump the thought
-   * under the answer.
-   */
   pinOpenReasoning = (): boolean => {
     let pinned = false;
     for (const region of this.ephemeralRegions.values()) {
@@ -693,11 +614,6 @@ export class UIStore {
     return pinned;
   };
 
-  /**
-   * Expand the most recently collapsed reasoning *in the place it was
-   * thought*. Appending it as a new log line put the thought under the
-   * answer, which is the opposite of the order it happened.
-   */
   expandLastReasoning = (): boolean => {
     const value = this.expandableReasoningStack.pop();
     if (value === undefined) return this.pinOpenReasoning();
@@ -715,8 +631,9 @@ export class UIStore {
       timestamp: new Date(),
       ...(value.entryId === undefined ? {} : { id: value.entryId }),
     };
-    if (value.entryId !== undefined && this.updateOutputHandler !== null) {
-      this.updateOutputHandler(value.entryId, entry);
+    if (value.entryId !== undefined) {
+      this.flushOutputBatchNow();
+      this.updateOutputEntry(value.entryId, entry);
     } else {
       this.printOutput(entry);
       this.flushOutputBatchNow();
@@ -727,129 +644,61 @@ export class UIStore {
 
   appendStream = (kind: StreamKind, delta: string): void => {
     if (delta.length === 0) return;
-    // Streaming bypasses the printOutput batch — deltas go straight in.
-    // Flush any pending non-streaming batch first to preserve ordering.
     this.flushOutputBatchNow();
-    if (!this.streamingHandler) return;
-    this.streamingHandler.appendStream(kind, delta);
+    this.publishScrollback(
+      reduceScrollback(this.scrollback, {
+        type: "appendStream",
+        kind,
+        delta,
+        nextId: `queued-output-${++this.pendingOutputIdCounter}`,
+        finalizeId: `queued-output-${++this.pendingOutputIdCounter}`,
+      }),
+    );
   };
 
   finalizeStream = (): void => {
     this.flushOutputBatchNow();
-    if (!this.streamingHandler) return;
-    this.streamingHandler.finalizeStream();
+    this.publishScrollback(
+      reduceScrollback(this.scrollback, {
+        type: "finalizeStream",
+        finalizeId: `queued-output-${++this.pendingOutputIdCounter}`,
+      }),
+    );
   };
 
   clearOutputs = (): void => {
-    // Discard any pending batched outputs to prevent race condition where
-    // a queued microtask flushes after clear
     this.outputBatch = [];
     this.batchFlushScheduled = false;
-
-    // Reasoning from before the clear is stale context — drop it so Ctrl+R
-    // can't resurrect output the user just wiped.
     this.expandableReasoningStack = [];
     this.pinnedReasoningIds.clear();
     this.setExpandableReasoning(null);
-
-    if (!this.clearOutputsHandler) {
-      this._pendingClear = true;
-      this.pendingOutputQueue.length = 0;
-      return;
-    }
-    this.clearOutputsHandler();
+    this.publishScrollback(reduceScrollback(this.scrollback, { type: "clear" }));
   };
 
-  // ── Registration methods (called by island components) ────────────
+  setActiveMenu = (menu: ActiveMenu | null): void => {
+    patchSlice(this.session, { activeMenu: menu });
+  };
 
-  private activeMenuSnapshot: ActiveMenu | null = null;
-  private activeMenuSetter: ((menu: ActiveMenu | null) => void) | null = null;
-  private connectorsSnapshot: ReadonlyMap<string, ConnectorStatus> = new Map();
-  private connectorsSetter: ((connectors: ReadonlyMap<string, ConnectorStatus>) => void) | null =
-    null;
-  private approvalRequestSnapshot: PendingApproval | null = null;
-  private approvalRequestSetter: ((request: PendingApproval | null) => void) | null = null;
-
-  registerPrintOutput(handler: PrintOutputHandler | null): void {
-    this.printOutputHandler = handler;
+  getActiveMenuSnapshot(): ActiveMenu | null {
+    return this.session.getSnapshot().activeMenu;
   }
 
-  registerUpdateOutput(handler: UpdateOutputHandler | null): void {
-    this.updateOutputHandler = handler;
+  setConnector = (name: string, status: ConnectorStatus): void => {
+    const next = new Map(this.session.getSnapshot().connectors);
+    next.set(name, status);
+    patchSlice(this.session, { connectors: next });
+  };
+
+  getConnectorsSnapshot(): ReadonlyMap<string, ConnectorStatus> {
+    return this.session.getSnapshot().connectors;
   }
 
-  registerStreamingHandler(handler: StreamingHandler | null): void {
-    this.streamingHandler = handler;
-  }
+  setApprovalRequest = (request: PendingApproval | null): void => {
+    patchSlice(this.session, { approvalRequest: request });
+  };
 
-  registerClearOutputs(handler: (() => void) | null): void {
-    this.clearOutputsHandler = handler;
-  }
-
-  registerActivitySetter(setter: ((activity: ActivityState) => void) | null): void {
-    this.activitySetter = setter;
-  }
-
-  registerPromptSetter(setter: ((prompt: PromptState | null) => void) | null): void {
-    this.promptSetter = setter;
-    if (setter) {
-      setter(this.promptSnapshot);
-    }
-  }
-
-  registerCurrentConversationSetter(
-    setter: ((conversation: CurrentConversation | null) => void) | null,
-  ): void {
-    this.currentConversationSetter = setter;
-    if (setter) {
-      setter(this.currentConversationSnapshot);
-    }
-  }
-
-  registerWorkingDirectorySetter(setter: ((wd: string | null) => void) | null): void {
-    this.workingDirectorySetter = setter;
-    if (setter) {
-      setter(this.workingDirectorySnapshot);
-    }
-  }
-
-  registerRunStatsSetter(setter: ((stats: RunStats) => void) | null): void {
-    this.runStatsSetter = setter;
-    if (setter) {
-      setter(this.runStatsSnapshot);
-    }
-  }
-
-  registerCustomView(setter: (view: React.ReactNode | null) => void): () => void {
-    this.customViewSetter = setter;
-    setter(this.customViewSnapshot);
-    return () => {
-      if (this.customViewSetter === setter) {
-        this.customViewSetter = null;
-      }
-    };
-  }
-
-  registerMessageQueueSetter(setter: ((queue: readonly string[]) => void) | null): void {
-    this.messageQueueSetter = setter;
-    if (setter) {
-      setter(this.messageQueueSnapshot);
-    }
-  }
-
-  registerChatBusySetter(setter: ((busy: boolean) => void) | null): void {
-    this.chatBusySetter = setter;
-    if (setter) {
-      setter(this.chatBusySnapshot);
-    }
-  }
-
-  registerInterruptHandler(setter: ((handler: (() => void) | null) => void) | null): void {
-    this.interruptHandlerSetter = setter;
-    if (setter) {
-      const top = this.interruptHandlerStack[this.interruptHandlerStack.length - 1] ?? null;
-      setter(top);
-    }
+  getApprovalRequestSnapshot(): PendingApproval | null {
+    return this.session.getSnapshot().approvalRequest;
   }
 
   requestRendererFallback = (): void => {
@@ -865,135 +714,69 @@ export class UIStore {
     };
   };
 
-  /** The menu currently awaiting a choice, or null. */
-  setActiveMenu = (menu: ActiveMenu | null): void => {
-    this.activeMenuSnapshot = menu;
-    if (this.activeMenuSetter) this.activeMenuSetter(menu);
-  };
-
-  registerActiveMenuSetter(setter: ((menu: ActiveMenu | null) => void) | null): void {
-    this.activeMenuSetter = setter;
-    if (setter) {
-      setter(this.activeMenuSnapshot);
-    }
-  }
-
-  getActiveMenuSnapshot(): ActiveMenu | null {
-    return this.activeMenuSnapshot;
-  }
-
-  /** Reachability of the named connectors, newest state wins per name. */
-  setConnector = (name: string, status: ConnectorStatus): void => {
-    const next = new Map(this.connectorsSnapshot);
-    next.set(name, status);
-    this.connectorsSnapshot = next;
-    if (this.connectorsSetter) this.connectorsSetter(next);
-  };
-
-  registerConnectorsSetter(
-    setter: ((connectors: ReadonlyMap<string, ConnectorStatus>) => void) | null,
-  ): void {
-    this.connectorsSetter = setter;
-    if (setter) {
-      setter(this.connectorsSnapshot);
-    }
-  }
-
-  getConnectorsSnapshot(): ReadonlyMap<string, ConnectorStatus> {
-    return this.connectorsSnapshot;
-  }
-
-  /**
-   * The approval currently awaiting a decision, as structured data.
-   *
-   * The fullscreen approval card needs details that do not survive flattening
-   * the request into a select prompt, so the request travels alongside it.
-   */
-  setApprovalRequest = (request: PendingApproval | null): void => {
-    this.approvalRequestSnapshot = request;
-    if (this.approvalRequestSetter) this.approvalRequestSetter(request);
-  };
-
-  registerApprovalRequestSetter(setter: ((request: PendingApproval | null) => void) | null): void {
-    this.approvalRequestSetter = setter;
-    if (setter) {
-      setter(this.approvalRequestSnapshot);
-    }
-  }
-
-  getApprovalRequestSnapshot(): PendingApproval | null {
-    return this.approvalRequestSnapshot;
-  }
-
-  registerEphemeralRegionsSetter(
-    setter: ((regions: readonly EphemeralRegion[]) => void) | null,
-  ): void {
-    this.ephemeralRegionsSetter = setter;
-    if (setter) {
-      setter(this.ephemeralRegionsSnapshot);
-    }
-  }
-
-  registerExpandableReasoningSetter(
-    setter: ((value: ExpandableReasoning | null) => void) | null,
-  ): void {
-    this.expandableReasoningSetter = setter;
-    if (setter) {
-      setter(this.expandableReasoningSnapshot);
-    }
-  }
-
-  // ── Snapshot accessors (for hydrating late-registering components) ─
-
   getActivitySnapshot(): ActivityState {
-    return this.activitySnapshot;
+    return this.session.getSnapshot().activity;
   }
 
   getPromptSnapshot(): PromptState | null {
-    return this.promptSnapshot;
+    return this.prompt.getSnapshot().prompt;
   }
 
   getCurrentConversationSnapshot(): CurrentConversation | null {
-    return this.currentConversationSnapshot;
+    return this.session.getSnapshot().currentConversation;
   }
 
   getWorkingDirectorySnapshot(): string | null {
-    return this.workingDirectorySnapshot;
+    return this.session.getSnapshot().workingDirectory;
   }
 
   getRunStatsSnapshot(): RunStats {
-    return this.runStatsSnapshot;
+    return this.session.getSnapshot().runStats;
   }
 
   getEphemeralRegionsSnapshot(): readonly EphemeralRegion[] {
-    return this.ephemeralRegionsSnapshot;
+    return this.ephemeral.getSnapshot().regions;
   }
 
   getExpandableReasoningSnapshot(): ExpandableReasoning | null {
-    return this.expandableReasoningSnapshot;
+    return this.ephemeral.getSnapshot().expandableReasoning;
   }
 
   getMessageQueueSnapshot(): readonly string[] {
-    return this.messageQueueSnapshot;
+    return this.prompt.getSnapshot().messageQueue;
   }
 
   getChatBusySnapshot(): boolean {
-    return this.chatBusySnapshot;
-  }
-
-  // ── Pending queue management ──────────────────────────────────────
-
-  hasPendingClear(): boolean {
-    return this._pendingClear;
-  }
-
-  consumePendingClear(): void {
-    this._pendingClear = false;
-  }
-
-  drainPendingOutputQueue(): OutputEntry[] {
-    return this.pendingOutputQueue.splice(0, this.pendingOutputQueue.length);
+    return this.session.getSnapshot().chatBusy;
   }
 }
 
 export const store = new UIStore();
+
+export function useOutputSlice(): OutputSnapshot {
+  return useSyncExternalStore(
+    store.subscribeOutput,
+    store.getOutputSnapshot,
+    store.getOutputSnapshot,
+  );
+}
+
+export function useSessionSlice(): SessionSnapshot {
+  return useSyncExternalStore(
+    store.subscribeSession,
+    store.getSessionSnapshot,
+    store.getSessionSnapshot,
+  );
+}
+
+export function usePromptSlice(): PromptSnapshot {
+  return useSyncExternalStore(store.subscribePrompt, store.getPromptSlice, store.getPromptSlice);
+}
+
+export function useEphemeralSlice(): EphemeralSnapshot {
+  return useSyncExternalStore(
+    store.subscribeEphemeral,
+    store.getEphemeralSnapshot,
+    store.getEphemeralSnapshot,
+  );
+}

--- a/src/cli/ui/store.ts
+++ b/src/cli/ui/store.ts
@@ -614,7 +614,10 @@ export class UIStore {
     return pinned;
   };
 
-  expandLastReasoning = (): boolean => {
+  // Ink's <Static> never repaints entries it has already emitted, so the
+  // islands renderer must ask for "append": patching the collapsed stub
+  // in place would change the store without changing the screen.
+  expandLastReasoning = (target: "in-place" | "append" = "in-place"): boolean => {
     const value = this.expandableReasoningStack.pop();
     if (value === undefined) return this.pinOpenReasoning();
     const seconds = (value.durationMs / 1000).toFixed(1);
@@ -629,9 +632,9 @@ export class UIStore {
         label: value.label,
       },
       timestamp: new Date(),
-      ...(value.entryId === undefined ? {} : { id: value.entryId }),
+      ...(target === "in-place" && value.entryId !== undefined ? { id: value.entryId } : {}),
     };
-    if (value.entryId !== undefined) {
+    if (target === "in-place" && value.entryId !== undefined) {
       this.flushOutputBatchNow();
       this.updateOutputEntry(value.entryId, entry);
     } else {


### PR DESCRIPTION
## What & why
Ink islands and the fullscreen chat used to fight over a single setter slot, so only the last renderer to mount saw live updates. The store still has one process-wide write port, but each slice now multicast-subscribes with an `Object.is`-stable snapshot — both trees can stay mounted and stay in sync.

## How to verify
- Run `bun test src/cli/ui/store.test.ts src/cli/ui/fullscreen/bridge.test.tsx`.
- Start a chat and confirm transcript, activity, prompt, and live reasoning still update in the active renderer.
- While a run is busy, queue a follow-up and confirm the queue appears (both trees subscribe to the same prompt slice).
- `/clear` then keep chatting — scrollback empties and new output still lands.
- Toggle safe/yolo (Shift+Tab) and confirm the footer mode updates without a toast-only flicker.