### PR TITLE
feat(cli): pin the OpenRouter gateway models to the top of the picker

### DIFF
--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -43,7 +43,7 @@ import type { LLMProvider, LLMProviderListItem } from "@/core/types/llm";
 import type { MCPTool } from "@/core/types/mcp";
 import { isAuthenticationRequired } from "@/core/utils/mcp";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
-import { sortProvidersForPicker } from "@/core/utils/provider-picker";
+import { sortModelsForPicker, sortProvidersForPicker } from "@/core/utils/provider-picker";
 import { toPascalCase } from "@/core/utils/string";
 
 /**
@@ -477,7 +477,11 @@ async function promptForAgentInfo(
       case "model": {
         const result = await Effect.runPromise(
           terminal.search<string>(`Which model would you like to use? ${hint}`, {
-            choices: state.providerInfo!.supportedModels.map((model) => ({
+            choices: sortModelsForPicker(
+              state.llmProvider!,
+              state.providerInfo!.supportedModels,
+              (model) => model.id,
+            ).map((model) => ({
               name: model.displayName || model.id,
               description: model.displayName || model.id,
               value: model.id,

--- a/src/cli/commands/edit-agent.ts
+++ b/src/cli/commands/edit-agent.ts
@@ -48,6 +48,7 @@ import type { MCPTool } from "@/core/types/mcp";
 import { extractServerNamesFromToolNames, isAuthenticationRequired } from "@/core/utils/mcp";
 import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { formatProviderDisplayName } from "@/core/utils/provider-model";
+import { sortModelsForPicker } from "@/core/utils/provider-picker";
 import { sortProvidersForPicker } from "@/core/utils/provider-picker";
 import { toPascalCase } from "@/core/utils/string";
 
@@ -664,7 +665,11 @@ async function promptForAgentUpdates(
 
       const llmModel = await Effect.runPromise(
         terminal.search<string>(`Select model for ${providerDisplayName}:`, {
-          choices: providerInfo.supportedModels.map((model) => ({
+          choices: sortModelsForPicker(
+            llmProvider,
+            providerInfo.supportedModels,
+            (model) => model.id,
+          ).map((model) => ({
             name: model.displayName || model.id,
             value: model.id,
           })),
@@ -720,7 +725,11 @@ async function promptForAgentUpdates(
 
     const llmModel = await Effect.runPromise(
       terminal.search<string>(`Select model for ${providerToUse}:`, {
-        choices: providerInfo.supportedModels.map((model) => ({
+        choices: sortModelsForPicker(
+          providerToUse,
+          providerInfo.supportedModels,
+          (model) => model.id,
+        ).map((model) => ({
           name: model.displayName || model.id,
           value: model.id,
         })),

--- a/src/core/utils/model-picker.test.ts
+++ b/src/core/utils/model-picker.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { sortModelsForPicker } from "@/core/utils/provider-picker";
+
+describe("sortModelsForPicker", () => {
+  const toModels = (...list: string[]): { id: string }[] => list.map((id) => ({ id }));
+  const order = (providerId: string, models: readonly { id: string }[]): string[] =>
+    sortModelsForPicker(providerId, models, (model) => model.id).map((model) => model.id);
+
+  it("lifts the OpenRouter gateway models to the top, free before auto", () => {
+    const models = toModels(
+      "anthropic/claude-sonnet-4-5",
+      "openrouter/auto",
+      "z-ai/glm-5.2:free",
+      "openrouter/free",
+    );
+
+    expect(order("openrouter", models)).toEqual([
+      "openrouter/free",
+      "openrouter/auto",
+      "anthropic/claude-sonnet-4-5",
+      "z-ai/glm-5.2:free",
+    ]);
+  });
+
+  it("keeps catalog order for everything that is not pinned", () => {
+    const models = toModels("zeta", "alpha", "openrouter/free", "mid");
+
+    expect(order("openrouter", models)).toEqual(["openrouter/free", "zeta", "alpha", "mid"]);
+  });
+
+  it("leaves providers without pinned models untouched", () => {
+    const models = toModels("gpt-5-mini", "gpt-5", "o3");
+
+    expect(order("openai", models)).toEqual(["gpt-5-mini", "gpt-5", "o3"]);
+  });
+
+  it("ignores a pinned id the catalog does not offer", () => {
+    const models = toModels("openrouter/auto", "meta/llama-4");
+
+    expect(order("openrouter", models)).toEqual(["openrouter/auto", "meta/llama-4"]);
+  });
+});

--- a/src/core/utils/provider-picker.ts
+++ b/src/core/utils/provider-picker.ts
@@ -54,3 +54,44 @@ export function sortProvidersForPicker<T>(
     return canonicalizeProviderId(leftId).localeCompare(canonicalizeProviderId(rightId), "en");
   });
 }
+
+/**
+ * Models pinned to the top of a provider's model picker.
+ *
+ * OpenRouter lists hundreds of models; the two gateway meta-models are the ones that make
+ * choosing OpenRouter worthwhile in the first place — `openrouter/free` is the no-cost entry
+ * point and `openrouter/auto` picks a model for you — so burying them alphabetically among
+ * 300+ siblings hides the reason a newcomer picked this provider. A pinned id that the
+ * catalog does not offer simply never matches, so this stays correct as the catalog changes.
+ */
+const PINNED_MODELS_BY_PROVIDER: Readonly<Record<string, readonly string[]>> = {
+  openrouter: ["openrouter/free", "openrouter/auto"],
+};
+
+function pinnedModelRank(providerId: string, modelId: string): number {
+  const pinned = PINNED_MODELS_BY_PROVIDER[canonicalizeProviderId(providerId)];
+  if (pinned === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const rank = pinned.indexOf(modelId);
+  return rank === -1 ? Number.POSITIVE_INFINITY : rank;
+}
+
+/**
+ * Order a provider's models for the picker: pinned entry points first, everything else in the
+ * order the catalog supplied.
+ */
+export function sortModelsForPicker<T>(
+  providerId: string,
+  models: readonly T[],
+  getId: (model: T) => string,
+): T[] {
+  return [...models].sort((left, right) => {
+    const leftRank = pinnedModelRank(providerId, getId(left));
+    const rightRank = pinnedModelRank(providerId, getId(right));
+    if (leftRank === rightRank) {
+      return 0;
+    }
+    return leftRank < rightRank ? -1 : 1;
+  });
+}


### PR DESCRIPTION
## What changes

Picking OpenRouter in the wizard currently drops you into an alphabetical list of **360 models**. The two that make OpenRouter worth choosing — `openrouter/free` (no-cost entry point, no credit card) and `openrouter/auto` (picks a model for you) — are somewhere in the middle of it.

Both now sort to the top, free first:

```
Select model for OpenRouter:
> openrouter/free      ← was buried
  openrouter/auto      ← was buried
  agentica-org/deepcoder-14b-preview
  ai21/jamba-large-1.7
  …356 more
```

Applies to all three model pickers (one in `create-agent`, two in `edit-agent`).

## How

Mirrors the existing `sortProvidersForPicker` pinning pattern with a `sortModelsForPicker` sibling and a `PINNED_MODELS_BY_PROVIDER` map. Non-pinned models keep catalog order; providers with no pinned entries are untouched.

Both ids verified present in the live models.dev catalog, and a pinned id the catalog stops offering simply never matches — so the list degrades gracefully rather than breaking.

## Verification

- `bun test src/core/utils/` — 12 pass (4 new: ordering, catalog-order preservation, unpinned providers, missing pinned id)
- `bun run typecheck` clean, `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)