### PR TITLE
docs: drop the "Reader job" line

### DIFF
--- a/docs/concepts/peers.md
+++ b/docs/concepts/peers.md
@@ -1,8 +1,5 @@
 # Peers — talking to someone else's agent
 
-**Reader job:** let your agent ask a friend's agent something, and decide what theirs may
-ask yours.
-
 Your jazz runs on your machine. Your friend's runs on theirs. A peer is a link between the
 two: your agent can put a question to theirs, and — if you allow it — theirs can put one to
 yours.

--- a/docs/internals/threat-model.md
+++ b/docs/internals/threat-model.md
@@ -3,10 +3,6 @@
 **Status: draft — v1 to be dated and published. Items marked ☐ are self-audit checks still
 to be run before any public safety claim.**
 
-**Reader job:** decide whether Jazz is safe to leave running unattended on a machine you
-care about, without taking our word for it. Every claim below names the code that enforces
-it.
-
 Jazz's safety stance is *fail closed by construction*: when the agent, the classifier, or
 the operator hasn't explicitly widened what may run, the answer is "ask a human." This
 document lists what that means concretely, what it does **not** protect against, and how to


### PR DESCRIPTION
## What & why

Removes the bolded "Reader job:" line from `docs/concepts/peers.md` and `docs/internals/threat-model.md` — the only two places it appeared. The paragraph immediately after already says what the page is for; a separately labeled restatement of the same thing was redundant.

## How to verify

- `bunx markdownlint-cli2 "docs/**/*.md"` — 0 issues.
- `grep -rn "Reader job" docs/` — no matches.