### PR TITLE
feat(mcp): 2026-07-28 protocol support, elicitation, resources, and progress

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@effect/sql": "^0.52.1",
         "@effect/workflow": "^0.19.1",
         "@eslint/js": "^10.0.1",
-        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/client": "^2.0.0",
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@perplexity-ai/perplexity_ai": "^0.38.3",
         "@tavily/core": "^0.7.7",
@@ -161,8 +161,6 @@
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
-    "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -173,7 +171,9 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -369,8 +369,6 @@
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -379,9 +377,7 @@
 
     "ai": ["ai@7.0.66", "", { "dependencies": { "@ai-sdk/gateway": "4.0.52", "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-wBUyoCYF3GVr+62nelBgR8YbpTSsMZrzFyOOjiwijylNSM2TFCW35C+Pml2vc59/WLMpyhS/LWZ55M+B9DAcSg=="],
 
-    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -405,8 +401,6 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
-
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -415,11 +409,7 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@6.0.0", "", {}, "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg=="],
 
@@ -453,17 +443,7 @@
 
     "comment-parser": ["comment-parser@1.4.7", "", {}, "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ=="],
 
-    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cron-parser": ["cron-parser@5.10.0", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A=="],
 
@@ -481,8 +461,6 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devtools-protocol": ["devtools-protocol@0.0.1666840", "", {}, "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg=="],
@@ -493,15 +471,11 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
@@ -518,8 +492,6 @@
     "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -555,17 +527,11 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exa-js": ["exa-js@2.18.1", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-52TGyzOjJm3RLlIK5vTKZbn4wCiveFxdvbdiAz+9umtrn8VE2CwnsBSoDIUfCnjVDsOrwoC249gwPf7feAH/Dw=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
@@ -581,8 +547,6 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
-
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -592,8 +556,6 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
@@ -606,10 +568,6 @@
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -647,13 +605,7 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
-    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -661,17 +613,11 @@
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
     "ink": ["ink@7.1.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w=="],
 
     "ink-select-input": ["ink-select-input@6.2.0", "", { "dependencies": { "figures": "^6.1.0", "to-rotated": "^1.0.0" }, "peerDependencies": { "ink": ">=5.0.0", "react": ">=18.0.0" } }, "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ=="],
 
     "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
-
-    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
@@ -684,8 +630,6 @@
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -701,9 +645,7 @@
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -727,19 +669,15 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -763,8 +701,6 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
@@ -775,13 +711,7 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
     "ollama-ai-provider-v2": ["ollama-ai-provider-v2@4.0.1", "", { "dependencies": { "@ai-sdk/provider": "^4.0.2", "@ai-sdk/provider-utils": "^5.0.5" }, "peerDependencies": { "ai": "^7.0.0", "zod": "^4.0.16" } }, "sha512-JHw/Knt4kOTSwQ0oqorbdgzukK6iE73U3MPUyOuCEBpAQGAzm80CQDwyaXMwF80yFjY21RY9qfzkoLyPFFts/w=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -799,15 +729,11 @@
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pdf-parse": ["pdf-parse@2.4.5", "", { "dependencies": { "@napi-rs/canvas": "0.1.80", "pdfjs-dist": "5.4.296" }, "bin": { "pdf-parse": "bin/cli.mjs" } }, "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg=="],
 
@@ -825,8 +751,6 @@
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -835,13 +759,7 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -851,31 +769,19 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -884,14 +790,6 @@
     "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "short-uuid": ["short-uuid@6.0.3", "", { "dependencies": { "any-base": "^1.1.0" } }, "sha512-UMZ3rYOoid307EqWsPTnoBUSOB51Fi28vUMPigUsSCmbaSvslyf/SlXZWOn4btj8tokhBTBkPFKVKKlIolEG1w=="],
-
-    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
-
-    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -904,8 +802,6 @@
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
@@ -935,8 +831,6 @@
 
     "to-rotated": ["to-rotated@1.0.0", "", {}, "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
@@ -946,8 +840,6 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
-
-    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
 
@@ -963,15 +855,11 @@
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
     "unrs-resolver": ["unrs-resolver@1.12.2", "", { "dependencies": { "napi-postinstall": "^0.3.4" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.12.2", "@unrs/resolver-binding-android-arm64": "1.12.2", "@unrs/resolver-binding-darwin-arm64": "1.12.2", "@unrs/resolver-binding-darwin-x64": "1.12.2", "@unrs/resolver-binding-freebsd-x64": "1.12.2", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2", "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2", "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2", "@unrs/resolver-binding-linux-arm64-musl": "1.12.2", "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2", "@unrs/resolver-binding-linux-loong64-musl": "1.12.2", "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2", "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2", "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2", "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2", "@unrs/resolver-binding-linux-x64-gnu": "1.12.2", "@unrs/resolver-binding-linux-x64-musl": "1.12.2", "@unrs/resolver-binding-openharmony-arm64": "1.12.2", "@unrs/resolver-binding-wasm32-wasi": "1.12.2", "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2", "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2", "@unrs/resolver-binding-win32-x64-msvc": "1.12.2" } }, "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vercel-minimax-ai-provider": ["vercel-minimax-ai-provider@0.0.2", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.6", "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.4" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-h9QzLL7RBmOreqWfr2fcoFVNTJgusENJVagVm8vAi+DBfd+1t+sVJZ/hAhKrtuCKCrm33BlOSWVdJehQFju5jQ=="],
 
@@ -990,8 +878,6 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
@@ -1055,8 +941,6 @@
 
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
-    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
     "bun-types/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1071,13 +955,9 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
     "exa-js/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ink/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1096,8 +976,6 @@
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
-    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vercel-minimax-ai-provider/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.6", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ns5OOPHXbODzitvqCySnAFZCAm9ldpx+fdbC0c/f9QwX5b4MQtQJIQ0xZyKm+tB/ynBoeV6zhtyWDXjYeVEWIw=="],
 
@@ -1134,10 +1012,6 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "ollama-ai-provider-v2/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 

--- a/oauth-client-metadata.json
+++ b/oauth-client-metadata.json
@@ -1,0 +1,15 @@
+{
+  "client_id": "https://raw.githubusercontent.com/lvndry/jazz/main/oauth-client-metadata.json",
+  "client_name": "Jazz",
+  "client_uri": "https://github.com/lvndry/jazz",
+  "redirect_uris": [
+    "http://127.0.0.1:33418/callback",
+    "http://127.0.0.1:33419/callback",
+    "http://127.0.0.1:33420/callback",
+    "http://127.0.0.1:33421/callback"
+  ],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none",
+  "application_type": "native"
+}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@effect/sql": "^0.52.1",
     "@effect/workflow": "^0.19.1",
     "@eslint/js": "^10.0.1",
-    "@modelcontextprotocol/sdk": "^1.30.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@perplexity-ai/perplexity_ai": "^0.38.3",
     "@tavily/core": "^0.7.7",
@@ -145,7 +144,8 @@
     "vercel-minimax-ai-provider": "^0.0.2",
     "wrap-ansi": "^10.0.0",
     "zhipu-ai-provider": "^0.4.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@modelcontextprotocol/client": "^2.0.0"
   },
   "engines": {
     "node": ">=22.16.0",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -427,11 +427,6 @@ export function testMcpServerCommand(name: string): Effect.Effect<void, never, M
       }
     }
 
-    const roots = yield* manager.getRoots();
-    yield* terminal.log(
-      fmt.keyValue("Roots advertised", roots.map((root) => root.uri).join(", ") || "none"),
-    );
-
     if (config.trusted !== true) {
       yield* terminal.info(
         `Untrusted: every tool call will ask for approval. Run \`jazz mcp trust ${name}\` to let read-only annotations through.`,

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -377,10 +377,21 @@ export function testMcpServerCommand(name: string): Effect.Effect<void, never, M
     }
 
     const capabilities = yield* manager.getCapabilities(name);
+    const protocolEra = yield* manager.getProtocolEra(name);
     const tools = yield* manager.getServerTools(name).pipe(Effect.either);
     const prompts = yield* manager.getServerPrompts(name).pipe(Effect.either);
 
     yield* terminal.success(`Connected to ${name}`);
+    yield* terminal.log(
+      fmt.keyValue(
+        "Protocol",
+        protocolEra === "modern"
+          ? "2026-07-28 (modern)"
+          : protocolEra === "legacy"
+            ? "2025-era handshake (legacy)"
+            : "unknown",
+      ),
+    );
 
     if (tools._tag === "Right") {
       yield* terminal.log(fmt.keyValue("Tools", String(tools.right.length)));

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -19,6 +19,9 @@ import { authorizeServer, clearServerAuth, hasStoredAuth } from "@/services/mcp/
 
 type McpServersRecord = Record<string, MCPServerConfig>;
 
+/** How many resource URIs `mcp test` prints before summarising the rest. */
+const RESOURCE_PREVIEW_LIMIT = 10;
+
 /** Services every MCP CLI command needs. */
 type McpCommandDeps = AgentConfigService | TerminalService | FileSystem.FileSystem;
 
@@ -406,8 +409,28 @@ export function testMcpServerCommand(name: string): Effect.Effect<void, never, M
     }
 
     if (capabilities?.resources !== undefined) {
-      yield* terminal.log(fmt.keyValue("Resources", "advertised (not yet used by Jazz)"));
+      const resources = yield* manager.getServerResources(name).pipe(Effect.either);
+      if (resources._tag === "Right") {
+        yield* terminal.log(fmt.keyValue("Resources", String(resources.right.length)));
+        for (const resource of resources.right.slice(0, RESOURCE_PREVIEW_LIMIT)) {
+          yield* terminal.log(
+            fmt.itemWithDesc(resource.uri, resource.name ?? resource.description ?? ""),
+          );
+        }
+        if (resources.right.length > RESOURCE_PREVIEW_LIMIT) {
+          yield* terminal.log(
+            fmt.item(`… ${resources.right.length - RESOURCE_PREVIEW_LIMIT} more`),
+          );
+        }
+      } else {
+        yield* terminal.warn(`Resources unavailable: ${resources.left.reason}`);
+      }
     }
+
+    const roots = yield* manager.getRoots();
+    yield* terminal.log(
+      fmt.keyValue("Roots advertised", roots.map((root) => root.uri).join(", ") || "none"),
+    );
 
     if (config.trusted !== true) {
       yield* terminal.info(

--- a/src/core/agent/tools/mcp-resources.test.ts
+++ b/src/core/agent/tools/mcp-resources.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import type { MCPServerConfig } from "@/core/interfaces/mcp-server";
+import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { MCPResource } from "@/core/types/mcp";
+import { buildResourceTools } from "./mcp-tools";
+
+const serverConfig = { name: "probe", command: "noop" } as MCPServerConfig;
+
+function makeResources(count: number): MCPResource[] {
+  return Array.from({ length: count }, (_unused, index) => ({
+    uri: `demo://resource/${index}`,
+    name: `resource-${index}`,
+    description: index % 2 === 0 ? "even numbered" : "odd numbered",
+  }));
+}
+
+function harness(resources: MCPResource[], text = "body") {
+  const manager = Layer.succeed(MCPServerManagerTag, {
+    isConnected: () => Effect.succeed(true),
+    getServerResources: () => Effect.succeed(resources),
+    readResource: () => Effect.succeed([{ uri: "demo://resource/0", text }]),
+  } as never);
+  const presentation = Layer.succeed(PresentationServiceTag, {
+    presentStatus: () => Effect.void,
+  } as never);
+  const logger = Layer.succeed(LoggerServiceTag, { debug: () => Effect.void } as never);
+  return Layer.mergeAll(manager, presentation, logger);
+}
+
+async function runList(resources: MCPResource[], args: Record<string, unknown> = {}) {
+  const [listTool] = buildResourceTools(serverConfig);
+  const result = await Effect.runPromise(
+    (
+      listTool!.execute(args, { agentId: "a", conversationId: "c" }) as never as Effect.Effect<
+        {
+          success: boolean;
+          result: { resources: MCPResource[]; total: number; matched?: number; truncated?: string };
+        },
+        never,
+        never
+      >
+    ).pipe(Effect.provide(harness(resources))) as Effect.Effect<
+      {
+        success: boolean;
+        result: { resources: MCPResource[]; total: number; matched?: number; truncated?: string };
+      },
+      never,
+      never
+    >,
+  );
+  return result.result;
+}
+
+describe("MCP resource listing", () => {
+  test("caps a large catalogue and says so", async () => {
+    // A server may advertise thousands of resources; returning all of them
+    // would spend the context window on a directory listing.
+    const result = await runList(makeResources(500));
+
+    expect(result.resources).toHaveLength(100);
+    expect(result.total).toBe(500);
+    expect(result.truncated).toContain("filter");
+  });
+
+  test("returns a small catalogue whole with no truncation note", async () => {
+    const result = await runList(makeResources(7));
+
+    expect(result.resources).toHaveLength(7);
+    expect(result.total).toBe(7);
+    expect(result.truncated).toBeUndefined();
+  });
+
+  test("filters case-insensitively across uri, name, and description", async () => {
+    const result = await runList(makeResources(10), { filter: "EVEN" });
+
+    expect(result.matched).toBe(5);
+    expect(result.resources.every((resource) => resource.description === "even numbered")).toBe(
+      true,
+    );
+  });
+
+  test("honours a smaller explicit limit", async () => {
+    const result = await runList(makeResources(50), { limit: 5 });
+    expect(result.resources).toHaveLength(5);
+  });
+
+  test("does not let an explicit limit exceed the cap", async () => {
+    const result = await runList(makeResources(500), { limit: 10_000 });
+    expect(result.resources).toHaveLength(100);
+  });
+});
+
+describe("MCP resource reads", () => {
+  async function runRead(text: string) {
+    const [, readTool] = buildResourceTools(serverConfig);
+    const result = await Effect.runPromise(
+      (
+        readTool!.execute(
+          { uri: "demo://resource/0" },
+          {
+            agentId: "a",
+            conversationId: "c",
+          },
+        ) as never as Effect.Effect<{ success: boolean; result: string }, never, never>
+      ).pipe(Effect.provide(harness([], text))) as Effect.Effect<
+        { success: boolean; result: string },
+        never,
+        never
+      >,
+    );
+    return result;
+  }
+
+  test("returns a small resource intact", async () => {
+    const result = await runRead("hello");
+    expect(result.result).toBe("hello");
+  });
+
+  test("truncates an oversized resource with a visible marker", async () => {
+    const result = await runRead("x".repeat(250_000));
+
+    expect(result.result.length).toBeLessThan(120_000);
+    expect(result.result).toContain("truncated");
+    expect(result.result).toContain("250000 characters");
+  });
+
+  // The declared schema rejects this before the handler runs, which is why the
+  // handler's own empty-uri guard only ever sees an explicit blank string.
+  test("rejects a call with no uri", async () => {
+    const [, readTool] = buildResourceTools(serverConfig);
+    const result = await Effect.runPromise(
+      (
+        readTool!.execute({}, { agentId: "a", conversationId: "c" }) as never as Effect.Effect<
+          { success: boolean; error: string },
+          never,
+          never
+        >
+      ).pipe(Effect.provide(harness([]))) as Effect.Effect<
+        { success: boolean; error: string },
+        never,
+        never
+      >,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("uri");
+  });
+});

--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -10,7 +10,7 @@ import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { TerminalService } from "@/core/interfaces/terminal";
 import type { Tool, ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
-import type { MCPTool, MCPToolAnnotations } from "@/core/types/mcp";
+import type { MCPResourceContent, MCPTool, MCPToolAnnotations } from "@/core/types/mcp";
 import { convertMCPSchemaToZod, unwrapMCPJsonSchema } from "@/core/utils/mcp-schema-converter";
 import { safeStringify, toPascalCase } from "@/core/utils/string";
 import { defineApprovalTool, defineTool, type ToolValidatorResult } from "./base-tool";
@@ -103,6 +103,51 @@ function resolveParameters(inputSchema: unknown): z.ZodTypeAny {
 }
 
 /**
+ * Make sure the server is connected, reconnecting if the session dropped it.
+ *
+ * Returns undefined on success, or the failed tool result to hand straight
+ * back to the model.
+ */
+function ensureConnected(
+  serverConfig: MCPServerConfig,
+): Effect.Effect<ToolExecutionResult | undefined, never, MCPToolDependencies> {
+  return Effect.gen(function* () {
+    const mcpManager = yield* MCPServerManagerTag;
+    const presentation = yield* PresentationServiceTag;
+    const serverName = serverConfig.name;
+
+    const isConnected = yield* mcpManager.isConnected(serverName);
+    if (isConnected) return undefined;
+
+    yield* presentation.presentStatus(
+      `Connecting to ${toPascalCase(serverName)} MCP server...`,
+      "progress",
+    );
+
+    const connectResult = yield* Effect.either(mcpManager.connectServer(serverConfig));
+    if (connectResult._tag === "Left") {
+      const error = connectResult.left;
+      yield* presentation.presentStatus(
+        `Failed to connect to ${toPascalCase(serverName)} MCP server`,
+        "warning",
+      );
+      return {
+        success: false,
+        result: null,
+        error: `${error.reason}${error.suggestion ? ` — ${error.suggestion}` : ""}`,
+      };
+    }
+
+    yield* presentation.presentStatus(
+      `Connected to ${toPascalCase(serverName)} MCP server`,
+      "success",
+    );
+
+    return undefined;
+  });
+}
+
+/**
  * Run one MCP tool, connecting the server first if the session dropped it.
  */
 function executeMCPTool(
@@ -113,38 +158,13 @@ function executeMCPTool(
   return Effect.gen(function* () {
     const mcpManager = yield* MCPServerManagerTag;
     const logger = yield* LoggerServiceTag;
-    const presentation = yield* PresentationServiceTag;
 
     const serverName = serverConfig.name;
 
     yield* logger.debug(`Executing MCP tool: ${serverName}.${toolName}`, { args });
 
-    const isConnected = yield* mcpManager.isConnected(serverName);
-    if (!isConnected) {
-      yield* presentation.presentStatus(
-        `Connecting to ${toPascalCase(serverName)} MCP server...`,
-        "progress",
-      );
-
-      const connectResult = yield* Effect.either(mcpManager.connectServer(serverConfig));
-      if (connectResult._tag === "Left") {
-        const error = connectResult.left;
-        yield* presentation.presentStatus(
-          `Failed to connect to ${toPascalCase(serverName)} MCP server`,
-          "warning",
-        );
-        return {
-          success: false,
-          result: null,
-          error: `${error.reason}${error.suggestion ? ` — ${error.suggestion}` : ""}`,
-        };
-      }
-
-      yield* presentation.presentStatus(
-        `Connected to ${toPascalCase(serverName)} MCP server`,
-        "success",
-      );
-    }
+    const connectionFailure = yield* ensureConnected(serverConfig);
+    if (connectionFailure !== undefined) return connectionFailure;
 
     const callResult = yield* Effect.either(mcpManager.callTool(serverName, toolName, args));
 
@@ -233,6 +253,88 @@ function adaptMCPToolToJazz(
   });
 
   return pair.all();
+}
+
+/** Render one resource block as text the model can read. */
+function renderResourceContent(content: MCPResourceContent): string {
+  if (content.text !== undefined) return content.text;
+  if (content.blob !== undefined) {
+    return `[binary resource ${content.mimeType ?? "of unknown type"}, ${content.blob.length} base64 chars — not inlined]`;
+  }
+  return "[empty resource]";
+}
+
+/**
+ * Build the pair of tools that let the model reach a server's resources.
+ *
+ * Resources are application-controlled in the spec — the host picks what enters
+ * context — but a terminal has no attach menu, so exposing them as tools is how
+ * they become usable at all. Both are registered read-only without consulting
+ * trust: unlike a tool's `readOnlyHint`, which is a server's claim about
+ * itself, `resources/read` is read-only by protocol definition.
+ */
+export function buildResourceTools(
+  serverConfig: MCPServerConfig,
+): readonly Tool<MCPToolDependencies>[] {
+  const serverName = serverConfig.name;
+  const prefix = `mcp_${serverName.toLowerCase()}`;
+
+  const listTool = defineTool<MCPToolDependencies, Record<string, unknown>>({
+    name: `${prefix}_list_resources`,
+    description: `List the resources available from the ${toPascalCase(serverName)} MCP server. Returns each resource's URI, name, and description. Use ${prefix}_read_resource to read one.`,
+    parameters: z.object({}).passthrough(),
+    hidden: false,
+    riskLevel: "read-only",
+    validate: passThroughMCPArguments,
+    handler: () =>
+      Effect.gen(function* () {
+        const mcpManager = yield* MCPServerManagerTag;
+
+        const connected = yield* ensureConnected(serverConfig);
+        if (connected !== undefined) return connected;
+
+        const resources = yield* Effect.either(mcpManager.getServerResources(serverName));
+        if (resources._tag === "Left") {
+          return { success: false, result: null, error: resources.left.reason };
+        }
+
+        return { success: true, result: resources.right };
+      }),
+  });
+
+  const readTool = defineTool<MCPToolDependencies, Record<string, unknown>>({
+    name: `${prefix}_read_resource`,
+    description: `Read one resource from the ${toPascalCase(serverName)} MCP server by its URI. Call ${prefix}_list_resources first to discover URIs.`,
+    parameters: z.object({
+      uri: z.string().describe("The resource URI, exactly as advertised by the server"),
+    }),
+    hidden: false,
+    riskLevel: "read-only",
+    handler: (args: Record<string, unknown>) =>
+      Effect.gen(function* () {
+        const mcpManager = yield* MCPServerManagerTag;
+        const uri = typeof args["uri"] === "string" ? args["uri"] : "";
+
+        if (uri === "") {
+          return { success: false, result: null, error: "A resource uri is required." };
+        }
+
+        const connected = yield* ensureConnected(serverConfig);
+        if (connected !== undefined) return connected;
+
+        const contents = yield* Effect.either(mcpManager.readResource(serverName, uri));
+        if (contents._tag === "Left") {
+          return { success: false, result: null, error: contents.left.reason };
+        }
+
+        return {
+          success: true,
+          result: contents.right.map(renderResourceContent).join("\n\n"),
+        };
+      }),
+  });
+
+  return [listTool, readTool];
 }
 
 /**

--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -24,6 +24,24 @@ export type MCPToolDependencies =
 /** How much of an argument blob to show in an approval prompt. */
 const APPROVAL_ARGS_PREVIEW_LIMIT = 500;
 
+/**
+ * Ceiling on entries returned by a resource listing.
+ *
+ * Chosen to stay well under a single screen's worth of context: a server may
+ * advertise thousands of resources, and the listing is a means of finding one,
+ * not content worth spending the window on.
+ */
+const RESOURCE_LIST_LIMIT = 100;
+
+/**
+ * Ceiling on the text returned by a single resource read.
+ *
+ * The model picks a URI, not a size, and a server is free to back one URI with
+ * a whole file. Truncating with a visible marker keeps a large resource
+ * useful instead of letting it swallow the conversation.
+ */
+const RESOURCE_READ_CHAR_LIMIT = 100_000;
+
 /** An object schema that keeps every key the model supplied. */
 function emptyPassthroughObject(): z.ZodTypeAny {
   return z.object({}).passthrough();
@@ -281,12 +299,20 @@ export function buildResourceTools(
 
   const listTool = defineTool<MCPToolDependencies, Record<string, unknown>>({
     name: `${prefix}_list_resources`,
-    description: `List the resources available from the ${toPascalCase(serverName)} MCP server. Returns each resource's URI, name, and description. Use ${prefix}_read_resource to read one.`,
-    parameters: z.object({}).passthrough(),
+    description: `List resources available from the ${toPascalCase(serverName)} MCP server. Returns each resource's URI, name, and description. Narrow a large catalogue with "filter" rather than paging through it, then read one with ${prefix}_read_resource.`,
+    parameters: z.object({
+      filter: z
+        .string()
+        .optional()
+        .describe("Case-insensitive substring matched against URI, name, and description"),
+      limit: z
+        .number()
+        .optional()
+        .describe(`Maximum entries to return (default and maximum ${RESOURCE_LIST_LIMIT})`),
+    }),
     hidden: false,
     riskLevel: "read-only",
-    validate: passThroughMCPArguments,
-    handler: () =>
+    handler: (args: Record<string, unknown>) =>
       Effect.gen(function* () {
         const mcpManager = yield* MCPServerManagerTag;
 
@@ -298,7 +324,41 @@ export function buildResourceTools(
           return { success: false, result: null, error: resources.left.reason };
         }
 
-        return { success: true, result: resources.right };
+        const filter =
+          typeof args["filter"] === "string" ? args["filter"].toLowerCase() : undefined;
+        const matched =
+          filter === undefined
+            ? resources.right
+            : resources.right.filter((resource) =>
+                [resource.uri, resource.name, resource.title, resource.description]
+                  .filter((value): value is string => typeof value === "string")
+                  .some((value) => value.toLowerCase().includes(filter)),
+              );
+
+        // A server's catalogue is its own business and can run to thousands of
+        // entries; returning all of them would spend the context window on a
+        // directory listing. Hosts that surface resources in a picker keep this
+        // list out of the model entirely — a cap is the equivalent here.
+        const requested =
+          typeof args["limit"] === "number" && Number.isFinite(args["limit"])
+            ? Math.max(1, Math.floor(args["limit"]))
+            : RESOURCE_LIST_LIMIT;
+        const limit = Math.min(requested, RESOURCE_LIST_LIMIT);
+        const shown = matched.slice(0, limit);
+
+        return {
+          success: true,
+          result: {
+            resources: shown,
+            total: resources.right.length,
+            ...(filter !== undefined ? { matched: matched.length } : {}),
+            ...(matched.length > shown.length
+              ? {
+                  truncated: `Showing ${shown.length} of ${matched.length}. Narrow the results with "filter".`,
+                }
+              : {}),
+          },
+        };
       }),
   });
 
@@ -327,9 +387,14 @@ export function buildResourceTools(
           return { success: false, result: null, error: contents.left.reason };
         }
 
+        const rendered = contents.right.map(renderResourceContent).join("\n\n");
+
         return {
           success: true,
-          result: contents.right.map(renderResourceContent).join("\n\n"),
+          result:
+            rendered.length > RESOURCE_READ_CHAR_LIMIT
+              ? `${rendered.slice(0, RESOURCE_READ_CHAR_LIMIT)}\n\n[truncated — resource is ${rendered.length} characters, showing the first ${RESOURCE_READ_CHAR_LIMIT}]`
+              : rendered,
         };
       }),
   });

--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -10,7 +10,12 @@ import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import type { TerminalService } from "@/core/interfaces/terminal";
 import type { Tool, ToolRiskLevel } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext, ToolExecutionResult } from "@/core/types";
-import type { MCPResourceContent, MCPTool, MCPToolAnnotations } from "@/core/types/mcp";
+import type {
+  MCPProgress,
+  MCPResourceContent,
+  MCPTool,
+  MCPToolAnnotations,
+} from "@/core/types/mcp";
 import { convertMCPSchemaToZod, unwrapMCPJsonSchema } from "@/core/utils/mcp-schema-converter";
 import { safeStringify, toPascalCase } from "@/core/utils/string";
 import { defineApprovalTool, defineTool, type ToolValidatorResult } from "./base-tool";
@@ -20,6 +25,15 @@ import { defineApprovalTool, defineTool, type ToolValidatorResult } from "./base
  */
 export type MCPToolDependencies =
   AgentConfigService | LoggerService | MCPServerManager | TerminalService | PresentationService;
+
+/**
+ * Minimum gap between progress lines shown for one tool call.
+ *
+ * A server is free to report every few milliseconds; the point of showing
+ * progress is that the call is alive, which one line per second conveys as
+ * well as thirty do.
+ */
+const PROGRESS_THROTTLE_MS = 1000;
 
 /** How much of an argument blob to show in an approval prompt. */
 const APPROVAL_ARGS_PREVIEW_LIMIT = 500;
@@ -184,7 +198,34 @@ function executeMCPTool(
     const connectionFailure = yield* ensureConnected(serverConfig);
     if (connectionFailure !== undefined) return connectionFailure;
 
-    const callResult = yield* Effect.either(mcpManager.callTool(serverName, toolName, args));
+    const presentation = yield* PresentationServiceTag;
+
+    // Without this a server doing thirty seconds of work is indistinguishable
+    // from one that has hung. Reports arrive on the transport's callback rather
+    // than inside this fiber, hence the detached run.
+    let lastShownAt = 0;
+    const reportProgress = (progress: MCPProgress): void => {
+      const now = Date.now();
+      const isFinal = progress.total !== undefined && progress.progress >= progress.total;
+      if (!isFinal && now - lastShownAt < PROGRESS_THROTTLE_MS) return;
+      lastShownAt = now;
+
+      const share =
+        progress.total !== undefined && progress.total > 0
+          ? ` ${Math.round((progress.progress / progress.total) * 100)}%`
+          : "";
+      const detail = progress.message !== undefined ? ` — ${progress.message}` : "";
+
+      void Effect.runPromise(
+        presentation
+          .presentStatus(`${toolName}${share}${detail}`, "progress")
+          .pipe(Effect.catchAllCause(() => Effect.void)),
+      );
+    };
+
+    const callResult = yield* Effect.either(
+      mcpManager.callTool(serverName, toolName, args, reportProgress),
+    );
 
     if (callResult._tag === "Left") {
       const error = callResult.left;

--- a/src/core/agent/tools/register-mcp-tools.ts
+++ b/src/core/agent/tools/register-mcp-tools.ts
@@ -12,7 +12,7 @@ import { ToolRegistryTag } from "@/core/interfaces/tool-registry";
 import type { MCPTool } from "@/core/types/mcp";
 import { isAuthenticationRequired } from "@/core/utils/mcp";
 import { toPascalCase } from "@/core/utils/string";
-import { registerMCPServerTools, type MCPToolDependencies } from "./mcp-tools";
+import { buildResourceTools, registerMCPServerTools, type MCPToolDependencies } from "./mcp-tools";
 import { mcpToolCategory } from "./tool-categories";
 
 /**
@@ -25,7 +25,11 @@ import { mcpToolCategory } from "./tool-categories";
  */
 const registeredServers = new Map<
   string,
-  { readonly config: MCPServerConfig; toolNames: readonly string[] }
+  {
+    readonly config: MCPServerConfig;
+    readonly hasResources: boolean;
+    toolNames: readonly string[];
+  }
 >();
 
 /** Set once the manager-level `list_changed` subscription is installed. */
@@ -36,6 +40,7 @@ function syncServerTools(
   registry: ToolRegistry,
   serverConfig: MCPServerConfig,
   mcpTools: readonly MCPTool[],
+  hasResources: boolean,
 ): Effect.Effect<readonly string[], never> {
   return Effect.gen(function* () {
     const category = mcpToolCategory(serverConfig.name);
@@ -45,8 +50,16 @@ function syncServerTools(
       Effect.catchAll(() => Effect.succeed([] as readonly Tool<MCPToolDependencies>[])),
     );
 
+    // A server's own tool names win a collision: the resource pair is Jazz's
+    // addition, and shadowing something the server actually advertises would
+    // be worse than going without.
+    const advertised = new Set(jazzTools.map((tool) => tool.name));
+    const resourceTools = hasResources
+      ? buildResourceTools(serverConfig).filter((tool) => !advertised.has(tool.name))
+      : [];
+
     const nextNames: string[] = [];
-    for (const tool of jazzTools) {
+    for (const tool of [...jazzTools, ...resourceTools]) {
       yield* registerTool(tool);
       nextNames.push(tool.name);
     }
@@ -59,7 +72,11 @@ function syncServerTools(
       }
     }
 
-    registeredServers.set(serverConfig.name, { config: serverConfig, toolNames: nextNames });
+    registeredServers.set(serverConfig.name, {
+      config: serverConfig,
+      hasResources,
+      toolNames: nextNames,
+    });
 
     // Only the model-facing half of each approval pair is worth reporting; the
     // hidden `execute_*` twin is an implementation detail.
@@ -88,7 +105,7 @@ function subscribeToToolChanges(): Effect.Effect<
       if (!entry) return;
 
       void Effect.runPromise(
-        syncServerTools(registry, entry.config, tools).pipe(
+        syncServerTools(registry, entry.config, tools, entry.hasResources).pipe(
           Effect.tap((names) =>
             logger.info(
               `MCP server ${serverName} changed its tool list; now ${names.length} tool(s)`,
@@ -259,7 +276,17 @@ export function registerMCPToolsForAgent(
           );
         }
 
-        const registeredToolNames = yield* syncServerTools(registry, serverConfig, mcpTools);
+        // Only worth adding the resource tools when the server actually
+        // advertised the capability; otherwise they would always fail.
+        const capabilities = yield* mcpManager.getCapabilities(serverName);
+        const hasResources = capabilities?.resources !== undefined;
+
+        const registeredToolNames = yield* syncServerTools(
+          registry,
+          serverConfig,
+          mcpTools,
+          hasResources,
+        );
 
         if (registeredToolNames.length > 0) {
           yield* logger.info(

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -1,5 +1,5 @@
-import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import type { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Context, Effect } from "effect";
 import type {
   MCPConnectionError,
@@ -12,10 +12,12 @@ import type {
 import type {
   MCPElicitationRequest,
   MCPElicitationResponse,
+  MCPProgress,
   MCPPrompt,
   MCPPromptResult,
   MCPResource,
   MCPResourceContent,
+  MCPResourceTemplate,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
@@ -105,6 +107,14 @@ export type ElicitationHandler = (
   request: MCPElicitationRequest,
 ) => Promise<MCPElicitationResponse>;
 
+/**
+ * Receives progress reports from a long-running server operation.
+ *
+ * A server doing thirty seconds of work is otherwise indistinguishable from a
+ * hung one, so these are surfaced rather than dropped.
+ */
+export type ProgressReporter = (progress: MCPProgress) => void;
+
 /** Called when a server reports its tool list changed. */
 export type ToolsChangedHandler = (serverName: string, tools: readonly MCPTool[]) => void;
 
@@ -144,6 +154,7 @@ export interface MCPServerManager {
     serverName: string,
     toolName: string,
     args: Record<string, unknown>,
+    onProgress?: ProgressReporter,
   ) => Effect.Effect<MCPToolResult, MCPToolExecutionError, LoggerService>;
 
   /**
@@ -192,6 +203,25 @@ export interface MCPServerManager {
     serverName: string,
     uri: string,
   ) => Effect.Effect<readonly MCPResourceContent[], MCPResourceError, LoggerService>;
+
+  /**
+   * List a server's parameterized resource URIs. Servers that advertise
+   * resources without implementing templates return an empty list.
+   */
+  readonly getResourceTemplates: (
+    serverName: string,
+  ) => Effect.Effect<readonly MCPResourceTemplate[], MCPResourceError, LoggerService>;
+
+  /**
+   * Ask a server to complete a partially typed prompt or resource argument.
+   * Returns an empty list when the server does not implement completion.
+   */
+  readonly completeArgument: (
+    serverName: string,
+    reference: { readonly type: "prompt" | "resource"; readonly name: string },
+    argumentName: string,
+    partialValue: string,
+  ) => Effect.Effect<readonly string[], never, LoggerService>;
 
   /**
    * Register the handler that answers servers' elicitation requests. Returns an

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -16,7 +16,6 @@ import type {
   MCPPromptResult,
   MCPResource,
   MCPResourceContent,
-  MCPRoot,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
@@ -199,16 +198,6 @@ export interface MCPServerManager {
    * unregister function.
    */
   readonly onElicitation: (handler: ElicitationHandler) => Effect.Effect<() => void, never>;
-
-  /**
-   * Roots currently advertised to servers via `roots/list`.
-   */
-  readonly getRoots: () => Effect.Effect<readonly MCPRoot[], never>;
-
-  /**
-   * Replace the advertised roots and notify connected servers.
-   */
-  readonly setRoots: (roots: readonly MCPRoot[]) => Effect.Effect<void, never, LoggerService>;
 
   /**
    * Discover tools from an MCP server (connects, discovers, then disconnects)

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -227,6 +227,7 @@ export interface MCPServerManager {
     reference: { readonly type: "prompt" | "resource"; readonly name: string },
     argumentName: string,
     partialValue: string,
+    resolvedArguments?: Record<string, string>,
   ) => Effect.Effect<readonly string[], never, LoggerService>;
 
   /**

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -175,6 +175,12 @@ export interface MCPServerManager {
   ) => Effect.Effect<MCPPromptResult, MCPPromptError, LoggerService>;
 
   /**
+   * Which protocol era a connection negotiated — "modern" for 2026-07-28,
+   * "legacy" for the 2025 handshake. Undefined when not connected.
+   */
+  readonly getProtocolEra: (serverName: string) => Effect.Effect<string | undefined, never>;
+
+  /**
    * Capabilities the server declared at initialize, or undefined when not
    * connected.
    */

--- a/src/core/interfaces/mcp-server.ts
+++ b/src/core/interfaces/mcp-server.ts
@@ -5,12 +5,18 @@ import type {
   MCPConnectionError,
   MCPDisconnectionError,
   MCPPromptError,
+  MCPResourceError,
   MCPToolDiscoveryError,
   MCPToolExecutionError,
 } from "@/core/types/errors";
 import type {
+  MCPElicitationRequest,
+  MCPElicitationResponse,
   MCPPrompt,
   MCPPromptResult,
+  MCPResource,
+  MCPResourceContent,
+  MCPRoot,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
@@ -90,6 +96,16 @@ export function isHttpConfig(config: MCPServerConfig): config is MCPServerConfig
  */
 export type MCPTransport = StdioClientTransport | StreamableHTTPClientTransport;
 
+/**
+ * Asks the user a server's elicitation question.
+ *
+ * Registered only by surfaces that can actually reach a person; where none is
+ * registered the manager declines, which is what an unattended run needs.
+ */
+export type ElicitationHandler = (
+  request: MCPElicitationRequest,
+) => Promise<MCPElicitationResponse>;
+
 /** Called when a server reports its tool list changed. */
 export type ToolsChangedHandler = (serverName: string, tools: readonly MCPTool[]) => void;
 
@@ -161,6 +177,38 @@ export interface MCPServerManager {
    * function. Handlers fire with the re-listed tools already resolved.
    */
   readonly onToolsChanged: (handler: ToolsChangedHandler) => Effect.Effect<() => void, never>;
+
+  /**
+   * List resources a connected server exposes. Servers that do not advertise
+   * the `resources` capability return an empty list rather than error.
+   */
+  readonly getServerResources: (
+    serverName: string,
+  ) => Effect.Effect<readonly MCPResource[], MCPResourceError, LoggerService>;
+
+  /**
+   * Read one resource by URI.
+   */
+  readonly readResource: (
+    serverName: string,
+    uri: string,
+  ) => Effect.Effect<readonly MCPResourceContent[], MCPResourceError, LoggerService>;
+
+  /**
+   * Register the handler that answers servers' elicitation requests. Returns an
+   * unregister function.
+   */
+  readonly onElicitation: (handler: ElicitationHandler) => Effect.Effect<() => void, never>;
+
+  /**
+   * Roots currently advertised to servers via `roots/list`.
+   */
+  readonly getRoots: () => Effect.Effect<readonly MCPRoot[], never>;
+
+  /**
+   * Replace the advertised roots and notify connected servers.
+   */
+  readonly setRoots: (roots: readonly MCPRoot[]) => Effect.Effect<void, never, LoggerService>;
 
   /**
    * Discover tools from an MCP server (connects, discovers, then disconnects)

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -261,6 +261,13 @@ export class MCPToolDiscoveryError extends Data.TaggedError("MCPToolDiscoveryErr
   readonly suggestion?: string;
 }> {}
 
+export class MCPResourceError extends Data.TaggedError("MCPResourceError")<{
+  readonly serverName: string;
+  readonly reason: string;
+  readonly cause?: unknown;
+  readonly suggestion?: string;
+}> {}
+
 export class MCPPromptError extends Data.TaggedError("MCPPromptError")<{
   readonly serverName: string;
   readonly reason: string;

--- a/src/core/types/mcp.ts
+++ b/src/core/types/mcp.ts
@@ -106,3 +106,68 @@ export interface MCPJSONSchema {
   readonly $ref?: string;
   readonly const?: unknown;
 }
+
+/** A resource a server exposes by URI, as advertised by `resources/list`. */
+export interface MCPResource {
+  readonly uri: string;
+  readonly name?: string | undefined;
+  readonly title?: string | undefined;
+  readonly description?: string | undefined;
+  readonly mimeType?: string | undefined;
+}
+
+/** One block of a `resources/read` result. */
+export interface MCPResourceContent {
+  readonly uri: string;
+  readonly mimeType?: string | undefined;
+  /** Text body, present for textual resources. */
+  readonly text?: string | undefined;
+  /** Base64 body, present for binary resources. */
+  readonly blob?: string | undefined;
+}
+
+/**
+ * A field an elicitation asks the user to fill.
+ *
+ * Narrowed from the spec's `PrimitiveSchemaDefinition` to what a terminal can
+ * actually render: a line of text, a number, a yes/no, or a choice from a list.
+ */
+export interface MCPElicitationField {
+  readonly name: string;
+  readonly type: "string" | "number" | "integer" | "boolean" | "enum" | "multi-enum";
+  readonly title?: string | undefined;
+  readonly description?: string | undefined;
+  readonly required: boolean;
+  /** Present when `type` is "enum" or "multi-enum". */
+  readonly options?: readonly { readonly value: string; readonly label: string }[] | undefined;
+  readonly default?: string | number | boolean | readonly string[] | undefined;
+}
+
+/** A server's request for structured input from the user. */
+export interface MCPElicitationRequest {
+  readonly serverName: string;
+  readonly message: string;
+  readonly fields: readonly MCPElicitationField[];
+}
+
+/**
+ * The user's answer to an elicitation.
+ *
+ * `decline` means "no, continue without this"; `cancel` means the user
+ * dismissed the request entirely. The spec distinguishes them and servers are
+ * expected to react differently, so Jazz does not collapse the two.
+ */
+export type MCPElicitationResponse =
+  | {
+      readonly action: "accept";
+      readonly content: Record<string, string | number | boolean | readonly string[]>;
+    }
+  | { readonly action: "decline" }
+  | { readonly action: "cancel" };
+
+/** A filesystem root Jazz exposes to servers via `roots/list`. */
+export interface MCPRoot {
+  /** A `file://` URI. */
+  readonly uri: string;
+  readonly name?: string | undefined;
+}

--- a/src/core/types/mcp.ts
+++ b/src/core/types/mcp.ts
@@ -164,3 +164,19 @@ export type MCPElicitationResponse =
     }
   | { readonly action: "decline" }
   | { readonly action: "cancel" };
+
+/** A parameterized resource URI, as advertised by `resources/templates/list`. */
+export interface MCPResourceTemplate {
+  readonly uriTemplate: string;
+  readonly name?: string | undefined;
+  readonly title?: string | undefined;
+  readonly description?: string | undefined;
+  readonly mimeType?: string | undefined;
+}
+
+/** One progress report from a long-running server operation. */
+export interface MCPProgress {
+  readonly progress: number;
+  readonly total?: number | undefined;
+  readonly message?: string | undefined;
+}

--- a/src/core/types/mcp.ts
+++ b/src/core/types/mcp.ts
@@ -164,10 +164,3 @@ export type MCPElicitationResponse =
     }
   | { readonly action: "decline" }
   | { readonly action: "cancel" };
-
-/** A filesystem root Jazz exposes to servers via `roots/list`. */
-export interface MCPRoot {
-  /** A `file://` URI. */
-  readonly uri: string;
-  readonly name?: string | undefined;
-}

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -1323,18 +1323,46 @@ function handleRunMcpPromptCommand(
     }
 
     const declared = definition.arguments ?? [];
-    const bound = bindPromptArguments(declared, args.slice(1));
+    const bound: Record<string, string> = { ...bindPromptArguments(declared, args.slice(1)) };
 
-    const missing = declared
-      .filter((argument) => argument.required === true && bound[argument.name] === undefined)
-      .map((argument) => argument.name);
+    // Rather than rejecting an under-specified invocation, ask for what is
+    // missing — offering the server's own completions where it implements
+    // them, which is the only place completion/complete is reachable without
+    // an autocomplete-aware composer.
+    for (const argument of declared) {
+      if (bound[argument.name] !== undefined) continue;
+      if (argument.required !== true) continue;
 
-    if (missing.length > 0) {
-      yield* terminal.error(`Missing required argument(s): ${missing.join(", ")}`);
-      yield* terminal.info(
-        `Usage: /${commandName} ${declared.map((argument) => `${argument.name}=<value>`).join(" ")}`,
+      const label = argument.description
+        ? `${argument.name} — ${argument.description}`
+        : argument.name;
+
+      const suggestions = yield* mcpManager.completeArgument(
+        serverName,
+        { type: "prompt", name: promptName },
+        argument.name,
+        "",
+        bound,
       );
-      return { shouldContinue: true };
+
+      if (suggestions.length > 0) {
+        const chosen = yield* terminal.select<string>(label, {
+          choices: suggestions.map((value) => ({ name: value, value })),
+        });
+        if (!chosen) {
+          yield* terminal.info("Cancelled.");
+          return { shouldContinue: true };
+        }
+        bound[argument.name] = chosen;
+        continue;
+      }
+
+      const typed = yield* terminal.ask(label, { cancellable: true });
+      if (typed === undefined || typed.trim() === "") {
+        yield* terminal.info("Cancelled.");
+        return { shouldContinue: true };
+      }
+      bound[argument.name] = typed.trim();
     }
 
     const resolved = yield* mcpManager.getPrompt(serverName, promptName, bound).pipe(Effect.either);

--- a/src/services/chat/commands/mcp-prompt-args.test.ts
+++ b/src/services/chat/commands/mcp-prompt-args.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { MCPServerManagerTag, type MCPServerManager } from "@/core/interfaces/mcp-server";
+import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
+import type { Agent } from "@/core/types/agent";
+import { handleSpecialCommand } from "./handler";
+import type { CommandContext, CommandResult } from "./types";
+
+const agent = {
+  id: "a",
+  name: "A",
+  config: { persona: "default", llmProvider: "openai", llmModel: "gpt-4", tools: [] },
+} as unknown as Agent;
+
+const context: CommandContext = {
+  agent,
+  conversationHistory: [],
+  conversationId: "c",
+  sessionUsage: { promptTokens: 0, completionTokens: 0 },
+  sessionStartedAt: new Date(),
+};
+
+const PROMPT = {
+  name: "staff",
+  description: "pick a team",
+  arguments: [
+    { name: "department", required: true },
+    { name: "name", required: true },
+  ],
+};
+
+/** Records every completion request so argument context can be asserted. */
+function harness(options: {
+  completions: Record<string, string[]>;
+  selections: string[];
+  typed?: string[];
+}) {
+  const completionCalls: { argument: string; resolved: Record<string, string> }[] = [];
+  const selectCalls: string[] = [];
+  let getPromptArgs: Record<string, string> = {};
+  const selections = [...options.selections];
+  const typed = [...(options.typed ?? [])];
+
+  const manager = {
+    getServerPrompts: () => Effect.succeed([PROMPT]),
+    completeArgument: (
+      _server: string,
+      _ref: unknown,
+      argumentName: string,
+      _partial: string,
+      resolved: Record<string, string> = {},
+    ) => {
+      completionCalls.push({ argument: argumentName, resolved: { ...resolved } });
+      return Effect.succeed(options.completions[argumentName] ?? []);
+    },
+    getPrompt: (_server: string, _name: string, args: Record<string, string>) => {
+      getPromptArgs = args;
+      return Effect.succeed({
+        messages: [{ role: "user", content: { type: "text", text: "ok" } }],
+      });
+    },
+  } as unknown as MCPServerManager;
+
+  const terminal = {
+    log: mock(() => Effect.void),
+    info: mock(() => Effect.void),
+    warn: mock(() => Effect.void),
+    error: mock(() => Effect.void),
+    select: mock((message: string) => {
+      selectCalls.push(message);
+      return Effect.succeed(selections.shift());
+    }),
+    ask: mock(() => Effect.succeed(typed.shift())),
+  } as unknown as TerminalService;
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(MCPServerManagerTag, manager),
+    Layer.succeed(TerminalServiceTag, terminal),
+  );
+
+  return { layer, completionCalls, selectCalls, getPromptArgs: () => getPromptArgs };
+}
+
+function run(layer: Layer.Layer<never, never, never>, args: string[]) {
+  return Effect.runPromise(
+    handleSpecialCommand({ type: "runMcpPrompt", args }, context).pipe(
+      Effect.provide(layer),
+    ) as Effect.Effect<CommandResult, unknown, never>,
+  );
+}
+
+describe("MCP prompt argument filling", () => {
+  test("asks for a missing required argument and offers the server's completions", async () => {
+    const h = harness({
+      completions: { department: ["Engineering", "Sales"], name: ["Alice"] },
+      selections: ["Engineering", "Alice"],
+    });
+
+    const result = await run(h.layer as never, ["srv:staff"]);
+
+    expect(h.selectCalls).toHaveLength(2);
+    expect(h.getPromptArgs()).toEqual({ department: "Engineering", name: "Alice" });
+    expect(result.resendMessage).toBe("ok");
+  });
+
+  test("passes already-chosen arguments as completion context", async () => {
+    // A prompt may narrow one argument by an earlier one; without the context
+    // the dependent argument completes to nothing and the picker vanishes.
+    const h = harness({
+      completions: { department: ["Engineering"], name: ["Alice"] },
+      selections: ["Engineering", "Alice"],
+    });
+
+    await run(h.layer as never, ["srv:staff"]);
+
+    expect(h.completionCalls[0]).toEqual({ argument: "department", resolved: {} });
+    expect(h.completionCalls[1]).toEqual({
+      argument: "name",
+      resolved: { department: "Engineering" },
+    });
+  });
+
+  test("does not re-ask for an argument supplied inline", async () => {
+    const h = harness({ completions: { name: ["Alice"] }, selections: ["Alice"] });
+
+    await run(h.layer as never, ["srv:staff", "department=Sales"]);
+
+    expect(h.completionCalls.map((call) => call.argument)).toEqual(["name"]);
+    expect(h.getPromptArgs()).toEqual({ department: "Sales", name: "Alice" });
+  });
+
+  test("falls back to free text when the server offers no completions", async () => {
+    const h = harness({ completions: {}, selections: [], typed: ["Ops", "Dana"] });
+
+    await run(h.layer as never, ["srv:staff"]);
+
+    expect(h.selectCalls).toHaveLength(0);
+    expect(h.getPromptArgs()).toEqual({ department: "Ops", name: "Dana" });
+  });
+
+  test("cancels cleanly when the user dismisses a picker", async () => {
+    const h = harness({
+      completions: { department: ["Engineering"] },
+      selections: [undefined as never],
+    });
+
+    const result = await run(h.layer as never, ["srv:staff"]);
+
+    expect(result.resendMessage).toBeUndefined();
+    expect(result.shouldContinue).toBe(true);
+  });
+});

--- a/src/services/chat/session/agent-setup.ts
+++ b/src/services/chat/session/agent-setup.ts
@@ -1,9 +1,7 @@
-import { pathToFileURL } from "node:url";
 import { Effect } from "effect";
 import { registerMCPToolsForAgent } from "@/core/agent/tools/register-mcp-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
-import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { MCPServerManager } from "@/core/interfaces/mcp-server";
 import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
@@ -31,7 +29,6 @@ export function setupAgent(
   | ToolRegistry
   | MCPServerManager
   | AgentConfigService
-  | FileSystemContextService
   | LoggerService
   | TerminalService
   | PresentationService
@@ -45,10 +42,6 @@ export function setupAgent(
     const agentToolNames = normalizeToolConfig(agent.config.tools, {
       agentId: agent.id,
     });
-
-    // Tell servers which directory this agent works in before they connect, so
-    // one that scopes itself to roots starts out pointed at the right place.
-    yield* advertiseAgentRoots(agent.id, conversationId);
 
     // Registered before connecting: a server may elicit during its very first
     // tool call, and there is no later hook that would still be in time.
@@ -79,25 +72,6 @@ export function setupAgent(
       yield* logger.debug("Agent setup completed - MCP tools registered");
       yield* registerMcpPromptCommands(setupResult.right);
     }
-  });
-}
-
-/**
- * Advertise the agent's working directory as its MCP root.
- *
- * Without this a filesystem-scoped server has to be handed its paths at spawn
- * time, which pins it to whatever directory Jazz happened to launch in.
- */
-function advertiseAgentRoots(
-  agentId: string,
-  conversationId: string,
-): Effect.Effect<void, never, MCPServerManager | FileSystemContextService | LoggerService> {
-  return Effect.gen(function* () {
-    const shell = yield* FileSystemContextServiceTag;
-    const mcpManager = yield* MCPServerManagerTag;
-
-    const cwd = yield* shell.getCwd({ agentId, conversationId });
-    yield* mcpManager.setRoots([{ uri: pathToFileURL(cwd).href, name: "workspace" }]);
   });
 }
 

--- a/src/services/chat/session/agent-setup.ts
+++ b/src/services/chat/session/agent-setup.ts
@@ -1,7 +1,9 @@
+import { pathToFileURL } from "node:url";
 import { Effect } from "effect";
 import { registerMCPToolsForAgent } from "@/core/agent/tools/register-mcp-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
+import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import type { MCPServerManager } from "@/core/interfaces/mcp-server";
 import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
@@ -10,6 +12,7 @@ import type { TerminalService } from "@/core/interfaces/terminal";
 import type { ToolRegistry } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types";
 import { setMcpPromptCommands } from "@/services/chat/commands";
+import { registerElicitationHandler } from "./elicitation";
 
 /**
  * Set up agent before first message: Connect to MCP servers and register tools.
@@ -28,6 +31,7 @@ export function setupAgent(
   | ToolRegistry
   | MCPServerManager
   | AgentConfigService
+  | FileSystemContextService
   | LoggerService
   | TerminalService
   | PresentationService
@@ -41,6 +45,14 @@ export function setupAgent(
     const agentToolNames = normalizeToolConfig(agent.config.tools, {
       agentId: agent.id,
     });
+
+    // Tell servers which directory this agent works in before they connect, so
+    // one that scopes itself to roots starts out pointed at the right place.
+    yield* advertiseAgentRoots(agent.id, conversationId);
+
+    // Registered before connecting: a server may elicit during its very first
+    // tool call, and there is no later hook that would still be in time.
+    yield* registerElicitationHandler();
 
     // Register MCP tools for this agent (connects to relevant servers)
     // This happens before the first message as part of agent setup
@@ -67,6 +79,25 @@ export function setupAgent(
       yield* logger.debug("Agent setup completed - MCP tools registered");
       yield* registerMcpPromptCommands(setupResult.right);
     }
+  });
+}
+
+/**
+ * Advertise the agent's working directory as its MCP root.
+ *
+ * Without this a filesystem-scoped server has to be handed its paths at spawn
+ * time, which pins it to whatever directory Jazz happened to launch in.
+ */
+function advertiseAgentRoots(
+  agentId: string,
+  conversationId: string,
+): Effect.Effect<void, never, MCPServerManager | FileSystemContextService | LoggerService> {
+  return Effect.gen(function* () {
+    const shell = yield* FileSystemContextServiceTag;
+    const mcpManager = yield* MCPServerManagerTag;
+
+    const cwd = yield* shell.getCwd({ agentId, conversationId });
+    yield* mcpManager.setRoots([{ uri: pathToFileURL(cwd).href, name: "workspace" }]);
   });
 }
 

--- a/src/services/chat/session/elicitation.ts
+++ b/src/services/chat/session/elicitation.ts
@@ -1,0 +1,156 @@
+import { Effect } from "effect";
+import type { LoggerService } from "@/core/interfaces/logger";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import type { MCPServerManager } from "@/core/interfaces/mcp-server";
+import { MCPServerManagerTag } from "@/core/interfaces/mcp-server";
+import type { PresentationService } from "@/core/interfaces/presentation";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import type { TerminalService } from "@/core/interfaces/terminal";
+import { TerminalServiceTag } from "@/core/interfaces/terminal";
+import type {
+  MCPElicitationField,
+  MCPElicitationRequest,
+  MCPElicitationResponse,
+} from "@/core/types/mcp";
+import { toPascalCase } from "@/core/utils/string";
+
+/** Label to show for a field, preferring the server's own wording. */
+function fieldLabel(field: MCPElicitationField): string {
+  const base = field.title ?? field.name;
+  return field.required ? `${base} (required)` : `${base} (optional, blank to skip)`;
+}
+
+/** Ask for one field's value using whichever prompt fits its type. */
+function askField(
+  terminal: TerminalService,
+  field: MCPElicitationField,
+): Effect.Effect<string | number | boolean | readonly string[] | undefined, never> {
+  return Effect.gen(function* () {
+    const label = fieldLabel(field);
+
+    if (field.type === "boolean") {
+      return yield* terminal.confirm(label, field.default === true);
+    }
+
+    if (field.type === "multi-enum") {
+      const options = field.options ?? [];
+      if (options.length === 0) return undefined;
+      const chosen = yield* terminal.checkbox<string>(label, {
+        choices: options.map((option) => ({ name: option.label, value: option.value })),
+        ...(Array.isArray(field.default) ? { default: field.default as readonly string[] } : {}),
+      });
+      return chosen.length > 0 ? chosen : undefined;
+    }
+
+    if (field.type === "enum") {
+      const options = field.options ?? [];
+      if (options.length === 0) return undefined;
+      return yield* terminal.select<string>(label, {
+        choices: options.map((option) => ({ name: option.label, value: option.value })),
+      });
+    }
+
+    const answer = yield* terminal.ask(label, {
+      ...(field.default !== undefined ? { defaultValue: String(field.default) } : {}),
+      validate: (input: string) => {
+        const trimmed = input.trim();
+        if (trimmed === "") {
+          return field.required ? `${field.title ?? field.name} is required` : true;
+        }
+        if (field.type === "number" || field.type === "integer") {
+          if (Number.isNaN(Number(trimmed))) return "Enter a number";
+          if (field.type === "integer" && !Number.isInteger(Number(trimmed))) {
+            return "Enter a whole number";
+          }
+        }
+        return true;
+      },
+    });
+
+    const trimmed = (answer ?? "").trim();
+    if (trimmed === "") return undefined;
+    return field.type === "number" || field.type === "integer" ? Number(trimmed) : trimmed;
+  });
+}
+
+/**
+ * Ask the user a server's elicitation question and return its answer.
+ *
+ * A server asking for something it cannot get on its own is the point of the
+ * primitive, but it is still a server driving a prompt in the user's terminal:
+ * which server is asking is stated up front, and declining is always one
+ * keypress away.
+ */
+export function runElicitation(
+  terminal: TerminalService,
+  request: MCPElicitationRequest,
+): Effect.Effect<MCPElicitationResponse, never> {
+  return Effect.gen(function* () {
+    yield* terminal.log("");
+    yield* terminal.warn(`${toPascalCase(request.serverName)} MCP server is asking for input:`);
+    if (request.message !== "") {
+      yield* terminal.log(request.message);
+    }
+
+    const proceed = yield* terminal.confirm("Answer it?", true);
+    if (!proceed) {
+      return { action: "decline" as const };
+    }
+
+    const content: Record<string, string | number | boolean | readonly string[]> = {};
+
+    for (const field of request.fields) {
+      if (field.description) {
+        yield* terminal.info(field.description);
+      }
+
+      const value = yield* askField(terminal, field);
+
+      if (value === undefined) {
+        if (field.required) {
+          // A required field left empty means the answer cannot be completed,
+          // which is a cancel rather than a considered decline.
+          yield* terminal.warn("Required field skipped — cancelling this request.");
+          return { action: "cancel" as const };
+        }
+        continue;
+      }
+
+      content[field.name] = value;
+    }
+
+    return { action: "accept" as const, content };
+  });
+}
+
+/**
+ * Register the elicitation handler for surfaces that can reach a person.
+ *
+ * Deliberately a no-op where they cannot: on a bridge or a scheduled run there
+ * is nobody to ask, and the manager's default of declining is what keeps an
+ * unattended job moving instead of blocking on a dialog no one will see.
+ */
+export function registerElicitationHandler(): Effect.Effect<
+  void,
+  never,
+  MCPServerManager | TerminalService | PresentationService | LoggerService
+> {
+  return Effect.gen(function* () {
+    const presentation = yield* PresentationServiceTag;
+    const logger = yield* LoggerServiceTag;
+
+    if (presentation.canPromptForApproval?.() !== true) {
+      yield* logger.debug("Skipping MCP elicitation handler: this surface cannot prompt the user");
+      return;
+    }
+
+    const mcpManager = yield* MCPServerManagerTag;
+    const terminal = yield* TerminalServiceTag;
+
+    yield* mcpManager.onElicitation((request) =>
+      Effect.runPromise(runElicitation(terminal, request)),
+    );
+
+    yield* logger.debug("MCP elicitation handler registered");
+  });
+}

--- a/src/services/mcp/elicitation-schema.test.ts
+++ b/src/services/mcp/elicitation-schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { readChoices, toElicitationFields } from "./elicitation-schema";
+
+function field(schema: Record<string, unknown>, required: string[] = []) {
+  return toElicitationFields({ type: "object", properties: { probe: schema }, required })[0];
+}
+
+describe("readChoices", () => {
+  test("reads a bare enum", () => {
+    expect(readChoices({ enum: ["a", "b"] })).toEqual([
+      { value: "a", label: "a" },
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  test("pairs enumNames with enum values", () => {
+    expect(readChoices({ enum: ["h1", "h2"], enumNames: ["Superman", "Batman"] })).toEqual([
+      { value: "h1", label: "Superman" },
+      { value: "h2", label: "Batman" },
+    ]);
+  });
+
+  test("reads titled oneOf and anyOf const entries", () => {
+    const expected = [{ value: "hero-1", label: "Superman" }];
+    expect(readChoices({ oneOf: [{ const: "hero-1", title: "Superman" }] })).toEqual(expected);
+    expect(readChoices({ anyOf: [{ const: "hero-1", title: "Superman" }] })).toEqual(expected);
+  });
+
+  test("falls back to the const when a titled entry has no title", () => {
+    expect(readChoices({ oneOf: [{ const: "x" }] })).toEqual([{ value: "x", label: "x" }]);
+  });
+
+  test("returns undefined for a node with no choices", () => {
+    expect(readChoices({ type: "string" })).toBeUndefined();
+    expect(readChoices(undefined)).toBeUndefined();
+    // A oneOf that is a real union rather than a choice list is not a picker.
+    expect(readChoices({ oneOf: [{ type: "string" }, { type: "number" }] })).toBeUndefined();
+  });
+});
+
+describe("toElicitationFields", () => {
+  test("maps scalar types", () => {
+    expect(field({ type: "string" })?.type).toBe("string");
+    expect(field({ type: "boolean" })?.type).toBe("boolean");
+    expect(field({ type: "integer" })?.type).toBe("integer");
+    expect(field({ type: "number" })?.type).toBe("number");
+  });
+
+  test("coerces an unrenderable type to a string field", () => {
+    expect(field({ type: "object" })?.type).toBe("string");
+    expect(field({})?.type).toBe("string");
+  });
+
+  test("recognises all four ways the spec spells a single-select", () => {
+    // Only the first two were handled originally; the titled forms silently
+    // became free-text prompts asking for a raw value.
+    expect(field({ type: "string", enum: ["a"] })?.type).toBe("enum");
+    expect(field({ enum: ["a"], enumNames: ["A"] })?.type).toBe("enum");
+    expect(field({ type: "string", oneOf: [{ const: "a", title: "A" }] })?.type).toBe("enum");
+    expect(field({ type: "string", anyOf: [{ const: "a", title: "A" }] })?.type).toBe("enum");
+  });
+
+  test("recognises multi-select arrays in both spellings", () => {
+    expect(field({ type: "array", items: { type: "string", enum: ["a"] } })?.type).toBe(
+      "multi-enum",
+    );
+    expect(field({ type: "array", items: { anyOf: [{ const: "a", title: "A" }] } })?.type).toBe(
+      "multi-enum",
+    );
+  });
+
+  test("keeps an array without choices as a plain field", () => {
+    expect(field({ type: "array", items: { type: "string" } })?.type).toBe("string");
+  });
+
+  test("carries titles, descriptions, and required flags", () => {
+    const result = field({ type: "string", title: "Name", description: "Your name" }, ["probe"]);
+    expect(result).toMatchObject({
+      name: "probe",
+      title: "Name",
+      description: "Your name",
+      required: true,
+    });
+  });
+
+  test("marks unlisted fields optional", () => {
+    expect(field({ type: "string" })?.required).toBe(false);
+  });
+
+  test("carries defaults of each shape", () => {
+    expect(field({ type: "string", default: "x" })?.default).toBe("x");
+    expect(field({ type: "integer", default: 42 })?.default).toBe(42);
+    expect(field({ type: "boolean", default: true })?.default).toBe(true);
+    expect(field({ type: "array", items: { enum: ["a", "b"] }, default: ["a"] })?.default).toEqual([
+      "a",
+    ]);
+  });
+
+  test("returns nothing for a schema with no properties", () => {
+    expect(toElicitationFields({ type: "object" })).toEqual([]);
+    expect(toElicitationFields(null)).toEqual([]);
+    expect(toElicitationFields("nonsense")).toEqual([]);
+  });
+});

--- a/src/services/mcp/elicitation-schema.ts
+++ b/src/services/mcp/elicitation-schema.ts
@@ -1,0 +1,124 @@
+import type { MCPElicitationField } from "@/core/types/mcp";
+
+/**
+ * Read the choices out of one schema node, whichever way it spells them.
+ *
+ * The spec grew four spellings: a bare `enum`, `enum` plus parallel
+ * `enumNames`, and `oneOf`/`anyOf` arrays of `{ const, title }`. They all
+ * mean "pick from this list", and a terminal should show a picker for each
+ * rather than making someone type a raw value it could have offered.
+ */
+export function readChoices(
+  node: Record<string, unknown> | undefined,
+): readonly { value: string; label: string }[] | undefined {
+  if (!node) return undefined;
+
+  const enumValues = node["enum"];
+  if (Array.isArray(enumValues)) {
+    const enumNames = node["enumNames"];
+    return enumValues.map((value, index) => ({
+      value: String(value),
+      label:
+        Array.isArray(enumNames) && typeof enumNames[index] === "string"
+          ? enumNames[index]
+          : String(value),
+    }));
+  }
+
+  const titled = node["oneOf"] ?? node["anyOf"];
+  if (Array.isArray(titled)) {
+    const options = titled
+      .filter(
+        (entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null,
+      )
+      .filter((entry) => entry["const"] !== undefined)
+      .map((entry) => ({
+        value: String(entry["const"]),
+        label: typeof entry["title"] === "string" ? entry["title"] : String(entry["const"]),
+      }));
+    if (options.length > 0) return options;
+  }
+
+  return undefined;
+}
+
+/**
+ * Translate a server's requested schema into fields a terminal can render.
+ *
+ * The spec allows richer JSON Schema than a prompt can express, so anything
+ * that does not map onto a line of text, a number, a yes/no, or a choice is
+ * coerced to a string field and left to the user to type.
+ */
+export function toElicitationFields(requestedSchema: unknown): readonly MCPElicitationField[] {
+  if (typeof requestedSchema !== "object" || requestedSchema === null) return [];
+
+  const schema = requestedSchema as {
+    properties?: Record<string, Record<string, unknown>>;
+    required?: unknown;
+  };
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter((name): name is string => typeof name === "string")
+      : [],
+  );
+
+  return Object.entries(schema.properties ?? {}).map((entry) => {
+    const [name, property] = entry;
+    const rawType = property["type"];
+    const rawDefault = property["default"];
+
+    const base = {
+      name,
+      required: required.has(name),
+      ...(typeof property["title"] === "string" ? { title: property["title"] } : {}),
+      ...(typeof property["description"] === "string"
+        ? { description: property["description"] }
+        : {}),
+    };
+
+    // A multi-select is an array whose *items* carry the choices.
+    if (rawType === "array") {
+      const items = property["items"];
+      const options = readChoices(
+        typeof items === "object" && items !== null
+          ? (items as Record<string, unknown>)
+          : undefined,
+      );
+      if (options) {
+        return {
+          ...base,
+          type: "multi-enum" as const,
+          options,
+          ...(Array.isArray(rawDefault)
+            ? { default: rawDefault.map((value) => String(value)) }
+            : {}),
+        };
+      }
+    }
+
+    const options = readChoices(property);
+    if (options) {
+      return {
+        ...base,
+        type: "enum" as const,
+        options,
+        ...(typeof rawDefault === "string" ? { default: rawDefault } : {}),
+      };
+    }
+
+    const type =
+      rawType === "number" || rawType === "integer" || rawType === "boolean"
+        ? rawType
+        : ("string" as const);
+
+    return {
+      ...base,
+      type,
+      ...(typeof rawDefault === "string" ||
+      typeof rawDefault === "number" ||
+      typeof rawDefault === "boolean"
+        ? { default: rawDefault }
+        : {}),
+    };
+  });
+}

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -1,12 +1,6 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import {
-  ElicitRequestSchema,
-  PromptListChangedNotificationSchema,
-  ToolListChangedNotificationSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import type { Transport } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Effect, Layer } from "effect";
 import type { AgentConfigService } from "@/core/interfaces/agent-config";
 import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
@@ -18,6 +12,7 @@ import type {
   MCPServerManager,
   MCPTransport,
   MCPTransportType,
+  ProgressReporter,
   ToolsChangedHandler,
 } from "@/core/interfaces/mcp-server";
 import { isHttpConfig, isStdioConfig, MCPServerManagerTag } from "@/core/interfaces/mcp-server";
@@ -37,6 +32,7 @@ import type {
   MCPPromptResult,
   MCPResource,
   MCPResourceContent,
+  MCPResourceTemplate,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
@@ -182,14 +178,24 @@ class MCPServerManagerImpl implements MCPServerManager {
         { capabilities: { elicitation: {} } },
       );
 
-      client.setRequestHandler(ElicitRequestSchema, (request) =>
+      client.setRequestHandler("elicitation/create", (request) =>
         manager.handleElicitation(config.name, request.params),
       );
 
-      client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      client.setNotificationHandler("notifications/tools/list_changed", () => {
         manager.handleToolsListChanged(config.name);
       });
-      client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+      client.setNotificationHandler("notifications/resources/list_changed", () => {
+        // Resource listings are fetched fresh on every call rather than cached,
+        // so there is no stale state to invalidate. Handled anyway so the
+        // notification is not silently dropped by the transport.
+        void Effect.runPromise(
+          manager.logger
+            .debug(`MCP server ${config.name} changed its resource list`)
+            .pipe(Effect.catchAllCause(() => Effect.void)),
+        );
+      });
+      client.setNotificationHandler("notifications/prompts/list_changed", () => {
         // Prompts are re-listed on demand by the chat command, so the
         // notification only needs to not be an unhandled-method error.
       });
@@ -400,6 +406,7 @@ class MCPServerManagerImpl implements MCPServerManager {
     serverName: string,
     toolName: string,
     args: Record<string, unknown>,
+    onProgress?: ProgressReporter,
   ): Effect.Effect<MCPToolResult, MCPToolExecutionError, LoggerService> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
@@ -417,7 +424,25 @@ class MCPServerManagerImpl implements MCPServerManager {
       }
 
       const result = yield* Effect.tryPromise({
-        try: () => connection.client.callTool({ name: toolName, arguments: args }),
+        try: () =>
+          connection.client.callTool(
+            { name: toolName, arguments: args },
+            onProgress
+              ? {
+                  onprogress: (progress) => {
+                    onProgress({
+                      progress: progress.progress,
+                      ...(progress.total !== undefined ? { total: progress.total } : {}),
+                      ...(progress.message !== undefined ? { message: progress.message } : {}),
+                    });
+                  },
+                  // A server that keeps reporting is working, not hung — let it
+                  // keep going rather than timing out mid-report.
+                  resetTimeoutOnProgress: true,
+                  maxTotalTimeout: CALL_TIMEOUT_MS,
+                }
+              : undefined,
+          ),
         catch: (error) => (error instanceof Error ? error : new Error(String(error))),
       }).pipe(
         Effect.timeoutFail({
@@ -579,7 +604,10 @@ class MCPServerManagerImpl implements MCPServerManager {
       message?: string | undefined;
       requestedSchema?: unknown;
     },
-  ): Promise<{ action: "accept" | "decline" | "cancel"; content?: Record<string, unknown> }> {
+  ): Promise<{
+    action: "accept" | "decline" | "cancel";
+    content?: Record<string, string | number | boolean | string[]>;
+  }> {
     const handler = this.elicitationHandler;
 
     if (!handler) {
@@ -609,9 +637,22 @@ class MCPServerManagerImpl implements MCPServerManager {
 
     try {
       const response: MCPElicitationResponse = await handler(request);
-      return response.action === "accept"
-        ? { action: "accept", content: response.content }
-        : { action: response.action };
+      if (response.action !== "accept") {
+        return { action: response.action };
+      }
+
+      // v2 types elicitation content precisely, and a readonly array is not
+      // assignable to the mutable one the wire type declares.
+      const content: Record<string, string | number | boolean | string[]> = {};
+      for (const [key, value] of Object.entries(response.content)) {
+        // `Array.isArray` does not narrow a readonly array out of the union,
+        // so the scalar cases are what get tested.
+        content[key] =
+          typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+            ? value
+            : [...value];
+      }
+      return { action: "accept", content };
     } catch (error) {
       await Effect.runPromise(
         this.logger.warn(
@@ -736,6 +777,69 @@ class MCPServerManagerImpl implements MCPServerManager {
         ...("text" in content && typeof content.text === "string" ? { text: content.text } : {}),
         ...("blob" in content && typeof content.blob === "string" ? { blob: content.blob } : {}),
       }));
+    });
+  }
+
+  getResourceTemplates(
+    serverName: string,
+  ): Effect.Effect<readonly MCPResourceTemplate[], MCPResourceError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection || connection.capabilities?.resources === undefined) {
+        return [];
+      }
+
+      return yield* Effect.tryPromise({
+        try: async () => {
+          const result = await connection.client.listResourceTemplates({});
+          return result.resourceTemplates.map((template) => ({
+            uriTemplate: template.uriTemplate,
+            name: template.name,
+            title: template.title,
+            description: template.description,
+            mimeType: template.mimeType,
+          }));
+        },
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        // A server may advertise `resources` without implementing templates, so
+        // a failure here means "none", not a broken server.
+        Effect.catchAll(() => Effect.succeed([] as readonly MCPResourceTemplate[])),
+      );
+    });
+  }
+
+  completeArgument(
+    serverName: string,
+    reference: { readonly type: "prompt" | "resource"; readonly name: string },
+    argumentName: string,
+    partialValue: string,
+  ): Effect.Effect<readonly string[], never, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) return [];
+
+      return yield* Effect.tryPromise({
+        try: async () => {
+          const result = await connection.client.complete({
+            ref:
+              reference.type === "prompt"
+                ? { type: "ref/prompt", name: reference.name }
+                : { type: "ref/resource", uri: reference.name },
+            argument: { name: argumentName, value: partialValue },
+          });
+          return result.completion.values;
+        },
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        // Completion is a convenience: a server that does not implement it
+        // should cost the user a picker, not the whole prompt.
+        Effect.catchAll(() => Effect.succeed([] as readonly string[])),
+      );
     });
   }
 

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -58,12 +58,51 @@ const CALL_TIMEOUT_MS = 120_000;
 /** Guard against a server paginating `tools/list` without end. */
 const MAX_LIST_PAGES = 50;
 
+/** Narrow an SDK tool definition to the fields Jazz reads. */
+function toMCPTool(tool: {
+  name: string;
+  title?: string | undefined;
+  description?: string | undefined;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  annotations?:
+    | {
+        readOnlyHint?: boolean | undefined;
+        destructiveHint?: boolean | undefined;
+        idempotentHint?: boolean | undefined;
+        openWorldHint?: boolean | undefined;
+      }
+    | undefined;
+}): MCPTool {
+  return {
+    name: tool.name,
+    ...(tool.title !== undefined ? { title: tool.title } : {}),
+    ...(tool.description !== undefined ? { description: tool.description } : {}),
+    ...(tool.inputSchema !== undefined ? { inputSchema: tool.inputSchema as MCPJSONSchema } : {}),
+    ...(tool.outputSchema !== undefined
+      ? { outputSchema: tool.outputSchema as MCPJSONSchema }
+      : {}),
+    ...(tool.annotations !== undefined
+      ? {
+          annotations: {
+            readOnlyHint: tool.annotations.readOnlyHint,
+            destructiveHint: tool.annotations.destructiveHint,
+            idempotentHint: tool.annotations.idempotentHint,
+            openWorldHint: tool.annotations.openWorldHint,
+          },
+        }
+      : {}),
+  };
+}
+
 interface Connection {
   readonly serverName: string;
   readonly client: Client;
   readonly transport: MCPTransport;
   readonly transportType: MCPTransportType;
   readonly capabilities: MCPServerCapabilities | undefined;
+  /** Which protocol era the connection negotiated: "modern" is 2026-07-28. */
+  readonly protocolEra: string | undefined;
 }
 
 /**
@@ -129,28 +168,41 @@ class MCPServerManagerImpl implements MCPServerManager {
   }
 
   /**
-   * Re-list a server's tools and fan the result out to subscribers.
+   * Fan a server's new tool list out to subscribers.
    *
-   * Runs detached from any fiber: notifications arrive on the transport's own
-   * callback, not inside an Effect the caller is awaiting.
+   * `items` is null only when auto-refresh is disabled, which Jazz does not do;
+   * it is still guarded so a change never turns into an empty tool list.
    */
-  private handleToolsListChanged(serverName: string): void {
-    if (this.toolsChangedHandlers.size === 0) return;
+  private handleToolsChanged(
+    serverName: string,
+    items:
+      | readonly {
+          name: string;
+          title?: string | undefined;
+          description?: string | undefined;
+          inputSchema?: unknown;
+          outputSchema?: unknown;
+          annotations?:
+            | {
+                readOnlyHint?: boolean | undefined;
+                destructiveHint?: boolean | undefined;
+                idempotentHint?: boolean | undefined;
+                openWorldHint?: boolean | undefined;
+              }
+            | undefined;
+        }[]
+      | null,
+  ): void {
+    if (items === null || this.toolsChangedHandlers.size === 0) return;
 
-    void Effect.runPromise(
-      this.getServerTools(serverName).pipe(
-        Effect.provideService(LoggerServiceTag, this.logger),
-        Effect.catchAll(() => Effect.succeed([] as readonly MCPTool[])),
-      ),
-    ).then((tools) => {
-      for (const handler of this.toolsChangedHandlers) {
-        try {
-          handler(serverName, tools);
-        } catch {
-          // One bad subscriber must not stop the others.
-        }
+    const tools = items.map(toMCPTool);
+    for (const handler of this.toolsChangedHandlers) {
+      try {
+        handler(serverName, tools);
+      } catch {
+        // One bad subscriber must not stop the others.
       }
-    });
+    }
   }
 
   connectServer(config: MCPServerConfig): Effect.Effect<void, MCPConnectionError, LoggerService> {
@@ -168,37 +220,49 @@ class MCPServerManagerImpl implements MCPServerManager {
 
       const client = new Client(
         { name: "jazz", version: packageJson.version },
-        // `elicitation` is advertised unconditionally even though a given
-        // surface may have no way to ask a person: the capability says Jazz
-        // speaks the request, and declining is a valid answer to it.
-        // Roots is deliberately not declared: the 2026-07-28 spec deprecates it
-        // (SEP-2577) and removes notifications/roots/list_changed, with the
-        // migration being to pass directories as tool parameters or server
-        // config instead.
-        { capabilities: { elicitation: {} } },
+        {
+          // Roots is deliberately not declared: 2026-07-28 deprecates it
+          // (SEP-2577) and removes notifications/roots/list_changed, with the
+          // migration being to pass directories as tool parameters or server
+          // config instead.
+          //
+          // `elicitation` is advertised unconditionally even though a given
+          // surface may have no way to ask a person: the capability says Jazz
+          // speaks the request, and declining is a valid answer to it. On a
+          // 2026-era connection the SDK fulfils the same handler through the
+          // multi-round-trip `input_required` flow, so one handler serves both.
+          capabilities: { elicitation: {} },
+          // Probe `server/discover` for the 2026-07-28 era and fall back to the
+          // 2025 handshake against older servers, at the cost of one round trip.
+          versionNegotiation: { mode: "auto" },
+          // Era-transparent list-change handling: unsolicited notifications on
+          // 2025 connections, an auto-opened `subscriptions/listen` stream on
+          // 2026 ones. The SDK re-lists and hands back the new items, which is
+          // why nothing here re-fetches by hand.
+          listChanged: {
+            tools: {
+              onChanged: (error, items) => {
+                if (error) {
+                  void Effect.runPromise(
+                    manager.logger
+                      .warn(
+                        `Failed to refresh tools for ${config.name} after a list change: ${error.message}`,
+                      )
+                      .pipe(Effect.catchAllCause(() => Effect.void)),
+                  );
+                  return;
+                }
+                manager.handleToolsChanged(config.name, items);
+              },
+            },
+          },
+        },
       );
 
+      // v2 registers handlers by method name rather than by schema.
       client.setRequestHandler("elicitation/create", (request) =>
         manager.handleElicitation(config.name, request.params),
       );
-
-      client.setNotificationHandler("notifications/tools/list_changed", () => {
-        manager.handleToolsListChanged(config.name);
-      });
-      client.setNotificationHandler("notifications/resources/list_changed", () => {
-        // Resource listings are fetched fresh on every call rather than cached,
-        // so there is no stale state to invalidate. Handled anyway so the
-        // notification is not silently dropped by the transport.
-        void Effect.runPromise(
-          manager.logger
-            .debug(`MCP server ${config.name} changed its resource list`)
-            .pipe(Effect.catchAllCause(() => Effect.void)),
-        );
-      });
-      client.setNotificationHandler("notifications/prompts/list_changed", () => {
-        // Prompts are re-listed on demand by the chat command, so the
-        // notification only needs to not be an unhandled-method error.
-      });
 
       const connectEffect = Effect.tryPromise({
         try: () => client.connect(transport as Transport),
@@ -258,16 +322,19 @@ class MCPServerManagerImpl implements MCPServerManager {
           }
         : undefined;
 
+      const protocolEra = client.getProtocolEra();
+
       manager.connections.set(config.name, {
         serverName: config.name,
         client,
         transport,
         transportType,
         capabilities,
+        protocolEra,
       });
 
       yield* manager.logger.info(
-        `Connected to MCP server: ${config.name} (${transportType} transport)`,
+        `Connected to MCP server: ${config.name} (${transportType} transport, ${protocolEra ?? "unknown"} protocol era)`,
       );
     }).pipe(
       Effect.mapError((error: unknown) => {
@@ -341,27 +408,7 @@ class MCPServerManagerImpl implements MCPServerManager {
               );
 
               for (const tool of result.tools) {
-                collected.push({
-                  name: tool.name,
-                  ...(tool.title !== undefined ? { title: tool.title } : {}),
-                  ...(tool.description !== undefined ? { description: tool.description } : {}),
-                  ...(tool.inputSchema !== undefined
-                    ? { inputSchema: tool.inputSchema as MCPJSONSchema }
-                    : {}),
-                  ...(tool.outputSchema !== undefined
-                    ? { outputSchema: tool.outputSchema as MCPJSONSchema }
-                    : {}),
-                  ...(tool.annotations !== undefined
-                    ? {
-                        annotations: {
-                          readOnlyHint: tool.annotations.readOnlyHint,
-                          destructiveHint: tool.annotations.destructiveHint,
-                          idempotentHint: tool.annotations.idempotentHint,
-                          openWorldHint: tool.annotations.openWorldHint,
-                        },
-                      }
-                    : {}),
-                });
+                collected.push(toMCPTool(tool));
               }
 
               cursor = result.nextCursor;
@@ -841,6 +888,10 @@ class MCPServerManagerImpl implements MCPServerManager {
         Effect.catchAll(() => Effect.succeed([] as readonly string[])),
       );
     });
+  }
+
+  getProtocolEra(serverName: string): Effect.Effect<string | undefined, never> {
+    return Effect.sync(() => this.connections.get(serverName)?.protocolEra);
   }
 
   getCapabilities(serverName: string): Effect.Effect<MCPServerCapabilities | undefined, never> {

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -1,8 +1,11 @@
+import { pathToFileURL } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
+  ElicitRequestSchema,
+  ListRootsRequestSchema,
   PromptListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -12,6 +15,7 @@ import { AgentConfigServiceTag } from "@/core/interfaces/agent-config";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type {
+  ElicitationHandler,
   MCPServerConfig,
   MCPServerManager,
   MCPTransport,
@@ -23,19 +27,26 @@ import {
   MCPConnectionError,
   MCPDisconnectionError,
   MCPPromptError,
+  MCPResourceError,
   MCPToolDiscoveryError,
   MCPToolExecutionError,
 } from "@/core/types/errors";
 import type {
+  MCPElicitationRequest,
+  MCPElicitationResponse,
   MCPJSONSchema,
   MCPPrompt,
   MCPPromptResult,
+  MCPResource,
+  MCPResourceContent,
+  MCPRoot,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
 } from "@/core/types/mcp";
 import { createSanitizedEnv } from "@/core/utils/env";
 import { retryWithBackoff } from "@/core/utils/mcp";
+import { toElicitationFields } from "./elicitation-schema";
 import { createStoredTokenProvider, InteractiveAuthRequiredError } from "./oauth";
 import packageJson from "../../../package.json";
 
@@ -73,11 +84,24 @@ class MCPServerManagerImpl implements MCPServerManager {
   private connections: Map<string, Connection>;
   private toolsChangedHandlers: Set<ToolsChangedHandler>;
   private logger: LoggerService;
+  /**
+   * Roots advertised to servers. Defaults to the launch directory, which is
+   * the same thing a server would otherwise have to be told at spawn time.
+   */
+  private roots: readonly MCPRoot[];
+  /**
+   * Set by whichever surface can actually put a question to a person. Left
+   * unset on bridges and scheduled runs, where the correct answer to an
+   * elicitation is to decline rather than to block forever.
+   */
+  private elicitationHandler: ElicitationHandler | undefined;
 
   constructor(logger: LoggerService) {
     this.connections = new Map();
     this.toolsChangedHandlers = new Set();
     this.logger = logger;
+    this.roots = [{ uri: pathToFileURL(process.cwd()).href, name: "workspace" }];
+    this.elicitationHandler = undefined;
   }
 
   private buildTransport(config: MCPServerConfig): {
@@ -157,9 +181,27 @@ class MCPServerManagerImpl implements MCPServerManager {
 
       const client = new Client(
         { name: "jazz", version: packageJson.version },
-        // Declaring `roots` would oblige us to answer `roots/list`; Jazz does
-        // not yet, so it stays out of the handshake.
-        { capabilities: {} },
+        // Only declare what we actually answer below. `elicitation` is
+        // advertised unconditionally even though a given surface may have no
+        // way to ask a person: the capability says Jazz speaks the request,
+        // and declining is a valid answer to it.
+        {
+          capabilities: {
+            roots: { listChanged: true },
+            elicitation: {},
+          },
+        },
+      );
+
+      client.setRequestHandler(ListRootsRequestSchema, () => ({
+        roots: manager.roots.map((root) => ({
+          uri: root.uri,
+          ...(root.name !== undefined ? { name: root.name } : {}),
+        })),
+      }));
+
+      client.setRequestHandler(ElicitRequestSchema, (request) =>
+        manager.handleElicitation(config.name, request.params),
       );
 
       client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
@@ -538,6 +580,208 @@ class MCPServerManagerImpl implements MCPServerManager {
           content: message.content,
         })),
       };
+    });
+  }
+
+  /**
+   * Answer a server's `elicitation/create`.
+   *
+   * Declines rather than blocking whenever there is nobody to ask — an
+   * unattended bridge or scheduled run has no way to surface a dialog, and a
+   * hung request there would stall the whole job.
+   */
+  private async handleElicitation(
+    serverName: string,
+    params: {
+      mode?: string | undefined;
+      message?: string | undefined;
+      requestedSchema?: unknown;
+    },
+  ): Promise<{ action: "accept" | "decline" | "cancel"; content?: Record<string, unknown> }> {
+    const handler = this.elicitationHandler;
+
+    if (!handler) {
+      await Effect.runPromise(
+        this.logger.debug(
+          `Declined elicitation from ${serverName}: this surface cannot prompt the user`,
+        ),
+      );
+      return { action: "decline" };
+    }
+
+    // URL mode hands the user off to a browser page the server controls. Jazz
+    // has no way to confirm what happens there, so it is declined rather than
+    // silently opened.
+    if (params.mode === "url") {
+      await Effect.runPromise(
+        this.logger.warn(`Declined URL-mode elicitation from ${serverName}: not supported`),
+      );
+      return { action: "decline" };
+    }
+
+    const request: MCPElicitationRequest = {
+      serverName,
+      message: typeof params.message === "string" ? params.message : "",
+      fields: toElicitationFields(params.requestedSchema),
+    };
+
+    try {
+      const response: MCPElicitationResponse = await handler(request);
+      return response.action === "accept"
+        ? { action: "accept", content: response.content }
+        : { action: response.action };
+    } catch (error) {
+      await Effect.runPromise(
+        this.logger.warn(
+          `Elicitation handler failed for ${serverName}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+      return { action: "cancel" };
+    }
+  }
+
+  onElicitation(handler: ElicitationHandler): Effect.Effect<() => void, never> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.sync(() => {
+      manager.elicitationHandler = handler;
+      return () => {
+        if (manager.elicitationHandler === handler) {
+          manager.elicitationHandler = undefined;
+        }
+      };
+    });
+  }
+
+  getRoots(): Effect.Effect<readonly MCPRoot[], never> {
+    return Effect.sync(() => this.roots);
+  }
+
+  setRoots(roots: readonly MCPRoot[]): Effect.Effect<void, never, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const unchanged =
+        roots.length === manager.roots.length &&
+        roots.every((root, index) => manager.roots[index]?.uri === root.uri);
+      if (unchanged) return;
+
+      manager.roots = roots;
+
+      // Servers that scoped themselves to the old roots need to hear about it;
+      // ones that never asked simply ignore the notification.
+      for (const connection of manager.connections.values()) {
+        yield* Effect.tryPromise({
+          try: () => connection.client.sendRootsListChanged(),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        }).pipe(Effect.catchAll(() => Effect.void));
+      }
+
+      yield* manager.logger.debug(`MCP roots updated: ${roots.map((root) => root.uri).join(", ")}`);
+    });
+  }
+
+  getServerResources(
+    serverName: string,
+  ): Effect.Effect<readonly MCPResource[], MCPResourceError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) {
+        return yield* Effect.fail(
+          new MCPResourceError({
+            serverName,
+            reason: `MCP server ${serverName} is not connected`,
+            suggestion: `Call connectServer() before listing resources`,
+          }),
+        );
+      }
+
+      if (connection.capabilities?.resources === undefined) {
+        return [];
+      }
+
+      return yield* Effect.tryPromise({
+        try: async () => {
+          const collected: MCPResource[] = [];
+          let cursor: string | undefined;
+
+          for (let page = 0; page < MAX_LIST_PAGES; page += 1) {
+            const result = await connection.client.listResources(
+              cursor === undefined ? {} : { cursor },
+            );
+
+            for (const resource of result.resources) {
+              collected.push({
+                uri: resource.uri,
+                name: resource.name,
+                title: resource.title,
+                description: resource.description,
+                mimeType: resource.mimeType,
+              });
+            }
+
+            cursor = result.nextCursor;
+            if (cursor === undefined) break;
+          }
+
+          return collected;
+        },
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPResourceError({
+              serverName,
+              reason: `Failed to list resources: ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check that the MCP server is running and responding correctly`,
+            }),
+        ),
+      );
+    });
+  }
+
+  readResource(
+    serverName: string,
+    uri: string,
+  ): Effect.Effect<readonly MCPResourceContent[], MCPResourceError, LoggerService> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const manager = this;
+    return Effect.gen(function* () {
+      const connection = manager.connections.get(serverName);
+      if (!connection) {
+        return yield* Effect.fail(
+          new MCPResourceError({
+            serverName,
+            reason: `MCP server ${serverName} is not connected`,
+            suggestion: `Call connectServer() before reading a resource`,
+          }),
+        );
+      }
+
+      const result = yield* Effect.tryPromise({
+        try: () => connection.client.readResource({ uri }),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(
+        Effect.mapError(
+          (error: unknown) =>
+            new MCPResourceError({
+              serverName,
+              reason: `Failed to read resource "${uri}": ${error instanceof Error ? error.message : String(error)}`,
+              cause: error,
+              suggestion: `Check that the URI is one the server advertises`,
+            }),
+        ),
+      );
+
+      return result.contents.map((content) => ({
+        uri: content.uri,
+        mimeType: content.mimeType,
+        ...("text" in content && typeof content.text === "string" ? { text: content.text } : {}),
+        ...("blob" in content && typeof content.blob === "string" ? { blob: content.blob } : {}),
+      }));
     });
   }
 

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -1,11 +1,9 @@
-import { pathToFileURL } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   ElicitRequestSchema,
-  ListRootsRequestSchema,
   PromptListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -39,7 +37,6 @@ import type {
   MCPPromptResult,
   MCPResource,
   MCPResourceContent,
-  MCPRoot,
   MCPServerCapabilities,
   MCPTool,
   MCPToolResult,
@@ -85,11 +82,6 @@ class MCPServerManagerImpl implements MCPServerManager {
   private toolsChangedHandlers: Set<ToolsChangedHandler>;
   private logger: LoggerService;
   /**
-   * Roots advertised to servers. Defaults to the launch directory, which is
-   * the same thing a server would otherwise have to be told at spawn time.
-   */
-  private roots: readonly MCPRoot[];
-  /**
    * Set by whichever surface can actually put a question to a person. Left
    * unset on bridges and scheduled runs, where the correct answer to an
    * elicitation is to decline rather than to block forever.
@@ -100,7 +92,6 @@ class MCPServerManagerImpl implements MCPServerManager {
     this.connections = new Map();
     this.toolsChangedHandlers = new Set();
     this.logger = logger;
-    this.roots = [{ uri: pathToFileURL(process.cwd()).href, name: "workspace" }];
     this.elicitationHandler = undefined;
   }
 
@@ -181,24 +172,15 @@ class MCPServerManagerImpl implements MCPServerManager {
 
       const client = new Client(
         { name: "jazz", version: packageJson.version },
-        // Only declare what we actually answer below. `elicitation` is
-        // advertised unconditionally even though a given surface may have no
-        // way to ask a person: the capability says Jazz speaks the request,
-        // and declining is a valid answer to it.
-        {
-          capabilities: {
-            roots: { listChanged: true },
-            elicitation: {},
-          },
-        },
+        // `elicitation` is advertised unconditionally even though a given
+        // surface may have no way to ask a person: the capability says Jazz
+        // speaks the request, and declining is a valid answer to it.
+        // Roots is deliberately not declared: the 2026-07-28 spec deprecates it
+        // (SEP-2577) and removes notifications/roots/list_changed, with the
+        // migration being to pass directories as tool parameters or server
+        // config instead.
+        { capabilities: { elicitation: {} } },
       );
-
-      client.setRequestHandler(ListRootsRequestSchema, () => ({
-        roots: manager.roots.map((root) => ({
-          uri: root.uri,
-          ...(root.name !== undefined ? { name: root.name } : {}),
-        })),
-      }));
 
       client.setRequestHandler(ElicitRequestSchema, (request) =>
         manager.handleElicitation(config.name, request.params),
@@ -650,34 +632,6 @@ class MCPServerManagerImpl implements MCPServerManager {
           manager.elicitationHandler = undefined;
         }
       };
-    });
-  }
-
-  getRoots(): Effect.Effect<readonly MCPRoot[], never> {
-    return Effect.sync(() => this.roots);
-  }
-
-  setRoots(roots: readonly MCPRoot[]): Effect.Effect<void, never, LoggerService> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const manager = this;
-    return Effect.gen(function* () {
-      const unchanged =
-        roots.length === manager.roots.length &&
-        roots.every((root, index) => manager.roots[index]?.uri === root.uri);
-      if (unchanged) return;
-
-      manager.roots = roots;
-
-      // Servers that scoped themselves to the old roots need to hear about it;
-      // ones that never asked simply ignore the notification.
-      for (const connection of manager.connections.values()) {
-        yield* Effect.tryPromise({
-          try: () => connection.client.sendRootsListChanged(),
-          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-        }).pipe(Effect.catchAll(() => Effect.void));
-      }
-
-      yield* manager.logger.debug(`MCP roots updated: ${roots.map((root) => root.uri).join(", ")}`);
     });
   }
 

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -142,7 +142,7 @@ class MCPServerManagerImpl implements MCPServerManager {
       } else {
         // Static headers are the user saying "authenticate this way"; only fall
         // back to OAuth when they have not.
-        options.authProvider = createStoredTokenProvider(config.name);
+        options.authProvider = createStoredTokenProvider(config.name, config.url);
       }
 
       if (config.conversationId) {

--- a/src/services/mcp/mcp-server-manager.ts
+++ b/src/services/mcp/mcp-server-manager.ts
@@ -863,6 +863,7 @@ class MCPServerManagerImpl implements MCPServerManager {
     reference: { readonly type: "prompt" | "resource"; readonly name: string },
     argumentName: string,
     partialValue: string,
+    resolvedArguments: Record<string, string> = {},
   ): Effect.Effect<readonly string[], never, LoggerService> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
@@ -878,6 +879,11 @@ class MCPServerManagerImpl implements MCPServerManager {
                 ? { type: "ref/prompt", name: reference.name }
                 : { type: "ref/resource", uri: reference.name },
             argument: { name: argumentName, value: partialValue },
+            // Servers may narrow one argument by the values already chosen for
+            // earlier ones; without this such an argument completes to nothing.
+            ...(Object.keys(resolvedArguments).length > 0
+              ? { context: { arguments: resolvedArguments } }
+              : {}),
           });
           return result.completion.values;
         },

--- a/src/services/mcp/oauth.test.ts
+++ b/src/services/mcp/oauth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import metadataDocument from "../../../oauth-client-metadata.json";
+
+/**
+ * The published document and the client's own behaviour have to agree: an
+ * authorization server fetches the document and rejects the flow when the
+ * request does not match it.
+ */
+describe("Client ID Metadata Document", () => {
+  test("client_id is an https URL with a path, and matches its own location", () => {
+    const clientId = metadataDocument.client_id;
+    const url = new URL(clientId);
+
+    expect(url.protocol).toBe("https:");
+    expect(url.pathname).not.toBe("/");
+    // The server validates that the document's client_id equals the URL it
+    // fetched, so the filename here must match the constant in oauth.ts.
+    expect(clientId.endsWith("/oauth-client-metadata.json")).toBe(true);
+  });
+
+  test("declares the required properties", () => {
+    expect(metadataDocument.client_id).toBeTruthy();
+    expect(metadataDocument.client_name).toBeTruthy();
+    expect(Array.isArray(metadataDocument.redirect_uris)).toBe(true);
+    expect(metadataDocument.redirect_uris.length).toBeGreaterThan(0);
+  });
+
+  test("declares application_type native so OIDC servers accept loopback redirects", () => {
+    // Omitting this defaults to "web", which rejects 127.0.0.1 redirect URIs.
+    expect(metadataDocument.application_type).toBe("native");
+  });
+
+  test("every redirect URI is a fixed loopback callback", () => {
+    // Ephemeral ports cannot work under CIMD: the authorization server checks
+    // the request's redirect_uri against this exact list.
+    for (const uri of metadataDocument.redirect_uris) {
+      const url = new URL(uri);
+      expect(url.hostname).toBe("127.0.0.1");
+      expect(url.pathname).toBe("/callback");
+      expect(Number(url.port)).toBeGreaterThan(0);
+    }
+  });
+
+  test("the declared ports match the ones the callback listener tries", async () => {
+    const source = await Bun.file("src/services/mcp/oauth.ts").text();
+    const declared = metadataDocument.redirect_uris.map((uri) => new URL(uri).port).sort();
+
+    const match = source.match(/const CALLBACK_PORTS = \[([^\]]+)\]/);
+    const used = (match?.[1] ?? "")
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .sort();
+
+    // Drift here is invisible until a real authorization fails, so it is
+    // pinned rather than left to review.
+    expect(used).toEqual(declared);
+  });
+});

--- a/src/services/mcp/oauth.ts
+++ b/src/services/mcp/oauth.ts
@@ -1,12 +1,13 @@
 import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { auth, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { auth } from "@modelcontextprotocol/client";
 import type {
+  OAuthClientProvider,
   OAuthClientInformation,
   OAuthClientInformationFull,
   OAuthClientMetadata,
   OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
+} from "@modelcontextprotocol/client";
 import { Effect } from "effect";
 import {
   detectKeyringBackend,

--- a/src/services/mcp/oauth.ts
+++ b/src/services/mcp/oauth.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { auth } from "@modelcontextprotocol/client";
+import { auth, discoverOAuthServerInfo } from "@modelcontextprotocol/client";
 import type {
   OAuthClientProvider,
   OAuthClientInformation,
@@ -21,6 +21,32 @@ const CLIENT_NAME = "Jazz";
 const CLIENT_URI = "https://github.com/lvndry/jazz";
 
 /**
+ * Jazz's Client ID Metadata Document (SEP-991).
+ *
+ * Under 2026-07-28 this is the preferred registration mechanism and the
+ * `client_id` is the document's own URL. The SDK gates on the authorization
+ * server advertising `client_id_metadata_document_supported` and falls back to
+ * Dynamic Client Registration when it does not — which is the priority chain
+ * the spec prescribes, not legacy cruft.
+ *
+ * Kept byte-identical to `oauth-client-metadata.json` at the repository root:
+ * an authorization server fetches that file and rejects the flow if its
+ * `client_id` does not match the URL exactly.
+ */
+const CLIENT_METADATA_URL =
+  "https://raw.githubusercontent.com/lvndry/jazz/main/oauth-client-metadata.json";
+
+/**
+ * Loopback ports offered for the OAuth redirect, in preference order.
+ *
+ * A Client ID Metadata Document lists its redirect URIs up front and the
+ * authorization server MUST validate the request against that list, so the
+ * callback cannot bind an ephemeral port the way it could under DCR. These
+ * four are the ones the published document names.
+ */
+const CALLBACK_PORTS = [33418, 33419, 33420, 33421] as const;
+
+/**
  * How long the loopback listener waits for the browser to come back with a
  * code before giving up. Long enough to cover a fresh login plus consent on a
  * provider the user is not already signed into.
@@ -32,8 +58,33 @@ function tokensAccount(serverName: string): string {
   return `mcp.oauth.${serverName}.tokens`;
 }
 
-function clientAccount(serverName: string): string {
-  return `mcp.oauth.${serverName}.client`;
+/**
+ * Where a server's registered client credentials live.
+ *
+ * Keyed by the issuer as well as the server, because the spec requires
+ * credentials to be bound to the authorization server that minted them: if a
+ * server moves to a different authorization server, its old registration must
+ * not be reused and the client must re-register. Keying by server name alone
+ * would silently present the wrong credentials.
+ */
+function clientAccount(serverName: string, issuer: string): string {
+  return `mcp.oauth.${serverName}.client.${encodeURIComponent(issuer)}`;
+}
+
+/**
+ * Which issuer a server's stored credentials belong to.
+ *
+ * Recorded so credentials can be found and cleared later without re-running
+ * discovery, and so a changed authorization server is detectable.
+ */
+function issuerAccount(serverName: string): string {
+  return `mcp.oauth.${serverName}.issuer`;
+}
+
+/** Resolve which authorization server backs an MCP server URL. */
+async function resolveIssuer(serverUrl: string): Promise<string> {
+  const info = await discoverOAuthServerInfo(serverUrl);
+  return info.authorizationServerUrl;
 }
 
 /**
@@ -60,8 +111,29 @@ function readJson<T>(raw: string | undefined): T | undefined {
   }
 }
 
-/** Read/write halves shared by the interactive and non-interactive providers. */
-function createStorage(serverName: string) {
+/**
+ * Read/write halves shared by the interactive and non-interactive providers.
+ *
+ * The issuer is resolved lazily: transports are constructed synchronously, and
+ * discovering the authorization server is a network call that must not happen
+ * on that path. It is memoised per storage instance and recorded in the keyring
+ * so a later `clearServerAuth` can find the same entry.
+ */
+function createStorage(serverName: string, serverUrl: string) {
+  let issuerPromise: Promise<string> | undefined;
+
+  async function currentIssuer(): Promise<string> {
+    if (!issuerPromise) {
+      issuerPromise = (async () => {
+        const backend = await Effect.runPromise(detectKeyringBackend());
+        const issuer = await resolveIssuer(serverUrl);
+        await Effect.runPromise(keyringSet(backend, issuerAccount(serverName), issuer));
+        return issuer;
+      })();
+    }
+    return issuerPromise;
+  }
+
   return {
     async loadTokens(): Promise<OAuthTokens | undefined> {
       const backend = await Effect.runPromise(detectKeyringBackend());
@@ -76,12 +148,26 @@ function createStorage(serverName: string) {
     },
     async loadClient(): Promise<OAuthClientInformation | undefined> {
       const backend = await Effect.runPromise(detectKeyringBackend());
-      const raw = await Effect.runPromise(keyringGet(backend, clientAccount(serverName)));
+      const issuer = await currentIssuer();
+      const raw = await Effect.runPromise(keyringGet(backend, clientAccount(serverName, issuer)));
       return readJson<OAuthClientInformation>(raw);
     },
     async saveClient(info: OAuthClientInformationFull): Promise<void> {
       const backend = await Effect.runPromise(detectKeyringBackend());
-      await Effect.runPromise(keyringSet(backend, clientAccount(serverName), JSON.stringify(info)));
+      const issuer = await currentIssuer();
+      await Effect.runPromise(
+        keyringSet(backend, clientAccount(serverName, issuer), JSON.stringify(info)),
+      );
+    },
+    async forget(scope: "all" | "client" | "tokens"): Promise<void> {
+      const backend = await Effect.runPromise(detectKeyringBackend());
+      if (scope === "all" || scope === "tokens") {
+        await Effect.runPromise(keyringDelete(backend, tokensAccount(serverName)));
+      }
+      if (scope === "all" || scope === "client") {
+        const issuer = await currentIssuer();
+        await Effect.runPromise(keyringDelete(backend, clientAccount(serverName, issuer)));
+      }
     },
   };
 }
@@ -94,6 +180,9 @@ function clientMetadata(redirectUrl: string): OAuthClientMetadata {
     grant_types: ["authorization_code", "refresh_token"],
     response_types: ["code"],
     token_endpoint_auth_method: "none",
+    // Omitting this defaults to "web" under OIDC, which rejects loopback
+    // redirect URIs. Jazz is a CLI, which the spec classifies as native.
+    application_type: "native",
   };
 }
 
@@ -105,8 +194,11 @@ function clientMetadata(redirectUrl: string): OAuthClientMetadata {
  * where opening a browser would be wrong. A server that needs fresh consent
  * surfaces `InteractiveAuthRequiredError` instead.
  */
-export function createStoredTokenProvider(serverName: string): OAuthClientProvider {
-  const storage = createStorage(serverName);
+export function createStoredTokenProvider(
+  serverName: string,
+  serverUrl: string,
+): OAuthClientProvider {
+  const storage = createStorage(serverName, serverUrl);
   // Placeholder: only used to shape the registration request when a stored
   // client exists. A provider that reaches registration is already on its way
   // to `redirectToAuthorization`, which throws.
@@ -117,6 +209,7 @@ export function createStoredTokenProvider(serverName: string): OAuthClientProvid
     get redirectUrl() {
       return redirectUrl;
     },
+    clientMetadataUrl: CLIENT_METADATA_URL,
     get clientMetadata() {
       return clientMetadata(redirectUrl);
     },
@@ -137,15 +230,12 @@ export function createStoredTokenProvider(serverName: string): OAuthClientProvid
       return codeVerifierValue;
     },
     invalidateCredentials: async (scope) => {
-      const backend = await Effect.runPromise(detectKeyringBackend());
-      if (scope === "all" || scope === "tokens") {
-        await Effect.runPromise(keyringDelete(backend, tokensAccount(serverName)));
-      }
-      if (scope === "all" || scope === "client") {
-        await Effect.runPromise(keyringDelete(backend, clientAccount(serverName)));
-      }
       if (scope === "verifier") {
         codeVerifierValue = undefined;
+        return;
+      }
+      if (scope === "all" || scope === "tokens" || scope === "client") {
+        await storage.forget(scope);
       }
     },
   };
@@ -230,9 +320,25 @@ function startCallbackListener(expectedState: string): Promise<CallbackListener>
       response.end(SUCCESS_PAGE);
     });
 
-    server.once("error", reject);
+    // Try the published ports in order; a busy one is normal when another
+    // authorization is already in flight.
+    let portIndex = 0;
+    server.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EADDRINUSE" && portIndex < CALLBACK_PORTS.length - 1) {
+        portIndex += 1;
+        server.listen(CALLBACK_PORTS[portIndex], "127.0.0.1");
+        return;
+      }
+      reject(
+        error.code === "EADDRINUSE"
+          ? new Error(
+              `All OAuth callback ports are in use (${CALLBACK_PORTS.join(", ")}). Finish or cancel the other authorization and try again.`,
+            )
+          : error,
+      );
+    });
 
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(CALLBACK_PORTS[portIndex], "127.0.0.1", () => {
       const address = server.address();
       if (address === null || typeof address === "string") {
         server.close();
@@ -241,6 +347,9 @@ function startCallbackListener(expectedState: string): Promise<CallbackListener>
       }
 
       resolve({
+        // Must be one of the redirect URIs in the Client ID Metadata Document:
+        // the authorization server validates the request against that list, so
+        // an ephemeral port would be rejected outright.
         redirectUrl: `http://127.0.0.1:${address.port}/callback`,
         waitForCode: () =>
           new Promise<string>((resolveCode, rejectCode) => {
@@ -281,7 +390,7 @@ export function authorizeServer(
 ): Effect.Effect<void, Error> {
   return Effect.tryPromise({
     try: async () => {
-      const storage = createStorage(serverName);
+      const storage = createStorage(serverName, serverUrl);
       const state = crypto.randomUUID();
       const listener = await startCallbackListener(state);
       let codeVerifierValue: string | undefined;
@@ -291,6 +400,7 @@ export function authorizeServer(
           get redirectUrl() {
             return listener.redirectUrl;
           },
+          clientMetadataUrl: CLIENT_METADATA_URL,
           get clientMetadata() {
             return clientMetadata(listener.redirectUrl);
           },
@@ -334,12 +444,22 @@ export function authorizeServer(
   });
 }
 
-/** Forget stored tokens and registration for one server. */
+/**
+ * Forget stored tokens and registration for one server.
+ *
+ * The client entry is keyed by issuer, so the issuer recorded at registration
+ * time is what locates it. Tokens are cleared regardless.
+ */
 export function clearServerAuth(serverName: string): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const backend = yield* detectKeyringBackend();
     yield* keyringDelete(backend, tokensAccount(serverName));
-    yield* keyringDelete(backend, clientAccount(serverName));
+
+    const issuer = yield* keyringGet(backend, issuerAccount(serverName));
+    if (issuer !== undefined) {
+      yield* keyringDelete(backend, clientAccount(serverName, issuer));
+      yield* keyringDelete(backend, issuerAccount(serverName));
+    }
   });
 }
 


### PR DESCRIPTION
## What & why

Stacked on #414. That PR made Jazz a competent MCP client; this one moves it onto
the current protocol and fills in the parts of MCP it still ignored.

Jazz now negotiates **protocol revision 2026-07-28**, probing `server/discover`
and falling back to the 2025 handshake for servers that predate it. On top of
that:

- **Elicitation** — a server can ask you for input mid-task and get a real
  prompt, with pickers for every way the spec spells a choice list. Where
  there's nobody to ask, on a bridge or a scheduled run, the request is declined
  rather than left hanging.
- **Resources** — the data servers expose by URI, readable through a bounded
  per-server list/read tool pair.
- **Progress** — a server doing thirty seconds of work no longer looks identical
  to one that has hung.
- **Prompt completion** — invoking a prompt without its arguments now asks for
  them, offering the server's own suggestions.

Two new ideas are worth naming. **Multi-round-trip requests** replace the
server-to-client request channel in 2026-07-28; the SDK fulfils them through the
same handler, so elicitation needed no rewrite. **Client ID Metadata Documents**
replace Dynamic Client Registration as the preferred OAuth registration path —
Jazz publishes one and keeps DCR as the fallback the spec prescribes.

Roots and sampling are deliberately absent: both are deprecated by SEP-2577.

## Breaking changes / migration

| Change | What to do |
|---|---|
| SDK moved to `@modelcontextprotocol/client` v2 | Nothing — dependency swap only |
| OAuth callback uses fixed loopback ports (33418-33421) | Allow them locally if you firewall outbound loopback |
| Client credentials now keyed by issuer | Re-run `jazz mcp auth <name>` once per remote server |

CIMD only takes effect once `oauth-client-metadata.json` is on `main`; until
then every server falls back to DCR.

## How to verify

- `jazz mcp add everything -- npx -y @modelcontextprotocol/server-everything`,
  then `jazz mcp test everything` — reports the negotiated era, 14 tools with
  their annotations, 4 prompts, and 7 resources.
- Run `trigger-long-running-operation` from a chat and confirm progress lines
  appear while it runs rather than only at the end.
- Run `/everything:complex-prompt` with no arguments and confirm it asks, with a
  picker; on `completable-prompt`, confirm choosing a department narrows the
  names offered.
- Run `trigger-elicitation-request` and confirm the dialog names the server and
  that declining returns cleanly. Confirm the same call on an unattended surface
  declines immediately instead of blocking.
- Point a server at a bad command and confirm it fails within ~30s with a useful
  message rather than hanging, and that `/mcp reconnect <name>` retries without
  restarting the conversation.