### PR TITLE
fix(ui): Shift+Enter newlines and collapsed approval field previews

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -338,8 +338,9 @@ product.
 Two of these are safety requirements rather than aesthetics. The card opens in a
 deny-only state for 250ms, so buffered Enter and always-allow keys are discarded
 while Escape remains immediate. Rejection removes the approval card before the
-optional guidance prompt appears, and every action field remains available in a
-scrolling record rather than being truncated.
+optional guidance prompt appears. Long fields collapse to a 120-cell preview
+so a heredoc does not become the whole card; Ctrl+O expands them into a wrapping,
+scrolling record, so the tail is still inspectable before you commit.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -232,7 +232,7 @@ Available inside an interactive session. Type `/help` for the current list.
 | `/new`       | Start a fresh conversation                            |
 
 **Keys:** double-Escape interrupts generation or a running tool. Shift+Tab cycles the
-approval policy.
+approval policy. Shift+Enter inserts a newline in the composer; Enter sends.
 
 ---
 

--- a/src/cli/input/escape-state-machine.test.ts
+++ b/src/cli/input/escape-state-machine.test.ts
@@ -106,6 +106,16 @@ describe("EscapeStateMachine", () => {
       expect(result.type).toBe("submit");
     });
 
+    test("Shift+Enter inserts a newline", () => {
+      const result = process(machine, "", { ...mockKey, return: true, shift: true });
+      expect(result.type).toBe("insert-newline");
+    });
+
+    test("Alt+Enter inserts a newline", () => {
+      const result = process(machine, "", { ...mockKey, return: true, meta: true });
+      expect(result.type).toBe("insert-newline");
+    });
+
     test("Tab key", () => {
       const result = process(machine, "", { ...mockKey, tab: true });
       expect(result.type).toBe("tab");

--- a/src/cli/input/escape-state-machine.ts
+++ b/src/cli/input/escape-state-machine.ts
@@ -509,9 +509,8 @@ export function createEscapeStateMachine(capabilities: TerminalCapabilities): Es
       case "Idle": {
         // Check for special keys first (from Ink's key parsing)
         if (key.return) {
-          // Alt+Enter (ESC CR — Ink reports meta+return) inserts a newline
-          // for multi-line composition; plain Enter submits.
-          if (key.meta) {
+          // Shift/Alt+Enter insert a newline; plain Enter submits.
+          if (key.meta || key.shift) {
             return { type: "insert-newline" };
           }
           return { type: "submit" };

--- a/src/cli/ui/WizardHome.tsx
+++ b/src/cli/ui/WizardHome.tsx
@@ -26,7 +26,7 @@ export const TIPS = [
   // CLI Shortcuts
   "Type '/help' in chat to see every command and keyboard shortcut",
   "Use Arrow Up in chat to recall your previous messages",
-  "Press Alt+Enter in chat to write multi-line messages",
+  "Press Shift+Enter in chat to write multi-line messages",
   "Press Ctrl+R after a response to expand the agent's reasoning",
   "Run 'jazz agent list' to see all your active agents",
 

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -893,6 +893,41 @@ describe("fullscreen bridge", () => {
     expect(submitted).toBeUndefined();
   });
 
+  it("inserts a newline on Shift+Enter without submitting", async () => {
+    let submitted: string | undefined;
+    const rendered = await testRender(<FullscreenBridge />, {
+      width: WIDTH,
+      height: HEIGHT,
+      kittyKeyboard: true,
+    });
+    await rendered.renderOnce();
+    store.setPrompt({
+      type: "chat",
+      message: "",
+      resolve: (value) => {
+        submitted = String(value);
+      },
+    });
+    await rendered.flush();
+
+    await typeInto(rendered.mockInput, rendered.flush, "hello");
+    await rendered.mockInput.pressKey("RETURN", { shift: true });
+    await settleKeypress(rendered.flush, 100);
+    await typeInto(rendered.mockInput, rendered.flush, "world");
+    const frame = rendered.captureCharFrame();
+
+    expect(frame).toContain("hello");
+    expect(frame).toContain("world");
+    expect(submitted).toBeUndefined();
+
+    await rendered.mockInput.pressKey("RETURN");
+    await settleKeypress(rendered.flush, 100);
+    rendered.renderer.destroy();
+    store.setPrompt(null);
+
+    expect(submitted).toBe("hello\nworld");
+  });
+
   it("inserts a paste at the caret rather than at the end", async () => {
     const rendered = await liveComposer();
     await typeInto(rendered.mockInput, rendered.flush, "ab");
@@ -1548,6 +1583,41 @@ describe("fullscreen bridge", () => {
     store.setApprovalRequest(null);
     store.setPrompt(null);
     expect(decisions).toEqual(["no"]);
+  });
+
+  it("crops a long approval command and expands it with Ctrl+O", async () => {
+    const TAIL = "AND-THEN-RM-RF-TMP-BUILD";
+    const command = `${"a".repeat(160)} ${TAIL}`;
+    const rendered = await testRender(<FullscreenBridge />, { width: 100, height: 28 });
+    await rendered.renderOnce();
+    store.setPrompt({
+      type: "select",
+      message: "Approve this action?",
+      options: { choices: [] },
+      resolve: () => undefined,
+    });
+    store.setApprovalRequest({
+      toolName: "execute_command",
+      executeToolName: "execute_execute_command",
+      message: "This command will be executed on your system.",
+      args: { command },
+    });
+    await rendered.flush();
+
+    const collapsed = rendered.captureCharFrame();
+    expect(collapsed).toContain("ctrl+o");
+    expect(collapsed).toContain("expand");
+    expect(collapsed).not.toContain(TAIL);
+
+    await rendered.mockInput.pressKey("\x0f");
+    await settleKeypress(rendered.flush, 100);
+    const expanded = rendered.captureCharFrame();
+    expect(expanded).toContain(TAIL);
+    expect(expanded).toContain("collapse");
+
+    rendered.renderer.destroy();
+    store.setApprovalRequest(null);
+    store.setPrompt(null);
   });
 
   it("lets the user inspect overflowed approval fields before deciding", async () => {

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -948,6 +948,7 @@ function approvalFrom(
   pending: PendingApproval,
   armed: boolean,
   fieldOffset: number,
+  expanded: boolean,
 ): ApprovalOverlay {
   const entries = Object.entries(pending.args).filter(
     ([, value]) => value !== undefined && value !== null && value !== "",
@@ -973,6 +974,7 @@ function approvalFrom(
       })),
     consequence: pending.message,
     fieldOffset,
+    expanded,
     alwaysLabel,
     armed,
   };
@@ -1004,6 +1006,7 @@ export function FullscreenBridge(): React.ReactNode {
   const approval = session.approvalRequest;
   const [approvalArmed, setApprovalArmed] = useState(false);
   const [approvalFieldOffset, setApprovalFieldOffset] = useState(0);
+  const [approvalExpanded, setApprovalExpanded] = useState(false);
   /**
    * The composer's text and caret as one value, updated only through pure
    * updaters.
@@ -1110,6 +1113,7 @@ export function FullscreenBridge(): React.ReactNode {
     if (approval !== null) flushPendingTerminalKeys();
     setApprovalArmedState(false);
     setApprovalFieldOffset(0);
+    setApprovalExpanded(false);
   }, [approval, setApprovalArmedState]);
 
   useEffect(() => {
@@ -1410,8 +1414,14 @@ export function FullscreenBridge(): React.ReactNode {
       }
 
       // Ctrl+O expands the last truncated tool output, which is the other half
-      // of the promise the footer makes.
+      // of the promise the footer makes. While an approval is up, the same key
+      // expands long fields on the card instead — the overlay owns the keyboard.
       if (isCtrlLetter({ name, ctrl }, "o")) {
+        if (approvalRef.current !== null) {
+          setApprovalExpanded((current) => !current);
+          setApprovalFieldOffset(0);
+          return true;
+        }
         const payload = store.getExpandableDiff();
         if (payload === null || payload === undefined) {
           store.printOutput({
@@ -1475,6 +1485,11 @@ export function FullscreenBridge(): React.ReactNode {
       // it. Esc falls through to the ladder, which rejects.
       if (approvalRef.current !== null) {
         if (name === "escape") return false;
+        if (isCtrlLetter({ name, ctrl }, "o")) {
+          setApprovalExpanded((current) => !current);
+          setApprovalFieldOffset(0);
+          return true;
+        }
         if (name === "up" || name === "down" || name === "pageup" || name === "pagedown") {
           const delta = name === "up" ? -1 : name === "down" ? 1 : name === "pageup" ? -5 : 5;
           setApprovalFieldOffset((offset) => Math.max(0, offset + delta));
@@ -1805,7 +1820,11 @@ export function FullscreenBridge(): React.ReactNode {
         // Tab and Enter both accept here. A path is not a command, so there is
         // nothing to submit — accepting only edits the composer, which leaves
         // Enter free to mean "insert" while the menu is open.
-        if ((name === "tab" && !shift) || name === "return" || name === "enter") {
+        if (
+          (name === "tab" && !shift) ||
+          ((name === "return" || name === "enter") &&
+            !isComposerNewline({ name, shift, option, meta }))
+        ) {
           const entry = mentionItems[selected];
           if (entry !== undefined) {
             const applied = applyAtMention(composerRef.current.text, mentionSpan, entry.name);
@@ -1841,7 +1860,10 @@ export function FullscreenBridge(): React.ReactNode {
           }
           return true;
         }
-        if (name === "return" || name === "enter") {
+        if (
+          (name === "return" || name === "enter") &&
+          !isComposerNewline({ name, shift, option, meta })
+        ) {
           const command = slashCommands[selected];
           if (command === undefined) return true;
           const text = `/${command.name}`;
@@ -2073,7 +2095,7 @@ export function FullscreenBridge(): React.ReactNode {
       };
     }
     if (approval !== null) {
-      next = approvalFrom(approval, approvalArmed, approvalFieldOffset);
+      next = approvalFrom(approval, approvalArmed, approvalFieldOffset, approvalExpanded);
     }
     return next;
   }, [
@@ -2086,6 +2108,7 @@ export function FullscreenBridge(): React.ReactNode {
     approval,
     approvalArmed,
     approvalFieldOffset,
+    approvalExpanded,
   ]);
 
   const input = useMemo<InputModel>(() => {

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -1413,33 +1413,6 @@ export function FullscreenBridge(): React.ReactNode {
         return true;
       }
 
-      // Ctrl+O expands the last truncated tool output, which is the other half
-      // of the promise the footer makes. While an approval is up, the same key
-      // expands long fields on the card instead — the overlay owns the keyboard.
-      if (isCtrlLetter({ name, ctrl }, "o")) {
-        if (approvalRef.current !== null) {
-          setApprovalExpanded((current) => !current);
-          setApprovalFieldOffset(0);
-          return true;
-        }
-        const payload = store.getExpandableDiff();
-        if (payload === null || payload === undefined) {
-          store.printOutput({
-            type: "warn",
-            message: "No truncated output available to expand.",
-            timestamp: new Date(),
-          });
-        } else {
-          store.printOutput({
-            type: "log",
-            message: payload.fullDiff,
-            timestamp: new Date(),
-            meta: { expandedOutput: true },
-          });
-        }
-        return true;
-      }
-
       // A menu is a modal question: it owns the keyboard until it is answered.
       const openMenu = menuRef.current;
       if (openMenu !== null) {
@@ -1510,6 +1483,27 @@ export function FullscreenBridge(): React.ReactNode {
           );
           active.resolve(alwaysCommand ? "always_command" : "always_tool");
           return true;
+        }
+        return true;
+      }
+
+      // Ctrl+O expands the last truncated tool output. Approval already claimed
+      // the key above when a long field is on the card.
+      if (isCtrlLetter({ name, ctrl }, "o")) {
+        const payload = store.getExpandableDiff();
+        if (payload === null || payload === undefined) {
+          store.printOutput({
+            type: "warn",
+            message: "No truncated output available to expand.",
+            timestamp: new Date(),
+          });
+        } else {
+          store.printOutput({
+            type: "log",
+            message: payload.fullDiff,
+            timestamp: new Date(),
+            meta: { expandedOutput: true },
+          });
         }
         return true;
       }

--- a/src/cli/ui/fullscreen/keymap.test.ts
+++ b/src/cli/ui/fullscreen/keymap.test.ts
@@ -266,6 +266,19 @@ describe("normalizeKey", () => {
     expect(normalizeKey("\r").ctrl).toBe(false);
     expect(normalizeKey("\b").name).toBe("backspace");
     expect(normalizeKey("\b").ctrl).toBe(false);
+    expect(normalizeKey("\x1b[13u")).toMatchObject({ name: "return", ctrl: false, shift: false });
+    expect(normalizeKey("\x1b[13;2u")).toMatchObject({ name: "return", ctrl: false, shift: true });
+    expect(normalizeKey("\x1b[27;2;13~")).toMatchObject({
+      name: "return",
+      ctrl: false,
+      shift: true,
+    });
+    expect(normalizeKey({ name: "return", shift: true, sequence: "\x1b[13;2u" })).toMatchObject({
+      name: "return",
+      ctrl: false,
+      shift: true,
+    });
+    expect(normalizeKey("\x1b[9;2u")).toMatchObject({ name: "tab", ctrl: false, shift: true });
   });
 });
 
@@ -299,6 +312,9 @@ describe("composer newline", () => {
     expect(isComposerNewline({ name: "enter", shift: false, option: false, meta: true })).toBe(
       true,
     );
+    expect(isComposerNewline(normalizeKey("\x1b[13;2u"))).toBe(true);
+    expect(isComposerNewline(normalizeKey("\x1b[13u"))).toBe(false);
+    expect(isComposerNewline(normalizeKey("\r"))).toBe(false);
   });
 });
 

--- a/src/cli/ui/fullscreen/keymap.ts
+++ b/src/cli/ui/fullscreen/keymap.ts
@@ -82,6 +82,15 @@ const ESC = String.fromCharCode(27);
 const KITTY_CSI_U = new RegExp("^" + ESC + String.raw`\[(\d+)(?::[^;]*)?(?:;(\d+)(?::(\d+))?)?u$`);
 const MODIFY_OTHER_KEYS = new RegExp("^" + ESC + String.raw`\[27;(\d+);(\d+)~$`);
 
+/** CSI-u / modifyOtherKeys codepoints that are keys, not Ctrl+letter. */
+const CODED_KEY_NAMES: Readonly<Record<number, string>> = {
+  8: "backspace",
+  9: "tab",
+  13: "return",
+  27: "escape",
+  127: "backspace",
+};
+
 function fieldString(record: Record<string, unknown>, key: string): string {
   const value = record[key];
   return typeof value === "string" ? value : "";
@@ -181,7 +190,7 @@ function finalizeNormalized(fields: NormalizedKey): NormalizedKey {
     if (kitty[3] === "3") {
       return { ...fields, name: "", sequence, ctrl: false, shift: false };
     }
-    const letter = letterFromCodepoint(Number(kitty[1]));
+    const codepoint = Number(kitty[1]);
     const modifier = kitty[2] === undefined ? 1 : Number(kitty[2]);
     const bits = Number.isFinite(modifier) ? modifier - 1 : 0;
     if ((bits & 1) !== 0) shift = true;
@@ -191,9 +200,15 @@ function finalizeNormalized(fields: NormalizedKey): NormalizedKey {
     }
     if ((bits & 4) !== 0) ctrl = true;
     if ((bits & 8) !== 0) superKey = true;
-    if (letter !== undefined) {
-      name = letter;
-      if (Number(kitty[1]) <= 26 && !superKey) ctrl = true;
+    const coded = CODED_KEY_NAMES[codepoint];
+    if (coded !== undefined) {
+      name = coded;
+    } else {
+      const letter = letterFromCodepoint(codepoint);
+      if (letter !== undefined) {
+        name = letter;
+        if (codepoint <= 26 && !superKey) ctrl = true;
+      }
     }
     return { ...fields, name, sequence, ctrl, shift, meta, option, super: superKey };
   }
@@ -201,7 +216,7 @@ function finalizeNormalized(fields: NormalizedKey): NormalizedKey {
   const modifyOther = MODIFY_OTHER_KEYS.exec(sequence);
   if (modifyOther !== null) {
     const bits = Number(modifyOther[1]) - 1;
-    const letter = letterFromCodepoint(Number(modifyOther[2]));
+    const codepoint = Number(modifyOther[2]);
     if ((bits & 1) !== 0) shift = true;
     if ((bits & 2) !== 0) {
       meta = true;
@@ -209,7 +224,13 @@ function finalizeNormalized(fields: NormalizedKey): NormalizedKey {
     }
     if ((bits & 4) !== 0) ctrl = true;
     if ((bits & 8) !== 0) superKey = true;
-    if (letter !== undefined) name = letter;
+    const coded = CODED_KEY_NAMES[codepoint];
+    if (coded !== undefined) {
+      name = coded;
+    } else {
+      const letter = letterFromCodepoint(codepoint);
+      if (letter !== undefined) name = letter;
+    }
     return { ...fields, name, sequence, ctrl, shift, meta, option, super: superKey };
   }
 

--- a/src/cli/ui/fullscreen/overlays/Approval.tsx
+++ b/src/cli/ui/fullscreen/overlays/Approval.tsx
@@ -12,8 +12,10 @@
  *
  *   - The real account is rendered verbatim, because the whole trust argument
  *     is that jazz always says which real-world object is in scope.
- *   - Every field that will exist afterwards is on screen before you commit.
- *     Nothing is discoverable only after pressing enter.
+ *   - Every field that will exist afterwards is on the card before you commit.
+ *     Long values collapse to a preview so a multi-kilobyte command does not
+ *     bury the rest of the record; Ctrl+O expands them, and the expanded view
+ *     wraps and scrolls rather than clipping the tail.
  *   - Irreversibility is stated in prose, not encoded in an icon.
  *   - Red is reserved for things that already broke; this is a decision being
  *     offered, so the only hue is `warning`, on the marker and the verb.
@@ -46,8 +48,11 @@ const FIXED_CARD_ROWS = 6;
 /** The controls line, beneath the frame. */
 const CONTROL_ROWS = 1;
 
-/** Cells the left half of the controls line ("enter accept    esc reject") needs. */
-const CONTROLS_LEFT_CELLS = 27;
+/**
+ * Collapsed field preview, in terminal cells. Long enough to recognise the
+ * command, short enough that a heredoc does not become the whole card.
+ */
+export const COLLAPSED_FIELD_CELLS = 120;
 
 function displayWidth(text: string): number {
   return terminalCellWidth(text);
@@ -60,6 +65,14 @@ function clip(text: string, width: number): string {
 /** A field value is one row of a record, so newlines collapse rather than wrap. */
 function oneLine(text: string): string {
   return text.replace(/\s+/g, " ").trim();
+}
+
+export function approvalFieldNeedsExpand(value: string): boolean {
+  return displayWidth(oneLine(value)) > COLLAPSED_FIELD_CELLS;
+}
+
+function collapsedFieldValue(value: string): string {
+  return clip(oneLine(value), COLLAPSED_FIELD_CELLS);
 }
 
 export function wrapProse(text: string, width: number): string[] {
@@ -98,7 +111,8 @@ export function wrapProse(text: string, width: number): string[] {
  * Fields and prose share a list rather than occupying two fixed regions,
  * because the promise the card makes — nothing is discoverable only after
  * pressing enter — is only true if *everything* below the rule can be reached
- * by scrolling. Two regions meant one of them was clipped by the frame.
+ * by expanding and scrolling. Two regions meant one of them was clipped by
+ * the frame.
  */
 type BodyRow =
   | { readonly kind: "field"; readonly key: string; readonly label: string; readonly value: string }
@@ -106,21 +120,25 @@ type BodyRow =
   | { readonly kind: "blank"; readonly key: string };
 
 /**
- * A field is wrapped, never truncated: the argument that decides what runs is
- * usually the longest one on the card, and a shell command whose tail is off
- * screen is the exact thing an approval gate exists to prevent.
+ * Collapsed, a field is clipped to COLLAPSED_FIELD_CELLS so the card stays a
+ * decision rather than a wall of text. Expanded, it wraps without clipping:
+ * the argument that decides what runs is usually the longest one on the card,
+ * and a shell command whose tail is off screen is the exact thing an approval
+ * gate exists to prevent.
  */
 export function approvalBodyRows(
   fields: readonly { readonly label: string; readonly value: string }[],
   consequence: readonly string[],
   valueWidth: number,
   labelWidth: number,
+  expanded = false,
 ): BodyRow[] {
   const rows: BodyRow[] = [];
 
   fields.forEach((field, index) => {
     const label = clip(oneLine(field.label), labelWidth);
-    wrapProse(field.value, valueWidth).forEach((line, lineIndex) => {
+    const value = expanded ? field.value : collapsedFieldValue(field.value);
+    wrapProse(value, valueWidth).forEach((line, lineIndex) => {
       rows.push({
         kind: "field",
         key: `field:${String(index)}:${String(lineIndex)}`,
@@ -174,7 +192,15 @@ export function Approval({ model, viewport }: ApprovalProps): ReactNode {
   const valueWidth = Math.max(4, inner - LABEL_COLUMN);
 
   const consequence = wrapProse(model.consequence, inner);
-  const bodyRows = approvalBodyRows(model.fields, consequence, valueWidth, LABEL_COLUMN - 1);
+  const expanded = model.expanded === true;
+  const expandable = model.fields.some((field) => approvalFieldNeedsExpand(field.value));
+  const bodyRows = approvalBodyRows(
+    model.fields,
+    consequence,
+    valueWidth,
+    LABEL_COLUMN - 1,
+    expanded,
+  );
   const windowedHeight = FIXED_CARD_ROWS + bodyRows.length + CONTROL_ROWS;
   const height = fullscreen ? viewport.height : Math.min(windowedHeight, viewport.height);
   const cardHeight = Math.max(1, height - CONTROL_ROWS);
@@ -224,9 +250,14 @@ export function Approval({ model, viewport }: ApprovalProps): ReactNode {
 
   const scrollHint = bodyScrolls
     ? belowCount > 0
-      ? `${String(belowCount)} more below · up/down · `
-      : "up/down · "
+      ? `${String(belowCount)} more below · up/down`
+      : "up/down"
     : "";
+  const expandHint = expandable ? `ctrl+o ${expanded ? "collapse" : "expand"}` : "";
+  const rightHint = [scrollHint, expandHint, `a ${model.alwaysLabel}`]
+    .filter((part) => part.length > 0)
+    .join(" · ");
+  const rightBudget = Math.max(0, inner - displayWidth("enter accept    esc reject"));
 
   return (
     <box
@@ -304,9 +335,7 @@ export function Approval({ model, viewport }: ApprovalProps): ReactNode {
           <span style={{ fg: THEME.secondary }}>{" reject"}</span>
         </text>
         <box style={{ flexGrow: 1 }} />
-        <text style={{ fg: THEME.muted, flexShrink: 0 }}>
-          {clip(`${scrollHint}a ${model.alwaysLabel}`, Math.max(0, inner - CONTROLS_LEFT_CELLS))}
-        </text>
+        <text style={{ fg: THEME.muted, flexShrink: 0 }}>{clip(rightHint, rightBudget)}</text>
       </box>
     </box>
   );

--- a/src/cli/ui/fullscreen/overlays/overlays.test.tsx
+++ b/src/cli/ui/fullscreen/overlays/overlays.test.tsx
@@ -18,7 +18,13 @@ import type { ReactNode } from "react";
 import { getGlyphs } from "../../glyphs";
 import { THEME } from "../../theme";
 import type { ApprovalOverlay, SearchOverlay, Viewport } from "../types";
-import { approvalBodyRows, Approval, wrapProse } from "./Approval";
+import {
+  approvalBodyRows,
+  approvalFieldNeedsExpand,
+  Approval,
+  COLLAPSED_FIELD_CELLS,
+  wrapProse,
+} from "./Approval";
 import { Search } from "./Search";
 
 const WIDE: Viewport = { width: 120, height: 34 };
@@ -166,6 +172,7 @@ describe("approval overlay", () => {
     expect(frame).toContain(APPROVAL.consequence);
     expect(frame).toContain(APPROVAL.action);
     expect(frame).toContain(APPROVAL.app);
+    expect(frame).not.toContain("ctrl+o");
 
     renderer.destroy();
   });
@@ -312,9 +319,9 @@ describe("approval overlay", () => {
     narrow.renderer.destroy();
   });
 
-  // A shell command whose tail is off screen is the exact thing the gate
-  // exists to prevent, so nothing below the rule may be clipped: it wraps, and
-  // what does not fit is reachable by scrolling.
+  // A multi-kilobyte command would bury the rest of the card, so the collapsed
+  // preview clips. Ctrl+O expands; the expanded view wraps, and what still
+  // does not fit is reachable by scrolling — the tail is never undiscoverable.
   describe("a command too long for the card", () => {
     const TAIL = "AND-THEN-RM-RF-TMP-BUILD";
     const LONG_COMMAND =
@@ -332,24 +339,67 @@ describe("approval overlay", () => {
       consequence: "This command will be executed on your system.",
     };
 
+    function rebuiltField(expanded: boolean): string {
+      return approvalBodyRows([{ label: "command", value: LONG_COMMAND }], [], 40, 10, expanded)
+        .filter((row) => row.kind === "field")
+        .map((row) => (row.kind === "field" ? row.value : ""))
+        .join(" ");
+    }
+
     it("wraps every word instead of truncating, however long the word", () => {
       const unbroken = "x".repeat(500);
       const wrapped = wrapProse(unbroken, 20);
       expect(wrapped.join("")).toBe(unbroken);
       expect(wrapped.every((line) => line.length <= 20)).toBe(true);
+    });
 
-      const rows = approvalBodyRows([{ label: "command", value: LONG_COMMAND }], [], 40, 10);
-      const rebuilt = rows
-        .filter((row) => row.kind === "field")
-        .map((row) => (row.kind === "field" ? row.value : ""))
-        .join(" ");
-      expect(rebuilt).toContain(TAIL);
+    it("clips the collapsed preview and keeps the tail behind Ctrl+O", () => {
+      expect(approvalFieldNeedsExpand(LONG_COMMAND)).toBe(true);
+      expect(approvalFieldNeedsExpand("echo hi")).toBe(false);
+      expect(approvalFieldNeedsExpand("x".repeat(COLLAPSED_FIELD_CELLS))).toBe(false);
+
+      const collapsed = rebuiltField(false);
+      expect(collapsed).toContain("curl");
+      expect(collapsed).toContain("…");
+      expect(collapsed).not.toContain(TAIL);
+
+      expect(rebuiltField(true)).toContain(TAIL);
+    });
+
+    it("offers ctrl+o and hides the tail until expanded", async () => {
+      const first = await draw(
+        <Approval
+          model={LONG}
+          viewport={WIDE}
+        />,
+        WIDE,
+      );
+      const firstFrame = first.captureCharFrame();
+      expect(firstFrame).toContain("curl");
+      expect(firstFrame).not.toContain(TAIL);
+      expect(firstFrame).toContain("ctrl+o");
+      expect(firstFrame).toContain("expand");
+      expect(firstFrame).not.toContain("collapse");
+      first.renderer.destroy();
+
+      const expanded = await draw(
+        <Approval
+          model={{ ...LONG, expanded: true }}
+          viewport={WIDE}
+        />,
+        WIDE,
+      );
+      const expandedFrame = expanded.captureCharFrame();
+      expect(expandedFrame).toContain(TAIL);
+      expect(expandedFrame).toContain("ctrl+o");
+      expect(expandedFrame).toContain("collapse");
+      expanded.renderer.destroy();
     });
 
     it("says how much is below the fold and reveals it when scrolled", async () => {
       const first = await draw(
         <Approval
-          model={LONG}
+          model={{ ...LONG, expanded: true }}
           viewport={TINY}
         />,
         TINY,
@@ -357,15 +407,16 @@ describe("approval overlay", () => {
       const firstFrame = first.captureCharFrame();
       expect(firstFrame).toContain("curl");
       // The tail is genuinely below the fold, and the card says so rather than
-      // letting the reader assume they have seen the whole command.
+      // letting the reader assume they have seen the whole command. On this
+      // viewport the expand hint clips the phrase to "more bel…".
       expect(firstFrame).not.toContain(TAIL);
-      expect(firstFrame).toContain("more below");
+      expect(firstFrame).toMatch(/more bel/);
       expect(firstFrame).not.toContain("executed on your system");
       first.renderer.destroy();
 
       const scrolled = await draw(
         <Approval
-          model={{ ...LONG, fieldOffset: 99 }}
+          model={{ ...LONG, expanded: true, fieldOffset: 99 }}
           viewport={TINY}
         />,
         TINY,

--- a/src/cli/ui/fullscreen/types.ts
+++ b/src/cli/ui/fullscreen/types.ts
@@ -267,6 +267,8 @@ export interface ApprovalOverlay {
   readonly fields: readonly ApprovalField[];
   readonly consequence: string;
   readonly fieldOffset?: number;
+  /** True after Ctrl+O: long fields wrap in full instead of the 120-cell preview. */
+  readonly expanded?: boolean;
   readonly alwaysLabel: string;
   /** True once the arming delay has passed; before that only deny is accepted. */
   readonly armed: boolean;

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -380,7 +380,7 @@ const KEYBOARD_SHORTCUTS: ReadonlyArray<readonly [keys: string, description: str
   ["Ctrl+O", "Expand the last truncated diff or tool output"],
   ["Tab", "Complete the highlighted slash command"],
   ["Up/Down", "Recall previously sent messages (empty input)"],
-  ["Alt+Enter", "Insert a newline for a multi-line message"],
+  ["Shift+Enter", "Insert a newline for a multi-line message"],
   ["Esc", "Clear the current draft"],
   ["Up (agent busy)", "Recall queued messages for editing"],
   ["Ctrl+X (agent busy)", "Clear the message queue"],


### PR DESCRIPTION
## Summary
- Shift+Enter inserts a newline in the composer instead of sending; Enter still sends.
- Long approval fields collapse to a short preview so a large command does not bury the rest of the card; Ctrl+O expands them.

## Test plan
- [ ] In the composer, type a line, press Shift+Enter, type a second line, then Enter — the message should send as two lines.
- [ ] Plain Enter on a single line still sends immediately.
- [ ] Trigger an `execute_command` approval with a long command: the tail should be hidden until Ctrl+O, then visible (and Ctrl+O again collapses).
- [ ] On a terminal that cannot distinguish Shift+Enter (e.g. macOS Terminal.app), Alt+Enter still inserts a newline.