### PR TITLE
obsidian: document vault auto-detection and fallback behavior

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -177,7 +177,7 @@ obsidian web url="https://example.com"
 If a vault is not explicitly supplied when writing or creating notes, the skill will attempt to detect a reasonable Obsidian vault automatically rather than guessing a default folder. Detection follows this priority:
 
 1. If the current working directory is inside a vault (a parent directory containing a top-level `.obsidian` folder), that vault is used.
-2. Search under the user's home subtree and common locations (e.g. `~/`, `~/Documents`, and iCloud `Library/Mobile Documents`) for directories that include a top-level `.obsidian` directory. The search is limited to a small depth (default 4) and skips common system directories.
+2. Search under the user's home subtree and common locations for directories that include a top-level `.obsidian` directory. The implementation chooses OS-appropriate candidate roots (examples below), limits the search to a small depth (default 4), and skips common system directories.
 3. If exactly one candidate vault is found, it is selected.
 4. If multiple candidates are found, the skill prefers one whose path includes `Personal` or matches a configured default vault name (if available). If ambiguity remains, the skill returns the short list to the caller so they can choose rather than guessing.
 5. If no vault is found, the skill falls back to `~/Obsidian` then `~/Documents/Obsidian` as a final fallback.
@@ -188,6 +188,15 @@ Notes:
 - The chosen vault path is logged and exposed in the skill's response so callers can confirm where content was written.
 
 
+
+
+Examples of candidate roots by platform (the skill chooses OS-appropriate defaults):
+
+- macOS: `~/`, `~/Documents`, `~/Library/Mobile Documents` (iCloud)
+- Linux: `~/`, `~/Documents`, `~/.local/share` (if used for cloud mounts)
+- Windows: `%USERPROFILE%\\`, `%USERPROFILE%\\Documents`, and known cloud folders such as `OneDrive` when present
+
+The implementation limits the search to the user's home subtree for safety and performance and does not scan system or root directories.
 
 1. **Vault:** Always specify `vault=Name`. If CWD is inside a vault, that vault is used; otherwise confirm vault to use.
 2. **Ask first:** For big or structured notes, confirm depth, visuals (images, LaTeX, Mermaid), and organization (single note, folder, canvas).

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -172,6 +172,23 @@ obsidian web url="https://example.com"
 
 ## Best Practices
 
+### Vault auto-detection
+
+If a vault is not explicitly supplied when writing or creating notes, the skill will attempt to detect a reasonable Obsidian vault automatically rather than guessing a default folder. Detection follows this priority:
+
+1. If the current working directory is inside a vault (a parent directory containing a top-level `.obsidian` folder), that vault is used.
+2. Search under the user's home subtree and common locations (e.g. `~/`, `~/Documents`, and iCloud `Library/Mobile Documents`) for directories that include a top-level `.obsidian` directory. The search is limited to a small depth (default 4) and skips common system directories.
+3. If exactly one candidate vault is found, it is selected.
+4. If multiple candidates are found, the skill prefers one whose path includes `Personal` or matches a configured default vault name (if available). If ambiguity remains, the skill returns the short list to the caller so they can choose rather than guessing.
+5. If no vault is found, the skill falls back to `~/Obsidian` then `~/Documents/Obsidian` as a final fallback.
+
+Notes:
+- The search is limited to the user's home subtree for safety and performance.
+- In interactive sessions the skill will prompt to choose when multiple vaults are found; in non-interactive/headless runs it will return the candidate list and refuse to guess.
+- The chosen vault path is logged and exposed in the skill's response so callers can confirm where content was written.
+
+
+
 1. **Vault:** Always specify `vault=Name`. If CWD is inside a vault, that vault is used; otherwise confirm vault to use.
 2. **Ask first:** For big or structured notes, confirm depth, visuals (images, LaTeX, Mermaid), and organization (single note, folder, canvas).
 3. **File vs path:** `file=` uses wikilink-style resolution (name only). Use `path=` for an exact path from vault root.


### PR DESCRIPTION
## What & why
Adds a 'Vault auto-detection' section to the Obsidian skill documentation so callers understand how the skill chooses an Obsidian vault when none is explicitly supplied. The new text documents a safe, cross-platform priority: (1) CWD inside a vault, (2) search the user's home subtree for folders containing a top-level .obsidian directory using OS-appropriate candidate roots, (3) simple heuristics to prefer 'Personal' or a configured default, and (4) fallbacks to ~/Obsidian and ~/Documents/Obsidian. It also clarifies interactive vs headless behavior and logging of the chosen path.

This change is docs-only; implementation will follow in a separate PR that adds a detectVaultPath() helper and unit tests.

Note: the skill already instructs callers to write note content by resolving a vault path and using the environment's file write tool (write_file) to create .md files. This PR does not change that guidance — it only ensures callers can reliably discover which vault will be used when they omit a vault parameter.

## How to verify
- Read the updated SKILL.md and confirm the new 'Vault auto-detection' section appears and lists the detection priority and fallback order.
- Confirm cross-platform examples are present (macOS, Linux, Windows) and that iCloud is only listed as a macOS example.
- Confirm the PR remains docs-only (no code changes).
- Optional next-step verification: after the implementation PR, exercise the behavior in interactive and headless modes to validate prompting and non-guessing behavior for multiple candidate vaults.