### PR TITLE
feat(peers): model other people's agents, and log what they are told

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -550,6 +550,81 @@ function registerUpdateCommand(program: Command): void {
 /**
  * Register `jazz runs` — find and answer runs that stopped for a person.
  */
+/**
+ * Register `jazz peers` — who else's agent this machine will talk to.
+ *
+ * A peer is added by editing the config file, not by a command. Deliberate: the decision
+ * worth making carefully is the tier, and someone choosing it should be looking at the file
+ * rather than at a flag. What the commands own is the part that must not touch disk in
+ * plaintext (the token) and the part worth reading back (the ledger).
+ */
+function registerPeersCommands(program: Command): void {
+  const peersCommand = program
+    .command("peers")
+    .description("Other people's agents this machine talks to, and what they have been told");
+
+  peersCommand
+    .command("list")
+    .alias("ls")
+    .description("List configured peers and what each may learn")
+    .option("--json", "Emit a single JSON envelope { ok, peers }")
+    .action((options: { json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/peers").then((mod) =>
+            mod.listPeersCommand({ json: options.json === true }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  peersCommand
+    .command("set-token <name>")
+    .description(
+      "Store a peer's bearer token in the OS keyring, read from an environment variable so it never reaches your shell history",
+    )
+    .option("--from-env <VAR>", "Environment variable holding the token", "JAZZ_PEER_TOKEN")
+    .action((name: string, options: { fromEnv: string }) =>
+      runCliAction(
+        () =>
+          import("./commands/peers").then((mod) =>
+            mod.setPeerTokenCommand({ name, envVar: options.fromEnv }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  peersCommand
+    .command("forget-token <name>")
+    .description("Remove a peer's stored token")
+    .action((name: string) =>
+      runCliAction(
+        () => import("./commands/peers").then((mod) => mod.forgetPeerTokenCommand({ name })),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  peersCommand
+    .command("log")
+    .description("Everything said to and by a peer, newest first")
+    .option("--peer <name>", "Only entries for this peer")
+    .option("--limit <n>", "How many entries to show", parsePositiveInt("--limit"), 50)
+    .option("--json", "Emit a single JSON envelope { ok, entries }")
+    .action((options: { peer?: string; limit: number; json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("./commands/peers").then((mod) =>
+            mod.peerLogCommand({
+              json: options.json === true,
+              limit: options.limit,
+              ...(options.peer !== undefined ? { peer: options.peer } : {}),
+            }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+}
+
 function registerRunsCommands(program: Command): void {
   const runsCommand = program
     .command("runs")
@@ -859,6 +934,7 @@ export function createCLIApp(): Command {
   registerConfigCommands(program);
   registerMCPCommands(program);
   registerUpdateCommand(program);
+  registerPeersCommands(program);
   registerRunsCommands(program);
   registerWorkflowCommands(program);
 

--- a/src/cli/commands/peers.ts
+++ b/src/cli/commands/peers.ts
@@ -1,0 +1,141 @@
+/**
+ * @fileoverview `jazz peers` — who else's agent this machine will talk to.
+ *
+ * Nothing here serves a request or makes one; that arrives later. What these commands give
+ * you is the ability to say who a peer is, what they may learn, and — the part worth having
+ * before anything talks — to read back everything that has been said.
+ */
+
+import { Effect } from "effect";
+import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
+import { getErrorMessage } from "@/core/presentation/error-handler";
+import { isPeerTier, PEER_TIERS, type PeerConfig, type PeerTier } from "@/core/types/peer";
+import { read as readLedger } from "@/services/peers/ledger";
+import { detectKeyringBackend, keyringDelete, keyringSet } from "@/services/secrets/keyring";
+import { KEYRING_SERVICE_NAME, peerTokenPath } from "@/services/secrets/registry";
+
+function describeTier(tier: PeerTier | undefined): string {
+  switch (tier ?? "none") {
+    case "none":
+      return "nothing (suspended)";
+    case "public":
+      return "nothing about you";
+    case "about-me":
+      return "the shape of your machine";
+    case "ask-me-anything":
+      return "anything readable";
+  }
+}
+
+function configuredPeers(): Effect.Effect<readonly PeerConfig[], Error, AgentConfigService> {
+  return Effect.gen(function* () {
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    return appConfig.peers ?? [];
+  });
+}
+
+export function listPeersCommand(options: { readonly json: boolean }) {
+  return Effect.gen(function* () {
+    const peers = yield* configuredPeers();
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ ok: true, peers })}\n`);
+      return;
+    }
+    if (peers.length === 0) {
+      process.stdout.write("No peers configured.\n");
+      return;
+    }
+    for (const peer of peers) {
+      process.stdout.write(`${peer.name}  ${peer.url}  may learn: ${describeTier(peer.may)}\n`);
+    }
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.sync(() => {
+        process.stderr.write(`${getErrorMessage(error)}\n`);
+        process.exitCode = 1;
+      }),
+    ),
+  );
+}
+
+/**
+ * Store a peer's token.
+ *
+ * The token is read from an environment variable rather than an argument, so it never
+ * reaches the shell history of the person adding it. The peer itself still has to be added
+ * to the config file by hand — deliberately, for now: writing config from a command is a
+ * separate concern, and the interesting decision here is the tier, which someone should be
+ * looking at the file to make.
+ */
+export function setPeerTokenCommand(options: { readonly name: string; readonly envVar: string }) {
+  return Effect.gen(function* () {
+    const token = process.env[options.envVar];
+    if (token === undefined || token.trim().length === 0) {
+      process.stderr.write(
+        `No token found in $${options.envVar}. Set it in the environment and run this again.\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const backend = yield* detectKeyringBackend();
+    if (backend === "none") {
+      process.stderr.write(
+        "No OS keyring is available, and a peer token is not written to disk in plaintext.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const stored = yield* keyringSet(backend, peerTokenPath(options.name), token);
+    if (!stored) {
+      process.stderr.write(`Could not store the token for "${options.name}".\n`);
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(`Stored a token for "${options.name}" in the ${backend} keyring.\n`);
+  });
+}
+
+export function forgetPeerTokenCommand(options: { readonly name: string }) {
+  return Effect.gen(function* () {
+    const backend = yield* detectKeyringBackend();
+    yield* keyringDelete(backend, peerTokenPath(options.name));
+    process.stdout.write(
+      `Removed any stored token for "${options.name}". Remove the peer from your config to stop talking to it entirely.\n`,
+    );
+  });
+}
+
+export function peerLogCommand(options: {
+  readonly json: boolean;
+  readonly peer?: string;
+  readonly limit: number;
+}) {
+  return Effect.gen(function* () {
+    const entries = yield* readLedger({
+      limit: options.limit,
+      ...(options.peer !== undefined ? { peer: options.peer } : {}),
+    });
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ ok: true, entries })}\n`);
+      return;
+    }
+    if (entries.length === 0) {
+      process.stdout.write("Nothing has been said to or by a peer.\n");
+      return;
+    }
+    for (const entry of entries) {
+      const arrow = entry.direction === "out" ? "->" : "<-";
+      const detail = entry.reason !== undefined ? ` (${entry.reason})` : "";
+      process.stdout.write(
+        `${entry.at}  ${arrow} ${entry.peer}  ${entry.outcome}${detail}\n    ${entry.question}\n`,
+      );
+    }
+  });
+}
+
+export { KEYRING_SERVICE_NAME, PEER_TIERS, isPeerTier };

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -4,6 +4,7 @@
 
 import type { MCPServerConfig } from "@/core/interfaces/mcp-server";
 import type { OutputConfig } from "./output";
+import type { PeerConfig } from "./peer";
 
 export interface AppConfig {
   readonly storage: StorageConfig;
@@ -25,6 +26,14 @@ export interface AppConfig {
   /** Iteration budget for a sub-agent run. Defaults to 30. */
   readonly maxSubagentIterations?: number;
   readonly context?: ContextConfig;
+  /**
+   * Other people's agents this machine will talk to.
+   *
+   * Explicit and never discovered: no request from an unlisted origin is served, whatever
+   * it presents. Discovery can describe a peer somebody already decided to add; it must
+   * never be the thing that creates one.
+   */
+  readonly peers?: readonly PeerConfig[];
 }
 
 export interface ContextConfig {

--- a/src/core/types/peer.ts
+++ b/src/core/types/peer.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Someone else's agent, and how much of your life it may see.
+ *
+ * A peer is another agent — a friend's jazz, or anything else that answers questions over
+ * HTTP. Two properties make this unlike every other trust decision in the product.
+ *
+ * First, **authentication is not authorization**. Knowing a request really came from Sam's
+ * agent says nothing about whether Sam asked it, whether their agent invented the question,
+ * or whether something it read an hour ago told it to. There is no way to tell those apart,
+ * and a design that pretends otherwise is the dangerous kind.
+ *
+ * Second, **the risk is disclosure, not damage**. Every other approval in jazz asks what a
+ * tool can do to this machine. A peer asking questions does nothing to the machine at all;
+ * what it costs you is what it learns. That is why {@link ToolDisclosure} exists as an axis
+ * separate from `riskLevel`, and why tiers here are expressed in those terms.
+ */
+
+/** How much a peer's agent may learn, expressed in {@link ToolDisclosure} terms. */
+export type PeerTier =
+  /** Configured but answering nothing. The default, and what revoking a peer sets. */
+  | "none"
+  /** Only `none`-disclosure answers: nothing about the operator or their machine. */
+  | "public"
+  /** Adds `context`: paths, names, what is installed. Not file contents. */
+  | "about-me"
+  /** Adds `personal`, but still read-only. The most a peer can ever be given. */
+  | "ask-me-anything";
+
+export const PEER_TIERS: readonly PeerTier[] = ["none", "public", "about-me", "ask-me-anything"];
+
+export function isPeerTier(value: string): value is PeerTier {
+  return (PEER_TIERS as readonly string[]).includes(value);
+}
+
+export interface PeerConfig {
+  /** Local name, used in commands and in the ledger. Unique. */
+  readonly name: string;
+  /** Where the peer's agent answers. Its token lives in the keyring, never here. */
+  readonly url: string;
+  /**
+   * What this peer may learn. Absent means {@link PeerTier} `none`: a peer that was added
+   * but never granted anything answers nothing, rather than defaulting to something.
+   */
+  readonly may?: PeerTier;
+}
+
+/**
+ * No tier permits a peer to cause anything.
+ *
+ * Not a gap to be filled later — a line. A remote agent that could write a file, run a
+ * command or send a message would put the blast radius of somebody else's compromised
+ * assistant on this machine, and "their agent books the restaurant" is not worth that.
+ * Where an action is genuinely wanted, it goes through a human, never through a tier.
+ */
+export const PEER_TIER_MAX_RISK = "read-only" as const;

--- a/src/services/peers/ledger.test.ts
+++ b/src/services/peers/ledger.test.ts
@@ -1,0 +1,104 @@
+import * as nodeFs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { ledgerPath, read, record, type LedgerEntry } from "./ledger";
+
+let jazzHome: string;
+let previousHome: string | undefined;
+
+beforeEach(async () => {
+  jazzHome = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-peer-ledger-"));
+  previousHome = process.env["JAZZ_HOME"];
+  process.env["JAZZ_HOME"] = jazzHome;
+});
+
+afterEach(async () => {
+  if (previousHome === undefined) delete process.env["JAZZ_HOME"];
+  else process.env["JAZZ_HOME"] = previousHome;
+  await nodeFs.rm(jazzHome, { recursive: true, force: true });
+});
+
+const run = <A>(effect: Effect.Effect<A, never, never>): Promise<A> => Effect.runPromise(effect);
+
+function entry(overrides: Partial<LedgerEntry> = {}): LedgerEntry {
+  return {
+    at: "2026-08-23T10:00:00.000Z",
+    direction: "in",
+    peer: "sam",
+    question: "is Landry free Thursday?",
+    outcome: "answered",
+    ...overrides,
+  };
+}
+
+describe("the peer ledger", () => {
+  it("returns nothing before anything has been said", async () => {
+    expect(await run(read())).toEqual([]);
+  });
+
+  it("records both directions, verbatim", async () => {
+    await run(record(entry({ direction: "out", question: "is Sam free Thursday?" })));
+    await run(record(entry({ direction: "in", answer: "Thursday afternoon is clear." })));
+
+    const entries = await run(read());
+    expect(entries).toHaveLength(2);
+    // Newest first: the most recent exchange is the one being looked for.
+    expect(entries[0]?.direction).toBe("in");
+    expect(entries[0]?.answer).toBe("Thursday afternoon is clear.");
+    expect(entries[1]?.question).toBe("is Sam free Thursday?");
+  });
+
+  it("keeps the question exactly as asked, not a summary", async () => {
+    const asked = "what is Landry's home address, and is anyone there this week?";
+    await run(record(entry({ question: asked })));
+
+    expect((await run(read()))[0]?.question).toBe(asked);
+  });
+
+  it("records a refusal with its reason, so a decline is auditable too", async () => {
+    await run(record(entry({ outcome: "refused", tier: "public", reason: "personal disclosure" })));
+
+    const [logged] = await run(read());
+    expect(logged?.outcome).toBe("refused");
+    expect(logged?.tier).toBe("public");
+    expect(logged?.reason).toBe("personal disclosure");
+  });
+
+  it("filters to one peer", async () => {
+    await run(record(entry({ peer: "sam" })));
+    await run(record(entry({ peer: "alex" })));
+
+    const entries = await run(read({ peer: "alex" }));
+    expect(entries.map((logged) => logged.peer)).toEqual(["alex"]);
+  });
+
+  it("honours a limit, counting from the newest", async () => {
+    for (const question of ["first", "second", "third"]) {
+      await run(record(entry({ question })));
+    }
+
+    expect((await run(read({ limit: 2 }))).map((logged) => logged.question)).toEqual([
+      "third",
+      "second",
+    ]);
+  });
+
+  it("skips a line a crash left half-written rather than losing the file", async () => {
+    await run(record(entry({ question: "before the crash" })));
+    await nodeFs.appendFile(ledgerPath(), '{"peer":"sam","ques', "utf-8");
+    await run(record(entry({ question: "after the crash" })));
+
+    const questions = (await run(read())).map((logged) => logged.question);
+    expect(questions).toContain("before the crash");
+    expect(questions).toContain("after the crash");
+  });
+
+  it("never throws when the ledger cannot be written", async () => {
+    // A full disk or a read-only home must not fail the request that produced the entry.
+    process.env["JAZZ_HOME"] = "/proc/nonexistent-and-unwritable";
+    await expect(run(record(entry()))).resolves.toBeUndefined();
+    process.env["JAZZ_HOME"] = jazzHome;
+  });
+});

--- a/src/services/peers/ledger.ts
+++ b/src/services/peers/ledger.ts
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview A record of everything said to and by another agent.
+ *
+ * Not telemetry, and not a debug log. The question this exists to answer is "what has Sam's
+ * agent learned about me", and no amount of policy design substitutes for being able to
+ * look. It records both directions, because what my agent volunteers on the way out is at
+ * least as disclosing as what a peer manages to ask for.
+ *
+ * Append-only JSONL, one entry per line, unparseable lines skipped — the same discipline as
+ * the conversation log, and for the same reason: a process killed mid-write should cost the
+ * last entry, not the file.
+ *
+ * Written before anything can talk to a peer, deliberately. A ledger added after the first
+ * request is a ledger with a hole at the beginning.
+ */
+
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { Effect } from "effect";
+import type { PeerTier } from "@/core/types/peer";
+import { getJazzHomeDirectory } from "@/core/utils/paths";
+
+const LEDGER_FILENAME = "ledger.jsonl";
+
+/** Directory holding peer state. Separate from history: this is about other people's agents. */
+export function getPeersDirectory(): string {
+  return path.join(getJazzHomeDirectory(), "peers");
+}
+
+export function ledgerPath(): string {
+  return path.join(getPeersDirectory(), LEDGER_FILENAME);
+}
+
+/**
+ * What happened to a request.
+ *
+ * `refused` and `expired` are distinct on purpose. A refusal is the policy doing its job and
+ * is unremarkable; a parked request nobody answered is a question left hanging, which is a
+ * different thing to notice when reading back.
+ */
+export type LedgerOutcome = "answered" | "refused" | "parked" | "expired" | "failed";
+
+export interface LedgerEntry {
+  readonly at: string;
+  /** `out` — my agent asked theirs. `in` — theirs asked mine. */
+  readonly direction: "in" | "out";
+  readonly peer: string;
+  /** The question, verbatim. Never a summary: a summary is the thing you cannot audit. */
+  readonly question: string;
+  /** What was actually said back, verbatim, when anything was. */
+  readonly answer?: string;
+  readonly outcome: LedgerOutcome;
+  /** The tier in force when the decision was made, for inbound requests. */
+  readonly tier?: PeerTier;
+  /** Why, when the outcome was not `answered`. */
+  readonly reason?: string;
+}
+
+function serialize(entry: LedgerEntry): string {
+  return `${JSON.stringify(entry)}\n`;
+}
+
+/**
+ * Append one entry.
+ *
+ * Failure is swallowed, matching every other logging path in the product: losing a ledger
+ * line must not fail the request that produced it. The tradeoff is real and uncomfortable —
+ * a full disk or a read-only home produces silent gaps in the one record whose value is
+ * being complete. Nothing here detects that yet.
+ */
+export function record(entry: LedgerEntry): Effect.Effect<void, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      await nodeFs.mkdir(getPeersDirectory(), { recursive: true });
+      const line = serialize(entry);
+      await nodeFs.appendFile(ledgerPath(), (await endsMidLine()) ? `\n${line}` : line, "utf-8");
+    },
+    catch: (error) => error,
+  }).pipe(Effect.catchAll(() => Effect.void));
+}
+
+/**
+ * Whether the last write was cut off mid-line.
+ *
+ * A process killed mid-append leaves a line with no terminator. Appending straight onto it
+ * would splice the next entry into the broken one and lose both, so the truncated line is
+ * closed first — the same guard the conversation log uses. One byte is read rather than the
+ * file, because a ledger grows without bound and this runs on every entry.
+ */
+async function endsMidLine(): Promise<boolean> {
+  let handle;
+  try {
+    handle = await nodeFs.open(ledgerPath(), "r");
+    const { size } = await handle.stat();
+    if (size === 0) return false;
+    const tail = Buffer.alloc(1);
+    await handle.read(tail, 0, 1, size - 1);
+    return tail.toString("utf-8") !== "\n";
+  } catch {
+    // No file yet, or unreadable: either way there is no partial line to close.
+    return false;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function parseLine(line: string): LedgerEntry | undefined {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const entry = parsed as LedgerEntry;
+    if (typeof entry.peer !== "string" || typeof entry.question !== "string") return undefined;
+    return entry;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Entries newest first, optionally for one peer. */
+export function read(filter?: {
+  readonly peer?: string;
+  readonly limit?: number;
+}): Effect.Effect<readonly LedgerEntry[], never> {
+  return Effect.tryPromise({
+    try: () => nodeFs.readFile(ledgerPath(), "utf-8"),
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((content) => {
+      const entries: LedgerEntry[] = [];
+      for (const line of content.split("\n")) {
+        const entry = parseLine(line);
+        if (entry === undefined) continue;
+        if (filter?.peer !== undefined && entry.peer !== filter.peer) continue;
+        entries.push(entry);
+      }
+      entries.reverse();
+      return filter?.limit === undefined ? entries : entries.slice(0, filter.limit);
+    }),
+    Effect.catchAll(() => Effect.succeed([] as readonly LedgerEntry[])),
+  );
+}

--- a/src/services/secrets/registry.ts
+++ b/src/services/secrets/registry.ts
@@ -72,6 +72,14 @@ const OTLP_HEADER_PATH = /^telemetry\.otlp\.headers\.[^.]+$/;
 /** The header operators actually set; listed so the keyring is checked for it on load. */
 export const OTLP_AUTHORIZATION_PATH = "telemetry.otlp.headers.authorization";
 
+/** A peer's bearer token, e.g. `peers.sam.token`. */
+const PEER_TOKEN_PATH = /^peers\.[^.]+\.token$/;
+
+/** The config path holding one peer's token. */
+export function peerTokenPath(peerName: string): string {
+  return `peers.${peerName}.token`;
+}
+
 /** Every config path Jazz treats as a secret. */
 export const SECRET_PATHS: readonly string[] = [
   ...Object.keys(SECRET_ENV_VARS),
@@ -86,6 +94,10 @@ export const SECRET_PATHS: readonly string[] = [
  */
 export function isSecretPath(path: string): boolean {
   if (path in SECRET_ENV_VARS) return true;
+  // A peer's bearer token authenticates this machine to somebody else's agent. It belongs
+  // in the keyring for the same reason an API key does, and the config file names the peer
+  // without ever holding its credential.
+  if (PEER_TOKEN_PATH.test(path)) return true;
   // Every OTLP header is treated as a secret, not just `authorization`: a
   // backend may name its credential header anything, and guessing wrong writes
   // it to disk in plaintext.


### PR DESCRIPTION
## What & why

Groundwork for talking to someone else's agent. **Nothing here talks to anything** — this is the model, the storage, and the means of reading it back. Built before the first request on purpose: a ledger added afterwards is a ledger with a hole at the beginning.

Independent of [#415](https://github.com/lvndry/jazz/pull/415); either can merge first.

### The model

A peer is an **explicit config entry, never discovered**. No request from an unlisted origin will be served, whatever it presents. Discovery can one day describe a peer somebody already chose to add; it must not be the thing that creates one.

```jsonc
"peers": [{ "name": "sam", "url": "https://sam.example/agent", "may": "about-me" }]
```

Tiers are expressed as **disclosure, not risk** — `none` / `public` / `about-me` / `ask-me-anything` — defaulting to `none`, so a peer added but never granted anything answers nothing.

**No tier permits a peer to cause an action.** That is a line, not a gap to fill later: a remote agent able to write a file or run a command would put the blast radius of somebody else's compromised assistant on this machine, and "their agent books the restaurant" is not worth that. Where an action is genuinely wanted it goes through a human.

### The ledger

Append-only JSONL at `~/.jazz/peers/ledger.jsonl`, recording **both directions verbatim**, including refusals and their reason. What an agent volunteers on the way out is at least as disclosing as what a peer manages to ask for, and a decline is as worth auditing as an answer.

The question this exists to answer is "what has Sam's agent learned about me", and no amount of policy design substitutes for being able to look.

### Tokens

Stored in the OS keyring through the existing secret-path machinery, so redaction and env-var fallback apply unchanged. `jazz peers set-token` reads from an environment variable rather than an argument, so a token never reaches shell history. A peer is still added by editing the config file — deliberately: the decision worth making carefully is the tier, and someone choosing it should be looking at the file.

### A bug the tests found

The crash-recovery test failed first time. A half-written line has no terminator, so the next append spliced into it and lost **both** entries. Closed the way `conversation-log.ts` already does, reading one byte rather than the file since a ledger grows without bound.

## How to verify

- `jazz peers list` → "No peers configured."; add one to `config.json` and confirm the tier renders as what it *means*, not its name.
- `JAZZ_PEER_TOKEN=xyz jazz peers set-token sam` → stored in the keyring; confirm the token appears nowhere in `~/.jazz/config.json`.
- `jazz peers log` → "Nothing has been said to or by a peer."
- `bun test src/services/peers/` — 8 tests, including the crash case and that a write failure never throws.

## Not done

No serving, no calling out. Phase 3 (`ask_peer`) is next and needs no daemon; serving needs one.