### PR TITLE
docs: rewrite AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,187 +1,152 @@
 # Working on Jazz
 
-Instructions for AI agents contributing to this codebase. Read
-[README.md](README.md) and [docs/](docs/index.md) first for what the product does;
-[docs/internals/](docs/internals/index.md) for how the harness works and
-[design-decisions.md](docs/internals/design-decisions.md) for why it works that way.
+Jazz is an agent harness. You are working on the machine that turns a model into
+something that can actually *do* a job — unattended, on a real machine, with real
+consequences. That is hard, interesting work. Treat it that way.
+
+Do not reconstruct Jazz from memory. Do not answer from vibes. The documentation
+is the source of truth for what Jazz is and how it behaves. The code is the
+source of truth for how it is implemented. Read both before you speak.
 
 ---
 
-## What Jazz is
+## Go read
 
-An agentic automation CLI: users define autonomous agents that carry out real tasks —
-reading and writing files, driving git, searching the web, running shell commands, calling
-APIs — with an approval gate in front of anything destructive.
+Start here, in this order, for whatever you are about to do:
 
-The thesis is that **automation should decide, not just execute**. A shell script follows a
-fixed path; a Jazz agent reads the situation, picks tools, checks its own work, and reports
-what it did. Everything in the codebase serves that difference.
+- What is Jazz, and what can it do? [README.md](README.md), [docs/](docs/index.md)
+- How does the harness work? [docs/internals/](docs/internals/index.md)
+- Why is it built this way? [design-decisions.md](docs/internals/design-decisions.md)
+- Where does my change go? [code-map.md](docs/internals/code-map.md)
+- What does the interface demand? [docs/design/](docs/design/index.md)
+- What is the security model? [SECURITY.md](SECURITY.md), [threat-model.md](docs/internals/threat-model.md)
+- How do I contribute? [CONTRIBUTING.md](CONTRIBUTING.md)
+- Public flags, tools, config? [docs/reference/](docs/reference/index.md)
+- Did this harness change help? [evals](evals/README.md), [evals internals](docs/internals/evals.md)
 
-Jazz is pre-1.0 and ships frequently. It is not "done", and pretending otherwise in docs or
-commit messages helps nobody.
-
----
-
-## What already exists
-
-Know these before proposing to build them:
-
-| Area | Reality |
-| --- | --- |
-| Providers | 18 behind one AI SDK adapter, including local Ollama and llama.cpp |
-| Tools | 34 agent-facing, 7 of them approval-gated, plus MCP and declarative custom tools |
-| Context | Two-tier token counting with per-model calibration, turn-aware trimming, compaction at 80% |
-| Long runs | 80-iteration budget with pressure injection at 70%/90%, meltdown detection, sub-agents with isolated context |
-| Surfaces | Terminal TUI, headless `jazz run`, launchd/cron, GitHub Actions, a Telegram bridge |
-| Measurement | An eval harness with pass@k, Pass^k reliability, bootstrap CIs, and A/B between harness configs |
-
-There is **no** plugin system, and agents do **not** learn across runs. Don't describe either
-as if it exists.
+The stack, the commands, the architecture, the Effect patterns, the naming: they
+live in the repo. Open the files. Match what you find.
 
 ---
 
-## How to approach a change
+## Read the code before you answer
 
-### Understand before building
+A question about Jazz is a request to go look. Trace the path. Read the tests
+around it. Follow the types. Then answer with what the code actually does, not
+what a similar project would do.
 
-Read the code paths you're about to touch, and the tests around them. Check
-`docs/internals/` for whether the pattern already exists — several things that look missing
-are implemented under a different name.
+If you have not opened the relevant files, you are not ready to:
 
-### Consider more than one design
+- explain how something works
+- propose a design
+- estimate scope
+- change anything
 
-For anything non-trivial, sketch two or three approaches and pick deliberately. Say in the PR
-why you rejected the others; that reasoning is the part reviewers can't reconstruct.
-
-### Work at the frontier, then prove the lift
-
-Jazz exists to find out how much of the gap between a weak model and a strong one is closable
-by the harness rather than the model. So novel patterns are welcome — speculative execution,
-verification-refinement loops, multi-model consensus, better context strategies — but a claim
-about agent quality is worth only as much as its measurement.
-
-The eval harness exists for exactly this: `bun run evals --agent eval-sut --ab eval-sut-variant`
-A/Bs the same tasks across two configs and attributes the difference. If you change the
-harness, run it. See [evals/README.md](evals/README.md) and
-[docs/internals/evals.md](docs/internals/evals.md).
-
-### Prefer clean breaks to compatibility shims
-
-This is a pre-1.0 CLI, not a library with downstream consumers. When you rename or
-restructure, update every usage and delete the old path in the same change. **No
-`@deprecated` aliases, no back-compat shims, no dead code left behind.**
-
-That licenses breaking changes *within the work you were asked to do*. It is not a licence to
-rewrite adjacent subsystems you happen to be passing through — scope creep is still scope
-creep, and an unrequested redesign is a review burden rather than a contribution. If you spot
-something worth changing outside your scope, say so instead of doing it.
+Guessing is slower than reading. Reading is the job.
 
 ---
 
-## Standards
+## Think at the frontier
 
-### Security
+Jazz exists to find out how much of the gap between a weak model and a strong
+one is closable by the harness rather than the model. That is the interesting
+problem. Lean into it.
 
-Jazz executes real actions on a user's machine, so this is load-bearing rather than
-box-ticking. See [SECURITY.md](SECURITY.md) for the model.
+Novel patterns are welcome: speculative execution, verification-refinement
+loops, multi-model consensus, better context strategies, tighter approval UX,
+cheaper long runs. Bring ambition. Bring a design. Then prove the lift —
+a claim about agent quality is worth only as much as its measurement.
 
-- Validate every external input with a Zod schema at the boundary
-- Never log credentials, tokens, or secrets — and check what your error messages interpolate
-- New tools declare an honest `riskLevel`; anything mutating is gated, no exceptions
-- A tool that shells out inherits `execute_command`'s risk, not its own optimism
-- Threat-model the untrusted-input surfaces: chat bridges, fetched web content, PR diffs
+If you change the harness, run the evals. See [evals/README.md](evals/README.md).
 
-### Testing
+Do not shrink a hard problem into a cosmetic one because the cosmetic one is
+easier to ship. Do not paper over a real gap with a comment, a default, or a
+shim. Do the hard version. That is why you are here.
 
-- `bun test` (bun:test, not vitest). Tests live beside the code they cover
-- Cover the failure modes, not just the happy path — timeouts, malformed tool arguments, provider errors
-- Effect code gets tested with mock Layers; pure functions get tested directly
-- A test that cannot fail is worse than no test. Break your own assertion once to confirm it catches the thing
-- Security-relevant behavior gets a regression test (see `shell-tools.security.test.ts`)
-
-### Documentation
-
-Match the level of documentation to how non-obvious the thing is.
-
-- **Code comments: default to none.** Add one only when the *why* isn't evident from the code. Never narrate what the next line does
-- Document *decisions* rather than mechanics — a reader can see what the code does, not what you rejected
-- Public tools, config fields, and CLI flags need reference entries. `docs/reference/tools.md` is verified by a test and will fail if you add a tool without updating it
-- Outdated docs are worse than absent ones: if you change behavior, fix the page that described it
-- Run `bun run docs:check-links` before you claim the docs are fine
-
-### Performance
-
-- Profile before optimizing; "this feels slow" is a hypothesis, not a finding
-- The dominant costs in an agent run are LLM round trips and tool output volume, in that order — optimize those before micro-optimizing TypeScript
-- Parallelize independent tool calls; cache what's expensive and stable
-- Lazy-load anything that spawns a process. MCP servers connect on first use for this reason
+Do not assume because a code exists that it's correct. Everything is improvable.
 
 ---
 
-## Stack
+## Work with the developer
 
-- **Bun** — runtime, test runner, and bundler
-- **TypeScript**, strict mode, 100% of the codebase
-- **Effect-TS** — typed errors, tracked effects, `Layer`-based dependency injection
-- **Commander.js** — CLI parsing
-- **Ink** (React for terminals) — the interactive TUI
-- **Vercel AI SDK** — the provider port
+You are a collaborator, not a silent code emitter. The person on the other side
+knows the product, the users, and the taste. Use them.
 
-Commands: `bun test` · `bun run typecheck` · `bun run lint` · `bun run build` ·
-`bun run docs:check-links` · `bun run evals`
+- **Arrive with a point of view.** For anything non-trivial, sketch two or three
+  approaches, say which one you would pick and why, and name what you are
+  rejecting. That reasoning is the part a reviewer cannot reconstruct later.
+- **Validate before you act.** If the request is ambiguous, if the design has
+  real trade-offs, if you would touch more than the obvious files, or if you
+  might break a user-facing contract — stop and check. Come with a
+  recommendation, not a blank. Then wait for the go.
+- **Do not expand the job in the dark.** Spotting something worth changing
+  outside your scope is useful. Silently rewriting it is not. Say it. Ask.
+- **Clear, obvious work does not need a ceremony.** A typo, a failing test, a
+  requested one-file fix: do it. Validation is for when the path is not unique.
+
+The failure mode on one side is disappearing for forty files. The failure mode
+on the other is asking permission to breathe. Aim between them: think hard,
+propose sharply, confirm when it matters, then execute all the way.
 
 ---
 
-## Code style
+## Documentation
 
-### Functions
+- Everytime a behavior changes, a feature is added or removed  update the `docs` folder to reflect the change.
+- Add a docstring on top of files the explain in details its purpose and how to use the functions/objects declared in it.
+- Document functions when needed. Avoid inline comments and prefer to document at the function or file level.
 
-- Use function declarations for top-level functions, not arrow consts — better stack traces
-- Arrow functions for callbacks, array methods, and inline operations
-- No one-letter names or abbreviations. `agentConfiguration`, not `cfg`
+---
 
-### TypeScript
+## How to write the change
 
-- `interface` over `type` for object shapes
-- Discriminated unions for variants; exhaustive switches over them
-- Explicit return types on exported functions
-- `readonly` on arrays and object fields that shouldn't be mutated
-- Never `any` outside tests. `unknown` plus a narrowing check instead
+Prefer clean breaks to compatibility shims. When you rename or restructure,
+update every usage and delete the old path in the same change. No `@deprecated`
+aliases, no back-compat shims, no dead code left behind. 
 
-### Effect-TS
+`core/` imports nothing from `services/`.
 
-- Every side effect returns an `Effect`
-- `Effect.gen` for sequential work, `pipe()` for composition, `Effect.all` for parallel
-- Errors are `Data.TaggedError` subclasses, so callers can match on the tag
-- Dependencies arrive as `Layer`s; a service is an interface in `core/interfaces/` plus a `Context.Tag`
-- `Effect.Ref` for mutable state
-- To break a dependency cycle, pass a function parameter rather than importing across layers (see how `summarizer.ts` takes a `RecursiveRunner`)
+Jazz executes real actions on a user's machine. Security is load-bearing.
+Validate external input at the boundary. Never log secrets. New tools declare
+an honest `riskLevel`; anything mutating is gated. A tool that shells out
+inherits `execute_command`'s risk. Threat-model untrusted-input surfaces. Read
+[SECURITY.md](SECURITY.md) before you touch any of that, and add a regression
+test when you do.
 
-### Architecture boundaries
+Tests live beside the code they cover. Cover the failure modes, not just the
+happy path. A test that cannot fail is worse than no test.
 
-`core/` imports nothing from `services/` — the rule is enforced, and breaking it is how the
-codebase stops being testable. `core/` defines ports, `services/` implements them, `cli/`
-wires the Layers. See [code-map.md](docs/internals/code-map.md).
+### Code
 
-CLI commands are hierarchical (`jazz agent <action>`), one module each, and must work both
-interactively and headlessly.
+Write advanced TypeScript. Use the type system for real: discriminated unions,
+exhaustive switches, precise generics, `readonly` where mutation would be a
+bug, narrowed `unknown` instead of `any`. Follow the patterns already in the
+tree, then go further when a sharper type or a tighter abstraction earns its
+keep.
 
-### Errors
+Lean toward the most performance- and memory-efficient solution that is still
+correct and readable. Allocate less. Copy less. Stream when the alternative is
+buffering. Lazy-load anything that spawns a process. Parallelize independent
+work. The dominant costs in an agent run are LLM round trips and tool output
+volume — attack those before micro-optimizing a map. "This feels slow" is a
+hypothesis; profile before you declare a win.
 
-- Specific tagged error types, never a bare `Error` for a known failure mode
-- Messages state what failed and what the user can do about it
-- A tool failure returns a failed result the agent can reason about; it does not throw and kill the run
+### UX
 
-### Naming
-
-`PascalCase` types and classes · `camelCase` functions and variables · `SCREAMING_SNAKE_CASE`
-constants · `kebab-case` CLI commands and filenames. Don't prefix interfaces with `I`.
+A person is sitting in a terminal, or waiting on a scheduled run, or reading a
+chat message from their own bot. Every extra frame, extra line, extra question,
+extra round trip is a tax on them. Design the interaction: what they see,
+when they are asked, what happens when they say no, how failure is explained.
+If you change the TUI, the approval card, the CLI output, or a chat surface,
+go use it the way they would — or the closest substitute the tests give you —
+before you call it done.
 
 ---
 
 ## Git
 
-- **Never push to `main`.** Feature branches only, and `git pull origin main` before branching
-- No `Co-Authored-By: Claude` trailers
-- Never stash, reset, or discard uncommitted work without asking first
-- Nothing under `docs/superpowers/` is ever committed — it's gitignored deliberately
+- **Never push to `main`.** Feature branches only. `git pull origin main`
+  before branching.
+- No `Co-Authored-By` in commit.
+- Never stash, reset, or discard uncommitted work without asking first.
+


### PR DESCRIPTION
## What & why
Rewrites the agent instructions so contributors (and coding agents) are sent to the docs and the code instead of a stale stack cheat sheet. The new page asks them to read before answering, think at the frontier, check in before acting on non-obvious work, and keep `docs/` in sync when behavior changes.

## How to verify
- Open `AGENTS.md` and follow each docs link; none should 404.
- Confirm it no longer lists providers, tool counts, or the runtime stack — those live in the docs and the repo.
- Skim as if you were an agent landing on the repo: the first screen should tell you to go read, not how to write an Effect Layer.