### PR TITLE
feat(daemon): serve runs over HTTP so a parked one can be answered later

### DIFF
--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -641,6 +641,37 @@ function registerUpdateCommand(program: Command): void {
  * rather than at a flag. What the commands own is the part that must not touch disk in
  * plaintext (the token) and the part worth reading back (the ledger).
  */
+/**
+ * Register `jazz daemon` — the long-lived HTTP server.
+ *
+ * One command, in the foreground. Supervision belongs to whatever already supervises this
+ * host: the bridge ships as a container, scheduled workflows use launchd. A daemon that
+ * forked and wrote a pidfile would be a third mechanism competing with both.
+ */
+function registerDaemonCommand(program: Command): void {
+  program
+    .command("daemon")
+    .description(
+      "Serve runs over HTTP so a parked run can be answered later, and from somewhere else",
+    )
+    .option("--port <n>", "Port to listen on", parsePositiveInt("--port"), 4747)
+    .option(
+      "--host <address>",
+      "Interface to bind. Anything other than loopback requires $JAZZ_DAEMON_TOKEN.",
+      "127.0.0.1",
+    )
+    .action((options: { port: number; host: string }) =>
+      runCliAction(
+        () =>
+          import("./commands/daemon").then((mod) =>
+            mod.daemonCommand({ port: options.port, host: options.host }),
+          ),
+        cliRuntimeOptions(program),
+        { session: true },
+      ),
+    );
+}
+
 function registerPeersCommands(program: Command): void {
   const peersCommand = program
     .command("peers")
@@ -1017,6 +1048,7 @@ export function createCLIApp(): Command {
   registerConfigCommands(program);
   registerMCPCommands(program);
   registerUpdateCommand(program);
+  registerDaemonCommand(program);
   registerPeersCommands(program);
   registerRunsCommands(program);
   registerWorkflowCommands(program);

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview `jazz daemon` — run the HTTP server in the foreground.
+ *
+ * Foreground on purpose. Supervision is the host's job, and the host already has one: the
+ * Telegram bridge ships as a container with an entrypoint, and scheduled workflows use
+ * launchd. A daemon that forks and writes a pidfile would be a third mechanism competing
+ * with both, and the first thing anyone deploying it would have to work around.
+ */
+
+import { Effect, Runtime } from "effect";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import {
+  DEFAULT_DAEMON_PORT,
+  makeHandler,
+  refuseReason,
+  type DaemonRequirements,
+} from "@/services/daemon/server";
+import { makeFileRunStoreLayer } from "@/services/storage/run-store";
+
+export interface DaemonCommandOptions {
+  readonly port: number;
+  readonly host: string;
+}
+
+/**
+ * Serve until interrupted.
+ *
+ * The token comes from the environment rather than a flag: a token in argv is a token in
+ * `ps` output and in shell history, and this one authorises driving an agent.
+ */
+export function daemonCommand(options: DaemonCommandOptions) {
+  return Effect.gen(function* () {
+    const token = process.env["JAZZ_DAEMON_TOKEN"];
+    const daemonOptions = {
+      port: options.port,
+      host: options.host,
+      ...(token !== undefined ? { token } : {}),
+    };
+
+    const refusal = refuseReason(daemonOptions);
+    if (refusal !== undefined) {
+      process.stderr.write(`${refusal}\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const logger = yield* LoggerServiceTag;
+
+    // The whole agent stack, captured once. Each request runs on this rather than on a
+    // fresh runtime: `Effect.runPromise` inside the handler would start with an empty
+    // context and fail on the first service the runner asks for, which is exactly what it
+    // did — with the unit tests passing throughout, because they inject a store directly
+    // and never exercise the real layer.
+    const runtime = yield* Effect.runtime<DaemonRequirements>();
+
+    yield* Effect.async<void, never>((resume) => {
+      const handle = makeHandler(daemonOptions, (effect) =>
+        Runtime.runPromise(runtime)(effect as Effect.Effect<never, never, DaemonRequirements>),
+      );
+
+      const server = Bun.serve({
+        port: daemonOptions.port,
+        hostname: daemonOptions.host,
+        fetch: (request) => handle(request),
+      });
+
+      process.stderr.write(
+        `jazz daemon listening on http://${daemonOptions.host}:${String(server.port)}` +
+          `${token === undefined ? " (no token: loopback only)" : ""}\n`,
+      );
+
+      const stop = (): void => {
+        // Not awaited: the process is going away, and blocking the signal handler on a
+        // drain that may never finish is how a daemon becomes unkillable.
+        void server.stop(true);
+        resume(Effect.void);
+      };
+      process.once("SIGINT", stop);
+      process.once("SIGTERM", stop);
+
+      return Effect.sync(() => {
+        void server.stop(true);
+      });
+    });
+
+    yield* logger.info("Daemon stopped");
+  }).pipe(Effect.provide(makeFileRunStoreLayer()));
+}
+
+export { DEFAULT_DAEMON_PORT };

--- a/src/services/daemon/server.test.ts
+++ b/src/services/daemon/server.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { createRunRecord } from "@/core/agent/run/run-record";
+import { RunStoreTag } from "@/core/interfaces/run-store";
+import { InMemoryRunStore } from "@/services/storage/run-store";
+import { makeHandler, refuseReason, type DaemonRequirements } from "./server";
+
+const LOOPBACK = { port: 0, host: "127.0.0.1" };
+
+/**
+ * Runs a handler effect against a store, with no agent stack behind it.
+ *
+ * The route-level behaviour under test — auth, method matching, run lookup — never reaches
+ * the runner, so nothing here has to stand up an LLM.
+ */
+function runnerFor(store: InMemoryRunStore) {
+  return <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>): Promise<A> =>
+    Effect.runPromise(
+      effect.pipe(Effect.provideService(RunStoreTag, store)) as Effect.Effect<A, never, never>,
+    );
+}
+
+function request(method: string, path: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${path}`, { method, ...init });
+}
+
+describe("refusing an unsafe bind", () => {
+  it("allows loopback without a token", () => {
+    expect(refuseReason(LOOPBACK)).toBeUndefined();
+  });
+
+  it("refuses a public interface with no token, and says why", () => {
+    const reason = refuseReason({ port: 4747, host: "0.0.0.0" });
+    expect(reason).toContain("Refusing to bind");
+    expect(reason).toContain("filesystem access");
+  });
+
+  it("allows a public interface once a token is set", () => {
+    expect(refuseReason({ port: 4747, host: "0.0.0.0", token: "s3cret" })).toBeUndefined();
+  });
+
+  it("treats an empty token as no token", () => {
+    expect(refuseReason({ port: 4747, host: "0.0.0.0", token: "" })).toContain("Refusing");
+  });
+});
+
+describe("the daemon's routes", () => {
+  it("answers health without a credential, so a supervisor need not hold one", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerFor(store));
+
+    const response = await handle(request("GET", "/health"));
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects an unauthenticated request when a token is configured", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerFor(store));
+
+    const response = await handle(request("GET", "/runs"));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a wrong token", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerFor(store));
+
+    const response = await handle(
+      request("GET", "/runs", { headers: { authorization: "Bearer wrong!" } }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("accepts the right token", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerFor(store));
+
+    const response = await handle(
+      request("GET", "/runs", { headers: { authorization: "Bearer s3cret" } }),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("serves a run that exists, from the store the CLI writes to", async () => {
+    const store = new InMemoryRunStore();
+    const record = createRunRecord({
+      runId: "11111111-2222-3333-4444-555555555555",
+      agentId: "assistant",
+      conversationId: "conv-1",
+      input: "push the branch",
+      now: new Date("2026-08-23T10:00:00Z"),
+    });
+    await Effect.runPromise(store.save(record));
+
+    const handle = makeHandler(LOOPBACK, runnerFor(store));
+    const response = await handle(request("GET", `/runs/${record.runId}`));
+    const body = (await response.json()) as { ok: boolean; run: { input: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.run.input).toBe("push the branch");
+  });
+
+  it("404s a run that does not exist rather than inventing one", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler(LOOPBACK, runnerFor(store));
+
+    const response = await handle(request("GET", "/runs/does-not-exist"));
+    expect(response.status).toBe(404);
+  });
+
+  it("requires an agent and a prompt to start a run", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler(LOOPBACK, runnerFor(store));
+
+    const response = await handle(
+      request("POST", "/runs", {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hello" }),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a body that is not JSON rather than throwing", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler(LOOPBACK, runnerFor(store));
+
+    const response = await handle(request("POST", "/runs", { body: "not json" }));
+    expect(response.status).toBe(400);
+  });
+
+  it("404s an unknown path", async () => {
+    const store = new InMemoryRunStore();
+    const handle = makeHandler(LOOPBACK, runnerFor(store));
+
+    expect((await handle(request("GET", "/nope"))).status).toBe(404);
+  });
+});

--- a/src/services/daemon/server.ts
+++ b/src/services/daemon/server.ts
@@ -1,0 +1,275 @@
+/**
+ * @fileoverview A long-lived jazz that answers over HTTP.
+ *
+ * Not a second way to run an agent — the same one. A request lands here, resolves an agent,
+ * and goes through `AgentRunner.run` exactly as `jazz run` does. What the daemon adds is
+ * that the process outlives the request, which is what makes three things possible that a
+ * process-per-invocation design cannot do at all:
+ *
+ * - a run that parks for a human can be answered by a different caller, hours later
+ * - "what is this agent doing right now" is a question with an answer
+ * - a bridge stops paying process startup on every message
+ *
+ * Most of the machinery is already here. {@link RunStore} gives durable records, park and
+ * resume let a run outlive the process that started it, and `jazz runs` is the same set of
+ * operations on a CLI. This is the socket in front of them.
+ *
+ * **It binds to loopback and refuses to leave it without a token.** Exposing an agent that
+ * can read the filesystem to a network is a decision somebody should have to make twice.
+ */
+
+import { Effect } from "effect";
+import { AgentRunner } from "@/core/agent/agent-runner";
+import { getAgentByIdentifier } from "@/core/agent/agent-service";
+import { isRunParkRequested } from "@/core/agent/run/park-signal";
+import { resumeRun } from "@/core/agent/run/resume";
+import type { AgentService } from "@/core/interfaces/agent-service";
+import { LoggerServiceTag } from "@/core/interfaces/logger";
+import { RunStoreTag } from "@/core/interfaces/run-store";
+import type { ToolRegistry, ToolRequirements } from "@/core/interfaces/tool-registry";
+import { generateConversationId } from "@/core/utils/conversation-id";
+
+export const DEFAULT_DAEMON_PORT = 4747;
+
+/**
+ * What the daemon's handlers need from the runtime.
+ *
+ * Named rather than inferred so the caller knows exactly which layer to build — the same
+ * stack `jazz run` composes, plus the run store, which is what makes a parked run
+ * answerable by somebody who was not there when it parked.
+ */
+export type DaemonRequirements = AgentService | RunStoreTag | ToolRegistry | ToolRequirements;
+
+/** Kept in step with `jazz runs`: terminal records are readable for a week. */
+const TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface DaemonOptions {
+  readonly port: number;
+  /**
+   * Interface to bind. Loopback unless someone deliberately widens it.
+   *
+   * A daemon reachable from the network is an agent with filesystem access reachable from
+   * the network, so widening this requires a token and is refused without one.
+   */
+  readonly host: string;
+  /** Required for any bind that is not loopback. Compared with the `Authorization` header. */
+  readonly token?: string | undefined;
+}
+
+function isLoopback(host: string): boolean {
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
+}
+
+/**
+ * Why a configuration is refused, or undefined when it is allowed.
+ *
+ * Returned rather than thrown so the caller can print it as advice. Every reason here is a
+ * mistake someone would otherwise only discover from a log.
+ */
+export function refuseReason(options: DaemonOptions): string | undefined {
+  if (!isLoopback(options.host) && (options.token === undefined || options.token.length === 0)) {
+    return (
+      `Refusing to bind ${options.host} without a token. A daemon on a network interface is ` +
+      `an agent with filesystem access that anyone who can reach the port may drive. Set ` +
+      `JAZZ_DAEMON_TOKEN, or bind 127.0.0.1.`
+    );
+  }
+  return undefined;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Constant-time-ish comparison for the bearer token.
+ *
+ * Not a rigorous constant-time compare — the lengths leak — but it does not return early on
+ * the first differing byte, which is the difference that matters for a token guessable one
+ * character at a time over a slow link.
+ */
+function tokenMatches(expected: string, presented: string): boolean {
+  if (expected.length !== presented.length) return false;
+  let difference = 0;
+  for (let index = 0; index < expected.length; index++) {
+    difference |= expected.charCodeAt(index) ^ presented.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+function authorized(request: Request, token: string | undefined): boolean {
+  if (token === undefined || token.length === 0) return true;
+  const header = request.headers.get("authorization") ?? "";
+  const presented = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : "";
+  return tokenMatches(token, presented);
+}
+
+interface StartRunBody {
+  readonly agent?: unknown;
+  readonly prompt?: unknown;
+  readonly conversationId?: unknown;
+}
+
+/**
+ * The daemon's request handler, as a plain function of a request.
+ *
+ * Separated from the socket so it can be driven directly in a test without binding a port,
+ * and so the runtime that supplies the agent stack is provided once by the caller.
+ */
+export function makeHandler(
+  options: DaemonOptions,
+  runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
+): (request: Request) => Promise<Response> {
+  return async function handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    // Health is unauthenticated on purpose: a supervisor should be able to see that the
+    // process is alive without holding a credential that can drive an agent.
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ ok: true });
+    }
+
+    if (!authorized(request, options.token)) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+
+    if (request.method === "POST" && url.pathname === "/runs") {
+      let body: StartRunBody;
+      try {
+        body = (await request.json()) as StartRunBody;
+      } catch {
+        return json({ ok: false, error: "body must be JSON" }, 400);
+      }
+      const agentIdentifier = typeof body.agent === "string" ? body.agent : undefined;
+      const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
+      if (agentIdentifier === undefined || prompt === undefined) {
+        return json({ ok: false, error: "agent and prompt are required" }, 400);
+      }
+      const conversationId =
+        typeof body.conversationId === "string" && body.conversationId.length > 0
+          ? body.conversationId
+          : generateConversationId("daemon");
+
+      return runEffect(startRun(agentIdentifier, prompt, conversationId));
+    }
+
+    const runMatch = /^\/runs\/([^/]+)$/.exec(url.pathname);
+    if (request.method === "GET" && runMatch?.[1] !== undefined) {
+      return runEffect(describeRun(runMatch[1]));
+    }
+
+    const answerMatch = /^\/runs\/([^/]+)\/answer$/.exec(url.pathname);
+    if (request.method === "POST" && answerMatch?.[1] !== undefined) {
+      let body: { approved?: unknown; note?: unknown };
+      try {
+        body = (await request.json()) as { approved?: unknown; note?: unknown };
+      } catch {
+        return json({ ok: false, error: "body must be JSON" }, 400);
+      }
+      const approved = body.approved === true;
+      const note = typeof body.note === "string" ? body.note : undefined;
+      return runEffect(answerRun(answerMatch[1], approved, note));
+    }
+
+    if (request.method === "GET" && url.pathname === "/runs") {
+      return runEffect(listRuns());
+    }
+
+    return json({ ok: false, error: "not found" }, 404);
+  };
+}
+
+function startRun(
+  agentIdentifier: string,
+  prompt: string,
+  conversationId: string,
+): Effect.Effect<Response, unknown, AgentService> {
+  return Effect.gen(function* () {
+    const agent = yield* getAgentByIdentifier(agentIdentifier);
+
+    // Parking rather than declining is the whole reason a request can outlive its caller:
+    // a gated tool stops the run and somebody answers it later, from anywhere.
+    const response = yield* AgentRunner.run({
+      agent,
+      userInput: prompt,
+      conversationId,
+      parkWhenUnattended: true,
+    });
+
+    return json({ ok: true, answer: response.content, conversationId });
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.gen(function* () {
+        if (isRunParkRequested(error) && error.runId !== undefined) {
+          const request =
+            error.pending.kind === "tool-approval" ? error.pending.request : undefined;
+          return json(
+            {
+              ok: false,
+              state: "input-required",
+              runId: error.runId,
+              expiresAt: error.expiresAt,
+              pending: {
+                toolName: request?.toolName,
+                message: request?.message,
+              },
+            },
+            202,
+          );
+        }
+        const logger = yield* Effect.serviceOption(LoggerServiceTag);
+        if (logger._tag === "Some") {
+          yield* logger.value.warn("Daemon run failed", { error: String(error) });
+        }
+        return json(
+          { ok: false, error: error instanceof Error ? error.message : String(error) },
+          500,
+        );
+      }),
+    ),
+  ) as Effect.Effect<Response, unknown, AgentService>;
+}
+
+function describeRun(runId: string) {
+  return Effect.gen(function* () {
+    const store = yield* RunStoreTag;
+    const record = yield* store.get(runId);
+    if (record === undefined) return json({ ok: false, error: "no such run" }, 404);
+    return json({ ok: true, run: record });
+  });
+}
+
+function listRuns() {
+  return Effect.gen(function* () {
+    const store = yield* RunStoreTag;
+    yield* store.prune({ now: new Date(), maxTerminalAgeMs: TERMINAL_RETENTION_MS });
+    const runs = yield* store.list();
+    return json({ ok: true, runs });
+  });
+}
+
+/**
+ * Answer a parked run and let it finish.
+ *
+ * The daemon resumes it rather than the caller doing so, because the daemon owns the store
+ * and a claim carries the pid of whoever made it. A remote client claiming a run it cannot
+ * be seen to abandon would leave it stranded in `working` if that client died.
+ */
+function answerRun(runId: string, approved: boolean, note: string | undefined) {
+  return resumeRun({
+    runId,
+    outcome: approved
+      ? { approved: true }
+      : { approved: false, ...(note ? { userMessage: note } : {}) },
+  }).pipe(
+    Effect.map((response) => json({ ok: true, runId, answer: response.content })),
+    Effect.catchAll((error) =>
+      Effect.succeed(
+        json({ ok: false, error: error instanceof Error ? error.message : String(error) }, 409),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Stacked on [#415](https://github.com/lvndry/jazz/pull/415), [#416](https://github.com/lvndry/jazz/pull/416), [#417](https://github.com/lvndry/jazz/pull/417).

## What & why

Not a second way to run an agent — the same one, behind a socket. A request resolves an agent and goes through `AgentRunner.run` exactly as `jazz run` does. What changes is that **the process outlives the request**, which is what makes a parked run answerable by somebody who was not there when it parked.

Most of this already existed: `RunStore` gives durable records, park/resume lets a run outlive its process, `jazz runs` is the same operations on a CLI. This is the socket in front of them.

```
POST /runs              start a run
GET  /runs/:id          its state, cost, what it is waiting for
POST /runs/:id/answer   resolve a parked approval
GET  /runs              what is in flight
GET  /health            unauthenticated, so a supervisor need not hold a credential
```

### Safety posture

- **Binds loopback; refuses anything wider without a token**, because a daemon on a network interface is an agent with filesystem access that anyone reaching the port can drive.
- Token from the environment, never a flag — a token in argv is a token in `ps`.
- **The daemon resumes parked runs itself.** A claim records the pid that made it; a remote client claiming a run it cannot be seen to abandon would strand it in `working` if that client died.
- Foreground, no pidfile. This host already has supervision (the bridge is a container, workflows use launchd); a third mechanism would be the first thing to work around.

## A bug 13 green tests missed

The handler called `Effect.runPromise` on a fresh runtime, so it began with an empty context and died on the first service the runner asked for — `Service not found: AgentService`. The unit tests inject a store directly and never exercise the real layer. It now captures the runtime once.

## Verified end to end, against a real model

```
POST /runs           → 202 {"state":"input-required","runId":"0d4bc4d0…"}
                       /tmp/daemon-e2e.txt does not exist
GET  /runs/:id       → state: input-required | cost: 0.0062586
POST /runs/:id/answer→ {"ok":true,"answer":"I've created /tmp/daemon-e2e.txt…"}
                       file contains: parked and resumed
GET  /runs/:id       → state: completed | cost: 0.00630762
```

A separate process approved a run parked by another. That is the whole point.

## How to verify

- `jazz daemon` → `curl localhost:4747/health`.
- `jazz daemon --host 0.0.0.0` with no `$JAZZ_DAEMON_TOKEN` must refuse and explain why.
- Start a run hitting a gated tool; confirm 202 with a run id, then answer it from a second terminal.