### PR TITLE
fix(mcp): declare disclosure for the resource tools

### DIFF
--- a/src/core/agent/tools/mcp-tools.ts
+++ b/src/core/agent/tools/mcp-tools.ts
@@ -359,6 +359,7 @@ export function buildResourceTools(
     }),
     hidden: false,
     riskLevel: "read-only",
+    disclosure: "personal",
     handler: (args: Record<string, unknown>) =>
       Effect.gen(function* () {
         const mcpManager = yield* MCPServerManagerTag;
@@ -417,6 +418,7 @@ export function buildResourceTools(
     }),
     hidden: false,
     riskLevel: "read-only",
+    disclosure: "personal",
     handler: (args: Record<string, unknown>) =>
       Effect.gen(function* () {
         const mcpManager = yield* MCPServerManagerTag;


### PR DESCRIPTION
## What & why

`main` currently fails to typecheck: `buildResourceTools`'s two tools (`mcp_*_list_resources`, `mcp_*_read_resource`), added in #417, never got the `disclosure` field that #415 made required a few commits earlier in the same merge sequence. A merge-order gap, not a logic bug.

Set both to `personal`, matching every other MCP-server tool in this file — content from a server outside this codebase is unclassifiable, and the safe reading of "I don't know what this returns" is "it could be anything".

## How to verify

- `bun run typecheck` — currently red on `main`, green with this.