### PR TITLE
feat(cli): suggest file paths while typing an @ mention

### DIFF
--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -15,9 +15,9 @@ import { InputResults, useInputHandler, useTextInput } from "./hooks/use-input-s
 import { PICKER_WINDOW_SIZE } from "./picker-window";
 import { isCursorOnFirstLine, isCursorOnLastLine } from "./queue-recall";
 import { store } from "./store";
+import { mergeSuggestions, type SuggestionPrefix } from "./suggestion-menu";
 import { PADDING, THEME } from "./theme";
 import type { PromptState } from "./types";
-import type { SuggestionPrefix } from "./types";
 import { useFileMentions } from "./use-file-mentions";
 
 const G = getGlyphs();
@@ -151,18 +151,19 @@ function PromptComponent({
         : [],
     [commandSuggestionsEnabled, suggestionPrefix, value],
   );
-  // `@path` completions share the suggestion list with slash commands. Only one
-  // can be live: a slash query needs the line to start with "/".
+  // `@path` completions share this list with slash commands; `mergeSuggestions`
+  // owns which of the two is live so both composers agree.
   const { span: mentionSpan, items: mentionItems } = useFileMentions(value, cursor);
-  const mentionSuggestions = useMemo<readonly ChatCommandInfo[]>(
+  const menu = useMemo(
     () =>
-      commandSuggestionsEnabled && mentionSpan !== null && filteredCommands.length === 0
-        ? mentionItems.map((item) => ({ name: item.name, description: item.description }))
-        : [],
-    [commandSuggestionsEnabled, mentionSpan, mentionItems, filteredCommands.length],
+      mergeSuggestions(
+        filteredCommands,
+        commandSuggestionsEnabled && mentionSpan !== null ? mentionItems : [],
+      ),
+    [filteredCommands, commandSuggestionsEnabled, mentionSpan, mentionItems],
   );
-  const mentioning = mentionSuggestions.length > 0;
-  const suggestions = mentioning ? mentionSuggestions : filteredCommands;
+  const mentioning = menu?.prefix === "@";
+  const suggestions: readonly ChatCommandInfo[] = menu?.items ?? [];
   const suggestionsVisible = suggestions.length > 0;
   const suggestionWindowStart = Math.min(
     Math.max(0, selectedSuggestionIndex - MAX_VISIBLE_SUGGESTIONS + 1),
@@ -412,7 +413,7 @@ function PromptComponent({
                     key={cmd.name}
                     command={cmd}
                     isSelected={suggestionWindowStart + index === selectedSuggestionIndex}
-                    prefix={mentioning ? "@" : "/"}
+                    prefix={menu?.prefix ?? "/"}
                   />
                 ))}
                 {hiddenSuggestionsBelow > 0 && (

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useInput } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Suggestion } from "@/core/interfaces/presentation";
 import { filterCommandsByPrefix, type ChatCommandInfo } from "@/services/chat/commands";
+import { applyAtMention } from "./at-mention";
 import { ChatInput } from "./components/ChatInput";
 import { FilePicker } from "./components/FilePicker";
 import { Questionnaire } from "./components/Questionnaire";
@@ -16,6 +17,7 @@ import { isCursorOnFirstLine, isCursorOnLastLine } from "./queue-recall";
 import { store } from "./store";
 import { PADDING, THEME } from "./theme";
 import type { PromptState } from "./types";
+import { useFileMentions } from "./use-file-mentions";
 
 const G = getGlyphs();
 
@@ -42,11 +44,14 @@ const MAX_VISIBLE_SUGGESTIONS = 8;
 interface CommandSuggestionItemProps {
   command: ChatCommandInfo;
   isSelected: boolean;
+  /** Sigil the row completes: "/" for a command, "@" for a file path. */
+  prefix?: "/" | "@";
 }
 
 function CommandSuggestionItem({
   command,
   isSelected,
+  prefix = "/",
 }: CommandSuggestionItemProps): React.ReactElement {
   return (
     <Box marginLeft={1}>
@@ -54,7 +59,9 @@ function CommandSuggestionItem({
         {...(isSelected ? { color: THEME.selected } : {})}
         bold={isSelected}
       >
-        {isSelected ? "> " : "  "}/{command.name}
+        {isSelected ? "> " : "  "}
+        {prefix}
+        {command.name}
       </Text>
       {command.usage ? <Text color={THEME.muted}> {command.usage}</Text> : null}
       {command.source ? (
@@ -143,34 +150,48 @@ function PromptComponent({
         : [],
     [commandSuggestionsEnabled, suggestionPrefix, value],
   );
-  const suggestionsVisible = filteredCommands.length > 0;
+  // `@path` completions share the suggestion list with slash commands. Only one
+  // can be live: a slash query needs the line to start with "/".
+  const { span: mentionSpan, items: mentionItems } = useFileMentions(value, cursor);
+  const mentionSuggestions = useMemo<readonly ChatCommandInfo[]>(
+    () =>
+      commandSuggestionsEnabled && mentionSpan !== null && filteredCommands.length === 0
+        ? mentionItems.map((item) => ({ name: item.name, description: item.description }))
+        : [],
+    [commandSuggestionsEnabled, mentionSpan, mentionItems, filteredCommands.length],
+  );
+  const mentioning = mentionSuggestions.length > 0;
+  const suggestions = mentioning ? mentionSuggestions : filteredCommands;
+  const suggestionsVisible = suggestions.length > 0;
   const suggestionWindowStart = Math.min(
     Math.max(0, selectedSuggestionIndex - MAX_VISIBLE_SUGGESTIONS + 1),
-    Math.max(0, filteredCommands.length - MAX_VISIBLE_SUGGESTIONS),
+    Math.max(0, suggestions.length - MAX_VISIBLE_SUGGESTIONS),
   );
-  const visibleSuggestions = filteredCommands.slice(
+  const visibleSuggestions = suggestions.slice(
     suggestionWindowStart,
     suggestionWindowStart + MAX_VISIBLE_SUGGESTIONS,
   );
   const hiddenSuggestionsBelow =
-    filteredCommands.length - suggestionWindowStart - visibleSuggestions.length;
+    suggestions.length - suggestionWindowStart - visibleSuggestions.length;
 
   // Keep selected index in bounds when list changes
   useEffect(() => {
-    if (filteredCommands.length > 0) {
-      setSelectedSuggestionIndex((i) => Math.min(i, filteredCommands.length - 1));
+    if (suggestions.length > 0) {
+      setSelectedSuggestionIndex((i) => Math.min(i, suggestions.length - 1));
     }
-  }, [filteredCommands.length]);
+  }, [suggestions.length]);
 
   // Refs for command-suggestions handler so it sees latest state
   const setSelectedSuggestionIndexRef = useRef(setSelectedSuggestionIndex);
-  const filteredCommandsRef = useRef(filteredCommands);
+  const filteredCommandsRef = useRef(suggestions);
   const selectedSuggestionIndexRef = useRef(selectedSuggestionIndex);
   const valueRef = useRef(value);
   const cursorRef = useRef(cursor);
   setSelectedSuggestionIndexRef.current = setSelectedSuggestionIndex;
-  filteredCommandsRef.current = filteredCommands;
+  filteredCommandsRef.current = suggestions;
   selectedSuggestionIndexRef.current = selectedSuggestionIndex;
+  const mentionSpanRef = useRef(mentionSpan);
+  mentionSpanRef.current = mentioning ? mentionSpan : null;
   valueRef.current = value;
   cursorRef.current = cursor;
 
@@ -188,6 +209,17 @@ function PromptComponent({
       if (action.type === "down") {
         setSelectedSuggestionIndexRef.current(Math.min(commands.length - 1, idx + 1));
         return InputResults.consumed();
+      }
+      const mention = mentionSpanRef.current;
+      if (mention !== null && commands[idx]) {
+        // Tab and Enter both accept a path: there is nothing to submit, so
+        // accepting only rewrites the span it came from.
+        if (action.type === "tab" || action.type === "submit") {
+          const applied = applyAtMention(valueRef.current, mention, commands[idx].name);
+          setValueRef.current(applied.text, applied.caret);
+          setSelectedSuggestionIndexRef.current(0);
+          return InputResults.consumed();
+        }
       }
       if (action.type === "tab" && commands[idx]) {
         const nextValue = "/" + commands[idx].name + " ";
@@ -369,12 +401,17 @@ function PromptComponent({
                 marginTop={1}
                 flexDirection="column"
               >
-                <Text dimColor>Commands (↑/↓ select · Tab complete · Enter run):</Text>
+                <Text dimColor>
+                  {mentioning
+                    ? "Files (↑/↓ select · Tab or Enter insert):"
+                    : "Commands (↑/↓ select · Tab complete · Enter run):"}
+                </Text>
                 {visibleSuggestions.map((cmd, index) => (
                   <CommandSuggestionItem
                     key={cmd.name}
                     command={cmd}
                     isSelected={suggestionWindowStart + index === selectedSuggestionIndex}
+                    prefix={mentioning ? "@" : "/"}
                   />
                 ))}
                 {hiddenSuggestionsBelow > 0 && (

--- a/src/cli/ui/Prompt.tsx
+++ b/src/cli/ui/Prompt.tsx
@@ -17,6 +17,7 @@ import { isCursorOnFirstLine, isCursorOnLastLine } from "./queue-recall";
 import { store } from "./store";
 import { PADDING, THEME } from "./theme";
 import type { PromptState } from "./types";
+import type { SuggestionPrefix } from "./types";
 import { useFileMentions } from "./use-file-mentions";
 
 const G = getGlyphs();
@@ -45,7 +46,7 @@ interface CommandSuggestionItemProps {
   command: ChatCommandInfo;
   isSelected: boolean;
   /** Sigil the row completes: "/" for a command, "@" for a file path. */
-  prefix?: "/" | "@";
+  prefix?: SuggestionPrefix;
 }
 
 function CommandSuggestionItem({

--- a/src/cli/ui/at-mention.test.ts
+++ b/src/cli/ui/at-mention.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { applyAtMention, atMentionSpan } from "./at-mention";
+
+describe("atMentionSpan", () => {
+  test("finds a mention at the start of the line", () => {
+    expect(atMentionSpan("@src/foo", 8)).toEqual({ query: "src/foo", start: 0, end: 8 });
+  });
+
+  test("finds a mention after whitespace", () => {
+    expect(atMentionSpan("look at @src/foo", 16)).toEqual({
+      query: "src/foo",
+      start: 8,
+      end: 16,
+    });
+  });
+
+  test("opens on a bare @ so the menu can show everything", () => {
+    expect(atMentionSpan("@", 1)).toEqual({ query: "", start: 0, end: 1 });
+  });
+
+  test("ignores an @ inside a word", () => {
+    // An email address must not turn the picker on.
+    expect(atMentionSpan("mail me@example.com", 19)).toBeNull();
+    expect(atMentionSpan("a@b", 3)).toBeNull();
+  });
+
+  test("closes at whitespace after the query", () => {
+    expect(atMentionSpan("@src/foo and", 12)).toBeNull();
+  });
+
+  test("uses the caret, not the end of the line", () => {
+    // Caret sits inside the first mention while a second one follows.
+    expect(atMentionSpan("@one @two", 4)).toEqual({ query: "one", start: 0, end: 4 });
+  });
+
+  test("finds the mention the caret is in when there are several", () => {
+    expect(atMentionSpan("@one @two", 9)).toEqual({ query: "two", start: 5, end: 9 });
+  });
+
+  test("returns null with no mention present", () => {
+    expect(atMentionSpan("", 0)).toBeNull();
+    expect(atMentionSpan("plain text", 10)).toBeNull();
+  });
+
+  test("clamps an out-of-range caret", () => {
+    expect(atMentionSpan("@abc", 99)).toEqual({ query: "abc", start: 0, end: 4 });
+    expect(atMentionSpan("@abc", -5)).toBeNull();
+  });
+
+  test("does not treat a slash command as a mention", () => {
+    expect(atMentionSpan("/model", 6)).toBeNull();
+  });
+});
+
+describe("applyAtMention", () => {
+  test("replaces the span and leaves the caret after a trailing space", () => {
+    const span = atMentionSpan("@src/f", 6);
+    expect(span).not.toBeNull();
+    expect(applyAtMention("@src/f", span!, "src/foo.ts")).toEqual({
+      text: "@src/foo.ts ",
+      caret: 12,
+    });
+  });
+
+  test("keeps text on both sides intact", () => {
+    const text = "compare @src/f with the spec";
+    const span = atMentionSpan(text, 14);
+    expect(applyAtMention(text, span!, "src/foo.ts")).toEqual({
+      text: "compare @src/foo.ts  with the spec",
+      caret: 20,
+    });
+  });
+
+  test("expands a bare @ into the chosen path", () => {
+    const span = atMentionSpan("@", 1);
+    expect(applyAtMention("@", span!, "README.md")).toEqual({
+      text: "@README.md ",
+      caret: 11,
+    });
+  });
+});
+
+describe("code-point offsets", () => {
+  // The composer's caret counts code points, so an astral character before the
+  // mention would shift every UTF-16 index by one and corrupt the replacement.
+  const text = "🎷 look at @src/f";
+  const caret = [...text].length;
+
+  test("locates a mention after an astral character", () => {
+    expect(atMentionSpan(text, caret)).toEqual({ query: "src/f", start: 10, end: 16 });
+  });
+
+  test("replaces correctly with an astral character present", () => {
+    const span = atMentionSpan(text, caret);
+    const applied = applyAtMention(text, span!, "src/foo.ts");
+    expect(applied.text).toBe("🎷 look at @src/foo.ts ");
+    expect([...applied.text].length).toBe(applied.caret);
+  });
+
+  test("handles an astral character inside the chosen path", () => {
+    const span = atMentionSpan("@s", 2);
+    const applied = applyAtMention("@s", span!, "notes/🎺.md");
+    expect(applied.text).toBe("@notes/🎺.md ");
+    expect([...applied.text].length).toBe(applied.caret);
+  });
+});

--- a/src/cli/ui/at-mention.ts
+++ b/src/cli/ui/at-mention.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Detecting the `@path` the user is mid-way through typing
+ *
+ * The slash-command picker can work off the whole line, because a command only
+ * ever sits at the start of it. An `@` mention can appear anywhere in a
+ * sentence, several times over, so the span being completed has to be located
+ * relative to the caret rather than the line.
+ *
+ * Path *resolution* already happens after submit (see
+ * `core/agent/user-input-attachments`); this module only decides what to
+ * suggest while typing.
+ */
+
+/**
+ * The `@…` span under the caret.
+ *
+ * Offsets are **code-point** indices, not UTF-16 ones, because that is what the
+ * composer's caret is. Mixing the two silently misplaces the replacement as
+ * soon as anything astral — an emoji in the message or in a filename — sits
+ * before the caret.
+ */
+export interface AtMentionSpan {
+  /** Text between the `@` and the caret — what to search for. */
+  readonly query: string;
+  /** Index of the `@` itself. */
+  readonly start: number;
+  /** Index one past the end of the span. */
+  readonly end: number;
+}
+
+/**
+ * Locate the mention being typed, or null when the caret is not in one.
+ *
+ * An `@` only opens a mention at the start of the line or after whitespace, so
+ * an email address or a decorator does not turn the picker on mid-word. The
+ * query itself stops at whitespace: a path with spaces in it is still
+ * attachable, but the user picks it from the menu rather than typing it, and
+ * treating a following word as part of the query would keep the menu open over
+ * the rest of the sentence.
+ */
+export function atMentionSpan(text: string, caret: number): AtMentionSpan | null {
+  const characters = [...text];
+  const clampedCaret = Math.max(0, Math.min(caret, characters.length));
+
+  for (let index = clampedCaret - 1; index >= 0; index -= 1) {
+    const character = characters[index];
+    if (character === undefined) return null;
+
+    if (character === "@") {
+      const preceding = index === 0 ? undefined : characters[index - 1];
+      if (preceding !== undefined && !/\s/.test(preceding)) return null;
+      return {
+        query: characters.slice(index + 1, clampedCaret).join(""),
+        start: index,
+        end: clampedCaret,
+      };
+    }
+
+    // Whitespace closes the candidate: whatever is under the caret is a plain
+    // word, not a mention.
+    if (/\s/.test(character)) return null;
+  }
+
+  return null;
+}
+
+/**
+ * Replace a mention span with a chosen path, leaving the caret after it.
+ *
+ * A trailing space is added so the next keystroke starts a new word rather than
+ * re-opening the menu on the path just accepted.
+ */
+export function applyAtMention(
+  text: string,
+  span: AtMentionSpan,
+  replacement: string,
+): { readonly text: string; readonly caret: number } {
+  const characters = [...text];
+  const inserted = [...`@${replacement} `];
+  const next = [
+    ...characters.slice(0, span.start),
+    ...inserted,
+    ...characters.slice(span.end),
+  ].join("");
+  return { text: next, caret: span.start + inserted.length };
+}

--- a/src/cli/ui/file-picker-files.test.ts
+++ b/src/cli/ui/file-picker-files.test.ts
@@ -1,0 +1,136 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resolveFilePickerPath, scanFilePickerEntries } from "./file-picker-files";
+
+/**
+ * The scan runs on every pause while typing an `@` mention, in both composers.
+ * Its bounds are the only thing keeping that cheap, so they are pinned here
+ * rather than left as an implementation detail.
+ */
+let root: string;
+
+beforeAll(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "jazz-picker-"));
+
+  await fs.writeFile(path.join(root, "alpha.ts"), "");
+  await fs.writeFile(path.join(root, "beta.md"), "");
+  await fs.writeFile(path.join(root, ".hidden.ts"), "");
+
+  await fs.mkdir(path.join(root, "nested", "one", "two", "three", "four", "five"), {
+    recursive: true,
+  });
+  await fs.writeFile(path.join(root, "nested", "shallow.ts"), "");
+  await fs.writeFile(
+    path.join(root, "nested", "one", "two", "three", "four", "five", "deep.ts"),
+    "",
+  );
+
+  for (const ignored of ["node_modules", "dist", "build"]) {
+    await fs.mkdir(path.join(root, ignored), { recursive: true });
+    await fs.writeFile(path.join(root, ignored, "ignored.ts"), "");
+  }
+
+  await fs.mkdir(path.join(root, "many"), { recursive: true });
+  for (let index = 0; index < 30; index += 1) {
+    await fs.writeFile(path.join(root, "many", `file-${index}.ts`), "");
+  }
+});
+
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+function scan(overrides: Partial<Parameters<typeof scanFilePickerEntries>[0]> = {}) {
+  return scanFilePickerEntries({
+    basePath: root,
+    query: "",
+    includeDirectories: false,
+    ...overrides,
+  });
+}
+
+describe("scanFilePickerEntries bounds", () => {
+  test("stops at maxResults", async () => {
+    const entries = await scan({ maxResults: 5 });
+    expect(entries).toHaveLength(5);
+  });
+
+  test("does not descend past maxDepth", async () => {
+    const shallow = await scan({ query: "deep.ts", maxDepth: 2 });
+    expect(shallow).toHaveLength(0);
+
+    const deep = await scan({ query: "deep.ts", maxDepth: 8 });
+    expect(deep.map((entry) => path.basename(entry.path))).toEqual(["deep.ts"]);
+  });
+
+  test("skips dependency and output directories", async () => {
+    const entries = await scan({ query: "ignored.ts", maxDepth: 8 });
+    expect(entries).toHaveLength(0);
+  });
+
+  test("skips dotfiles", async () => {
+    const entries = await scan({ query: "hidden" });
+    expect(entries).toHaveLength(0);
+  });
+});
+
+describe("scanFilePickerEntries matching", () => {
+  test("matches on a path fragment, not just the filename", async () => {
+    const entries = await scan({ query: "nested/shallow", maxDepth: 8 });
+    expect(entries.map((entry) => entry.name)).toContain(path.join("nested", "shallow.ts"));
+  });
+
+  test("matches case-insensitively", async () => {
+    const entries = await scan({ query: "ALPHA" });
+    expect(entries.map((entry) => path.basename(entry.path))).toEqual(["alpha.ts"]);
+  });
+
+  test("filters by extension when asked", async () => {
+    const entries = await scan({ query: "beta", extensions: ["ts"] });
+    expect(entries).toHaveLength(0);
+
+    const markdown = await scan({ query: "beta", extensions: ["md"] });
+    expect(markdown.map((entry) => path.basename(entry.path))).toEqual(["beta.md"]);
+  });
+
+  test("includes directories only when asked", async () => {
+    const without = await scan({ query: "nested" });
+    expect(without.some((entry) => entry.isDirectory)).toBe(false);
+
+    const with_ = await scan({ query: "nested", includeDirectories: true });
+    expect(with_.some((entry) => entry.isDirectory)).toBe(true);
+  });
+
+  test("returns names relative to basePath", async () => {
+    const entries = await scan({ query: "alpha" });
+    expect(entries[0]?.name).toBe("alpha.ts");
+    expect(path.isAbsolute(entries[0]?.path ?? "")).toBe(true);
+  });
+
+  test("returns nothing for an unreadable base path", async () => {
+    const entries = await scanFilePickerEntries({
+      basePath: path.join(root, "does-not-exist"),
+      query: "",
+      includeDirectories: false,
+    });
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("resolveFilePickerPath", () => {
+  test("resolves a relative path against the base", async () => {
+    expect(await resolveFilePickerPath(root, "alpha.ts")).toBe(path.join(root, "alpha.ts"));
+  });
+
+  test("accepts an absolute path that exists", async () => {
+    const absolute = path.join(root, "beta.md");
+    expect(await resolveFilePickerPath(root, absolute)).toBe(absolute);
+  });
+
+  test("returns null for a missing path or empty query", async () => {
+    expect(await resolveFilePickerPath(root, "nope.ts")).toBeNull();
+    expect(await resolveFilePickerPath(root, "")).toBeNull();
+  });
+});

--- a/src/cli/ui/fullscreen/Input.tsx
+++ b/src/cli/ui/fullscreen/Input.tsx
@@ -134,18 +134,23 @@ function commandSuggestRows(
 ): InputRow[] {
   if (size <= 0) return [];
   const visible = carouselWindow(commands.items, commands.selected, size);
+  const prefix = commands.prefix ?? "/";
   const rows: InputRow[] = visible.map((command) => {
     const selected = command === commands.items[commands.selected];
     const usage = command.usage === undefined ? "" : ` ${command.usage}`;
-    const skill = command.source ? (command.source === "skill" ? " (skill)" : " (mcp)") : "";
+    // A path list is all files, so a badge on every row would be noise; only
+    // the mixed command list needs to say where an entry came from — and a
+    // file entry's `source` is always undefined, so it falls out naturally.
+    const origin =
+      command.source === "skill" ? " (skill)" : command.source === "mcp-prompt" ? " (mcp)" : "";
     const segments: InputSegment[] = [
       { text: selected ? `${glyphs.rail} ` : "  ", fg: THEME.primary },
-      { text: `/${command.name}`, fg: selected ? THEME.selected : THEME.secondary },
+      { text: `${prefix}${command.name}`, fg: selected ? THEME.selected : THEME.secondary },
       ...(usage.length > 0 ? [{ text: usage, fg: THEME.muted }] : []),
-      ...(skill.length > 0 ? [{ text: skill, fg: THEME.muted }] : []),
+      ...(origin.length > 0 ? [{ text: origin, fg: THEME.muted }] : []),
       { text: `  ${command.description}`, fg: THEME.muted },
     ];
-    return { key: `cmd:${command.name}`, segments: fitTerminalSegments(segments, width) };
+    return { key: `${prefix}${command.name}`, segments: fitTerminalSegments(segments, width) };
   });
   return rows;
 }

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -2025,6 +2025,41 @@ describe("fullscreen bridge", () => {
     return rendered;
   }
 
+  it("suggests file paths while typing an @ mention and accepts one with Tab", async () => {
+    const rendered = await liveComposer();
+    await typeInto(rendered.mockInput, rendered.flush, "@package");
+    // The scan is debounced and walks the filesystem, so it needs a real wait
+    // rather than a microtask drain.
+    await settleKeypress(rendered.flush, 100);
+    await settleKeypress(rendered.flush, 100);
+
+    expect(rendered.captureCharFrame()).toContain("@package.json");
+
+    await rendered.mockInput.pressKey("TAB");
+    await settleKeypress(rendered.flush, 100);
+    const accepted = rendered.captureCharFrame();
+    rendered.renderer.destroy();
+    store.setPrompt(null);
+
+    // Accepting edits the composer rather than submitting: a path is not a
+    // command, so there is nothing to run.
+    expect(accepted).toContain("package.json");
+  });
+
+  it("does not open the file menu for an @ inside a word", async () => {
+    const rendered = await liveComposer();
+    await typeInto(rendered.mockInput, rendered.flush, "mail me@package");
+    await settleKeypress(rendered.flush, 100);
+    await settleKeypress(rendered.flush, 100);
+    const frame = rendered.captureCharFrame();
+    rendered.renderer.destroy();
+    store.setPrompt(null);
+
+    // An email address must not turn the picker on.
+    expect(frame).toContain("me@package");
+    expect(frame).not.toContain("@package.json");
+  });
+
   it("types capital letters as capitals", async () => {
     // `key.name` is lowercased for a shifted letter — "X" arrives as
     // `name: "x"` with `shift: true` — so a composer built on `name` types

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -23,11 +23,13 @@ import { filterCommandsByPrefix, slashCommandQuery } from "@/services/chat/comma
 import { search, type SearchHit } from "@/services/history/conversation-search";
 import packageJson from "../../../../package.json";
 import type { ActivityState } from "../activity-state";
+import { applyAtMention, type AtMentionSpan } from "../at-mention";
 import {
   type FilePickerEntry,
   resolveFilePickerPath,
   scanFilePickerEntries,
 } from "../file-picker-files";
+import { pickerItemMatches, wrapIndex } from "../picker-window";
 import { composeRecalledBuffer, isCursorOnFirstLine, isCursorOnLastLine } from "../queue-recall";
 import {
   store,
@@ -39,6 +41,7 @@ import {
   type PendingApproval,
 } from "../store";
 import type { Choice, OutputEntry, PromptState } from "../types";
+import { useFileMentions, type FileMentionItem } from "../use-file-mentions";
 import { App, type KeyChord } from "./App";
 import { flattenPaste, normalizePaste, readClipboard } from "./clipboard";
 import {
@@ -56,7 +59,6 @@ import {
   type ComposerHistory,
   undo,
 } from "./composer-edit";
-import { pickerItemMatches, wrapIndex } from "../picker-window";
 import { wrapCommandIndex } from "./Input";
 import {
   isComposerNewline,
@@ -1237,6 +1239,18 @@ export function FullscreenBridge(): React.ReactNode {
     setCommandIndex(0);
   }, [commandQuery, setCommandIndex]);
 
+  // `@path` completions. Unlike slash commands, the candidates come off disk,
+  // so they are fetched rather than filtered — the menu itself is shared.
+  const { span: mention, items: mentionEntries } = useFileMentions(draft, draftCaret);
+  const mentionRef = useRef<AtMentionSpan | null>(mention);
+  mentionRef.current = mention;
+  const mentionEntriesRef = useRef<readonly FileMentionItem[]>(mentionEntries);
+  mentionEntriesRef.current = mentionEntries;
+
+  useEffect(() => {
+    setCommandIndex(0);
+  }, [mention?.query, setCommandIndex]);
+
   const historyIndex = useRef<number | null>(null);
 
   const insertAtCaret = useCallback(
@@ -1775,6 +1789,36 @@ export function FullscreenBridge(): React.ReactNode {
         return true;
       }
 
+      const mentionSpan = mentionRef.current;
+      const mentionItems = mentionEntriesRef.current;
+      if (mentionSpan !== null && mentionItems.length > 0) {
+        const selected = wrapCommandIndex(commandIndexRef.current, mentionItems.length);
+        if (name === "up") {
+          setCommandIndex(wrapCommandIndex(selected - 1, mentionItems.length));
+          return true;
+        }
+        if (name === "down") {
+          setCommandIndex(wrapCommandIndex(selected + 1, mentionItems.length));
+          return true;
+        }
+        // Tab and Enter both accept here. A path is not a command, so there is
+        // nothing to submit — accepting only edits the composer, which leaves
+        // Enter free to mean "insert" while the menu is open.
+        if ((name === "tab" && !shift) || name === "return" || name === "enter") {
+          const entry = mentionItems[selected];
+          if (entry !== undefined) {
+            const applied = applyAtMention(composerRef.current.text, mentionSpan, entry.name);
+            historyIndex.current = null;
+            commitComposer({
+              text: applied.text,
+              caret: applied.caret,
+              anchor: applied.caret,
+            });
+          }
+          return true;
+        }
+      }
+
       const slashQuery = slashCommandQuery(composerRef.current.text);
       const slashCommands = slashQuery === null ? [] : filterCommandsByPrefix(slashQuery);
       if (slashCommands.length > 0) {
@@ -2045,12 +2089,17 @@ export function FullscreenBridge(): React.ReactNode {
 
   const input = useMemo<InputModel>(() => {
     const commandItems = commandQuery === null ? [] : filterCommandsByPrefix(commandQuery);
-    const commands =
-      commandItems.length === 0
+    const mentionItems = mention === null ? [] : mentionEntries;
+    // Both cannot be live at once: a slash query requires the line to start
+    // with "/", which no mention span can.
+    const activeItems = commandItems.length > 0 ? commandItems : mentionItems;
+    const commands: InputModel["commands"] =
+      activeItems.length === 0
         ? undefined
         : {
-            items: commandItems,
-            selected: wrapCommandIndex(commandIndex, commandItems.length),
+            items: activeItems,
+            selected: wrapCommandIndex(commandIndex, activeItems.length),
+            prefix: commandItems.length > 0 ? "/" : "@",
           };
     return {
       value: draft,
@@ -2062,7 +2111,19 @@ export function FullscreenBridge(): React.ReactNode {
       disabled: overlay !== undefined || (!busy && queue.length === 0 && prompt?.type !== "chat"),
       ...(commands === undefined ? {} : { commands }),
     };
-  }, [draft, draftCaret, draftAnchor, busy, queue, overlay, prompt, commandQuery, commandIndex]);
+  }, [
+    draft,
+    draftCaret,
+    draftAnchor,
+    busy,
+    queue,
+    overlay,
+    prompt,
+    commandQuery,
+    commandIndex,
+    mention,
+    mentionEntries,
+  ]);
 
   const footer = useMemo<FooterModel>(
     () => ({

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -40,6 +40,7 @@ import {
   type EphemeralRegion,
   type PendingApproval,
 } from "../store";
+import { mergeSuggestions } from "../suggestion-menu";
 import type { Choice, OutputEntry, PromptState } from "../types";
 import { useFileMentions, type FileMentionItem } from "../use-file-mentions";
 import { App, type KeyChord } from "./App";
@@ -2090,16 +2091,14 @@ export function FullscreenBridge(): React.ReactNode {
   const input = useMemo<InputModel>(() => {
     const commandItems = commandQuery === null ? [] : filterCommandsByPrefix(commandQuery);
     const mentionItems = mention === null ? [] : mentionEntries;
-    // Both cannot be live at once: a slash query requires the line to start
-    // with "/", which no mention span can.
-    const activeItems = commandItems.length > 0 ? commandItems : mentionItems;
+    const menu = mergeSuggestions(commandItems, mentionItems);
     const commands: InputModel["commands"] =
-      activeItems.length === 0
+      menu === undefined
         ? undefined
         : {
-            items: activeItems,
-            selected: wrapCommandIndex(commandIndex, activeItems.length),
-            prefix: commandItems.length > 0 ? "/" : "@",
+            items: menu.items,
+            selected: wrapCommandIndex(commandIndex, menu.items.length),
+            prefix: menu.prefix,
           };
     return {
       value: draft,

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -16,6 +16,7 @@
  *   overlay     floats above all of it, and must not disturb the transcript
  */
 
+import type { SuggestionPrefix } from "../types";
 import type { FilePickerModel } from "./overlays/FilePicker";
 import type { QuestionModel } from "./overlays/Question";
 import type { TextPromptModel } from "./overlays/TextPrompt";
@@ -215,7 +216,7 @@ export interface InputModel {
      * Sigil the suggestions complete. Slash commands and `@` file mentions
      * share this menu, and the rows have to show the one being typed.
      */
-    readonly prefix?: "/" | "@";
+    readonly prefix?: SuggestionPrefix;
   };
   /**
    * Code-point offset into `value` where the next typed character lands.

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -211,6 +211,11 @@ export interface InputModel {
   readonly commands?: {
     readonly items: readonly CommandSuggestion[];
     readonly selected: number;
+    /**
+     * Sigil the suggestions complete. Slash commands and `@` file mentions
+     * share this menu, and the rows have to show the one being typed.
+     */
+    readonly prefix?: "/" | "@";
   };
   /**
    * Code-point offset into `value` where the next typed character lands.

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -16,7 +16,7 @@
  *   overlay     floats above all of it, and must not disturb the transcript
  */
 
-import type { SuggestionPrefix } from "../types";
+import type { SuggestionPrefix } from "../suggestion-menu";
 import type { FilePickerModel } from "./overlays/FilePicker";
 import type { QuestionModel } from "./overlays/Question";
 import type { TextPromptModel } from "./overlays/TextPrompt";

--- a/src/cli/ui/suggestion-menu.test.ts
+++ b/src/cli/ui/suggestion-menu.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { mergeSuggestions } from "./suggestion-menu";
+
+const command = { name: "model", description: "Change model" };
+const mention = { name: "src/foo.ts", description: "" };
+
+describe("mergeSuggestions", () => {
+  test("shows slash commands when there are any", () => {
+    expect(mergeSuggestions([command], [])).toEqual({ items: [command], prefix: "/" });
+  });
+
+  test("shows mentions when there are no commands", () => {
+    expect(mergeSuggestions([], [mention])).toEqual({ items: [mention], prefix: "@" });
+  });
+
+  test("prefers commands over mentions when both are non-empty", () => {
+    // The rule both composers used to encode separately — and differently.
+    expect(mergeSuggestions([command], [mention])).toEqual({ items: [command], prefix: "/" });
+  });
+
+  test("hides the menu when there is nothing to show", () => {
+    expect(mergeSuggestions([], [])).toBeUndefined();
+  });
+});

--- a/src/cli/ui/suggestion-menu.ts
+++ b/src/cli/ui/suggestion-menu.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview What the composer's suggestion menu is showing
+ *
+ * Slash commands and `@` file mentions share one menu, one selection index, and
+ * one set of keys, across two independent composers — the fullscreen renderer
+ * and the Ink fallback. The rule for which of the two is live therefore has to
+ * live in exactly one place: encoded per-composer it agrees only until someone
+ * edits one copy, and then the fallback silently behaves differently from the
+ * thing it is a fallback for.
+ */
+
+/** Sigils the suggestion menu can complete. */
+export type SuggestionPrefix = "/" | "@";
+
+/** The shape both composers' suggestion rows share. */
+export interface SuggestionEntry {
+  readonly name: string;
+  readonly description: string;
+  readonly usage?: string | undefined;
+  readonly source?: string | undefined;
+}
+
+export interface SuggestionMenu<Entry extends SuggestionEntry = SuggestionEntry> {
+  readonly items: readonly Entry[];
+  readonly prefix: SuggestionPrefix;
+}
+
+/**
+ * Pick which suggestions the menu shows.
+ *
+ * Slash commands win: a line starting with `/` cannot also hold a mention span,
+ * so an overlap means the caller resolved the two differently and the command
+ * is the more specific read. Returns undefined when there is nothing to show,
+ * which is the signal to hide the menu entirely.
+ */
+export function mergeSuggestions<Command extends SuggestionEntry, Mention extends SuggestionEntry>(
+  commands: readonly Command[],
+  mentions: readonly Mention[],
+): SuggestionMenu<Command | Mention> | undefined {
+  if (commands.length > 0) return { items: commands, prefix: "/" };
+  if (mentions.length > 0) return { items: mentions, prefix: "@" };
+  return undefined;
+}

--- a/src/cli/ui/types.ts
+++ b/src/cli/ui/types.ts
@@ -1,5 +1,15 @@
 import type { TerminalOutput } from "@/core/interfaces/terminal";
 
+/**
+ * Sigils the composer's suggestion menu can complete.
+ *
+ * Shared by both composers on purpose. The Ink prompt is a fallback for the
+ * fullscreen renderer rather than an alternative to it, so a sigil one offers
+ * and the other does not is a bug — this keeps the two from drifting, the same
+ * way `use-file-mentions` keeps their scan behaviour aligned.
+ */
+export type SuggestionPrefix = "/" | "@";
+
 export type OutputType =
   "info" | "success" | "warn" | "error" | "debug" | "log" | "user" | "streamContent";
 

--- a/src/cli/ui/types.ts
+++ b/src/cli/ui/types.ts
@@ -1,15 +1,5 @@
 import type { TerminalOutput } from "@/core/interfaces/terminal";
 
-/**
- * Sigils the composer's suggestion menu can complete.
- *
- * Shared by both composers on purpose. The Ink prompt is a fallback for the
- * fullscreen renderer rather than an alternative to it, so a sigil one offers
- * and the other does not is a bug — this keeps the two from drifting, the same
- * way `use-file-mentions` keeps their scan behaviour aligned.
- */
-export type SuggestionPrefix = "/" | "@";
-
 export type OutputType =
   "info" | "success" | "warn" | "error" | "debug" | "log" | "user" | "streamContent";
 

--- a/src/cli/ui/use-file-mentions.ts
+++ b/src/cli/ui/use-file-mentions.ts
@@ -1,0 +1,79 @@
+import { useEffect, useMemo, useState } from "react";
+import { atMentionSpan, type AtMentionSpan } from "./at-mention";
+import { scanFilePickerEntries } from "./file-picker-files";
+
+/**
+ * How long a keystroke settles before the `@` menu walks the filesystem. Long
+ * enough that typing a path does not launch a scan per character, short enough
+ * that pausing feels like the menu was already there.
+ */
+export const MENTION_SCAN_DEBOUNCE_MS = 90;
+
+/** Candidates fetched for the `@` menu; it only ever shows a handful. */
+export const MENTION_MAX_RESULTS = 40;
+
+/** One suggested path, shaped like the entries the command menu renders. */
+export interface FileMentionItem {
+  readonly name: string;
+  readonly description: string;
+}
+
+export interface FileMentions {
+  /** The span being completed, or null when the caret is not in a mention. */
+  readonly span: AtMentionSpan | null;
+  /** Paths matching the span, empty while scanning or when nothing matches. */
+  readonly items: readonly FileMentionItem[];
+}
+
+/**
+ * Suggest local paths for the `@` mention under the caret.
+ *
+ * Shared by both composers — the fullscreen one and the Ink fallback — so the
+ * debounce, the scan bounds, and the "what counts as a mention" rule cannot
+ * drift between them.
+ */
+export function useFileMentions(text: string, caret: number): FileMentions {
+  const span = useMemo(() => atMentionSpan(text, caret), [text, caret]);
+  const query = span?.query;
+  const [items, setItems] = useState<readonly FileMentionItem[]>([]);
+
+  useEffect(() => {
+    if (query === undefined) {
+      setItems([]);
+      return;
+    }
+
+    let cancelled = false;
+    // A keystroke lands faster than a directory walk finishes, so the scan is
+    // held back briefly and any in-flight result is discarded on the next one.
+    const timer = setTimeout(() => {
+      void scanFilePickerEntries({
+        basePath: process.cwd(),
+        query,
+        includeDirectories: true,
+        maxResults: MENTION_MAX_RESULTS,
+      })
+        .then((entries) => {
+          if (cancelled) return;
+          setItems(
+            entries.map((entry) => ({
+              name: entry.name,
+              description: entry.isDirectory ? "directory" : "",
+            })),
+          );
+        })
+        .catch(() => {
+          // An unreadable directory is not worth surfacing mid-keystroke; the
+          // menu simply stays empty.
+          if (!cancelled) setItems([]);
+        });
+    }, MENTION_SCAN_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  return { span, items };
+}


### PR DESCRIPTION
## What & why

Typing `@` in jazz gave you nothing. Paths were only resolved *after* you hit
enter, so you had to already know the path and type it correctly — which is the
opposite of how `@` works everywhere else.

`@` now opens a file menu, using the same list, keys, and windowing that slash
commands already use: up/down to move, Tab or Enter to insert. Accepting a path
only edits what you're typing — a path isn't a command, so there's nothing to
run.

Both composers get it: the fullscreen TUI and the Ink fallback, through a shared
hook so the debounce and matching rules can't drift apart. Candidates come from
the same scanner the `ask_file_picker` tool uses, so ignores and depth limits
already match.

## How to verify

- Type `@pack` in a chat and confirm `@package.json` appears; Tab inserts it and
  leaves your cursor after it.
- Type `@` mid-sentence (`compare @src/`) and confirm the rest of the line
  survives insertion.
- Type an email address — `mail me@example.com` — and confirm no menu opens.
- Type `/mo` and confirm slash commands still work unchanged, then `@` in the
  same session to confirm the two menus don't interfere.
- With an emoji earlier in the message (`🎷 see @src/`), accept a path and
  confirm the text isn't mangled — the composer's caret counts code points, not
  UTF-16 units.
- Run with `--no-fullscreen` (or force the Ink fallback) and confirm `@` behaves
  the same there.
