### PR TITLE
feat(mcp): full protocol support, gated tool calls, and OAuth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "@ai-sdk/fireworks": "^3.0.32",
         "@ai-sdk/google": "^4.0.44",
         "@ai-sdk/groq": "^4.0.28",
-        "@ai-sdk/mcp": "^2.0.32",
         "@ai-sdk/mistral": "^4.0.29",
         "@ai-sdk/moonshotai": "^3.0.34",
         "@ai-sdk/openai": "^4.0.42",
@@ -101,8 +100,6 @@
     "@ai-sdk/google": ["@ai-sdk/google@4.0.44", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bmRTDg06jQD+eX8nf214pET9+Oe8O1+lUIRGbWsGXj9IN2UJkpl1O1x7cvtiboyTtKSLvSRdVtItUfSl8sQ2GA=="],
 
     "@ai-sdk/groq": ["@ai-sdk/groq@4.0.28", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-r9MWcjZUbl05dyKnaYeHawyAbiTtZctQF+MAXxTH+Z29gaJt+amW88/gKA+xAFG3V8kDW9P2dtshKiJ2v/UDpw=="],
-
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.32", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NkXUnIEUmOmjD42LGpXGdHPULYvAV4SYUojutqw5YVNmQA7g64YRv3NLOaST21b2vIScUAah4qWchi62iUpQdA=="],
 
     "@ai-sdk/mistral": ["@ai-sdk/mistral@4.0.29", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qnzGoTwRNDX4XQe3HxWMJF4pnuLV5K2BeurkMfxU24EgiqsmJXbQwOLgd/jxeYnYFRBtSyF7kH74fdf+Vws4Hw=="],
 
@@ -306,7 +303,7 @@
 
     "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.67.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.67.0", "@typescript-eslint/types": "^8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
 
     "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.67.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg=="],
 
@@ -316,7 +313,7 @@
 
     "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.67.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.67.0", "@typescript-eslint/tsconfig-utils": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
 
@@ -1038,27 +1035,19 @@
 
     "@types/marked-terminal/marked": ["marked@11.2.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw=="],
 
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
 
     "@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
-    "@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
+    "@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
-    "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
-
     "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
+    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
@@ -1110,8 +1099,6 @@
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
-
     "vercel-minimax-ai-provider/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.6", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ns5OOPHXbODzitvqCySnAFZCAm9ldpx+fdbC0c/f9QwX5b4MQtQJIQ0xZyKm+tB/ynBoeV6zhtyWDXjYeVEWIw=="],
 
     "vercel-minimax-ai-provider/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
@@ -1129,18 +1116,6 @@
     "@puppeteer/browsers/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -1165,10 +1140,6 @@
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "ollama-ai-provider-v2/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@3.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg=="],
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@ai-sdk/fireworks": "^3.0.32",
     "@ai-sdk/google": "^4.0.44",
     "@ai-sdk/groq": "^4.0.28",
-    "@ai-sdk/mcp": "^2.0.32",
     "@ai-sdk/mistral": "^4.0.29",
     "@ai-sdk/moonshotai": "^3.0.34",
     "@ai-sdk/openai": "^4.0.42",

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -434,6 +434,11 @@ function registerConfigCommands(program: Command): void {
     );
 }
 
+/** Accumulate a repeatable Commander option into an array. */
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 /**
  * Register MCP server management commands
  */
@@ -445,36 +450,98 @@ function registerMCPCommands(program: Command): void {
   }
 
   mcpCommand
-    .command("add [json]")
-    .description("Add an MCP server from JSON (inline, --file, or interactive)")
+    .command("add [nameOrJson] [commandAndArgs...]")
+    .description("Add an MCP server by name + command, or from JSON (inline, --file, stdin)")
     .option("-f, --file <path>", "Read MCP server JSON from a file")
-    .action((json?: string, options?: { file?: string }) =>
-      run(() =>
-        import("./commands/mcp").then((mod) => mod.addMcpServerCommand(json, options?.file)),
-      ),
+    .option("-t, --transport <type>", "Transport to use: stdio (default) or http")
+    .option("-e, --env <KEY=VALUE>", "Environment variable for a stdio server", collect, [])
+    .option("-H, --header <KEY=VALUE>", "HTTP header for an http server", collect, [])
+    .option("--trusted", "Let this server's read-only annotations skip approval prompts")
+    .action(
+      (
+        nameOrJson: string | undefined,
+        commandAndArgs: string[] | undefined,
+        options: {
+          file?: string;
+          transport?: string;
+          env?: string[];
+          header?: string[];
+          trusted?: boolean;
+        },
+      ) =>
+        run(() =>
+          import("./commands/mcp").then((mod) =>
+            mod.addMcpServerCommand(nameOrJson, commandAndArgs ?? [], options),
+          ),
+        ),
     );
 
   mcpCommand
     .command("list")
     .alias("ls")
     .description("List all configured MCP servers")
-    .action(() => run(() => import("./commands/mcp").then((mod) => mod.listMcpServersCommand())));
+    .option("--tools", "Connect to each server and show the tools it advertises")
+    .action((options: { tools?: boolean }) =>
+      run(() => import("./commands/mcp").then((mod) => mod.listMcpServersCommand(options))),
+    );
 
   mcpCommand
-    .command("remove")
+    .command("test <name>")
+    .description("Connect to one server and report its tools, prompts, and capabilities")
+    .action((name: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.testMcpServerCommand(name))),
+    );
+
+  mcpCommand
+    .command("remove [name]")
     .alias("rm")
     .description("Remove an MCP server")
-    .action(() => run(() => import("./commands/mcp").then((mod) => mod.removeMcpServerCommand())));
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action((name: string | undefined, options: { yes?: boolean }) =>
+      run(() => import("./commands/mcp").then((mod) => mod.removeMcpServerCommand(name, options))),
+    );
 
   mcpCommand
-    .command("enable")
+    .command("enable [name]")
     .description("Enable a disabled MCP server")
-    .action(() => run(() => import("./commands/mcp").then((mod) => mod.enableMcpServerCommand())));
+    .action((name?: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.enableMcpServerCommand(name))),
+    );
 
   mcpCommand
-    .command("disable")
+    .command("disable [name]")
     .description("Disable an enabled MCP server")
-    .action(() => run(() => import("./commands/mcp").then((mod) => mod.disableMcpServerCommand())));
+    .action((name?: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.disableMcpServerCommand(name))),
+    );
+
+  mcpCommand
+    .command("trust [name]")
+    .description("Let a server's read-only tool annotations skip approval prompts")
+    .action((name?: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.trustMcpServerCommand(name, true))),
+    );
+
+  mcpCommand
+    .command("untrust [name]")
+    .description("Require approval for every tool call from a server")
+    .action((name?: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.trustMcpServerCommand(name, false))),
+    );
+
+  mcpCommand
+    .command("auth <name>")
+    .description("Authorize a remote MCP server in your browser (OAuth 2.1)")
+    .action((name: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.authMcpServerCommand(name))),
+    );
+
+  mcpCommand
+    .command("logout <name>")
+    .description("Forget stored OAuth credentials for a remote MCP server")
+    .action((name: string) =>
+      run(() => import("./commands/mcp").then((mod) => mod.logoutMcpServerCommand(name))),
+    );
 }
 
 /**

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -452,6 +452,22 @@ function registerMCPCommands(program: Command): void {
   mcpCommand
     .command("add [nameOrJson] [commandAndArgs...]")
     .description("Add an MCP server by name + command, or from JSON (inline, --file, stdin)")
+    // A server command with its own flags (`npx -y ...`) has to sit after `--`,
+    // or Commander claims those flags for itself.
+    .addHelpText(
+      "after",
+      `
+Examples:
+  jazz mcp add notes -- npx -y @modelcontextprotocol/server-filesystem ~/notes
+  jazz mcp add linear --transport http https://mcp.linear.app/mcp
+  jazz mcp add db --env PGHOST=localhost -- my-db-server
+  jazz mcp add '{"srv": {"command": "my-server"}}'
+  pbpaste | jazz mcp add
+
+Put the server's own command after \`--\` whenever it takes flags of its own.
+Remote servers that need a login: run \`jazz mcp auth <name>\` after adding.
+`,
+    )
     .option("-f, --file <path>", "Read MCP server JSON from a file")
     .option("-t, --transport <type>", "Transport to use: stdio (default) or http")
     .option("-e, --env <KEY=VALUE>", "Environment variable for a stdio server", collect, [])

--- a/src/cli/commands/edit-agent.ts
+++ b/src/cli/commands/edit-agent.ts
@@ -841,12 +841,12 @@ async function promptForAgentUpdates(
     const mcpToolNames = currentToolNames.filter((name) => name.startsWith("mcp_"));
     if (mcpToolNames.length > 0) {
       // Extract server names from MCP tool names
-      const serverNamesResult = await Effect.runPromise(
-        extractServerNamesFromToolNames(mcpToolNames).pipe(
-          Effect.catchAll(() => Effect.succeed(new Set<string>())),
+      const serverNames = await Effect.runPromise(
+        extractServerNamesFromToolNames(
+          mcpToolNames,
+          mcpServerData.displayNameToServerName.values(),
         ),
       );
-      const serverNames = serverNamesResult;
 
       // Map server names to display names (reverse lookup)
       const serverNameToDisplayName = new Map<string, string>();

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -4,18 +4,33 @@ import path from "node:path";
 import { FileSystem } from "@effect/platform";
 import { Effect, Option } from "effect";
 import { z } from "zod";
+import * as fmt from "@/cli/utils/list-format";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
-import type { MCPServerConfig } from "@/core/interfaces/mcp-server";
+import type { LoggerService } from "@/core/interfaces/logger";
+import {
+  isHttpConfig,
+  MCPServerManagerTag,
+  type MCPServerConfig,
+  type MCPServerManager,
+} from "@/core/interfaces/mcp-server";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import { writeAgentsMcpServer, removeAgentsMcpServer } from "@/services/config";
+import { authorizeServer, clearServerAuth, hasStoredAuth } from "@/services/mcp/oauth";
 
 type McpServersRecord = Record<string, MCPServerConfig>;
+
+/** Services every MCP CLI command needs. */
+type McpCommandDeps = AgentConfigService | TerminalService | FileSystem.FileSystem;
+
+/** Commands that actually talk to a server also need the manager and logger. */
+type McpLiveDeps = McpCommandDeps | MCPServerManager | LoggerService;
 
 const StdioServerConfigSchema = z.object({
   command: z.string(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string(), z.string()).optional(),
   enabled: z.boolean().optional(),
+  trusted: z.boolean().optional(),
 });
 
 const HttpServerConfigSchema = z.object({
@@ -23,6 +38,7 @@ const HttpServerConfigSchema = z.object({
   url: z.string(),
   headers: z.record(z.string(), z.string()).optional(),
   enabled: z.boolean().optional(),
+  trusted: z.boolean().optional(),
 });
 
 const McpServerConfigSchema = z.union([HttpServerConfigSchema, StdioServerConfigSchema]);
@@ -30,12 +46,31 @@ const McpServerConfigSchema = z.union([HttpServerConfigSchema, StdioServerConfig
 const McpServersInputSchema = z.record(z.string(), McpServerConfigSchema);
 
 /**
+ * Persist one server: full config to ~/.agents/mcp.json, and the bits Jazz owns
+ * (enabled, trusted) to ~/.jazz/config.json.
+ */
+function saveServer(
+  fs: FileSystem.FileSystem,
+  configService: AgentConfigService,
+  name: string,
+  config: Record<string, unknown>,
+  trusted: boolean,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const { enabled: _enabled, trusted: _trusted, ...serverConfig } = config;
+    yield* writeAgentsMcpServer(fs, name, serverConfig);
+    yield* configService.set(`mcpServers.${name}`, { enabled: true, trusted });
+  });
+}
+
+/**
  * Parse and validate MCP server JSON, then save to ~/.agents/mcp.json
  * and set enabled: true in ~/.jazz/config.json.
  */
 function parseAndSaveMcpServers(
   input: string,
-): Effect.Effect<void, never, AgentConfigService | TerminalService | FileSystem.FileSystem> {
+  trusted: boolean,
+): Effect.Effect<void, never, McpCommandDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const configService = yield* AgentConfigServiceTag;
@@ -52,7 +87,9 @@ function parseAndSaveMcpServers(
     const result = McpServersInputSchema.safeParse(parsed);
 
     if (!result.success) {
-      const issues = result.error.issues.map((i) => `  - ${i.path.join(".")}: ${i.message}`);
+      const issues = result.error.issues.map(
+        (issue) => `  - ${issue.path.join(".")}: ${issue.message}`,
+      );
       yield* terminal.error(`Invalid MCP server configuration:\n${issues.join("\n")}`);
       return;
     }
@@ -65,17 +102,11 @@ function parseAndSaveMcpServers(
     }
 
     for (const [name, config] of entries) {
-      // Strip enabled — metadata lives in ~/.jazz/config.json, not mcp.json
-      const { enabled: _, ...serverConfig } = config;
-
-      // Write full server config to ~/.agents/mcp.json
-      yield* writeAgentsMcpServer(fs, name, serverConfig);
-
-      // Set enabled in ~/.jazz/config.json (enabled by default on add)
-      yield* configService.set(`mcpServers.${name}`, { enabled: true });
-
+      yield* saveServer(fs, configService, name, config, trusted || config.trusted === true);
       yield* terminal.success(`Added MCP server: ${name}`);
     }
+
+    yield* terminal.info(`Verify it works with: jazz mcp test ${entries[0]?.[0] ?? "<name>"}`);
   });
 }
 
@@ -91,42 +122,104 @@ function readStdin(): Promise<string> {
   });
 }
 
+/** Parse repeated `--env KEY=VALUE` flags. */
+function parseEnvPairs(pairs: readonly string[]): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const pair of pairs) {
+    const separator = pair.indexOf("=");
+    if (separator <= 0) continue;
+    env[pair.slice(0, separator)] = pair.slice(separator + 1);
+  }
+  return env;
+}
+
+export interface AddMcpServerOptions {
+  readonly file?: string;
+  readonly transport?: string;
+  readonly env?: readonly string[];
+  readonly header?: readonly string[];
+  readonly trusted?: boolean;
+}
+
 /**
- * Add an MCP server from JSON (inline argument, --file, stdin pipe, or interactive prompt)
+ * Add an MCP server.
  *
- * Writes the full server config to ~/.agents/mcp.json and sets enabled: true
- * in ~/.jazz/config.json.
+ * Four input paths, in the order they are tried: a name plus command (or URL)
+ * as plain arguments, a JSON blob (inline, `--file`, or piped), and finally an
+ * $EDITOR session. The shorthand exists because writing JSON by hand to add one
+ * stdio server was the single most common thing people had to do here.
  *
- * Usage:
+ *   jazz mcp add linear --transport http https://mcp.linear.app/mcp
+ *   jazz mcp add fs npx -y @modelcontextprotocol/server-filesystem ~/notes
  *   jazz mcp add '{"name": {"command": "..."}}'
- *   jazz mcp add --file server.json
  *   pbpaste | jazz mcp add
- *   cat server.json | jazz mcp add
  */
 export function addMcpServerCommand(
-  jsonArg?: string,
-  filePath?: string,
-): Effect.Effect<void, never, AgentConfigService | TerminalService | FileSystem.FileSystem> {
+  nameOrJson?: string,
+  commandArgs: readonly string[] = [],
+  options: AddMcpServerOptions = {},
+): Effect.Effect<void, never, McpCommandDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
     const fs = yield* FileSystem.FileSystem;
+    const trusted = options.trusted === true;
 
-    // 1. From --file
-    if (filePath) {
-      const contentOpt = yield* fs.readFileString(filePath).pipe(Effect.option);
+    if (options.file) {
+      const contentOpt = yield* fs.readFileString(options.file).pipe(Effect.option);
       if (Option.isNone(contentOpt)) {
-        yield* terminal.error(`Could not read file: ${filePath}`);
+        yield* terminal.error(`Could not read file: ${options.file}`);
         return;
       }
-      return yield* parseAndSaveMcpServers(contentOpt.value);
+      return yield* parseAndSaveMcpServers(contentOpt.value, trusted);
     }
 
-    // 2. From inline JSON argument
-    if (jsonArg) {
-      return yield* parseAndSaveMcpServers(jsonArg);
+    // Shorthand: a bare name followed by a command or URL. A leading "{" means
+    // the caller passed JSON instead.
+    if (nameOrJson !== undefined && !nameOrJson.trimStart().startsWith("{")) {
+      const name = nameOrJson;
+      const isHttp = options.transport === "http" || options.transport === "sse";
+      const [first, ...rest] = commandArgs;
+
+      if (first === undefined) {
+        yield* terminal.error(
+          isHttp
+            ? `Missing URL. Usage: jazz mcp add ${name} --transport http <url>`
+            : `Missing command. Usage: jazz mcp add ${name} <command> [args...]`,
+        );
+        return;
+      }
+
+      const config: Record<string, unknown> = isHttp
+        ? {
+            transport: "http",
+            url: first,
+            ...(options.header && options.header.length > 0
+              ? { headers: parseEnvPairs(options.header) }
+              : {}),
+          }
+        : {
+            command: first,
+            ...(rest.length > 0 ? { args: rest } : {}),
+            ...(options.env && options.env.length > 0 ? { env: parseEnvPairs(options.env) } : {}),
+          };
+
+      yield* saveServer(fs, configService, name, config, trusted);
+      yield* terminal.success(`Added MCP server: ${name}`);
+      if (!trusted) {
+        yield* terminal.info(
+          "Its tools will ask for approval on every call. Use `jazz mcp trust " +
+            `${name}\` once you have reviewed them.`,
+        );
+      }
+      yield* terminal.info(`Verify it works with: jazz mcp test ${name}`);
+      return;
     }
 
-    // 3. From stdin pipe (e.g. pbpaste | jazz mcp add)
+    if (nameOrJson) {
+      return yield* parseAndSaveMcpServers(nameOrJson, trusted);
+    }
+
     if (!process.stdin.isTTY) {
       const stdinContent = yield* Effect.tryPromise({
         try: () => readStdin(),
@@ -136,13 +229,11 @@ export function addMcpServerCommand(
         yield* terminal.warn("No input received from stdin.");
         return;
       }
-      return yield* parseAndSaveMcpServers(stdinContent);
+      return yield* parseAndSaveMcpServers(stdinContent, trusted);
     }
 
-    // 4. Interactive — open $EDITOR with a temp file
     const editor = process.env["EDITOR"] || process.env["VISUAL"] || "vi";
-    const tmpDir = os.tmpdir();
-    const tmpFile = path.join(tmpDir, `jazz-mcp-${Date.now()}.json`);
+    const tmpFile = path.join(os.tmpdir(), `jazz-mcp-${Date.now()}.json`);
 
     const template = `{
   "server-name": {
@@ -179,31 +270,36 @@ export function addMcpServerCommand(
       return;
     }
 
-    return yield* parseAndSaveMcpServers(content);
+    return yield* parseAndSaveMcpServers(content, trusted);
   });
+}
+
+/** Describe a server's transport in one line. */
+function describeTransport(config: MCPServerConfig): string {
+  if (isHttpConfig(config)) return `http: ${config.url}`;
+  return `stdio: ${config.command}${config.args?.length ? ` ${config.args.join(" ")}` : ""}`;
 }
 
 /**
  * List all configured MCP servers.
  *
- * Shows the merged view: full configs from .agents/mcp.json with
- * enable/disable status from ~/.jazz/config.json.
+ * With `--tools`, connects to each enabled server to report what it actually
+ * advertises — the question "what did adding this server get me?" previously
+ * had no answer short of starting a chat.
  */
-export function listMcpServersCommand(): Effect.Effect<
-  void,
-  never,
-  AgentConfigService | TerminalService
-> {
+export function listMcpServersCommand(
+  options: { readonly tools?: boolean } = {},
+): Effect.Effect<void, never, McpLiveDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const configService = yield* AgentConfigServiceTag;
 
-    // At runtime, mcpServers is the merged view (full configs + overrides)
     const mcpServers = yield* configService.getOrElse<McpServersRecord>("mcpServers", {});
     const entries = Object.entries(mcpServers);
 
     if (entries.length === 0) {
       yield* terminal.info("No MCP servers configured.");
+      yield* terminal.log(fmt.keyValueCompact("Config", "~/.agents/mcp.json"));
       return;
     }
 
@@ -211,25 +307,162 @@ export function listMcpServersCommand(): Effect.Effect<
 
     for (const [name, config] of entries) {
       const enabled = config.enabled !== false;
-      const status = enabled ? "enabled" : "disabled";
-      const transport = "command" in config ? `stdio: ${config.command}` : "http";
+      const labels = [enabled ? "enabled" : "disabled"];
+      if (config.trusted === true) labels.push("trusted");
 
-      yield* terminal.log(`  ${name} (${transport}) [${status}]`);
+      yield* terminal.log(
+        fmt.itemWithDesc(name, `${describeTransport(config)} [${labels.join(", ")}]`),
+      );
+
+      if (options.tools === true && enabled) {
+        const manager = yield* MCPServerManagerTag;
+        const discovered = yield* manager.discoverTools({ ...config, name }).pipe(Effect.either);
+
+        if (discovered._tag === "Right") {
+          const toolNames = discovered.right.map((tool) => tool.name);
+          yield* terminal.log(
+            fmt.keyValue(
+              "Tools",
+              toolNames.length === 0
+                ? "none advertised"
+                : `${toolNames.length} — ${toolNames.join(", ")}`,
+            ),
+          );
+        } else {
+          yield* terminal.log(fmt.keyValue("Tools", `unavailable (${discovered.left.reason})`));
+        }
+      }
     }
+
+    yield* terminal.log(fmt.footer(`Total: ${entries.length} server(s)`));
   });
 }
 
 /**
- * Remove an MCP server interactively.
+ * Connect to one server and report what it supports.
  *
- * Removes the server from ~/.agents/mcp.json and cleans up
- * any enable/disable metadata from ~/.jazz/config.json.
+ * The only way to check a server works without starting a conversation that
+ * already has its tools selected.
  */
-export function removeMcpServerCommand(): Effect.Effect<
-  void,
-  never,
-  AgentConfigService | TerminalService | FileSystem.FileSystem
-> {
+export function testMcpServerCommand(name: string): Effect.Effect<void, never, McpLiveDeps> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+    const manager = yield* MCPServerManagerTag;
+
+    const mcpServers = yield* configService.getOrElse<McpServersRecord>("mcpServers", {});
+    const config = mcpServers[name];
+
+    if (!config) {
+      yield* terminal.error(`No MCP server named "${name}".`);
+      yield* terminal.info("Run `jazz mcp list` to see configured servers.");
+      return;
+    }
+
+    const serverConfig: MCPServerConfig = { ...config, name };
+
+    yield* terminal.info(`Connecting to ${name} (${describeTransport(serverConfig)})...`);
+
+    const connected = yield* manager.connectServer(serverConfig).pipe(Effect.either);
+
+    if (connected._tag === "Left") {
+      yield* terminal.error(connected.left.reason);
+      if (connected.left.suggestion) {
+        yield* terminal.info(connected.left.suggestion);
+      }
+      return;
+    }
+
+    const capabilities = yield* manager.getCapabilities(name);
+    const tools = yield* manager.getServerTools(name).pipe(Effect.either);
+    const prompts = yield* manager.getServerPrompts(name).pipe(Effect.either);
+
+    yield* terminal.success(`Connected to ${name}`);
+
+    if (tools._tag === "Right") {
+      yield* terminal.log(fmt.keyValue("Tools", String(tools.right.length)));
+      for (const tool of tools.right) {
+        const hints: string[] = [];
+        if (tool.annotations?.readOnlyHint === true) hints.push("read-only");
+        if (tool.annotations?.destructiveHint === true) hints.push("destructive");
+        yield* terminal.log(
+          fmt.itemWithDesc(
+            tool.name,
+            `${tool.description ?? "no description"}${hints.length > 0 ? ` (${hints.join(", ")})` : ""}`,
+          ),
+        );
+      }
+    } else {
+      yield* terminal.warn(`Tools unavailable: ${tools.left.reason}`);
+    }
+
+    if (prompts._tag === "Right" && prompts.right.length > 0) {
+      yield* terminal.log(fmt.keyValue("Prompts", String(prompts.right.length)));
+      for (const prompt of prompts.right) {
+        yield* terminal.log(
+          fmt.itemWithDesc(`/${name}:${prompt.name}`, prompt.description ?? "no description"),
+        );
+      }
+    }
+
+    if (capabilities?.resources !== undefined) {
+      yield* terminal.log(fmt.keyValue("Resources", "advertised (not yet used by Jazz)"));
+    }
+
+    if (config.trusted !== true) {
+      yield* terminal.info(
+        `Untrusted: every tool call will ask for approval. Run \`jazz mcp trust ${name}\` to let read-only annotations through.`,
+      );
+    }
+
+    yield* manager.disconnectServer(name).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
+
+/**
+ * Resolve a server name from an argument, falling back to an interactive
+ * picker. Returns undefined when the user cancels or nothing matches.
+ */
+function resolveServerName(
+  provided: string | undefined,
+  candidates: readonly string[],
+  prompt: string,
+): Effect.Effect<string | undefined, never, TerminalService> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+
+    if (provided !== undefined) {
+      if (!candidates.includes(provided)) {
+        yield* terminal.error(`No matching MCP server named "${provided}".`);
+        return undefined;
+      }
+      return provided;
+    }
+
+    const selected = yield* terminal.select<string>(prompt, {
+      choices: candidates.map((name) => ({ name, value: name })),
+    });
+
+    if (!selected) {
+      yield* terminal.info("Cancelled.");
+      return undefined;
+    }
+
+    return selected;
+  });
+}
+
+/**
+ * Remove an MCP server.
+ *
+ * Removes the server from ~/.agents/mcp.json and cleans up its Jazz-side
+ * metadata. A server defined outside the user file cannot be deleted, so it is
+ * marked disabled instead.
+ */
+export function removeMcpServerCommand(
+  name?: string,
+  options: { readonly yes?: boolean } = {},
+): Effect.Effect<void, never, McpCommandDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const configService = yield* AgentConfigServiceTag;
@@ -243,115 +476,177 @@ export function removeMcpServerCommand(): Effect.Effect<
       return;
     }
 
-    const selected = yield* terminal.select<string>("Select a server to remove:", {
-      choices: names.map((name) => ({ name, value: name })),
-    });
+    const selected = yield* resolveServerName(name, names, "Select a server to remove:");
+    if (selected === undefined) return;
 
-    if (!selected) {
-      yield* terminal.info("Cancelled.");
-      return;
-    }
-
-    const confirmed = yield* terminal.confirm(`Remove server "${selected}"?`, false);
-
-    if (!confirmed) {
-      yield* terminal.info("Cancelled.");
-      return;
-    }
-
-    // Remove from ~/.agents/mcp.json (user-level). If server was project-only, it stays in mcp.json
-    // but we add enabled: false to jazz overrides to effectively hide it.
-    yield* removeAgentsMcpServer(fs, selected);
-
-    // Build overrides: for remaining servers keep their enabled; for removed server add enabled: false
-    const overrides: Record<string, { enabled?: boolean }> = {};
-    for (const [n, c] of Object.entries(mcpServers)) {
-      const o: { enabled?: boolean } = {};
-      if (n === selected) {
-        o.enabled = false;
-      } else if (c.enabled !== undefined) {
-        o.enabled = c.enabled;
+    if (options.yes !== true) {
+      const confirmed = yield* terminal.confirm(`Remove server "${selected}"?`, false);
+      if (!confirmed) {
+        yield* terminal.info("Cancelled.");
+        return;
       }
-      if (Object.keys(o).length > 0) overrides[n] = o;
     }
-    yield* configService.set("mcpServers", overrides);
+
+    yield* removeAgentsMcpServer(fs, selected);
+    // Touch only this server's key rather than rewriting the whole override
+    // map, so a concurrent edit to another server is not clobbered.
+    yield* configService.set(`mcpServers.${selected}`, { enabled: false });
+    yield* clearServerAuth(selected);
 
     yield* terminal.success(`Removed MCP server: ${selected}`);
   });
 }
 
-/**
- * Enable a disabled MCP server interactively.
- *
- * Sets enabled: true (or removes the override) in ~/.jazz/config.json.
- */
-export function enableMcpServerCommand(): Effect.Effect<
-  void,
-  never,
-  AgentConfigService | TerminalService
-> {
+/** Flip a server's `enabled` flag. */
+function setServerEnabled(
+  name: string | undefined,
+  enabled: boolean,
+): Effect.Effect<void, never, McpCommandDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const configService = yield* AgentConfigServiceTag;
 
     const mcpServers = yield* configService.getOrElse<McpServersRecord>("mcpServers", {});
-    const disabledServers = Object.entries(mcpServers).filter(
-      ([, config]) => config.enabled === false,
+    const candidates = Object.entries(mcpServers)
+      .filter(([, config]) => (config.enabled !== false) !== enabled)
+      .map(([serverName]) => serverName);
+
+    if (candidates.length === 0) {
+      yield* terminal.info(
+        `No ${enabled ? "disabled" : "enabled"} MCP servers to ${enabled ? "enable" : "disable"}.`,
+      );
+      return;
+    }
+
+    const selected = yield* resolveServerName(
+      name,
+      candidates,
+      `Select a server to ${enabled ? "enable" : "disable"}:`,
     );
+    if (selected === undefined) return;
 
-    if (disabledServers.length === 0) {
-      yield* terminal.info("No disabled MCP servers to enable.");
+    yield* configService.set(`mcpServers.${selected}`, { enabled });
+    yield* terminal.success(`${enabled ? "Enabled" : "Disabled"} MCP server: ${selected}`);
+  });
+}
+
+export function enableMcpServerCommand(name?: string): Effect.Effect<void, never, McpCommandDeps> {
+  return setServerEnabled(name, true);
+}
+
+export function disableMcpServerCommand(name?: string): Effect.Effect<void, never, McpCommandDeps> {
+  return setServerEnabled(name, false);
+}
+
+/**
+ * Mark whether the user vouches for a server.
+ *
+ * Trust is what lets a server's own `readOnlyHint` skip the approval prompt, so
+ * it is a deliberate per-server decision rather than a global setting.
+ */
+export function trustMcpServerCommand(
+  name: string | undefined,
+  trusted: boolean,
+): Effect.Effect<void, never, McpCommandDeps> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+
+    const mcpServers = yield* configService.getOrElse<McpServersRecord>("mcpServers", {});
+    const names = Object.keys(mcpServers);
+
+    if (names.length === 0) {
+      yield* terminal.info("No MCP servers configured.");
       return;
     }
 
-    const selected = yield* terminal.select<string>("Select a server to enable:", {
-      choices: disabledServers.map(([name]) => ({ name, value: name })),
-    });
+    const selected = yield* resolveServerName(
+      name,
+      names,
+      `Select a server to ${trusted ? "trust" : "untrust"}:`,
+    );
+    if (selected === undefined) return;
 
-    if (!selected) {
-      yield* terminal.info("Cancelled.");
-      return;
+    if (trusted) {
+      yield* terminal.warn(
+        `Trusting "${selected}" lets its tools declare themselves read-only and skip approval prompts.`,
+      );
+      const confirmed = yield* terminal.confirm(`Trust "${selected}"?`, false);
+      if (!confirmed) {
+        yield* terminal.info("Cancelled.");
+        return;
+      }
     }
 
-    yield* configService.set(`mcpServers.${selected}`, { enabled: true });
-    yield* terminal.success(`Enabled MCP server: ${selected}`);
+    yield* configService.set(`mcpServers.${selected}`, { trusted });
+    yield* terminal.success(`${trusted ? "Trusted" : "Untrusted"} MCP server: ${selected}`);
   });
 }
 
 /**
- * Disable an enabled MCP server interactively.
+ * Run the OAuth authorization flow for a remote server.
  *
- * Sets enabled: false in ~/.jazz/config.json.
+ * Kept out of the connect path on purpose: connecting happens inside agent runs
+ * and unattended bridges, where opening a browser would be the wrong thing to
+ * do. Those surfaces fail with a pointer to this command instead.
  */
-export function disableMcpServerCommand(): Effect.Effect<
-  void,
-  never,
-  AgentConfigService | TerminalService
-> {
+export function authMcpServerCommand(name: string): Effect.Effect<void, never, McpCommandDeps> {
   return Effect.gen(function* () {
     const terminal = yield* TerminalServiceTag;
     const configService = yield* AgentConfigServiceTag;
 
     const mcpServers = yield* configService.getOrElse<McpServersRecord>("mcpServers", {});
-    const enabledServers = Object.entries(mcpServers).filter(
-      ([, config]) => config.enabled !== false,
-    );
+    const config = mcpServers[name];
 
-    if (enabledServers.length === 0) {
-      yield* terminal.info("No enabled MCP servers to disable.");
+    if (!config) {
+      yield* terminal.error(`No MCP server named "${name}".`);
       return;
     }
 
-    const selected = yield* terminal.select<string>("Select a server to disable:", {
-      choices: enabledServers.map(([name]) => ({ name, value: name })),
-    });
+    const serverConfig: MCPServerConfig = { ...config, name };
 
-    if (!selected) {
-      yield* terminal.info("Cancelled.");
+    if (!isHttpConfig(serverConfig)) {
+      yield* terminal.error(
+        `"${name}" uses stdio transport, which does not use OAuth. Configure its credentials with env vars instead.`,
+      );
       return;
     }
 
-    yield* configService.set(`mcpServers.${selected}`, { enabled: false });
-    yield* terminal.success(`Disabled MCP server: ${selected}`);
+    if (serverConfig.headers) {
+      yield* terminal.warn(
+        `"${name}" has static headers configured, which take precedence over OAuth. Remove them to use the browser flow.`,
+      );
+      return;
+    }
+
+    yield* terminal.info(`Starting authorization for ${name}...`);
+
+    const result = yield* authorizeServer(name, serverConfig.url, (url) => {
+      process.stdout.write(`\nIf your browser did not open, visit:\n${url}\n\n`);
+    }).pipe(Effect.either);
+
+    if (result._tag === "Left") {
+      yield* terminal.error(`Authorization failed: ${result.left.message}`);
+      return;
+    }
+
+    yield* terminal.success(`Authorized ${name}. Tokens stored in your system keyring.`);
+    yield* terminal.info(`Verify with: jazz mcp test ${name}`);
+  });
+}
+
+/** Forget stored OAuth tokens for a server. */
+export function logoutMcpServerCommand(name: string): Effect.Effect<void, never, McpCommandDeps> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+
+    const stored = yield* hasStoredAuth(name);
+    if (!stored) {
+      yield* terminal.info(`No stored credentials for "${name}".`);
+      return;
+    }
+
+    yield* clearServerAuth(name);
+    yield* terminal.success(`Cleared stored credentials for ${name}.`);
   });
 }

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -57,7 +57,9 @@ function CommandSuggestionItem({
         {isSelected ? "> " : "  "}/{command.name}
       </Text>
       {command.usage ? <Text color={THEME.muted}> {command.usage}</Text> : null}
-      {command.source === "skill" ? <Text color={THEME.muted}> (skill)</Text> : null}
+      {command.source ? (
+        <Text color={THEME.muted}> ({command.source === "skill" ? "skill" : "mcp"})</Text>
+      ) : null}
       <Text dimColor> – {command.description}</Text>
     </Box>
   );

--- a/src/cli/ui/fullscreen/Input.tsx
+++ b/src/cli/ui/fullscreen/Input.tsx
@@ -137,7 +137,7 @@ function commandSuggestRows(
   const rows: InputRow[] = visible.map((command) => {
     const selected = command === commands.items[commands.selected];
     const usage = command.usage === undefined ? "" : ` ${command.usage}`;
-    const skill = command.source === "skill" ? " (skill)" : "";
+    const skill = command.source ? (command.source === "skill" ? " (skill)" : " (mcp)") : "";
     const segments: InputSegment[] = [
       { text: selected ? `${glyphs.rail} ` : "  ", fg: THEME.primary },
       { text: `/${command.name}`, fg: selected ? THEME.selected : THEME.secondary },

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -202,7 +202,7 @@ export interface CommandSuggestion {
   readonly name: string;
   readonly description: string;
   readonly usage?: string;
-  readonly source?: "skill";
+  readonly source?: "skill" | "mcp-prompt";
 }
 
 export interface InputModel {

--- a/src/core/agent/tools/mcp-tools.test.ts
+++ b/src/core/agent/tools/mcp-tools.test.ts
@@ -12,15 +12,22 @@ const context: ToolExecutionContext = {
   conversationId: "test-conversation",
 };
 
+/**
+ * An MCP tool from an untrusted server registers as an approval/execute pair.
+ * Both halves share the advertised schema and validator; only the execute half
+ * carries the handler that reaches the server, so argument handling has to be
+ * probed there.
+ */
 async function buildTool(inputSchema: unknown) {
   const tools = await Effect.runPromise(
     registerMCPServerTools(serverConfig, [
       { name: "search", description: "probe tool", inputSchema } as unknown as MCPTool,
     ]),
   );
-  const tool = tools[0];
-  if (!tool) throw new Error("no tool registered");
-  return tool;
+  const approval = tools[0];
+  const execute = tools[1];
+  if (!approval || !execute) throw new Error("no tool pair registered");
+  return { approval, execute };
 }
 
 /**
@@ -34,7 +41,7 @@ async function localValidationError(
   args: Record<string, unknown>,
 ): Promise<string | null> {
   const exit = await Effect.runPromiseExit(
-    tool.execute(args, context) as unknown as Effect.Effect<
+    tool.execute.execute(args, context) as unknown as Effect.Effect<
       { success: boolean; error?: string },
       unknown
     >,
@@ -48,7 +55,7 @@ function parseWithAdvertisedSchema(
   args: Record<string, unknown>,
 ) {
   return (
-    tool.parameters as unknown as {
+    tool.approval.parameters as unknown as {
       safeParse: (value: unknown) => { success: boolean; data?: unknown };
     }
   ).safeParse(args);

--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -1,7 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
-import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type { MCPServerConfig, MCPServerManager } from "@/core/interfaces/mcp-server";
@@ -9,23 +8,21 @@ import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
 import type { PresentationService } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { TerminalService } from "@/core/interfaces/terminal";
-import { TerminalServiceTag } from "@/core/interfaces/terminal";
-import type { Tool } from "@/core/interfaces/tool-registry";
+import type { Tool, ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
-import { MCPToolExecutionError } from "@/core/types/errors";
-import type { MCPTool } from "@/core/types/mcp";
+import type { MCPTool, MCPToolAnnotations } from "@/core/types/mcp";
 import { convertMCPSchemaToZod, unwrapMCPJsonSchema } from "@/core/utils/mcp-schema-converter";
 import { safeStringify, toPascalCase } from "@/core/utils/string";
-import { defineTool, type ToolValidatorResult } from "./base-tool";
+import { defineApprovalTool, defineTool, type ToolValidatorResult } from "./base-tool";
 
 /**
  * MCP Tool Dependencies - all services needed for MCP tool operations
- *
- * TerminalService is kept because connectServer requires it for template variable resolution.
- * PresentationService is used for status display (connection progress, success/failure).
  */
 export type MCPToolDependencies =
   AgentConfigService | LoggerService | MCPServerManager | TerminalService | PresentationService;
+
+/** How much of an argument blob to show in an approval prompt. */
+const APPROVAL_ARGS_PREVIEW_LIMIT = 500;
 
 /** An object schema that keeps every key the model supplied. */
 function emptyPassthroughObject(): z.ZodTypeAny {
@@ -59,218 +56,187 @@ function passThroughMCPArguments(
 }
 
 /**
- * Adapt an MCP tool to a Jazz tool with lazy connection support
+ * Decide how much a tool has to justify itself before it runs.
  *
- * @param serverConfig - The MCP server configuration for reconnection
- * @param mcpTool - The MCP tool definition
+ * Annotations are a server describing its own blast radius, and the spec is
+ * explicit that a client must not take them as guarantees from a server it does
+ * not trust — a hostile server would simply mark its destructive tools
+ * `readOnlyHint`. So they only ever relax the gate for a server the user has
+ * marked trusted; for anyone else every tool is treated as high-risk regardless
+ * of what it claims.
  */
-function adaptMCPToolToJazz(
-  serverConfig: MCPServerConfig,
-  mcpTool: {
-    name: string;
-    description?: string | undefined;
-    inputSchema?: unknown;
-  },
-): Tool<MCPToolDependencies> {
-  // Create prefixed tool name for Jazz (e.g., mcp_mongodb_aggregate)
-  const jazzToolName = `mcp_${serverConfig.name.toLowerCase()}_${mcpTool.name}`;
-  // Keep original MCP tool name for lookup (e.g., aggregate)
-  const mcpToolName = mcpTool.name;
+export function resolveToolRiskLevel(
+  annotations: MCPToolAnnotations | undefined,
+  trusted: boolean,
+): ToolRiskLevel {
+  if (!trusted) return "high-risk";
+  if (annotations?.readOnlyHint === true) return "read-only";
+  if (annotations?.destructiveHint === true) return "high-risk";
+  return "low-risk";
+}
 
-  // Convert MCP schema to Zod
-  // LLM function calling requires object schemas, so we must ensure we always return an object schema
-  let parameters: z.ZodTypeAny;
+/** One-line summary of what a tool call would touch, for the approval prompt. */
+function describeAnnotations(annotations: MCPToolAnnotations | undefined): string | undefined {
+  if (!annotations) return undefined;
+  const labels: string[] = [];
+  if (annotations.readOnlyHint === true) labels.push("read-only");
+  if (annotations.destructiveHint === true) labels.push("destructive");
+  if (annotations.idempotentHint === true) labels.push("idempotent");
+  if (annotations.openWorldHint === true) labels.push("open-world");
+  return labels.length > 0 ? labels.join(", ") : undefined;
+}
 
-  if (mcpTool.inputSchema === undefined || mcpTool.inputSchema === null) {
-    // No schema provided - default to an open object so nothing is stripped
-    parameters = emptyPassthroughObject();
-  } else {
-    parameters = convertMCPSchemaToZod(mcpTool.inputSchema, mcpToolName);
+function previewArguments(args: Record<string, unknown>): string {
+  const serialized = safeStringify(args);
+  if (serialized.length <= APPROVAL_ARGS_PREVIEW_LIMIT) return serialized;
+  return `${serialized.slice(0, APPROVAL_ARGS_PREVIEW_LIMIT)}… (truncated)`;
+}
 
-    if (isZodUnknown(parameters)) {
-      // Invalid or unsupported schema - default to an open object for LLM compatibility
-      parameters = emptyPassthroughObject();
-    }
+/** Parameter schema for an MCP tool, tolerant of servers with no usable schema. */
+function resolveParameters(inputSchema: unknown): z.ZodTypeAny {
+  if (inputSchema === undefined || inputSchema === null) {
+    return emptyPassthroughObject();
   }
 
-  const unwrappedJsonSchema = unwrapMCPJsonSchema(mcpTool.inputSchema);
-
-  return defineTool<MCPToolDependencies, Record<string, unknown>>({
-    name: jazzToolName,
-    description: mcpTool.description || `MCP tool: ${mcpToolName}`,
-    parameters,
-    ...(unwrappedJsonSchema !== undefined ? { jsonSchema: unwrappedJsonSchema } : {}),
-    hidden: false,
-    validate: passThroughMCPArguments,
-    handler: (args: Record<string, unknown>, context: ToolExecutionContext) =>
-      executeMCPToolWithLazyConnection(serverConfig, mcpToolName, args, context),
-  });
+  const converted = convertMCPSchemaToZod(inputSchema, "mcp_tool");
+  return isZodUnknown(converted) ? emptyPassthroughObject() : converted;
 }
 
 /**
- * Execute an MCP tool with lazy connection support
- *
- * This function handles the lazy connection pattern:
- * 1. Check if the server is connected
- * 2. If not, reconnect to the server
- * 3. Execute the tool
+ * Run one MCP tool, connecting the server first if the session dropped it.
  */
-function executeMCPToolWithLazyConnection(
+function executeMCPTool(
   serverConfig: MCPServerConfig,
   toolName: string,
   args: Record<string, unknown>,
-  _context: ToolExecutionContext,
 ): Effect.Effect<ToolExecutionResult, Error, MCPToolDependencies> {
   return Effect.gen(function* () {
     const mcpManager = yield* MCPServerManagerTag;
     const logger = yield* LoggerServiceTag;
-    const configService = yield* AgentConfigServiceTag;
-    const terminal = yield* TerminalServiceTag;
     const presentation = yield* PresentationServiceTag;
 
     const serverName = serverConfig.name;
 
     yield* logger.debug(`Executing MCP tool: ${serverName}.${toolName}`, { args });
 
-    // Check if server is connected, if not, reconnect (lazy connection)
     const isConnected = yield* mcpManager.isConnected(serverName);
     if (!isConnected) {
-      // Show connecting message
       yield* presentation.presentStatus(
         `Connecting to ${toPascalCase(serverName)} MCP server...`,
         "progress",
       );
 
-      yield* logger.debug(
-        `MCP server ${serverName} not connected, establishing lazy connection...`,
-      );
-
-      // Reconnect to the server - provide all required services
-      yield* mcpManager
-        .connectServer(serverConfig)
-        .pipe(
-          Effect.provideService(LoggerServiceTag, logger),
-          Effect.provideService(AgentConfigServiceTag, configService),
-          Effect.provideService(TerminalServiceTag, terminal),
+      const connectResult = yield* Effect.either(mcpManager.connectServer(serverConfig));
+      if (connectResult._tag === "Left") {
+        const error = connectResult.left;
+        yield* presentation.presentStatus(
+          `Failed to connect to ${toPascalCase(serverName)} MCP server`,
+          "warning",
         );
+        return {
+          success: false,
+          result: null,
+          error: `${error.reason}${error.suggestion ? ` — ${error.suggestion}` : ""}`,
+        };
+      }
 
-      // Show success
       yield* presentation.presentStatus(
         `Connected to ${toPascalCase(serverName)} MCP server`,
         "success",
       );
-      yield* logger.info(`Lazy connection established to MCP server: ${serverName}`);
     }
 
-    // Get server tools
-    const mcpTools = yield* mcpManager.getServerTools(serverName);
+    const callResult = yield* Effect.either(mcpManager.callTool(serverName, toolName, args));
 
-    // Find the tool by its original MCP name (not the prefixed Jazz name)
-    const tool = mcpTools.find((t) => t.name === toolName);
+    if (callResult._tag === "Left") {
+      const error = callResult.left;
+      yield* logger.error(`MCP tool execution failed: ${serverName}.${toolName}`, {
+        error: error.reason,
+      });
+      return { success: false, result: null, error: error.reason };
+    }
 
-    if (!tool) {
-      const availableTools = mcpTools.map((t) => t.name).join(", ");
+    const result = callResult.right;
+
+    if (result.isError === true) {
+      const content = result.content;
       return {
         success: false,
         result: null,
-        error: `Tool ${toolName} not found in MCP server ${serverName}. Available tools: ${availableTools}`,
+        error: typeof content === "string" ? content : safeStringify(content ?? "Unknown error"),
       };
     }
 
-    // Execute the tool
-    if (!tool.execute) {
-      return {
-        success: false,
-        result: null,
-        error: `Tool ${toolName} does not have an execute function`,
-      };
-    }
-
-    const result = yield* Effect.tryPromise({
-      try: () =>
-        tool.execute(args, {
-          messages: [],
-          toolCallId: `${serverName}_${toolName}_${Date.now()}`,
-        }),
-      catch: (error) => {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        return new MCPToolExecutionError({
-          serverName,
-          toolName,
-          reason: `MCP tool execution failed: ${errorMessage}`,
-          cause: error,
-          suggestion: `Check that the tool arguments are correct and the MCP server is functioning properly`,
-        });
-      },
-    }).pipe(
-      Effect.catchAll((error: unknown) =>
-        Effect.gen(function* () {
-          let errorMessage: string;
-          // Check if it's a TaggedError with _tag property
-          if (typeof error === "object" && error !== null && "_tag" in error) {
-            const taggedError = error as { _tag: string; reason?: string; message?: string };
-            if (taggedError._tag === "MCPToolExecutionError" && taggedError.reason) {
-              errorMessage = taggedError.reason;
-            } else if (taggedError.message) {
-              errorMessage = taggedError.message;
-            } else {
-              errorMessage = safeStringify(error);
-            }
-          } else if (error instanceof Error) {
-            errorMessage = error.message;
-          } else {
-            errorMessage = safeStringify(error);
-          }
-          yield* logger.error(`MCP tool execution failed: ${serverName}.${toolName}`, {
-            error: errorMessage,
-          });
-          // Return error result directly, not wrapped in Effect
-          return {
-            success: false,
-            result: null,
-            error: errorMessage,
-          };
-        }),
-      ),
-    );
-
-    // Handle MCP tool result format
-    if (typeof result === "object" && result !== null) {
-      const mcpResult = result as {
-        content?: unknown;
-        isError?: boolean;
-      };
-
-      if (mcpResult.isError) {
-        const errorContent = mcpResult.content;
-        const errorMessage =
-          typeof errorContent === "string"
-            ? errorContent
-            : errorContent instanceof Error
-              ? errorContent.message
-              : "Unknown error";
-        return {
-          success: false,
-          result: null,
-          error: errorMessage,
-        };
-      }
-
-      return {
-        success: true,
-        result: mcpResult.content || result,
-      };
-    }
-
+    // A server that advertises an `outputSchema` returns the parsed object in
+    // `structuredContent`; `content` is then just its text rendering, so the
+    // structured form is what the model should reason over.
     return {
       success: true,
-      result,
+      result: result.structuredContent ?? result.content ?? null,
     };
   });
 }
 
 /**
- * Register tools from an MCP server
+ * Adapt one MCP tool to Jazz's tool model.
+ *
+ * Returns one tool for calls that need no confirmation, or an approval/execute
+ * pair for everything else. The split has to happen here rather than through a
+ * risk level alone: the approval gate in the executor fires on the sentinel
+ * `defineApprovalTool` returns, so a tool registered as a plain tool runs
+ * ungated no matter what risk level it carries.
+ */
+function adaptMCPToolToJazz(
+  serverConfig: MCPServerConfig,
+  mcpTool: MCPTool,
+): readonly Tool<MCPToolDependencies>[] {
+  const jazzToolName = `mcp_${serverConfig.name.toLowerCase()}_${mcpTool.name}`;
+  const mcpToolName = mcpTool.name;
+  const parameters = resolveParameters(mcpTool.inputSchema);
+  const unwrappedJsonSchema = unwrapMCPJsonSchema(mcpTool.inputSchema);
+  const description = mcpTool.description || `MCP tool: ${mcpToolName}`;
+  const riskLevel = resolveToolRiskLevel(mcpTool.annotations, serverConfig.trusted === true);
+
+  if (riskLevel === "read-only") {
+    return [
+      defineTool<MCPToolDependencies, Record<string, unknown>>({
+        name: jazzToolName,
+        description,
+        parameters,
+        ...(unwrappedJsonSchema !== undefined ? { jsonSchema: unwrappedJsonSchema } : {}),
+        hidden: false,
+        riskLevel,
+        validate: passThroughMCPArguments,
+        handler: (args: Record<string, unknown>) => executeMCPTool(serverConfig, mcpToolName, args),
+      }),
+    ];
+  }
+
+  const annotationSummary = describeAnnotations(mcpTool.annotations);
+
+  const pair = defineApprovalTool<MCPToolDependencies, Record<string, unknown>>({
+    name: jazzToolName,
+    description,
+    parameters,
+    riskLevel,
+    validate: passThroughMCPArguments,
+    approvalMessage: (args: Record<string, unknown>, _context: ToolExecutionContext) =>
+      Effect.succeed(
+        [
+          `MCP server: ${toPascalCase(serverConfig.name)}${serverConfig.trusted === true ? " (trusted)" : ""}`,
+          `Tool: ${mcpToolName}`,
+          ...(annotationSummary ? [`Declared: ${annotationSummary}`] : []),
+          `Arguments: ${previewArguments(args)}`,
+        ].join("\n"),
+      ),
+    handler: (args: Record<string, unknown>) => executeMCPTool(serverConfig, mcpToolName, args),
+  });
+
+  return pair.all();
+}
+
+/**
+ * Build Jazz tools for every tool an MCP server advertises.
  *
  * @param serverConfig - The MCP server configuration (needed for lazy reconnection)
  * @param mcpTools - The MCP tool definitions from the server
@@ -279,18 +245,7 @@ export function registerMCPServerTools(
   serverConfig: MCPServerConfig,
   mcpTools: readonly MCPTool[],
 ): Effect.Effect<readonly Tool<MCPToolDependencies>[], Error> {
-  return Effect.sync(() => {
-    const jazzTools: Tool<MCPToolDependencies>[] = [];
-
-    for (const mcpTool of mcpTools) {
-      const jazzTool = adaptMCPToolToJazz(serverConfig, {
-        name: mcpTool.name,
-        description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema,
-      });
-      jazzTools.push(jazzTool);
-    }
-
-    return jazzTools;
-  });
+  return Effect.sync(() =>
+    mcpTools.flatMap((mcpTool) => adaptMCPToolToJazz(serverConfig, mcpTool)),
+  );
 }

--- a/src/core/agent/tools/mcp-trust.test.ts
+++ b/src/core/agent/tools/mcp-trust.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type { MCPServerConfig } from "@/core/interfaces/mcp-server";
+import type { MCPTool } from "@/core/types/mcp";
+import { registerMCPServerTools, resolveToolRiskLevel } from "./mcp-tools";
+
+function server(trusted: boolean): MCPServerConfig {
+  return { name: "probe", command: "noop", trusted } as MCPServerConfig;
+}
+
+function tool(name: string, annotations?: MCPTool["annotations"]): MCPTool {
+  return { name, description: `${name} tool`, ...(annotations ? { annotations } : {}) };
+}
+
+async function build(trusted: boolean, mcpTool: MCPTool) {
+  return Effect.runPromise(registerMCPServerTools(server(trusted), [mcpTool]));
+}
+
+describe("resolveToolRiskLevel", () => {
+  test("treats every tool from an untrusted server as high-risk", () => {
+    // The whole point: a server cannot talk its way past the gate by
+    // describing itself as harmless.
+    expect(resolveToolRiskLevel({ readOnlyHint: true }, false)).toBe("high-risk");
+    expect(resolveToolRiskLevel({ destructiveHint: true }, false)).toBe("high-risk");
+    expect(resolveToolRiskLevel(undefined, false)).toBe("high-risk");
+  });
+
+  test("honours annotations from a trusted server", () => {
+    expect(resolveToolRiskLevel({ readOnlyHint: true }, true)).toBe("read-only");
+    expect(resolveToolRiskLevel({ destructiveHint: true }, true)).toBe("high-risk");
+  });
+
+  test("defaults an unannotated tool from a trusted server to low-risk", () => {
+    expect(resolveToolRiskLevel(undefined, true)).toBe("low-risk");
+    expect(resolveToolRiskLevel({ idempotentHint: true }, true)).toBe("low-risk");
+  });
+
+  test("prefers readOnlyHint when a server sets both", () => {
+    expect(resolveToolRiskLevel({ readOnlyHint: true, destructiveHint: true }, true)).toBe(
+      "read-only",
+    );
+  });
+});
+
+describe("MCP tool registration", () => {
+  test("registers an approval/execute pair for an untrusted server", async () => {
+    const tools = await build(false, tool("delete_page", { destructiveHint: true }));
+
+    expect(tools.map((registered) => registered.name)).toEqual([
+      "mcp_probe_delete_page",
+      "execute_mcp_probe_delete_page",
+    ]);
+    // The executor gates on this field; without it the tool runs unprompted.
+    expect(tools[0]?.approvalExecuteToolName).toBe("execute_mcp_probe_delete_page");
+    expect(tools[0]?.riskLevel).toBe("high-risk");
+    expect(tools[1]?.hidden).toBe(true);
+  });
+
+  test("registers a single ungated tool only when trusted and read-only", async () => {
+    const tools = await build(true, tool("list_issues", { readOnlyHint: true }));
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("mcp_probe_list_issues");
+    expect(tools[0]?.approvalExecuteToolName).toBeUndefined();
+    expect(tools[0]?.riskLevel).toBe("read-only");
+  });
+
+  test("still gates a read-only tool when the server is untrusted", async () => {
+    const tools = await build(false, tool("list_issues", { readOnlyHint: true }));
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]?.approvalExecuteToolName).toBe("execute_mcp_probe_list_issues");
+  });
+
+  test("gates a trusted server's unannotated tools", async () => {
+    const tools = await build(true, tool("send_message"));
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]?.riskLevel).toBe("low-risk");
+  });
+
+  test("names the declared annotations in the approval prompt", async () => {
+    const tools = await build(false, tool("drop_table", { destructiveHint: true }));
+    const approval = tools[0];
+    if (!approval) throw new Error("no approval tool");
+
+    const result = (await Effect.runPromise(
+      approval.execute(
+        { table: "users" },
+        {
+          agentId: "a",
+          conversationId: "c",
+        },
+      ) as unknown as Effect.Effect<{ result: { message: string } }, never>,
+    )) as { result: { message: string } };
+
+    expect(result.result.message).toContain("drop_table");
+    expect(result.result.message).toContain("destructive");
+    expect(result.result.message).toContain("users");
+  });
+});

--- a/src/core/agent/tools/register-mcp-tools.ts
+++ b/src/core/agent/tools/register-mcp-tools.ts
@@ -1,18 +1,107 @@
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
-import type { MCPServerManager } from "@/core/interfaces/mcp-server";
+import type { MCPServerConfig, MCPServerManager } from "@/core/interfaces/mcp-server";
 import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
 import type { PresentationService } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { TerminalService } from "@/core/interfaces/terminal";
-import type { ToolRegistry } from "@/core/interfaces/tool-registry";
+import type { Tool, ToolRegistry } from "@/core/interfaces/tool-registry";
 import { ToolRegistryTag } from "@/core/interfaces/tool-registry";
 import type { MCPTool } from "@/core/types/mcp";
+import { isAuthenticationRequired } from "@/core/utils/mcp";
 import { toPascalCase } from "@/core/utils/string";
-import { registerMCPServerTools } from "./mcp-tools";
+import { registerMCPServerTools, type MCPToolDependencies } from "./mcp-tools";
 import { mcpToolCategory } from "./tool-categories";
+
+/**
+ * What is currently registered from each MCP server, so a `list_changed`
+ * notification can add new tools and retire ones the server dropped.
+ *
+ * Module-scoped because the tool registry and server manager are both
+ * process-wide singletons; a per-call structure would re-subscribe on every
+ * conversation and leak handlers.
+ */
+const registeredServers = new Map<
+  string,
+  { readonly config: MCPServerConfig; toolNames: readonly string[] }
+>();
+
+/** Set once the manager-level `list_changed` subscription is installed. */
+let toolsChangedSubscribed = false;
+
+/** Register a server's tools, retiring any the server no longer advertises. */
+function syncServerTools(
+  registry: ToolRegistry,
+  serverConfig: MCPServerConfig,
+  mcpTools: readonly MCPTool[],
+): Effect.Effect<readonly string[], never> {
+  return Effect.gen(function* () {
+    const category = mcpToolCategory(serverConfig.name);
+    const registerTool = registry.registerForCategory(category);
+
+    const jazzTools = yield* registerMCPServerTools(serverConfig, mcpTools).pipe(
+      Effect.catchAll(() => Effect.succeed([] as readonly Tool<MCPToolDependencies>[])),
+    );
+
+    const nextNames: string[] = [];
+    for (const tool of jazzTools) {
+      yield* registerTool(tool);
+      nextNames.push(tool.name);
+    }
+
+    const previous = registeredServers.get(serverConfig.name)?.toolNames ?? [];
+    const nextNameSet = new Set(nextNames);
+    for (const staleName of previous) {
+      if (!nextNameSet.has(staleName)) {
+        yield* registry.unregisterTool(staleName);
+      }
+    }
+
+    registeredServers.set(serverConfig.name, { config: serverConfig, toolNames: nextNames });
+
+    // Only the model-facing half of each approval pair is worth reporting; the
+    // hidden `execute_*` twin is an implementation detail.
+    return nextNames.filter((name) => !name.startsWith("execute_"));
+  });
+}
+
+/**
+ * Install the one-time subscription that keeps the registry in step with
+ * servers that re-advertise their tools mid-session.
+ */
+function subscribeToToolChanges(): Effect.Effect<
+  void,
+  never,
+  MCPServerManager | ToolRegistry | LoggerService
+> {
+  return Effect.gen(function* () {
+    if (toolsChangedSubscribed) return;
+
+    const mcpManager = yield* MCPServerManagerTag;
+    const registry = yield* ToolRegistryTag;
+    const logger = yield* LoggerServiceTag;
+
+    yield* mcpManager.onToolsChanged((serverName, tools) => {
+      const entry = registeredServers.get(serverName);
+      if (!entry) return;
+
+      void Effect.runPromise(
+        syncServerTools(registry, entry.config, tools).pipe(
+          Effect.tap((names) =>
+            logger.info(
+              `MCP server ${serverName} changed its tool list; now ${names.length} tool(s)`,
+            ),
+          ),
+          Effect.catchAllCause(() => Effect.void),
+        ),
+      );
+    });
+
+    toolsChangedSubscribed = true;
+  });
+}
 
 /**
  * Register MCP tools for a specific agent based on their tool requirements.
@@ -43,26 +132,21 @@ export function registerMCPToolsForAgent(
     const registry = yield* ToolRegistryTag;
     const logger = yield* LoggerServiceTag;
 
-    // Extract MCP tool names (format: mcp_<servername>_<toolname>)
     const mcpToolNames = agentToolNames.filter((name) => name.startsWith("mcp_"));
 
-    // If agent has no MCP tools, skip connection entirely
     if (mcpToolNames.length === 0) {
       yield* logger.debug("Agent has no MCP tools, skipping MCP server connections");
       return [];
     }
 
-    // Get all configured MCP servers
     const allServers = yield* mcpManager.listServers();
 
     yield* logger.debug(
-      `Found ${allServers.length} configured MCP server(s): ${allServers.map((s) => s.name).join(", ")}`,
+      `Found ${allServers.length} configured MCP server(s): ${allServers.map((server) => server.name).join(", ")}`,
     );
 
-    // Extract server names that the agent actually uses from its tool list
-    // Match tool names to known servers by prefix
-    // This handles cases where tool names contain underscores (e.g. mcp_server_tool_name)
-    // and avoids ambiguity in parsing
+    // Match tool names to servers by prefix rather than by splitting the name:
+    // both the server name and the tool name may contain underscores.
     const requiredServerNames = new Set<string>();
     for (const server of allServers) {
       const prefix = `mcp_${server.name.toLowerCase()}_`;
@@ -71,14 +155,6 @@ export function registerMCPToolsForAgent(
       }
     }
 
-    if (requiredServerNames.size > 0) {
-      yield* logger.debug(
-        `Agent uses tools from ${requiredServerNames.size} MCP server(s): ${Array.from(requiredServerNames).map(toPascalCase).join(", ")}`,
-      );
-    }
-
-    // Connect only to enabled servers that the agent actually uses
-    // This avoids unnecessary connections and improves startup performance
     const serversToConnect = allServers.filter(
       (server) => server.enabled !== false && requiredServerNames.has(server.name),
     );
@@ -92,43 +168,26 @@ export function registerMCPToolsForAgent(
       `Connecting to ${serversToConnect.length} MCP server(s) required by agent during setup`,
     );
 
-    // Track successfully connected servers for cleanup
+    yield* subscribeToToolChanges();
+
     const connectedServers: string[] = [];
 
-    // Connect to and register tools from required servers
-    // Credentials are validated early for servers the agent uses
     for (const serverConfig of serversToConnect) {
-      // Skip disabled servers
-      if (serverConfig.enabled === false) {
-        yield* logger.debug(`Skipping disabled MCP server: ${serverConfig.name}`);
-        continue;
-      }
-
       yield* Effect.gen(function* () {
         const presentation = yield* PresentationServiceTag;
         const serverName = serverConfig.name;
 
-        // Check if server is already connected to avoid showing duplicate connection messages
         const isAlreadyConnected = yield* mcpManager.isConnected(serverName);
 
-        let showedConnectionUI = false;
-        if (!isAlreadyConnected) {
-          showedConnectionUI = true;
-
-          // Show connecting message only if not already connected
+        const showedConnectionUI = !isAlreadyConnected;
+        if (showedConnectionUI) {
           yield* presentation.presentStatus(
             `Connecting to ${toPascalCase(serverName)} MCP server...`,
             "progress",
           );
-
           yield* logger.debug(`Connecting to MCP server ${serverName}...`);
-        } else {
-          yield* logger.debug(`MCP server ${serverName} already connected, skipping connection UI`);
         }
 
-        // Connect to server and maintain connection (don't disconnect after discovery)
-        // This ensures tools are available when needed and connections persist during the session
-        // If connection fails (e.g., invalid credentials), we show a clear message but continue
         const connectResult = yield* Effect.either(mcpManager.connectServer(serverConfig));
         // Tell the interface whether this connector is actually reachable. A
         // failure here is not fatal — the agent carries on without those tools —
@@ -139,48 +198,43 @@ export function registerMCPToolsForAgent(
             connectResult._tag === "Left" ? "offline" : "live",
           );
         }
+
         if (connectResult._tag === "Left") {
           const error = connectResult.left;
-          const errorMessage = String(error);
+          const isAuthError = isAuthenticationRequired(error.reason);
 
-          const isAuthError = isMcpAuthError(errorMessage);
-
-          // Show error with helpful context (only if we showed connection UI)
           if (showedConnectionUI) {
-            const errorPrefix = isAuthError
-              ? `${toPascalCase(serverName)} MCP unavailable (invalid credentials)`
-              : `Failed to connect to ${toPascalCase(serverName)} MCP server`;
-
-            yield* presentation.presentStatus(errorPrefix, "warning");
-
-            if (isAuthError) {
-              yield* presentation.presentStatus(
-                `The agent will continue without ${toPascalCase(serverName)} tools.`,
-                "info",
-              );
+            yield* presentation.presentStatus(
+              isAuthError
+                ? `${toPascalCase(serverName)} MCP unavailable (authorization required)`
+                : `Failed to connect to ${toPascalCase(serverName)} MCP server`,
+              "warning",
+            );
+            if (error.suggestion) {
+              yield* presentation.presentStatus(error.suggestion, "info");
             }
+            yield* presentation.presentStatus(
+              `The agent will continue without ${toPascalCase(serverName)} tools.`,
+              "info",
+            );
           }
 
           if (isAuthError) {
             yield* logger.warn(
-              `MCP server ${serverName} connection failed due to invalid credentials: ${errorMessage}`,
+              `MCP server ${serverName} connection failed due to authorization: ${error.reason}`,
             );
           } else {
-            yield* logger.error(`Failed to connect to MCP server ${serverName}: ${errorMessage}`);
+            yield* logger.error(`Failed to connect to MCP server ${serverName}: ${error.reason}`);
           }
 
-          // Skip this server but continue with others
           return;
         }
 
-        // Get tools from the connected server
         const mcpToolsResult = yield* Effect.either(mcpManager.getServerTools(serverName));
-        let mcpTools: readonly MCPTool[];
+        let mcpTools: readonly MCPTool[] = [];
         if (mcpToolsResult._tag === "Right") {
           mcpTools = mcpToolsResult.right;
         } else {
-          const error = mcpToolsResult.left;
-          const errorMessage = String(error);
           if (showedConnectionUI) {
             yield* presentation.presentStatus(
               `Failed to discover tools from ${toPascalCase(serverName)} MCP server`,
@@ -192,15 +246,12 @@ export function registerMCPToolsForAgent(
             );
           }
           yield* logger.warn(
-            `Failed to discover tools from MCP server ${serverName}: ${errorMessage}`,
+            `Failed to discover tools from MCP server ${serverName}: ${mcpToolsResult.left.reason}`,
           );
-          // Return empty array on error - tools won't be available, but we continue
-          mcpTools = [];
         }
 
         yield* logger.debug(`Discovered ${mcpTools.length} tool(s) from MCP server ${serverName}`);
 
-        // Show success - only if we showed connection UI
         if (showedConnectionUI) {
           yield* presentation.presentStatus(
             `Connected to ${toPascalCase(serverName)} MCP server`,
@@ -208,25 +259,12 @@ export function registerMCPToolsForAgent(
           );
         }
 
-        const category = mcpToolCategory(serverConfig.name);
-
-        // Register tools with server config for lazy reconnection
-        // Agents always use all tools from their selected MCP servers, so register all discovered tools
-        const registerTool = registry.registerForCategory(category);
-        const jazzTools = yield* registerMCPServerTools(serverConfig, mcpTools);
-
-        // Register all tools from this MCP server (agents use all tools from selected MCPs)
-        const registeredToolNames: string[] = [];
-        for (const tool of jazzTools) {
-          yield* registerTool(tool);
-          registeredToolNames.push(tool.name);
-        }
+        const registeredToolNames = yield* syncServerTools(registry, serverConfig, mcpTools);
 
         if (registeredToolNames.length > 0) {
           yield* logger.info(
             `Registered ${registeredToolNames.length} MCP tool(s) from ${serverConfig.name}: ${registeredToolNames.join(", ")}`,
           );
-          // Track this server as successfully connected
           connectedServers.push(serverConfig.name);
         } else {
           yield* logger.debug(
@@ -234,14 +272,12 @@ export function registerMCPToolsForAgent(
           );
         }
       }).pipe(
-        Effect.catchAll((error) =>
-          Effect.gen(function* () {
-            // Log error but continue with other servers
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            yield* logger.warn(
-              `Failed to register tools from MCP server ${serverConfig.name}: ${errorMessage}`,
-            );
-          }),
+        // Every failure inside is already turned into an Either above, so only
+        // a defect can land here. One broken server must not abort the rest.
+        Effect.catchAllCause((cause) =>
+          logger.warn(
+            `Failed to register tools from MCP server ${serverConfig.name}: ${Cause.pretty(cause)}`,
+          ),
         ),
       );
     }
@@ -274,36 +310,17 @@ export function getMCPServerCategories(): Effect.Effect<
     const mcpManager = yield* MCPServerManagerTag;
     const servers = yield* mcpManager.listServers();
 
-    const categories: Record<string, string[]> = {};
+    const categories: Record<string, readonly string[]> = {};
     const displayNameToServerName = new Map<string, string>();
 
     for (const serverConfig of servers) {
-      // Skip disabled servers
-      if (serverConfig.enabled === false) {
-        continue;
-      }
+      if (serverConfig.enabled === false) continue;
 
       const category = mcpToolCategory(serverConfig.name);
-
-      // Add category with empty array (we don't know tool count without connecting)
       categories[category.displayName] = [];
-      // Map display name to server name for later tool registration
       displayNameToServerName.set(category.displayName, serverConfig.name);
     }
 
     return { categories, displayNameToServerName };
   });
-}
-
-function isMcpAuthError(errorMessage: string): boolean {
-  const lower = errorMessage.toLowerCase();
-  return (
-    lower.includes("auth") ||
-    lower.includes("credential") ||
-    lower.includes("api key") ||
-    lower.includes("invalid") ||
-    lower.includes("unauthorized") ||
-    lower.includes("401") ||
-    lower.includes("403")
-  );
 }

--- a/src/core/agent/tools/tool-registry.ts
+++ b/src/core/agent/tools/tool-registry.ts
@@ -58,6 +58,25 @@ class DefaultToolRegistry implements ToolRegistry {
     });
   }
 
+  unregisterTool(name: string): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      const tool = this.tools.get(name);
+      if (!tool) return;
+
+      this.tools.delete(name);
+      this.toolCategories.delete(name);
+      this.cachedDefinitions = null;
+
+      if (tool.aliases) {
+        for (const alias of tool.aliases) {
+          if (this.aliasMap.get(alias) === name) {
+            this.aliasMap.delete(alias);
+          }
+        }
+      }
+    });
+  }
+
   registerForCategory(
     category: ToolCategory,
   ): (tool: Tool<ToolRequirements>) => Effect.Effect<void, never> {

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -4,9 +4,17 @@ import { Context, Effect } from "effect";
 import type {
   MCPConnectionError,
   MCPDisconnectionError,
+  MCPPromptError,
   MCPToolDiscoveryError,
+  MCPToolExecutionError,
 } from "@/core/types/errors";
-import type { MCPClient, MCPTool } from "@/core/types/mcp";
+import type {
+  MCPPrompt,
+  MCPPromptResult,
+  MCPServerCapabilities,
+  MCPTool,
+  MCPToolResult,
+} from "@/core/types/mcp";
 import type { AgentConfigService } from "./agent-config";
 import type { LoggerService } from "./logger";
 
@@ -21,6 +29,14 @@ export type MCPTransportType = "stdio" | "http";
 export interface MCPServerConfigBase {
   readonly name: string;
   readonly enabled?: boolean;
+  /**
+   * Whether the user vouches for this server.
+   *
+   * Tool annotations are self-declared, so they only relax the approval gate
+   * for servers marked here. An untrusted server's tools always prompt no
+   * matter what it claims about them.
+   */
+  readonly trusted?: boolean;
 }
 
 /**
@@ -40,7 +56,8 @@ export interface MCPServerConfigHttp extends MCPServerConfigBase {
   readonly transport: "http";
   readonly url: string;
   /**
-   * Optional headers to include in HTTP requests (e.g., Authorization)
+   * Optional headers to include in HTTP requests (e.g., Authorization).
+   * Static headers bypass the OAuth flow entirely.
    */
   readonly headers?: Record<string, string>;
   /**
@@ -73,29 +90,23 @@ export function isHttpConfig(config: MCPServerConfig): config is MCPServerConfig
  */
 export type MCPTransport = StdioClientTransport | StreamableHTTPClientTransport;
 
-/**
- * MCP Server connection state
- */
-export interface MCPServerConnection {
-  readonly serverName: string;
-  readonly process: NodeJS.Process | null;
-  readonly client: MCPClient;
-  readonly transport: MCPTransport;
-  readonly transportType: MCPTransportType;
-}
+/** Called when a server reports its tool list changed. */
+export type ToolsChangedHandler = (serverName: string, tools: readonly MCPTool[]) => void;
 
 /**
  * MCP Server Manager interface
  *
- * Manages connections to MCP servers and provides access to MCP tools.
+ * Owns one `Client` per configured server and exposes the subset of the
+ * protocol Jazz uses: tools, prompts, and list-changed notifications.
  */
 export interface MCPServerManager {
   /**
-   * Connect to an MCP server using stdio transport
+   * Connect to an MCP server. Reconnecting an already-connected server is a
+   * no-op.
    */
   readonly connectServer: (
     config: MCPServerConfig,
-  ) => Effect.Effect<MCPClient, MCPConnectionError, LoggerService>;
+  ) => Effect.Effect<void, MCPConnectionError, LoggerService>;
 
   /**
    * Disconnect from an MCP server
@@ -105,11 +116,51 @@ export interface MCPServerManager {
   ) => Effect.Effect<void, MCPDisconnectionError, LoggerService>;
 
   /**
-   * Get tools from a connected MCP server
+   * List tools advertised by a connected server.
    */
   readonly getServerTools: (
     serverName: string,
   ) => Effect.Effect<readonly MCPTool[], MCPToolDiscoveryError, LoggerService>;
+
+  /**
+   * Invoke a tool on a connected server.
+   */
+  readonly callTool: (
+    serverName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ) => Effect.Effect<MCPToolResult, MCPToolExecutionError, LoggerService>;
+
+  /**
+   * List prompts advertised by a connected server. Servers that do not
+   * advertise the `prompts` capability return an empty list rather than error.
+   */
+  readonly getServerPrompts: (
+    serverName: string,
+  ) => Effect.Effect<readonly MCPPrompt[], MCPPromptError, LoggerService>;
+
+  /**
+   * Resolve one prompt with arguments applied.
+   */
+  readonly getPrompt: (
+    serverName: string,
+    promptName: string,
+    args: Record<string, string>,
+  ) => Effect.Effect<MCPPromptResult, MCPPromptError, LoggerService>;
+
+  /**
+   * Capabilities the server declared at initialize, or undefined when not
+   * connected.
+   */
+  readonly getCapabilities: (
+    serverName: string,
+  ) => Effect.Effect<MCPServerCapabilities | undefined, never>;
+
+  /**
+   * Subscribe to `notifications/tools/list_changed`. Returns an unsubscribe
+   * function. Handlers fire with the re-listed tools already resolved.
+   */
+  readonly onToolsChanged: (handler: ToolsChangedHandler) => Effect.Effect<() => void, never>;
 
   /**
    * Discover tools from an MCP server (connects, discovers, then disconnects)

--- a/src/core/interfaces/tool-registry.ts
+++ b/src/core/interfaces/tool-registry.ts
@@ -165,6 +165,13 @@ export interface ToolRegistry {
    * @returns A function that registers tools under the specified category.
    *
    */
+  /**
+   * Removes a tool from the registry. Unknown names are ignored.
+   *
+   * Needed so a server that drops a tool via `notifications/tools/list_changed`
+   * stops advertising it, rather than leaving a name the model can still call.
+   */
+  readonly unregisterTool: (name: string) => Effect.Effect<void, never>;
   readonly registerForCategory: (
     category: ToolCategory,
   ) => (tool: Tool<ToolRequirements>) => Effect.Effect<void, never>;

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -114,6 +114,12 @@ export interface OtlpTelemetryConfig {
  */
 export interface MCPServerOverride {
   readonly enabled?: boolean;
+  /**
+   * Whether the user vouches for this server. Owned by Jazz rather than
+   * mcp.json, because it is a statement about the user's trust, not part of
+   * the server's own definition.
+   */
+  readonly trusted?: boolean;
 }
 
 export type StorageConfig =

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -261,6 +261,13 @@ export class MCPToolDiscoveryError extends Data.TaggedError("MCPToolDiscoveryErr
   readonly suggestion?: string;
 }> {}
 
+export class MCPPromptError extends Data.TaggedError("MCPPromptError")<{
+  readonly serverName: string;
+  readonly reason: string;
+  readonly cause?: unknown;
+  readonly suggestion?: string;
+}> {}
+
 export class MCPSchemaConversionError extends Data.TaggedError("MCPSchemaConversionError")<{
   readonly toolName: string;
   readonly reason: string;

--- a/src/core/types/mcp.ts
+++ b/src/core/types/mcp.ts
@@ -1,51 +1,92 @@
 /**
  * MCP (Model Context Protocol) Type Definitions
  *
- * These types provide type safety for MCP client interactions.
- * The @ai-sdk/mcp library doesn't export all types, so we define
- * compatible interfaces based on the actual runtime behavior.
+ * Shapes mirror the wire types in `@modelcontextprotocol/sdk`, narrowed to the
+ * fields Jazz reads. They are declared here rather than re-exported so the tool
+ * layer does not depend on the SDK's generated Zod inference.
  */
 
 /**
- * MCP Tool Definition
- * Represents a tool that can be executed on an MCP server
+ * Hints a server declares about a tool's blast radius.
+ *
+ * These are claims a server makes about itself, not guarantees. The spec is
+ * explicit that clients must not treat them as trustworthy from an untrusted
+ * server, so they only relax Jazz's approval gate for servers the user has
+ * marked trusted — see `resolveToolRiskLevel`.
+ */
+export interface MCPToolAnnotations {
+  readonly readOnlyHint?: boolean | undefined;
+  readonly destructiveHint?: boolean | undefined;
+  readonly idempotentHint?: boolean | undefined;
+  readonly openWorldHint?: boolean | undefined;
+}
+
+/**
+ * MCP tool definition as advertised by `tools/list`.
+ *
+ * Unlike the previous `@ai-sdk/mcp` shape this carries no `execute`: the raw
+ * client dispatches by name through `MCPServerManager.callTool`.
  */
 export interface MCPTool {
   readonly name: string;
+  readonly title?: string;
   readonly description?: string;
   readonly inputSchema?: MCPJSONSchema;
-  readonly execute: (args: unknown, context: MCPToolContext) => Promise<MCPToolResult>;
+  readonly outputSchema?: MCPJSONSchema;
+  readonly annotations?: MCPToolAnnotations;
+}
+
+/** A single argument accepted by an MCP prompt. */
+export interface MCPPromptArgument {
+  readonly name: string;
+  readonly description?: string;
+  readonly required?: boolean;
 }
 
 /**
- * MCP Tool Execution Context
+ * MCP prompt definition as advertised by `prompts/list`.
+ *
+ * Prompts are user-initiated templates, not model-callable tools; Jazz surfaces
+ * them as slash commands.
  */
-export interface MCPToolContext {
-  readonly messages?: readonly unknown[];
-  readonly toolCallId?: string;
+export interface MCPPrompt {
+  readonly name: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly arguments?: readonly MCPPromptArgument[];
+}
+
+/** One message of a resolved `prompts/get` result. */
+export interface MCPPromptMessage {
+  readonly role: "user" | "assistant";
+  readonly content: unknown;
+}
+
+/** Resolved prompt returned by `prompts/get`. */
+export interface MCPPromptResult {
+  readonly description?: string;
+  readonly messages: readonly MCPPromptMessage[];
 }
 
 /**
- * MCP Tool Execution Result
+ * Result of `tools/call`.
+ *
+ * `structuredContent` arrives only from servers that advertise an
+ * `outputSchema` (spec 2025-06-18); `content` is the universal fallback.
  */
 export interface MCPToolResult {
   readonly content?: unknown;
+  readonly structuredContent?: unknown;
   readonly isError?: boolean;
 }
 
-/**
- * MCP Tool Registry
- * Can be either an array of tools or an object mapping tool names to tool definitions
- */
-export type MCPToolRegistry = readonly MCPTool[] | Record<string, MCPTool>;
-
-/**
- * MCP Client Interface
- * Represents the client returned by @ai-sdk/mcp's createMCPClient
- */
-export interface MCPClient {
-  readonly tools: () => Promise<MCPToolRegistry>;
-  readonly close?: () => Promise<void>;
+/** Server-declared capabilities captured at initialize time. */
+export interface MCPServerCapabilities {
+  readonly tools?: { readonly listChanged?: boolean | undefined } | undefined;
+  readonly prompts?: { readonly listChanged?: boolean | undefined } | undefined;
+  readonly resources?:
+    | { readonly listChanged?: boolean | undefined; readonly subscribe?: boolean | undefined }
+    | undefined;
 }
 
 /**
@@ -64,167 +105,4 @@ export interface MCPJSONSchema {
   readonly additionalProperties?: boolean | MCPJSONSchema;
   readonly $ref?: string;
   readonly const?: unknown;
-}
-
-/**
- * Type guard to check if a value is an MCPTool
- */
-export function isMCPTool(value: unknown): value is MCPTool {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "name" in value &&
-    typeof value.name === "string" &&
-    "execute" in value &&
-    typeof (value as { execute: unknown }).execute === "function"
-  );
-}
-
-/**
- * Type guard to check if a value is an MCPClient
- */
-export function isMCPClient(value: unknown): value is MCPClient {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "tools" in value &&
-    typeof value.tools === "function"
-  );
-}
-
-/**
- * Type guard to check if a value is an array of MCPTools
- */
-export function isMCPToolArray(value: unknown): value is readonly MCPTool[] {
-  return Array.isArray(value) && value.every(isMCPTool);
-}
-
-/**
- * Type guard to check if a value is a tool registry object
- */
-/**
- * Check if a value looks like a tool definition (without execute function)
- * Tool definitions from MCP servers typically have description, inputSchema, or title
- */
-function isMCPToolDefinition(value: unknown): boolean {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const toolDef = value as {
-    description?: unknown;
-    inputSchema?: unknown;
-    title?: unknown;
-  };
-
-  const hasDescription = typeof toolDef.description === "string";
-  const hasInputSchema = typeof toolDef.inputSchema === "object" && toolDef.inputSchema !== null;
-  const hasTitle = typeof toolDef.title === "string";
-
-  return hasDescription || hasInputSchema || hasTitle;
-}
-
-/**
- * Type guard to check if a value is a tool registry object
- * A tool registry object maps tool names to either MCPTool instances or tool definitions
- */
-export function isMCPToolRegistryObject(value: unknown): value is Record<string, MCPTool> {
-  // Must be a non-null object (not an array)
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  // Check if at least one value looks like a tool or tool definition
-  const registryValues = Object.values(value);
-  const hasValidTool = registryValues.some((toolValue) => {
-    // Check if it's a complete MCPTool with execute function
-    if (isMCPTool(toolValue)) {
-      return true;
-    }
-    // Check if it's a tool definition (description/inputSchema without execute)
-    return isMCPToolDefinition(toolValue);
-  });
-
-  return hasValidTool;
-}
-
-/**
- * Normalize a tool registry to an array of tools
- * Handles both array and object registry formats
- */
-export function normalizeMCPToolRegistry(registry: MCPToolRegistry): readonly MCPTool[] {
-  if (isMCPToolArray(registry)) {
-    return registry;
-  }
-
-  if (isMCPToolRegistryObject(registry)) {
-    const tools: MCPTool[] = [];
-    for (const [toolName, toolDef] of Object.entries(registry)) {
-      if (isMCPTool(toolDef)) {
-        // Tool already has execute function - use as-is
-        tools.push({
-          ...toolDef,
-          name: toolDef.name || toolName,
-        });
-      } else if (typeof toolDef === "object" && toolDef !== null) {
-        // Handle tool definitions that may not have execute functions yet
-        // (execute functions are provided by the MCP client when tools are called)
-        const toolObj = toolDef as {
-          name?: string;
-          description?: string;
-          inputSchema?: unknown;
-          execute?: unknown;
-          title?: string;
-          [key: string]: unknown;
-        };
-
-        // Check if it has an execute function
-        if (typeof toolObj.execute === "function") {
-          // Tool has execute function - create full MCPTool
-          const toolNameValue = toolObj.name || toolName;
-          const toolExecute = toolObj.execute as MCPTool["execute"];
-
-          const mcpTool: MCPTool = {
-            name: toolNameValue,
-            execute: toolExecute,
-            ...(typeof toolObj.description === "string" && { description: toolObj.description }),
-            ...(toolObj.inputSchema !== undefined &&
-              toolObj.inputSchema !== null && {
-                inputSchema: toolObj.inputSchema,
-              }),
-          };
-
-          tools.push(mcpTool);
-        } else {
-          // Tool definition without execute function - create stub execute
-          // The actual execution will be handled by the MCP client when the tool is called
-          // The name comes from the object key if not present in the tool definition
-          const finalToolName = toolObj.name || toolObj.title || toolName;
-
-          const mcpTool: MCPTool = {
-            name: finalToolName,
-            // Stub execute function - will be replaced when tool is actually called via getServerTools
-            // This is just for type compatibility during discovery
-            execute: () => {
-              return Promise.reject(
-                new Error(
-                  `Tool ${finalToolName} execute function not available during discovery. The actual execute function will be provided by the MCP client when the tool is called.`,
-                ),
-              );
-            },
-            ...(typeof toolObj.description === "string" && { description: toolObj.description }),
-            ...(toolObj.inputSchema !== undefined &&
-              toolObj.inputSchema !== null && {
-                inputSchema: toolObj.inputSchema,
-              }),
-          };
-
-          tools.push(mcpTool);
-        }
-      }
-    }
-    return tools.length > 0 ? tools : Object.values(registry).filter(isMCPTool);
-  }
-
-  return [];
 }

--- a/src/core/utils/mcp.test.ts
+++ b/src/core/utils/mcp.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import {
+  extractServerNamesFromToolNames,
+  isAuthenticationRequired,
+  parseServerNameFromToolName,
+} from "./mcp";
+
+const SERVERS = ["railway", "notion", "atlas-local", "my_server"];
+
+async function parse(toolName: string, servers: readonly string[] = SERVERS) {
+  return Effect.runPromise(
+    parseServerNameFromToolName(toolName, servers).pipe(
+      Effect.map((name) => name as string | null),
+      Effect.catchAll(() => Effect.succeed(null)),
+    ),
+  );
+}
+
+describe("parseServerNameFromToolName", () => {
+  test("resolves a tool whose own name contains underscores", async () => {
+    // Splitting on the last underscore read this as server "railway_list",
+    // which matched nothing and silently dropped the tool.
+    expect(await parse("mcp_railway_list_projects")).toBe("railway");
+    expect(await parse("mcp_railway_get_service_config")).toBe("railway");
+  });
+
+  test("resolves a server whose own name contains underscores or dashes", async () => {
+    expect(await parse("mcp_my_server_do_thing")).toBe("my_server");
+    expect(await parse("mcp_atlas-local_connect")).toBe("atlas-local");
+  });
+
+  test("prefers the longest matching server name", async () => {
+    const servers = ["railway", "railway_staging"];
+    expect(await parse("mcp_railway_staging_deploy", servers)).toBe("railway_staging");
+    expect(await parse("mcp_railway_deploy", servers)).toBe("railway");
+  });
+
+  test("rejects a name without the mcp_ prefix", async () => {
+    expect(await parse("read_file")).toBeNull();
+  });
+
+  test("rejects a tool from a server that is no longer configured", async () => {
+    expect(await parse("mcp_removed_tool", SERVERS)).toBeNull();
+  });
+});
+
+describe("extractServerNamesFromToolNames", () => {
+  test("collects the distinct servers a tool list references", async () => {
+    const names = await Effect.runPromise(
+      extractServerNamesFromToolNames(
+        ["mcp_railway_list_projects", "mcp_railway_deploy", "mcp_notion_search"],
+        SERVERS,
+      ),
+    );
+
+    expect([...names].sort()).toEqual(["notion", "railway"]);
+  });
+
+  test("skips unmatched tools rather than failing the whole list", async () => {
+    // An agent saved against a server the user later removed must still open.
+    const names = await Effect.runPromise(
+      extractServerNamesFromToolNames(["mcp_gone_tool", "mcp_notion_search"], SERVERS),
+    );
+
+    expect([...names]).toEqual(["notion"]);
+  });
+});
+
+describe("isAuthenticationRequired", () => {
+  test("recognises real credential failures", () => {
+    expect(isAuthenticationRequired(new Error("HTTP 401 Unauthorized"))).toBe(true);
+    expect(isAuthenticationRequired("Request failed with status 403")).toBe(true);
+    expect(isAuthenticationRequired(new Error("invalid api key"))).toBe(true);
+    expect(isAuthenticationRequired(new Error("authentication required"))).toBe(true);
+  });
+
+  test("does not claim ordinary failures are credential problems", () => {
+    // The old heuristic matched any message containing "invalid" and sent
+    // people off to check credentials that were fine.
+    expect(isAuthenticationRequired(new Error("invalid schema for tool search"))).toBe(false);
+    expect(isAuthenticationRequired(new Error("Invalid argument: limit"))).toBe(false);
+    expect(isAuthenticationRequired(new Error("ECONNREFUSED 127.0.0.1:9000"))).toBe(false);
+    expect(isAuthenticationRequired(new Error("spawn npx ENOENT"))).toBe(false);
+  });
+
+  test("handles empty input", () => {
+    expect(isAuthenticationRequired(null)).toBe(false);
+    expect(isAuthenticationRequired(undefined)).toBe(false);
+  });
+});

--- a/src/core/utils/mcp.ts
+++ b/src/core/utils/mcp.ts
@@ -2,18 +2,22 @@ import { Duration, Effect, Schedule } from "effect";
 import { MCPServerNameParseError } from "@/core/types/errors";
 
 /**
- * Parse server name from MCP tool name
+ * Resolve which configured server a prefixed MCP tool name belongs to.
  *
- * MCP tool names follow the pattern: mcp_<servername>_<toolname>
- * Server names can contain underscores (e.g., "atlas-local", "my_server")
+ * The name alone cannot be split reliably: both halves may contain
+ * underscores, so `mcp_railway_list_projects` is equally readable as server
+ * `railway` tool `list_projects` or server `railway_list` tool `projects`.
+ * Matching against the servers that actually exist is the only correct read —
+ * splitting on the last underscore silently mis-attributes every tool whose
+ * own name has one.
  *
- * @param toolName - The full MCP tool name (e.g., "mcp_mongodb_aggregate" or "mcp_atlas-local_connect")
- * @returns The server name or an error
+ * @param toolName - The full MCP tool name (e.g. `mcp_railway_list_projects`)
+ * @param knownServerNames - Names of the configured MCP servers
  */
 export function parseServerNameFromToolName(
   toolName: string,
+  knownServerNames: Iterable<string>,
 ): Effect.Effect<string, MCPServerNameParseError> {
-  // Validate format: must start with "mcp_" and have at least 3 parts
   if (!toolName.startsWith("mcp_")) {
     return Effect.fail(
       new MCPServerNameParseError({
@@ -24,53 +28,52 @@ export function parseServerNameFromToolName(
     );
   }
 
-  // Remove "mcp_" prefix
-  const withoutPrefix = toolName.slice(4);
+  const lowerToolName = toolName.toLowerCase();
+  let bestMatch: string | undefined;
 
-  // Find the last underscore (separates server name from tool name)
-  const lastUnderscoreIndex = withoutPrefix.lastIndexOf("_");
+  for (const serverName of knownServerNames) {
+    const prefix = `mcp_${serverName.toLowerCase()}_`;
+    if (!lowerToolName.startsWith(prefix)) continue;
+    // Longest wins, so a server named `railway` cannot claim a tool that
+    // belongs to a more specific `railway_staging`.
+    if (bestMatch === undefined || serverName.length > bestMatch.length) {
+      bestMatch = serverName;
+    }
+  }
 
-  if (lastUnderscoreIndex === -1 || lastUnderscoreIndex === 0) {
+  if (bestMatch === undefined) {
     return Effect.fail(
       new MCPServerNameParseError({
         toolName,
-        reason: `Tool name must have format mcp_<servername>_<toolname>`,
-        suggestion: `Could not find server name separator. Expected at least one underscore after "mcp_" prefix`,
+        reason: `No configured MCP server matches tool "${toolName}"`,
+        suggestion: `The server may have been removed or renamed since this agent was saved`,
       }),
     );
   }
 
-  // Extract server name (everything before the last underscore)
-  const serverName = withoutPrefix.slice(0, lastUnderscoreIndex);
-
-  if (serverName.length === 0) {
-    return Effect.fail(
-      new MCPServerNameParseError({
-        toolName,
-        reason: `Server name cannot be empty`,
-        suggestion: `Tool name format: mcp_<servername>_<toolname>`,
-      }),
-    );
-  }
-
-  return Effect.succeed(serverName);
+  return Effect.succeed(bestMatch);
 }
 
 /**
- * Extract unique server names from a list of MCP tool names
+ * Extract the set of servers referenced by a list of MCP tool names.
  *
- * @param toolNames - Array of MCP tool names
- * @returns Set of unique server names
+ * Tool names that match no configured server are skipped rather than failing
+ * the whole list: an agent saved against a server the user later removed
+ * should still open.
  */
 export function extractServerNamesFromToolNames(
   toolNames: readonly string[],
-): Effect.Effect<Set<string>, MCPServerNameParseError> {
+  knownServerNames: Iterable<string>,
+): Effect.Effect<Set<string>, never> {
+  const known = Array.from(knownServerNames);
   return Effect.gen(function* () {
     const serverNames = new Set<string>();
 
     for (const toolName of toolNames) {
-      const serverName = yield* parseServerNameFromToolName(toolName);
-      serverNames.add(serverName);
+      const resolved = yield* parseServerNameFromToolName(toolName, known).pipe(Effect.option);
+      if (resolved._tag === "Some") {
+        serverNames.add(resolved.value);
+      }
     }
 
     return serverNames;
@@ -118,15 +121,17 @@ export function retryWithBackoff<E, A, R>(
 }
 
 /**
- * Check if an error indicates that authentication is required
+ * Whether an error looks like the server rejecting our credentials.
  *
- * MCP servers may require authentication and can take longer than normal timeouts.
- * This broad text heuristic may produce false positives and is suitable only
- * for deciding whether to offer authentication UX, never for security policy.
- *
- * @param error - The error to check
- * @returns true if the error suggests authentication is required
+ * Used only to pick which remediation to show — "run `jazz mcp auth`" versus a
+ * generic connection failure — never as a security decision. Matching is on
+ * whole words and specific phrases rather than loose substrings, because the
+ * previous heuristic tripped on any message containing "invalid" and sent
+ * people to check credentials that were fine.
  */
+const AUTH_ERROR_PATTERN =
+  /\b(401|403|unauthorized|unauthenticated|forbidden|authentication|authorization|credentials?|api[ _-]?key)\b|\b(invalid|expired|missing)[ _-](token|credentials?|api[ _-]?key|authorization)\b|\bsign[ -]in required\b/i;
+
 export function isAuthenticationRequired(error: unknown): boolean {
   if (error === null || error === undefined) {
     return false;
@@ -139,28 +144,5 @@ export function isAuthenticationRequired(error: unknown): boolean {
         ? error
         : JSON.stringify(error);
 
-  const lowerMessage = errorMessage.toLowerCase();
-
-  // Check for authentication-related keywords
-  const authKeywords = [
-    "authentication",
-    "authenticate",
-    "auth",
-    "login",
-    "credential",
-    "password",
-    "token",
-    "api key",
-    "api_key",
-    "authorization",
-    "unauthorized",
-    "401",
-    "403",
-    "please sign in",
-    "sign in required",
-    "authentication required",
-    "authentication needed",
-  ];
-
-  return authKeywords.some((keyword) => lowerMessage.includes(keyword));
+  return AUTH_ERROR_PATTERN.test(errorMessage);
 }

--- a/src/services/chat/commands/constants.ts
+++ b/src/services/chat/commands/constants.ts
@@ -7,8 +7,8 @@ export interface ChatCommandInfo {
   readonly description: string;
   /** Argument hint shown in autocomplete and /help, e.g. "[agent]". */
   readonly usage?: string;
-  /** Set for entries that come from a skill rather than a built-in command. */
-  readonly source?: "skill";
+  /** Set for entries that come from a skill or MCP server rather than a built-in command. */
+  readonly source?: "skill" | "mcp-prompt";
 }
 
 export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
@@ -27,7 +27,11 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "export", description: "Export the conversation to a markdown file", usage: "[path]" },
   { name: "fork", description: "Fork conversation (new branch from last message)" },
   { name: "help", description: "Show available commands and shortcuts", usage: "[command]" },
-  { name: "mcp", description: "Show MCP server status and connections" },
+  {
+    name: "mcp",
+    description: "Show MCP server status, or reconnect one",
+    usage: "[reconnect <server>]",
+  },
   {
     name: "mode",
     description: "Switch between safe mode and yolo mode for tool approvals",
@@ -81,6 +85,34 @@ export function getSkillCommandNames(): ReadonlySet<string> {
 }
 
 /**
+ * Prompts advertised by connected MCP servers, as `server:prompt` commands.
+ *
+ * MCP prompts are the user-initiated half of the protocol — templates a person
+ * invokes deliberately, unlike tools, which the model calls. A slash command is
+ * the shape that matches, so they are registered here alongside skills.
+ */
+let mcpPromptCommands: readonly ChatCommandInfo[] = [];
+
+/**
+ * Register connected servers' prompts as slash commands. Built-ins and skills
+ * both win a name collision, so a server cannot shadow `/help`.
+ */
+export function setMcpPromptCommands(prompts: readonly ChatCommandInfo[]): void {
+  const reserved = new Set([
+    ...CHAT_COMMANDS.map((command) => command.name.toLowerCase()),
+    ...skillCommands.map((skill) => skill.name.toLowerCase()),
+  ]);
+  mcpPromptCommands = prompts
+    .filter((prompt) => !reserved.has(prompt.name.toLowerCase()))
+    .map((prompt) => ({ ...prompt, source: "mcp-prompt" as const }));
+}
+
+/** Names of all registered MCP prompt commands, lower-cased, for parser routing. */
+export function getMcpPromptCommandNames(): ReadonlySet<string> {
+  return new Set(mcpPromptCommands.map((prompt) => prompt.name.toLowerCase()));
+}
+
+/**
  * Filter commands for autocomplete. Built-in commands and skills are merged
  * (built-ins first). Prefix matches rank first (in list order), then substring
  * matches (so "/ode" still surfaces /model and /mode). Case-insensitive.
@@ -101,7 +133,7 @@ export function slashCommandQuery(text: string): string | null {
 
 export function filterCommandsByPrefix(query: string): readonly ChatCommandInfo[] {
   const lower = query.toLowerCase();
-  const all = [...CHAT_COMMANDS, ...skillCommands];
+  const all = [...CHAT_COMMANDS, ...skillCommands, ...mcpPromptCommands];
   const prefixMatches = all.filter((cmd) => cmd.name.toLowerCase().startsWith(lower));
   if (lower.length === 0) return prefixMatches;
   const substringMatches = all.filter(

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -36,6 +36,7 @@ import {
 } from "@/core/interfaces/tool-registry";
 import { SkillServiceTag, type SkillService } from "@/core/skills/skill-service";
 import { StorageError, StorageNotFoundError } from "@/core/types/errors";
+import type { MCPPromptArgument, MCPPromptMessage } from "@/core/types/mcp";
 import type { ChatMessage } from "@/core/types/message";
 import type { AutoApprovePolicy } from "@/core/types/tools";
 import { generateConversationId } from "@/core/utils/conversation-id";
@@ -133,7 +134,7 @@ export function handleSpecialCommand(
         return yield* handleStatsCommand(terminal, agent, context);
 
       case "mcp":
-        return yield* handleMcpCommand(terminal);
+        return yield* handleMcpCommand(terminal, command.args);
 
       case "mode":
         return yield* handleModeCommand(
@@ -162,6 +163,9 @@ export function handleSpecialCommand(
 
       case "runSkill":
         return yield* handleRunSkillCommand(command.args);
+
+      case "runMcpPrompt":
+        return yield* handleRunMcpPromptCommand(terminal, command.args);
 
       case "unknown":
         return yield* handleUnknownCommand(terminal, command.args);
@@ -1218,6 +1222,139 @@ function handleRunSkillCommand(args: string[]): Effect.Effect<CommandResult, nev
 }
 
 /**
+ * Bind loose slash-command arguments to a prompt's declared parameters.
+ *
+ * Accepts `name=value` pairs in any order and falls back to positional order
+ * for bare words, so both `/srv:issue title=Bug` and `/srv:issue Bug` work.
+ * A single bare trailing phrase fills the first declared argument rather than
+ * being split, which is what people actually type.
+ */
+export function bindPromptArguments(
+  declared: readonly MCPPromptArgument[],
+  args: readonly string[],
+): Record<string, string> {
+  const bound: Record<string, string> = {};
+  const declaredNames = new Set(declared.map((argument) => argument.name));
+  const positional: string[] = [];
+
+  for (const arg of args) {
+    const separator = arg.indexOf("=");
+    const key = separator > 0 ? arg.slice(0, separator) : undefined;
+    if (key !== undefined && declaredNames.has(key)) {
+      bound[key] = arg.slice(separator + 1);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length > 0) {
+    const unfilled = declared.filter((argument) => bound[argument.name] === undefined);
+    const first = unfilled[0];
+    if (unfilled.length === 1 && first) {
+      bound[first.name] = positional.join(" ");
+    } else {
+      unfilled.forEach((argument, index) => {
+        const value = positional[index];
+        if (value !== undefined) bound[argument.name] = value;
+      });
+    }
+  }
+
+  return bound;
+}
+
+/** Flatten a resolved prompt's messages into text to send as the user turn. */
+export function flattenPromptMessages(messages: readonly MCPPromptMessage[]): string {
+  const parts: string[] = [];
+
+  for (const message of messages) {
+    const content = message.content;
+    if (typeof content === "string") {
+      parts.push(content);
+      continue;
+    }
+    if (typeof content === "object" && content !== null) {
+      const block = content as { type?: string; text?: string; resource?: { text?: string } };
+      if (typeof block.text === "string") {
+        parts.push(block.text);
+        continue;
+      }
+      // An embedded resource carries its body here; anything else (images,
+      // resource links) has no text form worth inlining.
+      if (typeof block.resource?.text === "string") {
+        parts.push(block.resource.text);
+      }
+    }
+  }
+
+  return parts.join("\n\n").trim();
+}
+
+/**
+ * Handle `/server:prompt` — resolve an MCP prompt and send it as the user turn.
+ */
+function handleRunMcpPromptCommand(
+  terminal: TerminalService,
+  args: string[],
+): Effect.Effect<CommandResult, never, MCPServerManager | LoggerService> {
+  return Effect.gen(function* () {
+    const mcpManager = yield* MCPServerManagerTag;
+    const commandName = args[0] ?? "";
+    const separator = commandName.indexOf(":");
+
+    if (separator <= 0) {
+      yield* terminal.error(`Not an MCP prompt: /${commandName}`);
+      return { shouldContinue: true };
+    }
+
+    const serverName = commandName.slice(0, separator);
+    const promptName = commandName.slice(separator + 1);
+
+    const prompts = yield* mcpManager.getServerPrompts(serverName).pipe(Effect.either);
+    if (prompts._tag === "Left") {
+      yield* terminal.error(prompts.left.reason);
+      return { shouldContinue: true };
+    }
+
+    const definition = prompts.right.find((prompt) => prompt.name === promptName);
+    if (!definition) {
+      yield* terminal.error(`${serverName} does not advertise a prompt named "${promptName}".`);
+      return { shouldContinue: true };
+    }
+
+    const declared = definition.arguments ?? [];
+    const bound = bindPromptArguments(declared, args.slice(1));
+
+    const missing = declared
+      .filter((argument) => argument.required === true && bound[argument.name] === undefined)
+      .map((argument) => argument.name);
+
+    if (missing.length > 0) {
+      yield* terminal.error(`Missing required argument(s): ${missing.join(", ")}`);
+      yield* terminal.info(
+        `Usage: /${commandName} ${declared.map((argument) => `${argument.name}=<value>`).join(" ")}`,
+      );
+      return { shouldContinue: true };
+    }
+
+    const resolved = yield* mcpManager.getPrompt(serverName, promptName, bound).pipe(Effect.either);
+    if (resolved._tag === "Left") {
+      yield* terminal.error(resolved.left.reason);
+      return { shouldContinue: true };
+    }
+
+    const text = flattenPromptMessages(resolved.right.messages);
+
+    if (text === "") {
+      yield* terminal.warn(`Prompt "${promptName}" resolved to no text content.`);
+      return { shouldContinue: true };
+    }
+
+    return { shouldContinue: true, resendMessage: text };
+  });
+}
+
+/**
  * Handle unknown command
  */
 function handleUnknownCommand(
@@ -1450,14 +1587,50 @@ function handleStatsCommand(
 }
 
 /**
- * Handle /mcp command - Show MCP server status and connections
+ * Handle `/mcp` — show server status, and `/mcp reconnect <name>` to retry one.
+ *
+ * Reconnect exists because a server that failed at startup was otherwise
+ * unreachable for the rest of the session: the only fix was to quit, repair it,
+ * and start the conversation over.
  */
 function handleMcpCommand(
   terminal: TerminalService,
-): Effect.Effect<CommandResult, never, MCPServerManager | AgentConfigService> {
+  args: readonly string[] = [],
+): Effect.Effect<CommandResult, never, MCPServerManager | AgentConfigService | LoggerService> {
   return Effect.gen(function* () {
     const mcpManager = yield* MCPServerManagerTag;
     const servers = yield* mcpManager.listServers();
+
+    const [subcommand, targetName] = args;
+
+    if (subcommand === "reconnect") {
+      const target = servers.find((server) => server.name === targetName);
+      if (!target) {
+        yield* terminal.error(
+          targetName === undefined
+            ? "Usage: /mcp reconnect <server>"
+            : `No MCP server named "${targetName}".`,
+        );
+        return { shouldContinue: true };
+      }
+
+      yield* mcpManager.disconnectServer(target.name).pipe(Effect.catchAll(() => Effect.void));
+      const reconnected = yield* mcpManager.connectServer(target).pipe(Effect.either);
+
+      if (reconnected._tag === "Left") {
+        yield* terminal.error(reconnected.left.reason);
+        if (reconnected.left.suggestion) {
+          yield* terminal.info(reconnected.left.suggestion);
+        }
+        return { shouldContinue: true };
+      }
+
+      const tools = yield* mcpManager.getServerTools(target.name).pipe(Effect.either);
+      yield* terminal.success(
+        `Reconnected to ${target.name}${tools._tag === "Right" ? ` (${tools.right.length} tool(s))` : ""}`,
+      );
+      return { shouldContinue: true };
+    }
 
     yield* terminal.log(fmt.heading("MCP Servers"));
 
@@ -1473,19 +1646,38 @@ function handleMcpCommand(
       const enabledStr = server.enabled === false ? "disabled" : "enabled";
       const connectedStr = connected ? "connected" : "disconnected";
 
-      if (connected) {
-        yield* terminal.log(fmt.statusConnected(server.name));
-      } else {
-        yield* terminal.log(fmt.statusDisconnected(server.name));
-      }
+      yield* terminal.log(
+        connected ? fmt.statusConnected(server.name) : fmt.statusDisconnected(server.name),
+      );
       yield* terminal.log(fmt.keyValue("Status", `${enabledStr}, ${connectedStr}`));
       yield* terminal.log(fmt.keyValue("Transport", server.transport ?? "stdio"));
+      // Trust decides whether this server's tools can skip approval prompts, so
+      // it belongs next to the connection state rather than buried in config.
+      yield* terminal.log(
+        fmt.keyValue("Trust", server.trusted === true ? "trusted" : "asks every call"),
+      );
 
       if (isStdioConfig(server)) {
         const cmd = `${server.command}${server.args?.length ? " " + server.args.join(" ") : ""}`;
         yield* terminal.log(fmt.keyValue("Command", cmd));
       } else if (isHttpConfig(server)) {
         yield* terminal.log(fmt.keyValue("URL", server.url));
+      }
+
+      if (connected) {
+        const tools = yield* mcpManager.getServerTools(server.name).pipe(Effect.either);
+        if (tools._tag === "Right") {
+          yield* terminal.log(fmt.keyValue("Tools", String(tools.right.length)));
+        }
+        const prompts = yield* mcpManager.getServerPrompts(server.name).pipe(Effect.either);
+        if (prompts._tag === "Right" && prompts.right.length > 0) {
+          yield* terminal.log(
+            fmt.keyValue(
+              "Prompts",
+              prompts.right.map((prompt) => `/${server.name}:${prompt.name}`).join(", "),
+            ),
+          );
+        }
       }
 
       yield* terminal.log(fmt.blank());

--- a/src/services/chat/commands/index.ts
+++ b/src/services/chat/commands/index.ts
@@ -1,7 +1,9 @@
 export {
   CHAT_COMMANDS,
   filterCommandsByPrefix,
+  getMcpPromptCommandNames,
   getSkillCommandNames,
+  setMcpPromptCommands,
   setSkillCommands,
   slashCommandQuery,
 } from "./constants";

--- a/src/services/chat/commands/mcp-prompt-routing.test.ts
+++ b/src/services/chat/commands/mcp-prompt-routing.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { filterCommandsByPrefix, setMcpPromptCommands, setSkillCommands } from "./constants";
+import { parseSpecialCommand } from "./parser";
+
+beforeEach(() => {
+  setSkillCommands([]);
+  setMcpPromptCommands([]);
+});
+
+describe("MCP prompt slash commands", () => {
+  test("routes a registered prompt to runMcpPrompt", () => {
+    setMcpPromptCommands([{ name: "linear:create-issue", description: "File an issue" }]);
+
+    expect(parseSpecialCommand("/linear:create-issue title=Bug")).toEqual({
+      type: "runMcpPrompt",
+      args: ["linear:create-issue", "title=Bug"],
+    });
+  });
+
+  test("an unregistered prompt name is still an unknown command", () => {
+    expect(parseSpecialCommand("/linear:create-issue")?.type).toBe("unknown");
+  });
+
+  test("appears in autocomplete tagged as an MCP prompt", () => {
+    setMcpPromptCommands([{ name: "linear:create-issue", description: "File an issue" }]);
+
+    const matches = filterCommandsByPrefix("linear");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.source).toBe("mcp-prompt");
+  });
+
+  test("a built-in command wins a name collision", () => {
+    // A server must not be able to shadow /help by naming a prompt after it.
+    setMcpPromptCommands([{ name: "help", description: "hostile prompt" }]);
+
+    expect(parseSpecialCommand("/help")?.type).toBe("help");
+    expect(filterCommandsByPrefix("help").every((cmd) => cmd.source === undefined)).toBe(true);
+  });
+
+  test("a skill wins a name collision", () => {
+    setSkillCommands([{ name: "deep-research", description: "a skill" }]);
+    setMcpPromptCommands([{ name: "deep-research", description: "a prompt" }]);
+
+    expect(parseSpecialCommand("/deep-research")?.type).toBe("runSkill");
+  });
+
+  test("re-registering replaces the previous server's prompts", () => {
+    setMcpPromptCommands([{ name: "old:prompt", description: "gone" }]);
+    setMcpPromptCommands([{ name: "new:prompt", description: "here" }]);
+
+    expect(parseSpecialCommand("/old:prompt")?.type).toBe("unknown");
+    expect(parseSpecialCommand("/new:prompt")?.type).toBe("runMcpPrompt");
+  });
+});

--- a/src/services/chat/commands/mcp-prompts.test.ts
+++ b/src/services/chat/commands/mcp-prompts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { MCPPromptArgument, MCPPromptMessage } from "@/core/types/mcp";
+import { bindPromptArguments, flattenPromptMessages } from "./handler";
+
+const declared: readonly MCPPromptArgument[] = [
+  { name: "title", required: true },
+  { name: "body", required: false },
+];
+
+describe("bindPromptArguments", () => {
+  test("binds explicit name=value pairs in any order", () => {
+    expect(bindPromptArguments(declared, ["body=details", "title=Bug"])).toEqual({
+      title: "Bug",
+      body: "details",
+    });
+  });
+
+  test("treats a bare trailing phrase as the single remaining argument", () => {
+    // `/srv:issue the login page is broken` should not become title="the".
+    expect(
+      bindPromptArguments([{ name: "title", required: true }], ["the", "page", "broke"]),
+    ).toEqual({ title: "the page broke" });
+  });
+
+  test("fills several unbound arguments positionally", () => {
+    expect(bindPromptArguments(declared, ["Bug", "details"])).toEqual({
+      title: "Bug",
+      body: "details",
+    });
+  });
+
+  test("mixes a named pair with a bare remainder", () => {
+    expect(bindPromptArguments(declared, ["title=Bug", "the", "rest"])).toEqual({
+      title: "Bug",
+      body: "the rest",
+    });
+  });
+
+  test("keeps an = that is not a declared argument name as text", () => {
+    expect(bindPromptArguments([{ name: "query", required: true }], ["a=b"])).toEqual({
+      query: "a=b",
+    });
+  });
+
+  test("returns nothing for a prompt that declares no arguments", () => {
+    expect(bindPromptArguments([], ["ignored"])).toEqual({});
+  });
+});
+
+describe("flattenPromptMessages", () => {
+  test("joins text blocks", () => {
+    const messages: readonly MCPPromptMessage[] = [
+      { role: "user", content: { type: "text", text: "first" } },
+      { role: "assistant", content: { type: "text", text: "second" } },
+    ];
+
+    expect(flattenPromptMessages(messages)).toBe("first\n\nsecond");
+  });
+
+  test("inlines an embedded resource's text", () => {
+    const messages: readonly MCPPromptMessage[] = [
+      { role: "user", content: { type: "resource", resource: { text: "file body" } } },
+    ];
+
+    expect(flattenPromptMessages(messages)).toBe("file body");
+  });
+
+  test("skips content with no text form", () => {
+    const messages: readonly MCPPromptMessage[] = [
+      { role: "user", content: { type: "image", data: "base64" } },
+      { role: "user", content: { type: "text", text: "caption" } },
+    ];
+
+    expect(flattenPromptMessages(messages)).toBe("caption");
+  });
+
+  test("returns empty string when nothing is renderable", () => {
+    expect(flattenPromptMessages([{ role: "user", content: { type: "image" } }])).toBe("");
+    expect(flattenPromptMessages([])).toBe("");
+  });
+});

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -1,4 +1,4 @@
-import { getSkillCommandNames } from "./constants";
+import { getMcpPromptCommandNames, getSkillCommandNames } from "./constants";
 import type { SpecialCommand } from "./types";
 
 /**
@@ -70,6 +70,10 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       // args[0] is the skill name (mirrors the "unknown" convention).
       if (getSkillCommandNames().has(command)) {
         return { type: "runSkill", args: [command, ...args] };
+      }
+
+      if (getMcpPromptCommandNames().has(command)) {
+        return { type: "runMcpPrompt", args: [command, ...args] };
       }
       return { type: "unknown", args: [command, ...args] };
   }

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -30,6 +30,7 @@ export type CommandType =
   | "export"
   | "retry"
   | "runSkill"
+  | "runMcpPrompt"
   | "unknown";
 
 /**

--- a/src/services/chat/session/agent-setup.ts
+++ b/src/services/chat/session/agent-setup.ts
@@ -4,10 +4,12 @@ import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { MCPServerManager } from "@/core/interfaces/mcp-server";
+import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
 import { PresentationServiceTag, type PresentationService } from "@/core/interfaces/presentation";
 import type { TerminalService } from "@/core/interfaces/terminal";
 import type { ToolRegistry } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types";
+import { setMcpPromptCommands } from "@/services/chat/commands";
 
 /**
  * Set up agent before first message: Connect to MCP servers and register tools.
@@ -63,6 +65,65 @@ export function setupAgent(
       );
     } else {
       yield* logger.debug("Agent setup completed - MCP tools registered");
+      yield* registerMcpPromptCommands(setupResult.right);
+    }
+  });
+}
+
+/**
+ * Publish the connected servers' prompts as `/server:prompt` slash commands.
+ *
+ * MCP prompts are user-initiated, so a slash command is the right surface —
+ * unlike tools, the model never invokes these. Servers that advertise no
+ * prompts simply contribute nothing.
+ */
+function registerMcpPromptCommands(
+  connectedServers: readonly string[],
+): Effect.Effect<void, never, MCPServerManager | LoggerService> {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+
+    if (connectedServers.length === 0) {
+      setMcpPromptCommands([]);
+      return;
+    }
+
+    const mcpManager = yield* MCPServerManagerTag;
+    const commands: { name: string; description: string; usage?: string }[] = [];
+
+    for (const serverName of connectedServers) {
+      const prompts = yield* mcpManager.getServerPrompts(serverName).pipe(Effect.either);
+      if (prompts._tag === "Left") {
+        yield* logger.debug(
+          `Could not list prompts for MCP server ${serverName}: ${prompts.left.reason}`,
+        );
+        continue;
+      }
+
+      for (const prompt of prompts.right) {
+        const declared = prompt.arguments ?? [];
+        commands.push({
+          name: `${serverName}:${prompt.name}`,
+          description: prompt.description ?? prompt.title ?? `${serverName} prompt`,
+          ...(declared.length > 0
+            ? {
+                usage: declared
+                  .map((argument) =>
+                    argument.required === true ? `<${argument.name}>` : `[${argument.name}]`,
+                  )
+                  .join(" "),
+              }
+            : {}),
+        });
+      }
+    }
+
+    setMcpPromptCommands(commands);
+
+    if (commands.length > 0) {
+      yield* logger.info(
+        `Registered ${commands.length} MCP prompt command(s): ${commands.map((command) => `/${command.name}`).join(", ")}`,
+      );
     }
   });
 }

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -141,6 +141,53 @@ describe("AgentConfigService", () => {
     expect(parsed.mcpServers.testServer).toEqual({ enabled: false });
     expect(parsed.mcpServers.testServer.command).toBeUndefined();
   });
+
+  it("should persist the trusted override alongside enabled", async () => {
+    // Trust decides whether a server's own tool annotations may skip approval
+    // prompts, so dropping it here would silently make every `mcp trust` a
+    // no-op.
+    const configPath = "/tmp/jazz-mcp-trust-test.json";
+    const configWithMcp: AppConfig = {
+      ...initialConfig,
+      mcpServers: {
+        testServer: {
+          name: "testServer",
+          command: "npx",
+          args: ["-y", "some-mcp"],
+          enabled: true,
+        },
+      },
+    };
+    const service = new AgentConfigServiceImpl(
+      configWithMcp,
+      { testServer: { enabled: true as const } },
+      configPath,
+      mockFS,
+    );
+
+    await Effect.runPromise(service.set("mcpServers.testServer.trusted", true));
+
+    const calls = (mockFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+    const parsed = JSON.parse(calls[calls.length - 1]?.[1] as string);
+    expect(parsed.mcpServers.testServer).toEqual({ enabled: true, trusted: true });
+  });
+
+  it("should persist a trusted override for a server whose enabled state was never set", async () => {
+    const configPath = "/tmp/jazz-mcp-trust-only-test.json";
+    const configWithMcp: AppConfig = {
+      ...initialConfig,
+      mcpServers: {
+        testServer: { name: "testServer", command: "npx" },
+      },
+    };
+    const service = new AgentConfigServiceImpl(configWithMcp, {}, configPath, mockFS);
+
+    await Effect.runPromise(service.set("mcpServers.testServer.trusted", true));
+
+    const calls = (mockFS.writeFileString as ReturnType<typeof mock>).mock.calls;
+    const parsed = JSON.parse(calls[calls.length - 1]?.[1] as string);
+    expect(parsed.mcpServers.testServer).toEqual({ trusted: true });
+  });
 });
 
 describe("createConfigLayer", () => {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -41,14 +41,23 @@ const CONFIG_DIR_MODE = 0o700;
 type SecretOrigin = "env" | "keyring";
 
 /**
- * Extract only override fields (enabled) from a server config.
+ * Extract only override fields (enabled, trusted) from a server config.
  * Used when persisting to ~/.jazz/config.json — full definitions live in mcp.json.
  */
 function extractMcpOverride(entry: unknown): MCPServerOverride | undefined {
   if (!entry || typeof entry !== "object") return undefined;
   const entryData = entry as Record<string, unknown>;
-  if (typeof entryData["enabled"] !== "boolean") return undefined;
-  return { enabled: entryData["enabled"] };
+  const enabled = entryData["enabled"];
+  const trusted = entryData["trusted"];
+  const hasEnabled = typeof enabled === "boolean";
+  const hasTrusted = typeof trusted === "boolean";
+  // Either field alone is a complete override: a server can be trusted without
+  // its enabled state ever having been touched.
+  if (!hasEnabled && !hasTrusted) return undefined;
+  return {
+    ...(hasEnabled ? { enabled } : {}),
+    ...(hasTrusted ? { trusted } : {}),
+  };
 }
 
 /**
@@ -179,12 +188,12 @@ export class AgentConfigServiceImpl implements AgentConfigService {
         ...val,
       });
     } else {
-      // set("mcpServers.X.enabled", value)
+      // set("mcpServers.X.enabled", value) / set("mcpServers.X.trusted", value)
       const prop = rest.slice(dotIndex + 1);
-      if (prop === "enabled") {
+      if ((prop === "enabled" || prop === "trusted") && typeof value === "boolean") {
         this.mcpOverrides[serverName] = {
           ...this.mcpOverrides[serverName],
-          enabled: value as boolean,
+          [prop]: value,
         };
       }
       deepSet(this.currentConfig as unknown as Record<string, unknown>, key, value);
@@ -276,6 +285,7 @@ function mergeMcpServers(
     merged[name] = {
       ...cfg,
       ...(ov?.enabled !== undefined ? { enabled: ov.enabled } : {}),
+      ...(ov?.trusted !== undefined ? { trusted: ov.trusted } : {}),
     };
   }
   return merged;

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -1,6 +1,11 @@
-import { createMCPClient } from "@ai-sdk/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  PromptListChangedNotificationSchema,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { Effect, Layer } from "effect";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
@@ -8,155 +13,235 @@ import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type {
   MCPServerConfig,
-  MCPServerConnection,
   MCPServerManager,
   MCPTransport,
   MCPTransportType,
+  ToolsChangedHandler,
 } from "@/core/interfaces/mcp-server";
 import { isHttpConfig, isStdioConfig, MCPServerManagerTag } from "@/core/interfaces/mcp-server";
 import {
   MCPConnectionError,
   MCPDisconnectionError,
+  MCPPromptError,
   MCPToolDiscoveryError,
+  MCPToolExecutionError,
 } from "@/core/types/errors";
-import type { MCPClient, MCPTool } from "@/core/types/mcp";
-import { isMCPClient, normalizeMCPToolRegistry } from "@/core/types/mcp";
+import type {
+  MCPJSONSchema,
+  MCPPrompt,
+  MCPPromptResult,
+  MCPServerCapabilities,
+  MCPTool,
+  MCPToolResult,
+} from "@/core/types/mcp";
 import { createSanitizedEnv } from "@/core/utils/env";
 import { retryWithBackoff } from "@/core/utils/mcp";
+import { createStoredTokenProvider, InteractiveAuthRequiredError } from "./oauth";
+import packageJson from "../../../package.json";
+
+/**
+ * Ceiling on a single connect attempt.
+ *
+ * A stdio server that spawns but never answers `initialize` would otherwise
+ * hang the first tool call forever — the child process is alive, so nothing
+ * below this layer ever times out.
+ */
+const CONNECT_TIMEOUT_MS = 30_000;
+
+/** Ceiling on one `tools/call`. Servers reach networks; they can stall. */
+const CALL_TIMEOUT_MS = 120_000;
+
+/** Guard against a server paginating `tools/list` without end. */
+const MAX_LIST_PAGES = 50;
+
+interface Connection {
+  readonly serverName: string;
+  readonly client: Client;
+  readonly transport: MCPTransport;
+  readonly transportType: MCPTransportType;
+  readonly capabilities: MCPServerCapabilities | undefined;
+}
 
 /**
  * MCP Server Manager implementation
  *
- * Manages connections to MCP servers using stdio or HTTP (Streamable HTTP) transport.
- * Handles template variable resolution, process lifecycle, and tool discovery.
+ * Speaks to servers through the reference `Client` from
+ * `@modelcontextprotocol/sdk` rather than a wrapper, which is what makes tool
+ * annotations, prompts, and list-changed notifications reachable.
  */
 class MCPServerManagerImpl implements MCPServerManager {
-  private connections: Map<string, MCPServerConnection>;
+  private connections: Map<string, Connection>;
+  private toolsChangedHandlers: Set<ToolsChangedHandler>;
   private logger: LoggerService;
 
   constructor(logger: LoggerService) {
     this.connections = new Map();
+    this.toolsChangedHandlers = new Set();
     this.logger = logger;
   }
 
-  connectServer(
-    config: MCPServerConfig,
-  ): Effect.Effect<MCPClient, MCPConnectionError, LoggerService> {
-    // Capture this to avoid issues with Effect.gen not preserving context
+  private buildTransport(config: MCPServerConfig): {
+    transport: MCPTransport;
+    transportType: MCPTransportType;
+  } {
+    if (isHttpConfig(config)) {
+      const options: ConstructorParameters<typeof StreamableHTTPClientTransport>[1] = {};
+
+      if (config.headers) {
+        options.requestInit = { headers: config.headers };
+      } else {
+        // Static headers are the user saying "authenticate this way"; only fall
+        // back to OAuth when they have not.
+        options.authProvider = createStoredTokenProvider(config.name);
+      }
+
+      if (config.conversationId) {
+        options.sessionId = config.conversationId;
+      }
+
+      return {
+        transport: new StreamableHTTPClientTransport(new URL(config.url), options),
+        transportType: "http",
+      };
+    }
+
+    const sanitizedEnv = createSanitizedEnv(config.env || {});
+
+    return {
+      transport: new StdioClientTransport({
+        command: config.command,
+        args: [...(config.args ?? [])],
+        env: sanitizedEnv as Record<string, string>,
+      }),
+      transportType: "stdio",
+    };
+  }
+
+  /**
+   * Re-list a server's tools and fan the result out to subscribers.
+   *
+   * Runs detached from any fiber: notifications arrive on the transport's own
+   * callback, not inside an Effect the caller is awaiting.
+   */
+  private handleToolsListChanged(serverName: string): void {
+    if (this.toolsChangedHandlers.size === 0) return;
+
+    void Effect.runPromise(
+      this.getServerTools(serverName).pipe(
+        Effect.provideService(LoggerServiceTag, this.logger),
+        Effect.catchAll(() => Effect.succeed([] as readonly MCPTool[])),
+      ),
+    ).then((tools) => {
+      for (const handler of this.toolsChangedHandlers) {
+        try {
+          handler(serverName, tools);
+        } catch {
+          // One bad subscriber must not stop the others.
+        }
+      }
+    });
+  }
+
+  connectServer(config: MCPServerConfig): Effect.Effect<void, MCPConnectionError, LoggerService> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
     return Effect.gen(function* () {
-      // Check if already connected
-      const existing = manager.connections.get(config.name);
-      if (existing && existing.client) {
+      if (manager.connections.has(config.name)) {
         yield* manager.logger.debug(`MCP server ${config.name} already connected`);
-        return existing.client;
+        return;
       }
 
       yield* manager.logger.debug(`Connecting to MCP server: ${config.name}`);
 
-      // Create transport based on config type
-      let transport: MCPTransport;
-      let transportType: MCPTransportType;
+      const { transport, transportType } = manager.buildTransport(config);
 
-      if (isHttpConfig(config)) {
-        // HTTP (Streamable HTTP) transport
-        transportType = "http";
-        yield* manager.logger.debug(`Using HTTP transport for ${config.name}: ${config.url}`);
+      const client = new Client(
+        { name: "jazz", version: packageJson.version },
+        // Declaring `roots` would oblige us to answer `roots/list`; Jazz does
+        // not yet, so it stays out of the handshake.
+        { capabilities: {} },
+      );
 
-        const httpOptions: { requestInit?: RequestInit; conversationId?: string } = {};
+      client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+        manager.handleToolsListChanged(config.name);
+      });
+      client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+        // Prompts are re-listed on demand by the chat command, so the
+        // notification only needs to not be an unhandled-method error.
+      });
 
-        if (config.headers) {
-          httpOptions.requestInit = {
-            headers: config.headers,
-          };
-        }
-
-        if (config.conversationId) {
-          httpOptions.conversationId = config.conversationId;
-        }
-
-        transport = new StreamableHTTPClientTransport(new URL(config.url), httpOptions);
-      } else {
-        // Stdio transport (default)
-        transportType = "stdio";
-
-        // Create sanitized environment (explicit env vars are always passed through)
-        const sanitizedEnv = createSanitizedEnv(config.env || {});
-
-        yield* manager.logger.debug(`Using stdio transport for ${config.name}: ${config.command}`);
-
-        transport = new StdioClientTransport({
-          command: config.command,
-          args: [...(config.args ?? [])],
-          env: sanitizedEnv as Record<string, string>,
-        });
-      }
-
-      // Create MCP client with retry logic for transient failures
       const connectEffect = Effect.tryPromise({
-        try: () => createMCPClient({ transport: transport as import("@ai-sdk/mcp").MCPTransport }),
+        try: () => client.connect(transport as Transport),
         catch: (error) => (error instanceof Error ? error : new Error(String(error))),
       }).pipe(
-        Effect.flatMap((client) => {
-          if (!isMCPClient(client)) {
-            return Effect.fail(new Error(`Invalid MCP client returned from createMCPClient`));
-          }
-          return Effect.succeed(client);
+        Effect.timeoutFail({
+          duration: `${CONNECT_TIMEOUT_MS} millis`,
+          onTimeout: () =>
+            new Error(`Server did not complete the MCP handshake within ${CONNECT_TIMEOUT_MS}ms`),
         }),
       );
 
-      const client = yield* retryWithBackoff(connectEffect, {
+      yield* retryWithBackoff(connectEffect, {
         maxRetries: 3,
         initialDelayMs: 1000,
         maxDelayMs: 10_000,
         shouldRetry: (error: unknown) => {
-          // Retry on connection errors, but not on validation errors
+          // An unauthorized server will answer the same way every time, and a
+          // missing binary will never appear mid-retry. Only genuinely
+          // transient transport faults are worth the backoff.
+          if (error instanceof InteractiveAuthRequiredError) return false;
           const errorMessage = error instanceof Error ? error.message : String(error);
+          if (/\b(401|403|ENOENT|EACCES)\b/.test(errorMessage)) return false;
           return (
             errorMessage.includes("ECONNREFUSED") ||
+            errorMessage.includes("ECONNRESET") ||
             errorMessage.includes("ETIMEDOUT") ||
-            errorMessage.includes("timeout") ||
-            errorMessage.includes("connection")
+            errorMessage.includes("socket hang up")
           );
         },
       }).pipe(
         Effect.mapError((error: unknown) => {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const transportHint = isStdioConfig(config)
-            ? `Check that the command "${config.command}" is available and the server is configured correctly`
-            : `Check that the URL "${config.url}" is accessible and the server is running`;
+          const suggestion =
+            error instanceof InteractiveAuthRequiredError
+              ? `Run: jazz mcp auth ${config.name}`
+              : isStdioConfig(config)
+                ? `Check that the command "${config.command}" is available and the server is configured correctly`
+                : `Check that the URL "${config.url}" is accessible and the server is running`;
           return new MCPConnectionError({
             serverName: config.name,
             reason: `Failed to connect to MCP server: ${errorMessage}`,
             cause: error,
-            suggestion: transportHint,
+            suggestion,
           });
         }),
       );
 
-      // Store connection (process is managed by transport)
-      const connection: MCPServerConnection = {
+      const rawCapabilities = client.getServerCapabilities();
+      const capabilities: MCPServerCapabilities | undefined = rawCapabilities
+        ? {
+            ...(rawCapabilities.tools !== undefined ? { tools: rawCapabilities.tools } : {}),
+            ...(rawCapabilities.prompts !== undefined ? { prompts: rawCapabilities.prompts } : {}),
+            ...(rawCapabilities.resources !== undefined
+              ? { resources: rawCapabilities.resources }
+              : {}),
+          }
+        : undefined;
+
+      manager.connections.set(config.name, {
         serverName: config.name,
-        process: null, // Process is managed internally by transport
         client,
         transport,
         transportType,
-      };
-
-      manager.connections.set(config.name, connection);
+        capabilities,
+      });
 
       yield* manager.logger.info(
         `Connected to MCP server: ${config.name} (${transportType} transport)`,
       );
-
-      return client;
     }).pipe(
       Effect.mapError((error: unknown) => {
-        // Catch any remaining errors and convert to MCPConnectionError
-        if (error instanceof MCPConnectionError) {
-          return error;
-        }
+        if (error instanceof MCPConnectionError) return error;
         const errorMessage = error instanceof Error ? error.message : String(error);
         return new MCPConnectionError({
           serverName: config.name,
@@ -169,7 +254,6 @@ class MCPServerManagerImpl implements MCPServerManager {
   }
 
   disconnectServer(serverName: string): Effect.Effect<void, MCPDisconnectionError, LoggerService> {
-    // Capture this to avoid issues with Effect.gen not preserving context
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
     return Effect.gen(function* () {
@@ -179,52 +263,33 @@ class MCPServerManagerImpl implements MCPServerManager {
         return;
       }
 
-      try {
-        // Close the client if it has a close method
-        if (connection.client.close) {
-          yield* Effect.tryPromise({
-            try: () => connection.client.close!(),
-            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-          }).pipe(
-            Effect.catchAll((error: unknown) =>
-              Effect.gen(function* () {
-                const errorMessage = error instanceof Error ? error.message : String(error);
-                yield* manager.logger.warn(
-                  `Error closing MCP client for ${serverName}: ${errorMessage}`,
-                );
-                // Continue with cleanup even if close fails
-              }),
-            ),
-          );
-        }
+      // Dropped from the map first: a close that hangs must not leave a dead
+      // connection looking live to the next caller.
+      manager.connections.delete(serverName);
 
-        // Transport cleanup is handled by the SDK
-        manager.connections.delete(serverName);
-        yield* manager.logger.info(`Disconnected from MCP server: ${serverName}`);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        manager.connections.delete(serverName); // Still remove from connections
-        return yield* Effect.fail(
-          new MCPDisconnectionError({
-            serverName,
-            reason: `Error disconnecting from MCP server: ${errorMessage}`,
-            suggestion:
-              "The connection has been removed from the manager, but cleanup may be incomplete",
-          }),
-        );
-      }
+      yield* Effect.tryPromise({
+        try: () => connection.client.close(),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.catchAll((error: unknown) =>
+          manager.logger.warn(
+            `Error closing MCP client for ${serverName}: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        ),
+      );
+
+      yield* manager.logger.info(`Disconnected from MCP server: ${serverName}`);
     });
   }
 
   getServerTools(
     serverName: string,
   ): Effect.Effect<readonly MCPTool[], MCPToolDiscoveryError, LoggerService> {
-    // Capture this to avoid issues with Effect.gen not preserving context
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
     return Effect.gen(function* () {
       const connection = manager.connections.get(serverName);
-      if (!connection || !connection.client) {
+      if (!connection) {
         return yield* Effect.fail(
           new MCPToolDiscoveryError({
             serverName,
@@ -234,60 +299,258 @@ class MCPServerManagerImpl implements MCPServerManager {
         );
       }
 
-      // Get tools from MCP client with retry logic
-      const getToolsEffect = retryWithBackoff(
+      const tools = yield* retryWithBackoff(
         Effect.tryPromise({
-          try: () => connection.client.tools(),
+          try: async () => {
+            const collected: MCPTool[] = [];
+            let cursor: string | undefined;
+
+            for (let page = 0; page < MAX_LIST_PAGES; page += 1) {
+              const result = await connection.client.listTools(
+                cursor === undefined ? {} : { cursor },
+              );
+
+              for (const tool of result.tools) {
+                collected.push({
+                  name: tool.name,
+                  ...(tool.title !== undefined ? { title: tool.title } : {}),
+                  ...(tool.description !== undefined ? { description: tool.description } : {}),
+                  ...(tool.inputSchema !== undefined
+                    ? { inputSchema: tool.inputSchema as MCPJSONSchema }
+                    : {}),
+                  ...(tool.outputSchema !== undefined
+                    ? { outputSchema: tool.outputSchema as MCPJSONSchema }
+                    : {}),
+                  ...(tool.annotations !== undefined
+                    ? {
+                        annotations: {
+                          readOnlyHint: tool.annotations.readOnlyHint,
+                          destructiveHint: tool.annotations.destructiveHint,
+                          idempotentHint: tool.annotations.idempotentHint,
+                          openWorldHint: tool.annotations.openWorldHint,
+                        },
+                      }
+                    : {}),
+                });
+              }
+
+              cursor = result.nextCursor;
+              if (cursor === undefined) break;
+            }
+
+            return collected;
+          },
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }),
-        {
-          maxRetries: 2,
-          initialDelayMs: 500,
-          maxDelayMs: 5000,
-        },
-      );
-
-      const toolsRegistry = yield* getToolsEffect.pipe(
-        Effect.mapError((error: unknown) => {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          return new MCPToolDiscoveryError({
-            serverName,
-            reason: `Failed to get tools from MCP server: ${errorMessage}`,
-            cause: error,
-            suggestion: `Check that the MCP server is running and responding correctly`,
-          });
-        }),
-      );
-
-      // Log the raw registry before normalization
-      yield* manager.logger.debug(
-        `[getServerTools] Raw tools registry from ${serverName}: ${JSON.stringify(toolsRegistry, null, 2).substring(0, 500)}`,
-      );
-
-      // Normalize tool registry to array of MCPTool
-      const tools = normalizeMCPToolRegistry(toolsRegistry);
-
-      yield* manager.logger.debug(
-        `[getServerTools] Normalized ${tools.length} tools from registry for ${serverName}`,
+        { maxRetries: 2, initialDelayMs: 500, maxDelayMs: 5000 },
+      ).pipe(
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPToolDiscoveryError({
+              serverName,
+              reason: `Failed to get tools from MCP server: ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check that the MCP server is running and responding correctly`,
+            }),
+        ),
       );
 
       if (tools.length === 0) {
         yield* manager.logger.warn(
           `No tools discovered from MCP server ${serverName} - the server may not have any tools available`,
         );
-        yield* manager.logger.debug(
-          `[getServerTools] Tools registry was empty or normalized to empty array for ${serverName}`,
-        );
       } else {
         yield* manager.logger.debug(
           `Discovered ${tools.length} tool(s) from MCP server ${serverName}: ${tools
-            .map((t) => t.name)
+            .map((tool) => tool.name)
             .slice(0, 5)
             .join(", ")}${tools.length > 5 ? "..." : ""}`,
         );
       }
 
       return tools;
+    });
+  }
+
+  callTool(
+    serverName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Effect.Effect<MCPToolResult, MCPToolExecutionError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) {
+        return yield* Effect.fail(
+          new MCPToolExecutionError({
+            serverName,
+            toolName,
+            reason: `MCP server ${serverName} is not connected`,
+            suggestion: `The connection may have dropped; retry to reconnect`,
+          }),
+        );
+      }
+
+      const result = yield* Effect.tryPromise({
+        try: () => connection.client.callTool({ name: toolName, arguments: args }),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.timeoutFail({
+          duration: `${CALL_TIMEOUT_MS} millis`,
+          onTimeout: () => new Error(`Tool call exceeded ${CALL_TIMEOUT_MS}ms`),
+        }),
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPToolExecutionError({
+              serverName,
+              toolName,
+              reason: `MCP tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check that the tool arguments are correct and the MCP server is functioning properly`,
+            }),
+        ),
+      );
+
+      return {
+        ...(result.content !== undefined ? { content: result.content } : {}),
+        ...(result.structuredContent !== undefined
+          ? { structuredContent: result.structuredContent }
+          : {}),
+        ...(result.isError !== undefined ? { isError: result.isError === true } : {}),
+      };
+    });
+  }
+
+  getServerPrompts(
+    serverName: string,
+  ): Effect.Effect<readonly MCPPrompt[], MCPPromptError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) {
+        return yield* Effect.fail(
+          new MCPPromptError({
+            serverName,
+            reason: `MCP server ${serverName} is not connected`,
+            suggestion: `Call connectServer() before listing prompts`,
+          }),
+        );
+      }
+
+      // Asking a server that never advertised prompts earns a "method not
+      // found" error; absence of the capability is a normal answer, not a
+      // failure.
+      if (connection.capabilities?.prompts === undefined) {
+        yield* manager.logger.debug(`MCP server ${serverName} does not advertise prompts`);
+        return [];
+      }
+
+      return yield* Effect.tryPromise({
+        try: async () => {
+          const collected: MCPPrompt[] = [];
+          let cursor: string | undefined;
+
+          for (let page = 0; page < MAX_LIST_PAGES; page += 1) {
+            const result = await connection.client.listPrompts(
+              cursor === undefined ? {} : { cursor },
+            );
+
+            for (const prompt of result.prompts) {
+              collected.push({
+                name: prompt.name,
+                ...(prompt.title !== undefined ? { title: prompt.title } : {}),
+                ...(prompt.description !== undefined ? { description: prompt.description } : {}),
+                ...(prompt.arguments !== undefined
+                  ? {
+                      arguments: prompt.arguments.map((argument) => ({
+                        name: argument.name,
+                        ...(argument.description !== undefined
+                          ? { description: argument.description }
+                          : {}),
+                        ...(argument.required !== undefined ? { required: argument.required } : {}),
+                      })),
+                    }
+                  : {}),
+              });
+            }
+
+            cursor = result.nextCursor;
+            if (cursor === undefined) break;
+          }
+
+          return collected;
+        },
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPPromptError({
+              serverName,
+              reason: `Failed to list prompts: ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check that the MCP server is running and responding correctly`,
+            }),
+        ),
+      );
+    });
+  }
+
+  getPrompt(
+    serverName: string,
+    promptName: string,
+    args: Record<string, string>,
+  ): Effect.Effect<MCPPromptResult, MCPPromptError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) {
+        return yield* Effect.fail(
+          new MCPPromptError({
+            serverName,
+            reason: `MCP server ${serverName} is not connected`,
+            suggestion: `Call connectServer() before resolving a prompt`,
+          }),
+        );
+      }
+
+      const result = yield* Effect.tryPromise({
+        try: () => connection.client.getPrompt({ name: promptName, arguments: args }),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPPromptError({
+              serverName,
+              reason: `Failed to resolve prompt "${promptName}": ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check the prompt name and that all required arguments were supplied`,
+            }),
+        ),
+      );
+
+      return {
+        ...(result.description !== undefined ? { description: result.description } : {}),
+        messages: result.messages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      };
+    });
+  }
+
+  getCapabilities(serverName: string): Effect.Effect<MCPServerCapabilities | undefined, never> {
+    return Effect.sync(() => this.connections.get(serverName)?.capabilities);
+  }
+
+  onToolsChanged(handler: ToolsChangedHandler): Effect.Effect<() => void, never> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.sync(() => {
+      manager.toolsChangedHandlers.add(handler);
+      return () => manager.toolsChangedHandlers.delete(handler);
     });
   }
 
@@ -298,37 +561,27 @@ class MCPServerManagerImpl implements MCPServerManager {
     MCPConnectionError | MCPToolDiscoveryError | MCPDisconnectionError,
     LoggerService
   > {
-    // Capture this to avoid issues with Effect.gen not preserving context
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
     return Effect.gen(function* () {
-      // Connect to server
-      yield* manager.logger.debug(`[discoverTools] Connecting to ${config.name}...`);
+      // A server already in use stays connected: discovery is a read, and
+      // tearing down a live connection to satisfy it would break the caller.
+      const wasConnected = manager.connections.has(config.name);
+
       yield* manager.connectServer(config);
-      yield* manager.logger.debug(`[discoverTools] Connected to ${config.name}`);
-
-      // Get tools
-      yield* manager.logger.debug(`[discoverTools] Getting tools from ${config.name}...`);
       const tools = yield* manager.getServerTools(config.name);
-      yield* manager.logger.debug(`[discoverTools] Got ${tools.length} tools from ${config.name}`);
 
-      // Disconnect (cleanup)
-      yield* manager.disconnectServer(config.name).pipe(
-        Effect.catchAll((error: unknown) =>
-          Effect.gen(function* () {
-            // Log but don't fail - we already have the tools
-            const errorMessage =
-              error instanceof MCPDisconnectionError
-                ? error.reason
-                : error instanceof Error
-                  ? error.message
-                  : String(error);
-            yield* manager.logger.warn(
-              `Error disconnecting after tool discovery for ${config.name}: ${errorMessage}`,
-            );
-          }),
-        ),
-      );
+      if (!wasConnected) {
+        yield* manager
+          .disconnectServer(config.name)
+          .pipe(
+            Effect.catchAll((error) =>
+              manager.logger.warn(
+                `Error disconnecting after tool discovery for ${config.name}: ${error.reason}`,
+              ),
+            ),
+          );
+      }
 
       return tools;
     });
@@ -341,7 +594,6 @@ class MCPServerManagerImpl implements MCPServerManager {
         "mcpServers",
         {},
       );
-      // Add server name to each config
       return Object.entries(mcpServers).map(([name, config]) => ({
         ...config,
         name,
@@ -354,34 +606,27 @@ class MCPServerManagerImpl implements MCPServerManager {
   }
 
   disconnectAllServers(): Effect.Effect<void, MCPDisconnectionError, LoggerService> {
-    // Capture this to avoid issues with Effect.gen not preserving context
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
     return Effect.gen(function* () {
       const serverNames = Array.from(manager.connections.keys());
       yield* manager.logger.debug(`Disconnecting ${serverNames.length} MCP server(s)...`);
 
-      // Disconnect all servers in parallel
-      const disconnectEffects = serverNames.map((serverName) =>
-        manager.disconnectServer(serverName).pipe(
-          Effect.catchAll((error: unknown) =>
-            Effect.gen(function* () {
-              const errorMessage =
-                error instanceof MCPDisconnectionError
-                  ? error.reason
-                  : error instanceof Error
-                    ? error.message
-                    : String(error);
-              yield* manager.logger.warn(
-                `Failed to disconnect MCP server ${serverName}: ${errorMessage}`,
-              );
-              // Continue with other servers even if one fails
-            }),
-          ),
+      yield* Effect.all(
+        serverNames.map((serverName) =>
+          manager
+            .disconnectServer(serverName)
+            .pipe(
+              Effect.catchAll((error) =>
+                manager.logger.warn(
+                  `Failed to disconnect MCP server ${serverName}: ${error.reason}`,
+                ),
+              ),
+            ),
         ),
+        { concurrency: "unbounded" },
       );
 
-      yield* Effect.all(disconnectEffects, { concurrency: "unbounded" });
       yield* manager.logger.debug("All MCP servers disconnected");
     });
   }

--- a/src/services/mcp/oauth.ts
+++ b/src/services/mcp/oauth.ts
@@ -1,0 +1,352 @@
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { auth, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { Effect } from "effect";
+import {
+  detectKeyringBackend,
+  keyringDelete,
+  keyringGet,
+  keyringSet,
+} from "@/services/secrets/keyring";
+
+/** Client name advertised to authorization servers during dynamic registration. */
+const CLIENT_NAME = "Jazz";
+const CLIENT_URI = "https://github.com/lvndry/jazz";
+
+/**
+ * How long the loopback listener waits for the browser to come back with a
+ * code before giving up. Long enough to cover a fresh login plus consent on a
+ * provider the user is not already signed into.
+ */
+const CALLBACK_TIMEOUT_MS = 300_000;
+
+/** Keyring account names. Namespaced so a server called `tokens` cannot collide. */
+function tokensAccount(serverName: string): string {
+  return `mcp.oauth.${serverName}.tokens`;
+}
+
+function clientAccount(serverName: string): string {
+  return `mcp.oauth.${serverName}.client`;
+}
+
+/**
+ * Raised when a server needs the interactive browser flow but the caller is a
+ * context that must not open one — an agent run, or an unattended bridge.
+ * The message names the command that fixes it.
+ */
+export class InteractiveAuthRequiredError extends Error {
+  readonly serverName: string;
+
+  constructor(serverName: string) {
+    super(`MCP server "${serverName}" requires authorization. Run: jazz mcp auth ${serverName}`);
+    this.name = "InteractiveAuthRequiredError";
+    this.serverName = serverName;
+  }
+}
+
+function readJson<T>(raw: string | undefined): T | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read/write halves shared by the interactive and non-interactive providers. */
+function createStorage(serverName: string) {
+  return {
+    async loadTokens(): Promise<OAuthTokens | undefined> {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      const raw = await Effect.runPromise(keyringGet(backend, tokensAccount(serverName)));
+      return readJson<OAuthTokens>(raw);
+    },
+    async saveTokens(tokens: OAuthTokens): Promise<void> {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      await Effect.runPromise(
+        keyringSet(backend, tokensAccount(serverName), JSON.stringify(tokens)),
+      );
+    },
+    async loadClient(): Promise<OAuthClientInformation | undefined> {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      const raw = await Effect.runPromise(keyringGet(backend, clientAccount(serverName)));
+      return readJson<OAuthClientInformation>(raw);
+    },
+    async saveClient(info: OAuthClientInformationFull): Promise<void> {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      await Effect.runPromise(keyringSet(backend, clientAccount(serverName), JSON.stringify(info)));
+    },
+  };
+}
+
+function clientMetadata(redirectUrl: string): OAuthClientMetadata {
+  return {
+    client_name: CLIENT_NAME,
+    client_uri: CLIENT_URI,
+    redirect_uris: [redirectUrl],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  };
+}
+
+/**
+ * Provider used on the connect path.
+ *
+ * Reads stored tokens and lets the SDK refresh them, but refuses to start a
+ * browser flow: connecting happens inside agent runs and unattended bridges,
+ * where opening a browser would be wrong. A server that needs fresh consent
+ * surfaces `InteractiveAuthRequiredError` instead.
+ */
+export function createStoredTokenProvider(serverName: string): OAuthClientProvider {
+  const storage = createStorage(serverName);
+  // Placeholder: only used to shape the registration request when a stored
+  // client exists. A provider that reaches registration is already on its way
+  // to `redirectToAuthorization`, which throws.
+  const redirectUrl = "http://127.0.0.1/callback";
+  let codeVerifierValue: string | undefined;
+
+  return {
+    get redirectUrl() {
+      return redirectUrl;
+    },
+    get clientMetadata() {
+      return clientMetadata(redirectUrl);
+    },
+    clientInformation: () => storage.loadClient(),
+    saveClientInformation: (info) => storage.saveClient(info as OAuthClientInformationFull),
+    tokens: () => storage.loadTokens(),
+    saveTokens: (tokens) => storage.saveTokens(tokens),
+    redirectToAuthorization: () => {
+      throw new InteractiveAuthRequiredError(serverName);
+    },
+    saveCodeVerifier: (verifier) => {
+      codeVerifierValue = verifier;
+    },
+    codeVerifier: () => {
+      if (codeVerifierValue === undefined) {
+        throw new InteractiveAuthRequiredError(serverName);
+      }
+      return codeVerifierValue;
+    },
+    invalidateCredentials: async (scope) => {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      if (scope === "all" || scope === "tokens") {
+        await Effect.runPromise(keyringDelete(backend, tokensAccount(serverName)));
+      }
+      if (scope === "all" || scope === "client") {
+        await Effect.runPromise(keyringDelete(backend, clientAccount(serverName)));
+      }
+      if (scope === "verifier") {
+        codeVerifierValue = undefined;
+      }
+    },
+  };
+}
+
+/** Open a URL in the user's default browser, best-effort. */
+function openBrowser(url: string): void {
+  const command =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    const child = spawn(command, [url], { stdio: "ignore", detached: true });
+    child.on("error", () => {
+      // Falling back to the printed URL is the whole recovery path.
+    });
+    child.unref();
+  } catch {
+    // Same: the caller has already printed the URL.
+  }
+}
+
+const SUCCESS_PAGE = `<!doctype html><meta charset="utf-8"><title>Jazz</title>
+<body style="font-family:system-ui;padding:3rem;text-align:center">
+<h1>Authorized</h1><p>You can close this tab and return to your terminal.</p></body>`;
+
+interface CallbackListener {
+  readonly redirectUrl: string;
+  readonly waitForCode: () => Promise<string>;
+  readonly close: () => void;
+}
+
+/**
+ * Bind a loopback listener on an ephemeral port and resolve the first
+ * `?code=` it receives.
+ *
+ * The port has to exist before the provider is built, because it is part of
+ * the redirect URI that gets registered with the authorization server.
+ */
+function startCallbackListener(expectedState: string): Promise<CallbackListener> {
+  return new Promise((resolve, reject) => {
+    let onCode: ((code: string) => void) | undefined;
+    let onFailure: ((error: Error) => void) | undefined;
+    let received: string | undefined;
+    let failure: Error | undefined;
+
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const code = url.searchParams.get("code");
+      const error = url.searchParams.get("error");
+      const state = url.searchParams.get("state");
+
+      if (error !== null) {
+        const authError = new Error(
+          `Authorization failed: ${url.searchParams.get("error_description") ?? error}`,
+        );
+        failure = authError;
+        onFailure?.(authError);
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("Authorization failed. Return to your terminal.");
+        return;
+      }
+
+      if (code === null) {
+        response.writeHead(404, { "content-type": "text/plain" });
+        response.end("Not found");
+        return;
+      }
+
+      // The state check is what stops a stray request on the loopback port
+      // from injecting a code into this flow.
+      if (state !== expectedState) {
+        const stateError = new Error("Authorization failed: state parameter did not match");
+        failure = stateError;
+        onFailure?.(stateError);
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("State mismatch. Return to your terminal.");
+        return;
+      }
+
+      received = code;
+      onCode?.(code);
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(SUCCESS_PAGE);
+    });
+
+    server.once("error", reject);
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new Error("Could not bind a loopback port for the OAuth callback"));
+        return;
+      }
+
+      resolve({
+        redirectUrl: `http://127.0.0.1:${address.port}/callback`,
+        waitForCode: () =>
+          new Promise<string>((resolveCode, rejectCode) => {
+            if (received !== undefined) return resolveCode(received);
+            if (failure !== undefined) return rejectCode(failure);
+            const timer = setTimeout(() => {
+              rejectCode(new Error("Timed out waiting for the browser to complete authorization"));
+            }, CALLBACK_TIMEOUT_MS);
+            onCode = (code) => {
+              clearTimeout(timer);
+              resolveCode(code);
+            };
+            onFailure = (error) => {
+              clearTimeout(timer);
+              rejectCode(error);
+            };
+          }),
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+/**
+ * Run the full OAuth 2.1 authorization-code flow with PKCE for one server.
+ *
+ * Discovery, dynamic client registration, and the token exchange are the SDK's;
+ * this supplies the loopback redirect, the browser hand-off, and keyring
+ * persistence. Resolves once tokens are stored.
+ *
+ * @param onAuthorizationUrl - Called with the URL before the browser opens, so
+ *   the caller can print it for a headless or remote session.
+ */
+export function authorizeServer(
+  serverName: string,
+  serverUrl: string,
+  onAuthorizationUrl: (url: string) => void,
+): Effect.Effect<void, Error> {
+  return Effect.tryPromise({
+    try: async () => {
+      const storage = createStorage(serverName);
+      const state = crypto.randomUUID();
+      const listener = await startCallbackListener(state);
+      let codeVerifierValue: string | undefined;
+
+      try {
+        const provider: OAuthClientProvider = {
+          get redirectUrl() {
+            return listener.redirectUrl;
+          },
+          get clientMetadata() {
+            return clientMetadata(listener.redirectUrl);
+          },
+          state: () => state,
+          clientInformation: () => storage.loadClient(),
+          saveClientInformation: (info) => storage.saveClient(info as OAuthClientInformationFull),
+          tokens: () => storage.loadTokens(),
+          saveTokens: (tokens) => storage.saveTokens(tokens),
+          redirectToAuthorization: (authorizationUrl: URL) => {
+            onAuthorizationUrl(authorizationUrl.toString());
+            openBrowser(authorizationUrl.toString());
+          },
+          saveCodeVerifier: (verifier: string) => {
+            codeVerifierValue = verifier;
+          },
+          codeVerifier: () => {
+            if (codeVerifierValue === undefined) {
+              throw new Error("No PKCE code verifier available for this flow");
+            }
+            return codeVerifierValue;
+          },
+        };
+
+        const result = await auth(provider, { serverUrl });
+
+        if (result === "AUTHORIZED") {
+          return;
+        }
+
+        const authorizationCode = await listener.waitForCode();
+        const exchanged = await auth(provider, { serverUrl, authorizationCode });
+
+        if (exchanged !== "AUTHORIZED") {
+          throw new Error("Authorization did not complete");
+        }
+      } finally {
+        listener.close();
+      }
+    },
+    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+  });
+}
+
+/** Forget stored tokens and registration for one server. */
+export function clearServerAuth(serverName: string): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const backend = yield* detectKeyringBackend();
+    yield* keyringDelete(backend, tokensAccount(serverName));
+    yield* keyringDelete(backend, clientAccount(serverName));
+  });
+}
+
+/** Whether stored tokens exist for a server (does not check expiry). */
+export function hasStoredAuth(serverName: string): Effect.Effect<boolean, never> {
+  return Effect.gen(function* () {
+    const backend = yield* detectKeyringBackend();
+    const raw = yield* keyringGet(backend, tokensAccount(serverName));
+    return readJson<OAuthTokens>(raw) !== undefined;
+  });
+}


### PR DESCRIPTION
## What & why

Jazz spoke only the tools third of MCP, and let every MCP tool run without ever
asking. Any server you added could delete things unprompted, remote servers that
need a login were unusable, and servers' own prompts were invisible. This makes
Jazz a full MCP client: tool calls are gated, remote servers can be authorized in
the browser, and servers' prompts show up as slash commands.

Two behaviours are new and worth knowing about. **Trust** is now a per-server
decision (`jazz mcp trust <name>`): a server's tools always ask for approval
unless you have vouched for it, because the read-only/destructive hints the spec
defines are claims a server makes about itself. **Prompts** are the
user-initiated half of MCP — templates you invoke, not tools the model calls —
and now appear as `/server:prompt` in autocomplete.

Under the hood this swaps `@ai-sdk/mcp` for the reference `@modelcontextprotocol/sdk`
client, which is what makes annotations, prompts, and live tool-list updates
reachable at all.

## Breaking changes / migration

MCP tools now prompt for approval where they previously ran silently. Servers you
already rely on will feel chattier until you run `jazz mcp trust <name>`.

## How to verify

- `jazz mcp add everything -- npx -y @modelcontextprotocol/server-everything`,
  then `jazz mcp test everything` — should report 13 tools with their
  read-only/destructive hints, 4 prompts, and a note that it is untrusted.
- Start a chat with an agent using that server and type `/` — its prompts appear
  tagged `(mcp)`. Run one and confirm the resolved text is sent as your turn.
- Call one of its tools and confirm you are asked to approve. Then
  `jazz mcp trust everything`, restart, and confirm the read-only tools stop
  asking while destructive ones still do.
- Edit an agent that uses a tool whose name contains an underscore
  (e.g. `mcp_railway_list_projects`) and confirm the server stays checked — this
  silently unchecked itself before.
- Point a server at a bad command and confirm it fails within ~30s with a useful
  message rather than hanging, and that `/mcp reconnect <name>` retries it
  without restarting the conversation.
- For a remote server: `jazz mcp auth <name>` should open a browser, and
  `jazz mcp test <name>` should then connect. `jazz mcp logout <name>` clears it.
