### PR TITLE
feat(tools): declare what each tool's answer reveals

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -56,6 +56,36 @@ You never call `execute_*` names yourself; they are hidden from the model's tool
 
 ---
 
+## What each tool reveals
+
+Risk is not the same question as disclosure. Risk asks what a tool can do **to** the
+machine; disclosure asks what its answer says **about you**. The two do not correlate:
+`read_file` is read-only and can reveal anything, `get_time` is read-only and reveals
+nothing, `write_file` changes the machine and reveals nothing at all.
+
+Every tool declares both. The field is required, with no default anywhere, so a new tool
+cannot be added without someone deciding.
+
+| Level        | The answer reveals                                                        | Tools |
+| ------------ | ------------------------------------------------------------------------- | ----- |
+| `none`       | nothing about you or your machine                                         | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file` |
+| `context`    | the shape of the machine or session — paths, names, what is installed     | `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `ls`, `pdf_page_count`, `pwd`, `stat` |
+| `personal`   | your own material — file contents, memory, schedule, transcript           | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory` |
+
+A tool spanning two levels takes the higher one — `edit_file` writes, but its approval
+message carries a diff of your file, so it is `personal`. `http_request` reaches private
+networks including services on localhost, so it is too.
+
+Skill tools (`find_skills`, `load_skill`, `load_skill_section`) are `context` too, and are
+absent from the table for the same reason they are absent from the one below: they are
+registered per agent rather than globally.
+
+There is no `unknown` level. **MCP and custom tools are `personal`**, because a tool defined
+outside this codebase returns something this codebase cannot classify, and the safe reading
+of "unknown" is the most restrictive one.
+
+---
+
 ## The tools
 
 ### File Management

--- a/src/core/agent/tools/base-tool.ts
+++ b/src/core/agent/tools/base-tool.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
-import type { Tool, ToolRiskLevel } from "@/core/interfaces/tool-registry";
+import type { Tool, ToolDisclosure, ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
 
 /**
@@ -52,6 +52,8 @@ export interface BaseToolConfig<R, Args extends Record<string, unknown>> {
    * Defaults to "read-only" for regular tools, "high-risk" for approval tools.
    */
   readonly riskLevel?: ToolRiskLevel;
+  /** What an answer from this tool reveals about the operator. No default: decide. */
+  readonly disclosure: ToolDisclosure;
   /**
    * Optional validator. When omitted, arguments are checked with
    * {@link makeZodValidator} against `parameters`.
@@ -112,6 +114,7 @@ export function defineTool<R, Args extends Record<string, unknown>>(
     ...(config.jsonSchema !== undefined ? { jsonSchema: config.jsonSchema } : {}),
     hidden: config.hidden === true,
     riskLevel: config.riskLevel ?? defaultRiskLevel,
+    disclosure: config.disclosure,
     ...(config.approvalExecuteToolName
       ? { approvalExecuteToolName: config.approvalExecuteToolName }
       : {}),
@@ -177,6 +180,8 @@ export interface ApprovalToolConfig<R, Args extends Record<string, unknown>> {
    * Defaults to "high-risk" for approval tools.
    */
   readonly riskLevel?: ToolRiskLevel;
+  /** What an answer from this tool reveals about the operator. No default: decide. */
+  readonly disclosure: ToolDisclosure;
   /** Optional custom validator */
   readonly validate?: ToolValidator<Args>;
   /**
@@ -253,6 +258,7 @@ export function defineApprovalTool<R, Args extends Record<string, unknown>>(
     ...(config.tags ? { tags: config.tags } : {}),
     parameters: config.parameters,
     riskLevel,
+    disclosure: config.disclosure,
     validate: validator,
     approvalExecuteToolName: executeToolName,
     handler: (args: Args, context: ToolExecutionContext) =>
@@ -291,6 +297,7 @@ export function defineApprovalTool<R, Args extends Record<string, unknown>>(
     ),
     hidden: true,
     riskLevel,
+    disclosure: config.disclosure,
     parameters: config.parameters,
     validate: validator,
     handler: config.handler,

--- a/src/core/agent/tools/context-tools.ts
+++ b/src/core/agent/tools/context-tools.ts
@@ -20,6 +20,7 @@ const DAYS = [
 export function createGetTimeTool(): Tool<never> {
   return {
     name: "get_time",
+    disclosure: "context",
     description:
       "Get the current date and time. The Environment block already has today's date — use this only when you need a fresh clock during a long run, for scheduling, relative times such as 'yesterday', or timestamps.",
     parameters: z.object({}).strict(),
@@ -56,6 +57,7 @@ export function createGetTimeTool(): Tool<never> {
 export function createContextInfoTool(): Tool<never> {
   return {
     name: "context_info",
+    disclosure: "context",
     description:
       "Report how much of the context window is in use. The harness already warns at 70% and 90% and auto-compacts around 80%. Do not poll this. If you need to free space now, call summarize_context.",
     parameters: z.object({}),

--- a/src/core/agent/tools/custom-tools.ts
+++ b/src/core/agent/tools/custom-tools.ts
@@ -165,6 +165,9 @@ function buildRecordTool(
   return {
     ...defineTool<never, Record<string, unknown>>({
       name: definition.name,
+      // Defined outside this codebase: its output is unknowable, and the safe
+      // reading of "unknown" is the most restrictive level.
+      disclosure: "personal",
       description: definition.description,
       parameters,
       validate,
@@ -216,6 +219,9 @@ function buildCommandTool(
   return {
     ...defineTool<FileSystemContextService | LoggerService, Record<string, unknown>>({
       name: definition.name,
+      // Defined outside this codebase: its output is unknowable, and the safe
+      // reading of "unknown" is the most restrictive level.
+      disclosure: "personal",
       description: definition.description,
       parameters,
       validate,

--- a/src/core/agent/tools/fs/cd.ts
+++ b/src/core/agent/tools/fs/cd.ts
@@ -24,6 +24,7 @@ export function createCdTool(): Tool<FileSystem.FileSystem | FileSystemContextSe
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, CdParams>({
     name: "cd",
+    disclosure: "context",
     description:
       "Change this session's working directory. Relative paths in later tool calls (read_file, grep, find, execute_command) resolve from the new directory until you call cd again. Prefer passing path on the tool you are about to use instead of changing directory first.",
     tags: ["filesystem", "navigation"],

--- a/src/core/agent/tools/fs/cp.ts
+++ b/src/core/agent/tools/fs/cp.ts
@@ -48,6 +48,7 @@ type CpDeps = FileSystem.FileSystem | FileSystemContextService;
 export function createCpTools(): ApprovalToolPair<CpDeps> {
   const config: ApprovalToolConfig<CpDeps, CpArgs> = {
     name: "cp",
+    disclosure: "none",
     description:
       "Copy a file or directory. Directories are always copied recursively. destination is the exact target path: if it is an existing directory, the source is not copied into it (unlike shell cp). force deletes the destination first.",
     tags: ["filesystem", "write"],

--- a/src/core/agent/tools/fs/edit.ts
+++ b/src/core/agent/tools/fs/edit.ts
@@ -498,6 +498,7 @@ function extractErrorType(error: unknown): string {
 export function createEditFileTools(): ApprovalToolPair<EditFileDeps> {
   const config: ApprovalToolConfig<EditFileDeps, EditFileArgs> = {
     name: "edit_file",
+    disclosure: "personal",
     description:
       "Change part of a file that already exists. To create a new file, use write_file. You can pass several edits in one call; they run one after another. If an earlier edit inserts or deletes lines, later edits must use the line numbers of the file as it is after those edits — not the numbers from the original read_file. " +
       "Use this whenever you are changing an existing file. Do not use this to create a file (write_file), to rewrite the whole file after a failed edit (read the errorType and retry), or to run sed via execute_command. " +

--- a/src/core/agent/tools/fs/find.ts
+++ b/src/core/agent/tools/fs/find.ts
@@ -542,6 +542,7 @@ export function createFindTool(): Tool<FileSystem.FileSystem | FileSystemContext
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, FindArgs>({
     name: "find",
+    disclosure: "context",
     aliases: ["glob"],
     description:
       "Locate files and directories by name, glob, or path. Does not search file contents — use grep for that. Also available as glob. " +

--- a/src/core/agent/tools/fs/grep.ts
+++ b/src/core/agent/tools/fs/grep.ts
@@ -374,6 +374,7 @@ export function createGrepTool(): Tool<FileSystem.FileSystem | FileSystemContext
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, GrepArgs>({
     name: "grep",
+    disclosure: "personal",
     description:
       "Search inside file contents. Uses ripgrep when installed, otherwise grep. " +
       "Use this to find a symbol or string. Prefer this over execute_command with rg or grep. " +

--- a/src/core/agent/tools/fs/ls.ts
+++ b/src/core/agent/tools/fs/ls.ts
@@ -51,6 +51,7 @@ export function createLsTool(): Tool<FileSystem.FileSystem | FileSystemContextSe
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, LsParams>({
     name: "ls",
+    disclosure: "context",
     description:
       "List the contents of one directory. Defaults: this directory only, hidden files excluded, 200 results. " +
       "Use this to see what is in a folder. Do not use this to locate files by glob (find, also available as glob), to search file contents (grep), or to recurse the whole repository (find). " +

--- a/src/core/agent/tools/fs/mkdir.ts
+++ b/src/core/agent/tools/fs/mkdir.ts
@@ -36,6 +36,7 @@ type MkdirDeps = FileSystem.FileSystem | FileSystemContextService;
 export function createMkdirTools(): ApprovalToolPair<MkdirDeps> {
   const config: ApprovalToolConfig<MkdirDeps, MkdirArgs> = {
     name: "mkdir",
+    disclosure: "none",
     description:
       "Create a directory. Parent directories are created automatically unless you set recursive to false. Calling this on a directory that already exists succeeds. For a new file, prefer write_file with createDirs: true instead of a separate mkdir.",
     tags: ["filesystem", "write"],

--- a/src/core/agent/tools/fs/mv.ts
+++ b/src/core/agent/tools/fs/mv.ts
@@ -48,6 +48,7 @@ type MvDeps = FileSystem.FileSystem | FileSystemContextService;
 export function createMvTools(): ApprovalToolPair<MvDeps> {
   const config: ApprovalToolConfig<MvDeps, MvArgs> = {
     name: "mv",
+    disclosure: "none",
     description:
       "Rename or move a file or directory on the same filesystem. destination is the exact target path: if it is an existing directory, the source is not moved into it (unlike shell mv). force deletes the destination first. Moves across devices fail; use execute_command for those.",
     tags: ["filesystem", "write"],

--- a/src/core/agent/tools/fs/pdfPageCount.ts
+++ b/src/core/agent/tools/fs/pdfPageCount.ts
@@ -31,6 +31,7 @@ export function createPdfPageCountTool(): Tool<FileSystem.FileSystem | FileSyste
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, PdfPageCountParams>({
     name: "pdf_page_count",
+    disclosure: "context",
     description:
       "Return the page count and file size of a PDF without extracting its text. Call this before read_pdf on large files so you can request a page list instead of dumping hundreds of pages.",
     tags: ["filesystem", "pdf", "info"],

--- a/src/core/agent/tools/fs/pwd.ts
+++ b/src/core/agent/tools/fs/pwd.ts
@@ -13,6 +13,7 @@ export function createPwdTool(): Tool<FileSystemContextService> {
   const parameters = z.object({}).strict();
   return defineTool<FileSystemContextService, Record<string, never>>({
     name: "pwd",
+    disclosure: "context",
     description:
       "Print this session's working directory. The same directory is used by filesystem tools and execute_command. cd changes it. This is not a new shell process.",
     tags: ["filesystem", "navigation"],

--- a/src/core/agent/tools/fs/read.ts
+++ b/src/core/agent/tools/fs/read.ts
@@ -119,6 +119,7 @@ export function createReadFileTool(): Tool<FileSystem.FileSystem | FileSystemCon
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, ReadFileParams>({
     name: "read_file",
+    disclosure: "personal",
     description:
       "Read a file relative to the session working directory. UTF-8 text is returned as numbered lines (`   12|content`) so edit_file can use those numbers for replace_lines, insert, and delete_lines. " +
       "Images, PDFs, audio, and video are attached to the conversation when the active model supports that modality. " +

--- a/src/core/agent/tools/fs/readPdf.ts
+++ b/src/core/agent/tools/fs/readPdf.ts
@@ -80,6 +80,7 @@ export function createReadPdfTool(): Tool<FileSystem.FileSystem | FileSystemCont
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, ReadPdfParams>({
     name: "read_pdf",
+    disclosure: "personal",
     description:
       "Extract text and tables from a PDF. Do not use read_file on PDFs. Use pdf_page_count first for large files, then read 10–20 pages at a time via pages (a list of 1-based numbers such as [1, 2, 3], not a range string). No OCR or images.",
     tags: ["filesystem", "read", "pdf"],

--- a/src/core/agent/tools/fs/rm.ts
+++ b/src/core/agent/tools/fs/rm.ts
@@ -44,6 +44,7 @@ type RmDeps = FileSystem.FileSystem | FileSystemContextService;
 export function createRmTools(): ApprovalToolPair<RmDeps> {
   const config: ApprovalToolConfig<RmDeps, RmArgs> = {
     name: "rm",
+    disclosure: "none",
     description:
       "Remove a file or directory. Directories require recursive: true. force reports success even when the path is missing or the remove fails. This is a permanent delete, not trash. To unstage a tracked git file, use execute_command with git rm.",
     tags: ["filesystem", "destructive"],

--- a/src/core/agent/tools/fs/stat.ts
+++ b/src/core/agent/tools/fs/stat.ts
@@ -27,6 +27,7 @@ export function createStatTool(): Tool<FileSystem.FileSystem | FileSystemContext
 
   return defineTool<FileSystem.FileSystem | FileSystemContextService, StatArgs>({
     name: "stat",
+    disclosure: "context",
     description:
       "Check whether a path exists and return its type, size in bytes, and modification times. A missing path is a successful result with exists set to false — not an error. Prefer this over ls -la or test -f via execute_command.",
     tags: ["filesystem", "info"],

--- a/src/core/agent/tools/fs/write.ts
+++ b/src/core/agent/tools/fs/write.ts
@@ -49,6 +49,7 @@ type WriteFileDeps = FileSystem.FileSystem | FileSystemContextService;
 export function createWriteFileTools(): ApprovalToolPair<WriteFileDeps> {
   const config: ApprovalToolConfig<WriteFileDeps, WriteFileArgs> = {
     name: "write_file",
+    disclosure: "none",
     description:
       "Create a new UTF-8 file, or replace an entire existing file. Use this when the file does not exist yet, or when you intend to replace every line. " +
       "To change part of an existing file, use edit_file. Prefer createDirs: true over a separate mkdir when creating a new file. " +

--- a/src/core/agent/tools/http-tools.ts
+++ b/src/core/agent/tools/http-tools.ts
@@ -343,6 +343,7 @@ function parseJsonBody(text: string): { data: unknown; error?: string } {
 export function createHttpRequestTool(): Tool<never> {
   return defineTool<never, HttpRequestArgs>({
     name: "http_request",
+    disclosure: "personal",
     description:
       "Call an HTTP API. Supports GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS, plus headers, a query string, and a json, text, or form body. Multipart and file upload are not supported. " +
       "JSON responses are parsed; images, audio, and video come back as base64; other bodies as text. Default timeout 15 seconds (max 120). Default response cap 1MB (max 5MB). Redirects are followed by default. " +

--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -201,6 +201,9 @@ function adaptMCPToolToJazz(
     return [
       defineTool<MCPToolDependencies, Record<string, unknown>>({
         name: jazzToolName,
+        // Defined outside this codebase: its output is unknowable, and the safe
+        // reading of "unknown" is the most restrictive level.
+        disclosure: "personal",
         description,
         parameters,
         ...(unwrappedJsonSchema !== undefined ? { jsonSchema: unwrappedJsonSchema } : {}),
@@ -216,6 +219,9 @@ function adaptMCPToolToJazz(
 
   const pair = defineApprovalTool<MCPToolDependencies, Record<string, unknown>>({
     name: jazzToolName,
+    // Defined outside this codebase: its output is unknowable, and the safe
+    // reading of "unknown" is the most restrictive level.
+    disclosure: "personal",
     description,
     parameters,
     riskLevel,

--- a/src/core/agent/tools/memory-tools.ts
+++ b/src/core/agent/tools/memory-tools.ts
@@ -69,6 +69,7 @@ type ViewMemoryArgs = z.infer<typeof viewMemoryParameters>;
 export function createViewMemoryTool(): Tool<MemoryToolDeps> {
   return defineTool<MemoryToolDeps, ViewMemoryArgs>({
     name: "view_memory",
+    disclosure: "personal",
     description:
       "Call this first, before you answer, at the start of every conversation — even a casual one. " +
       "No path lists everything you've stored; a path reads one file. " +
@@ -170,6 +171,7 @@ type ManageMemoryArgs = z.infer<typeof manageMemoryParameters>;
 export function createManageMemoryTool(): Tool<MemoryToolDeps> {
   return defineTool<MemoryToolDeps, ManageMemoryArgs>({
     name: "manage_memory",
+    disclosure: "personal",
     description:
       "Save facts about this person that will still matter later — preferences, location, age, how they like to work. Write as soon as you learn it. " +
       "Update an existing file instead of creating a new one for the same topic — call view_memory first. One file per person or project, not a running log. " +

--- a/src/core/agent/tools/pdf-tools.ts
+++ b/src/core/agent/tools/pdf-tools.ts
@@ -117,6 +117,7 @@ export function createPdfTool(
 ): Tool<FileSystem.FileSystem | FileSystemContextService> {
   return defineTool<FileSystem.FileSystem | FileSystemContextService, CreatePdfArgs>({
     name: "create_pdf",
+    disclosure: "context",
     description:
       "Render a PDF from HTML you write, saved to the user's working directory (or an explicit path). " +
       "Use for reports, summaries, invoices, or anything the person will keep, print, or send on. " +

--- a/src/core/agent/tools/register-tools.docs.test.ts
+++ b/src/core/agent/tools/register-tools.docs.test.ts
@@ -10,7 +10,11 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import { ToolRegistryTag, type ToolRiskLevel } from "@/core/interfaces/tool-registry";
+import {
+  ToolRegistryTag,
+  type ToolDisclosure,
+  type ToolRiskLevel,
+} from "@/core/interfaces/tool-registry";
 import { registerAllTools } from "./register-tools";
 import { createToolRegistryLayer } from "./tool-registry";
 
@@ -20,6 +24,7 @@ const DOCS_PATH = "docs/reference/tools.md";
 interface RegisteredTool {
   readonly name: string;
   readonly riskLevel: ToolRiskLevel;
+  readonly disclosure: ToolDisclosure;
 }
 
 /**
@@ -36,7 +41,7 @@ const collectTools = Effect.gen(function* () {
   const tools: RegisteredTool[] = [];
   for (const name of names) {
     const tool = yield* registry.getTool(name);
-    tools.push({ name: tool.name, riskLevel: tool.riskLevel });
+    tools.push({ name: tool.name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
   }
   return tools;
 });
@@ -85,6 +90,35 @@ describe("docs/reference/tools.md", () => {
       );
 
     expect(mismatches, mismatches.join("; ")).toEqual([]);
+  });
+
+  it("lists every tool under the disclosure level the registry gives it", async () => {
+    const tools = await registeredTools();
+    const markdown = readFileSync(DOCS_PATH, "utf-8");
+
+    // The "What each tool reveals" table has one row per level; the tool names live in its
+    // last cell. Parsed rather than hand-checked for the same reason the risk column is:
+    // a table maintained by hand is a table that drifts.
+    const documented = new Map<ToolDisclosure, Set<string>>();
+    for (const level of ["none", "context", "personal"] as const) {
+      const row = markdown.split("\n").find((line) => line.startsWith(`| \`${level}\``));
+      const names = [...(row ?? "").matchAll(/`([a-z_0-9]+)`/g)]
+        .map((match) => match[1]!)
+        .filter((name) => name !== level);
+      documented.set(level, new Set(names));
+    }
+
+    const misfiled = tools
+      .filter((tool) => !documented.get(tool.disclosure)?.has(tool.name))
+      .map((tool) => `${tool.name} is not listed under ${tool.disclosure}`);
+
+    const stale = [...documented].flatMap(([level, names]) =>
+      [...names]
+        .filter((name) => !tools.some((tool) => tool.name === name && tool.disclosure === level))
+        .map((name) => `${name} is listed under ${level} but the registry disagrees`),
+    );
+
+    expect([...misfiled, ...stale].join("; ")).toBe("");
   });
 
   it("reports the agent-facing tool count accurately", async () => {

--- a/src/core/agent/tools/reminder-tools.ts
+++ b/src/core/agent/tools/reminder-tools.ts
@@ -29,6 +29,7 @@ type AddReminderArgs = z.infer<typeof addReminderParameters>;
 export function createAddReminderTool(): Tool<ReminderToolDeps> {
   return defineTool<ReminderToolDeps, AddReminderArgs>({
     name: "add_reminder",
+    disclosure: "none",
     description:
       "Schedule a reminder that will be delivered back to this person later. " +
       `${WHEN_DESCRIPTION} Use this whenever someone asks to be reminded, pinged, or ` +
@@ -84,6 +85,7 @@ type ListRemindersArgs = z.infer<typeof listRemindersParameters>;
 export function createListRemindersTool(): Tool<ReminderToolDeps> {
   return defineTool<ReminderToolDeps, ListRemindersArgs>({
     name: "list_reminders",
+    disclosure: "personal",
     description: "List this person's pending reminders, including their id, fire time, and text.",
     parameters: listRemindersParameters,
     riskLevel: "read-only",
@@ -133,6 +135,7 @@ type CancelReminderArgs = z.infer<typeof cancelReminderParameters>;
 export function createCancelReminderTool(): Tool<ReminderToolDeps> {
   return defineTool<ReminderToolDeps, CancelReminderArgs>({
     name: "cancel_reminder",
+    disclosure: "personal",
     description: "Cancel a pending reminder by id (get the id from list_reminders first).",
     parameters: cancelReminderParameters,
     riskLevel: "low-risk",

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -434,6 +434,7 @@ export const EXECUTE_COMMAND_OUTPUT_CAP_BYTES = DEFAULT_SPAWN_OUTPUT_CAP_BYTES;
 export function createShellCommandTools(): ApprovalToolPair<ShellCommandDeps> {
   const config: ApprovalToolConfig<ShellCommandDeps, ExecuteCommandArgs> = {
     name: "execute_command",
+    disclosure: "personal",
     description:
       "Run a shell command. Do not use this when a dedicated tool exists: use ls to list files, find (also available as glob) to search names, grep to search contents, read_file to read a file (startLine: -N for the end), and mkdir to create directories. " +
       "Git has no dedicated tools — use this for status, diff, log, commit, push, rebase, stash, and the rest. " +

--- a/src/core/agent/tools/skill-tools.ts
+++ b/src/core/agent/tools/skill-tools.ts
@@ -18,6 +18,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
   return [
     {
       name: "find_skills",
+      disclosure: "context",
       description:
         "Search the skill catalog by keyword and return the top matches with their full descriptions. Matching is keyword, not semantic. Use this when the skill index in the system prompt is not enough to decide which skill to load, then call load_skill.",
       parameters: z.object({
@@ -72,6 +73,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
     },
     {
       name: "load_skill",
+      disclosure: "context",
       description:
         "Load a skill's full instruction body by name (the markdown after the frontmatter). Load only when the index or find_skills names a match for the current task. Do not preload every skill.",
       parameters: z.object({
@@ -102,6 +104,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
     },
     {
       name: "load_skill_section",
+      disclosure: "context",
       description:
         "Load a supplementary file referenced in a skill's instructions, for example references/foo.md. Call this only after load_skill. Allowed extensions: .md, .txt, .json, .yaml, .yml.",
       parameters: z.object({

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -77,6 +77,7 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
   return [
     defineTool({
       name: "spawn_subagent",
+      disclosure: "personal",
       longRunning: true,
       timeoutMs: SUBAGENT_TIMEOUT_MS,
       description:
@@ -281,6 +282,7 @@ ${args.task}`;
 
     defineTool({
       name: "summarize_context",
+      disclosure: "personal",
       longRunning: true,
       description:
         "Summarize older messages to free context. The harness already auto-compacts around 80% of the window — call this only when you need space before that, not as a habit. Empty or short histories return an error instead of summarizing.",

--- a/src/core/agent/tools/todo-tools.ts
+++ b/src/core/agent/tools/todo-tools.ts
@@ -119,6 +119,7 @@ export function createManageTodosTool(): Tool<never> {
 
   return defineTool<never, z.infer<typeof parameters>>({
     name: "manage_todos",
+    disclosure: "personal",
     description:
       "Replace this conversation's todo list, which steers the run and shows progress in the UI. Every call replaces the whole list — send every item, not just the ones that changed. " +
       "Use this when the work has three or more distinct steps; skip it for one-liners. Keep exactly one item in_progress, and mark it completed as soon as it is finished. " +
@@ -176,6 +177,7 @@ export function createManageTodosTool(): Tool<never> {
 export function createListTodosTool(): Tool<never> {
   return defineTool({
     name: "list_todos",
+    disclosure: "personal",
     description: "Read the current todo list. Returns all items with their status and priority.",
     parameters: z.object({}),
     riskLevel: "read-only",

--- a/src/core/agent/tools/user-interaction-tools.ts
+++ b/src/core/agent/tools/user-interaction-tools.ts
@@ -55,6 +55,7 @@ type FilePickerArgs = z.infer<typeof filePickerSchema>;
 export const userInteractionTools: Tool<ToolRequirements>[] = [
   defineTool({
     name: "ask_user_question",
+    disclosure: "personal",
     longRunning: true,
     description:
       "Ask the human one blocking question with 2–4 concrete options. Use this tool; do not bury the question in prose. " +
@@ -86,6 +87,7 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
   }),
   defineTool({
     name: "ask_file_picker",
+    disclosure: "personal",
     longRunning: true,
     description:
       "Show an interactive file picker so the human can choose a path. Use this when they need to pick among files you cannot uniquely identify. Prefer find or ls when you can locate the file yourself. When there is no TTY (headless), do not call this — decide or fail.",

--- a/src/core/agent/tools/web-app-tools.ts
+++ b/src/core/agent/tools/web-app-tools.ts
@@ -159,6 +159,7 @@ export function createWebAppTool(
 ): Tool<FileSystem.FileSystem> {
   return defineTool<FileSystem.FileSystem, CreateWebAppArgs>({
     name: "create_web_app",
+    disclosure: "context",
     description:
       "Create a UI — a chart, form, dashboard, small game, or any other webpage — and deliver it as a static image (mode: 'static') or a live page (mode: 'interactive'). " +
       "Use this when a plain text or markdown answer is the wrong medium. You write the full HTML yourself. " +

--- a/src/core/agent/tools/web-fetch-tools.ts
+++ b/src/core/agent/tools/web-fetch-tools.ts
@@ -46,6 +46,7 @@ type WebFetchArgs = z.infer<typeof webFetchSchema>;
 export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService, WebFetchArgs>> {
   return defineTool<LoggerService, WebFetchArgs>({
     name: "web_fetch",
+    disclosure: "none",
     description:
       "Fetch a URL with HTTP GET and return its title and body as plain text. HTML has tags stripped (not markdown, not reader mode). JavaScript is not run. PDFs and images are not supported. Allowed types: HTML, plain text, JSON, XML. " +
       "Default 50000 characters (max 200000); the full body is still downloaded first. Redirects are followed. For APIs, custom headers, POST, or binary, use http_request. To find URLs, use web_search.",

--- a/src/core/agent/tools/web-search-tools.ts
+++ b/src/core/agent/tools/web-search-tools.ts
@@ -121,6 +121,7 @@ export function createWebSearchTool(): ReturnType<
 > {
   return defineTool<AgentConfigService | LoggerService, WebSearchArgs>({
     name: "web_search",
+    disclosure: "none",
     description:
       "Search the public web. Each result has a title, url, snippet, and sometimes a publishedDate. This does not fetch full pages — follow up with web_fetch for HTML or text, or http_request for APIs and POST. " +
       "Put operators such as site: and filetype: in query. fromDate, toDate, searchDepth, sourceType, and searchQueries are hints; some providers ignore them. If search is unavailable the tool returns an error — do not invent sources.",

--- a/src/core/agent/tools/work-state-tools.ts
+++ b/src/core/agent/tools/work-state-tools.ts
@@ -39,6 +39,7 @@ type UpdateWorkStateArgs = z.infer<typeof updateWorkStateParameters>;
 export function createUpdateWorkStateTool(): Tool<never> {
   return defineTool<never, UpdateWorkStateArgs>({
     name: "update_work_state",
+    disclosure: "personal",
     description:
       "Record where you are in the current task so it survives context compaction and " +
       "picking the work back up later. Call it when you settle on a goal or plan, finish " +

--- a/src/core/interfaces/tool-registry.ts
+++ b/src/core/interfaces/tool-registry.ts
@@ -32,6 +32,31 @@ import type { TerminalService } from "./terminal";
 export type ToolRiskLevel = "read-only" | "low-risk" | "high-risk" | "unknown";
 
 /**
+ * What an answer from this tool reveals about the person the agent works for.
+ *
+ * Independent of {@link ToolRiskLevel}, which measures what a tool can do *to* the machine.
+ * The two do not correlate: `read_file` is read-only and can disclose anything, `get_time`
+ * is read-only and discloses nothing, `write_file` changes the machine and reveals nothing.
+ * A policy built on risk alone would let a caller read someone's notes on the grounds that
+ * reading is safe.
+ *
+ * The question is always about the *answer*, not the request. What an agent chooses to put
+ * into an outgoing call is a separate problem, handled where such calls are made.
+ *
+ * - `none` — the answer is not about the operator or their machine. A web search result, a
+ *   fetched page, a confirmation that something was written.
+ * - `context` — the shape of the machine or session: paths, filenames, the working
+ *   directory, which skills are installed, how full the context window is. Not contents.
+ * - `personal` — the operator's own material: file contents, memory, reminders, todos, the
+ *   transcript, or anything a shell command might print.
+ *
+ * When a tool spans two, it takes the higher one. `unknown` does not exist here on purpose:
+ * an unclassifiable tool is `personal`, because the safe reading of "I do not know what
+ * this returns" is "it could be anything".
+ */
+export type ToolDisclosure = "none" | "context" | "personal";
+
+/**
  * Union type representing all possible tool requirements.
  * This allows the registry to store tools with different requirement types
  *
@@ -78,6 +103,14 @@ export interface Tool<R = never> {
    *   an unresolved `unknown` is only auto-approved under yolo
    */
   readonly riskLevel: ToolRiskLevel;
+  /**
+   * What an answer from this tool reveals about the operator.
+   *
+   * Required, and with no default anywhere, so that adding a tool forces someone to decide.
+   * Every tool that skipped this decision would otherwise be silently readable by anything
+   * the machine ever answers to.
+   */
+  readonly disclosure: ToolDisclosure;
   /**
    * Optional helper for approval-based tools pointing to the follow-up tool name
    * that should be made available once user confirmation is granted.


### PR DESCRIPTION
## What & why

Every tool now declares a second, orthogonal classification beside `riskLevel`: what its **answer** reveals about the person the agent works for.

`riskLevel` measures what a tool can do *to* the machine. It says nothing about disclosure, and the two do not correlate — `read_file` is read-only and can reveal anything, `get_time` is read-only and reveals nothing, `write_file` changes the machine and reveals nothing at all. Any policy built on risk alone lets a caller read your notes on the grounds that reading is safe.

| Level | The answer reveals | Count |
| --- | --- | --- |
| `none` | nothing about you or your machine | 8 |
| `context` | shape of the machine or session — paths, names, what is installed | 13 |
| `personal` | your own material — file contents, memory, schedule, transcript | 21 |

**Required, with no default** in either `defineTool` or `defineApprovalTool`, so adding a tool forces someone to decide. That is the whole point — a tool that skipped this would be silently readable by anything the machine ever answers to. There is no `unknown` level: MCP and custom tools are `personal`, because a tool defined outside this codebase returns something this codebase cannot classify.

Spanning two levels takes the higher one, which is why `edit_file` is `personal` (its approval message carries a diff of your file) and `http_request` is too (it reaches private networks, including services on localhost).

## Why now

Two payoffs, one immediate:

- **Today:** `--approval-policy read-only` currently admits `read_file` on an unattended run. Defensible for a cron job on your own machine, indefensible for anything with a network peer. The axis is what lets that policy say "read-only *and* not personal" later without inventing a new concept.
- **Later:** it is the input a peer-disclosure policy needs, if agent-to-agent work happens. Nothing here assumes it will.

## How to verify

- `bun test` — 2935 passing. The docs guard fails if the registry and `docs/reference/tools.md` disagree; it caught three skill tools on first run that are registered per agent rather than globally.
- Add a tool without `disclosure` and confirm it does not compile.
- `docs/reference/tools.md` → "What each tool reveals" lists all three levels.