### PR TITLE
fix(ui): keep parenthesis ordered lists on their own line

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -143,9 +143,9 @@ The **skill-creator** skill walks through purpose, location (global vs project),
 
 When you send a message:
 
-1. The system injects the list of available skills (name + description) and the short **Skills** instructions: if the request matches a skill, load it with `load_skill`, follow its workflow, and use `load_skill_section` when the skill references more detail.
+1. The system injects the list of available skills (name + description) and the short **Skills** instructions: if the request matches a skill, load it with `load_skill`, treat the loaded body as the playbook (every named step, file write, and tool — not a shorter improvised path), and use `load_skill_section` when the skill references more detail.
 2. The agent compares your request to those descriptions and decides whether to call `load_skill`.
-3. If it does, it gets the full SKILL.md and follows it (calling other tools, shell, MCP, etc. as the skill specifies).
+3. If it does, the full SKILL.md is returned in the conversation as a tool result. The agent is instructed to execute that playbook rather than ask whether to follow it or substitute a shorter path.
 4. When the workflow says “for X, see references/foo.md,” the agent can call `load_skill_section(skill_name, "references/foo.md")` and then continue.
 
 So the **full feature set** of skills is:

--- a/docs/internals/design-decisions.md
+++ b/docs/internals/design-decisions.md
@@ -282,9 +282,12 @@ server surfaces mid-run instead of at startup.
 instructions), `load_skill_section` (a referenced file).
 
 **Alternatives rejected.** Preloading every skill's instructions into the system prompt. A
-hundred skills would consume the window before the user says anything.
+hundred skills would consume the window before the user says anything. Re-injecting a loaded
+skill into the system prompt on later turns — that would bust the cached system prefix, so
+the playbook stays in the conversation as the `load_skill` tool result.
 
-**Cost accepted.** Two extra round trips before the agent starts working with a skill.
+**Cost accepted.** Two extra round trips before the agent starts working with a skill. Later
+turns must follow a playbook that lives in transcript history, not in the system prompt.
 
 📄 [`skill-tools.ts`](../../src/core/agent/tools/skill-tools.ts) · [Skills loading](./skills-loading.md)
 

--- a/docs/internals/skills-loading.md
+++ b/docs/internals/skills-loading.md
@@ -113,6 +113,11 @@ what's available.
 price of not spending the window on skills nobody asked for. When the agent already knows
 the name from the index — the common case — it's one call.
 
+The loaded body stays in the conversation as a tool result. It is not copied into the system
+prompt on later turns: that prefix is cached, and mutating it on `load_skill` would miss on
+every subsequent request. The Skills instructions tell the model to treat that tool result
+as the playbook and execute it rather than improvise a shorter path.
+
 ---
 
 ## Related

--- a/src/cli/presentation/markdown-formatter.test.ts
+++ b/src/cli/presentation/markdown-formatter.test.ts
@@ -82,6 +82,12 @@ describe("markdown-formatter", () => {
       const result = formatMarkdownHybrid("    ## Hybrid H2");
       expect(result).toBe(`## ${chalk.bold.hex(THEME.selected)("Hybrid H2")}`);
     });
+
+    it("treats 1) as an ordered list marker, same as 1.", () => {
+      expect(stripAnsiCodes(formatMarkdown("1) Cloves"))).toBe(
+        stripAnsiCodes(formatMarkdown("1. Cloves")).replace("1.", "1)"),
+      );
+    });
   });
 
   describe("underscore italics — intraword underscores are not emphasis", () => {

--- a/src/cli/presentation/markdown-formatter.ts
+++ b/src/cli/presentation/markdown-formatter.ts
@@ -1021,8 +1021,7 @@ export function formatLists(text: string): string {
       return `${indentStr}${codeColor(bullet)} ${content}`;
     }
 
-    // Ordered lists (1., 2., etc.)
-    const orderedMatch = line.match(/^(\s*)(\d+\.)\s+(.+)$/);
+    const orderedMatch = line.match(/^(\s*)(\d+[.)])\s+(.+)$/);
     if (
       orderedMatch &&
       orderedMatch[1] !== undefined &&

--- a/src/cli/presentation/markdown-split.test.ts
+++ b/src/cli/presentation/markdown-split.test.ts
@@ -45,6 +45,11 @@ const cases: Case[] = [
     expected: (s) => s.indexOf("\n\n") + 2,
   },
   {
+    name: "open parenthesis-ordered list clamps split before the list",
+    input: "para.\n\n1) a\n2) b in flight " + "x".repeat(SOFT_TAIL),
+    expected: (s) => s.indexOf("\n\n") + 2,
+  },
+  {
     name: "20KB blob with no structure falls back to last newline before MAX_PENDING_TAIL",
     input: "a".repeat(MAX_PENDING_TAIL - 1) + "\n" + "b".repeat(5000),
     // Newline sits at index MAX_PENDING_TAIL - 1; function returns idx + 1.

--- a/src/cli/presentation/markdown-split.ts
+++ b/src/cli/presentation/markdown-split.ts
@@ -403,7 +403,7 @@ function isHeadingLine(line: string): boolean {
 }
 
 function isListLine(line: string): boolean {
-  return /^\s*([-*+]\s|\d+\.\s)/.test(line);
+  return /^\s*([-*+]\s|\d+[.)]\s)/.test(line);
 }
 
 /**

--- a/src/cli/ui/fullscreen/Transcript.tsx
+++ b/src/cli/ui/fullscreen/Transcript.tsx
@@ -471,7 +471,10 @@ function headingMarker(level: number, glyphs: GlyphSet): string {
   return glyphs.heading4;
 }
 
-/** Split agent markdown into items that read at the measure and items that scan. */
+/**
+ * Split agent markdown into items that read at the measure and items that scan.
+ * CommonMark ordered markers (`1.` and `1)`) start a new item even without a blank line.
+ */
 export function parseProse(markdown: string, glyphs: GlyphSet = getGlyphs()): ProseItem[] {
   const items: ProseItem[] = [];
   const lines = markdown.split("\n");
@@ -561,15 +564,16 @@ export function parseProse(markdown: string, glyphs: GlyphSet = getGlyphs()): Pr
       continue;
     }
 
-    const bullet = /^(\s*)(?:[-*+]|\d+\.)\s+(.*)$/.exec(line);
+    const bullet = /^(\s*)(?:[-*+]|\d+\.|(\d+\)))\s+(.*)$/.exec(line);
     if (bullet !== null) {
       const depth = Math.floor(terminalCellWidth(bullet[1] ?? "") / 2);
+      const paren = bullet[2];
       items.push({
         kind: "text",
-        indent: depth * 2 + 2,
+        indent: depth * 2 + (paren !== undefined ? 0 : 2),
         segments: [
-          { text: `${glyphs.bullet} `, fg: THEME.border },
-          ...inlineSegments(bullet[2] ?? "", THEME.selected, glyphs),
+          { text: `${paren ?? glyphs.bullet} `, fg: THEME.border },
+          ...inlineSegments(bullet[3] ?? "", THEME.selected, glyphs),
         ],
       });
       index += 1;
@@ -582,7 +586,7 @@ export function parseProse(markdown: string, glyphs: GlyphSet = getGlyphs()): Pr
       const candidate = lines[index] ?? "";
       if (
         candidate.trim().length === 0 ||
-        /^\s*(\||```|#{1,6}\s|>|[-*+]\s|\d+\.\s)/.test(candidate)
+        /^\s*(\||```|#{1,6}\s|>|[-*+]\s|\d+[.)]\s)/.test(candidate)
       ) {
         break;
       }

--- a/src/cli/ui/fullscreen/transcript.test.tsx
+++ b/src/cli/ui/fullscreen/transcript.test.tsx
@@ -19,7 +19,13 @@ import type { ReactNode } from "react";
 import { getGlyphs } from "../glyphs";
 import { setThemeVariant, THEME } from "../theme";
 import { terminalCellWidth } from "./terminal-cells";
-import { inlineSegments, Transcript, transcriptRows, type RenderRow } from "./Transcript";
+import {
+  inlineSegments,
+  parseProse,
+  Transcript,
+  transcriptRows,
+  type RenderRow,
+} from "./Transcript";
 import { measureFor, PROSE_MEASURE, type Block, type Viewport } from "./types";
 
 beforeAll(() => {
@@ -701,6 +707,68 @@ describe("newBelow", () => {
     expect(loud.rows).toHaveLength(quiet.rows.length);
     expect(loud.rows.slice(0, WIDE.height - 1)).toEqual(quiet.rows.slice(0, WIDE.height - 1));
     expect(quiet.rows.join("\n")).not.toContain("new below");
+  });
+});
+
+describe("parenthesis ordered lists", () => {
+  function rowText(rows: readonly RenderRow[], blockId: string): string[] {
+    return rows
+      .filter((row) => row.key.startsWith(`${blockId}:`))
+      .map((row) => row.content.map((segment) => segment.text).join(""));
+  }
+
+  it("keeps 1) on its own line when the model omitted a blank line", () => {
+    const markdown = [
+      "Safer, low-risk options (what you can try with low downside)",
+      "1) Cloves (whole or powdered)",
+      "- What people use it for: antiparasitic",
+      "",
+      "2) Garlic (raw or aged extract)",
+    ].join("\n");
+
+    const items = parseProse(markdown);
+    const texts = items.flatMap((item) => {
+      if (item.kind === "text") return [item.segments.map((segment) => segment.text).join("")];
+      return [];
+    });
+    expect(texts.some((text) => text.includes("low downside") && text.includes("1)"))).toBe(false);
+    expect(texts.find((text) => text.includes("Cloves"))).toContain("1)");
+    expect(texts.find((text) => text.includes("Garlic"))).toContain("2)");
+
+    const rows = transcriptRows([{ id: "a", seq: 1, kind: "agent", markdown }], WIDE);
+    const heading = rowText(rows, "a").find((line) => line.includes("low downside"));
+    const cloves = rowText(rows, "a").find((line) => line.includes("Cloves"));
+    expect(heading).toBeDefined();
+    expect(cloves).toBeDefined();
+    expect(heading).not.toContain("1)");
+    expect(cloves).toContain("1)");
+  });
+
+  it("does not join consecutive parenthesis items that share no blank line", () => {
+    const markdown = [
+      "3) Monitor: stop and get medical testing.",
+      "4) If you prefer a stronger attempt, read the dosing first.",
+    ].join("\n");
+    const items = parseProse(markdown);
+    const texts = items.flatMap((item) => {
+      if (item.kind === "text") return [item.segments.map((segment) => segment.text).join("")];
+      return [];
+    });
+    expect(texts).toHaveLength(2);
+    expect(texts[0]).toContain("3)");
+    expect(texts[0]).not.toContain("4)");
+    expect(texts[1]).toContain("4)");
+  });
+
+  it("still turns 1. into a bullet", () => {
+    const items = parseProse("Heading\n1. Cloves");
+    const texts = items.flatMap((item) => {
+      if (item.kind === "text") return [item.segments.map((segment) => segment.text).join("")];
+      return [];
+    });
+    expect(texts).toHaveLength(2);
+    expect(texts[1]).toContain(getGlyphs().bullet);
+    expect(texts[1]).not.toContain("1.");
   });
 });
 

--- a/src/core/agent/agent-prompt-environment.test.ts
+++ b/src/core/agent/agent-prompt-environment.test.ts
@@ -42,11 +42,9 @@ function build(personaName: string, systemPrompt: string): string {
 describe("environment block injection", () => {
   test("appends the canonical block with live values when no placeholder is authored", () => {
     const result = build("default", "You are {agentName}. Do good work.");
-    expect(result).toContain("# Environment");
-    expect(result).toContain("- Date:");
-    expect(result).toContain("- Hardware:");
-    expect(result).toContain("- Hostname:");
-    expect(result).toContain("- TTY:");
+    expect(result).toMatch(
+      /Environment: Date: .+ \| OS: .+ \| Hardware: .+ \| Shell: .+ \| Home: .+ \| Hostname: .+ \| User: .+ \| TTY: .+/,
+    );
     // Live values, not raw placeholders.
     expect(result).not.toContain("{currentDate}");
     expect(result).not.toContain("{osInfo}");
@@ -63,8 +61,8 @@ describe("environment block injection", () => {
 
   test("summarizer never receives the environment block", () => {
     const result = build("summarizer", "You are {agentName}, {agentDescription} Summarize.");
-    expect(result).not.toContain("# Environment");
-    expect(result).not.toContain("- Hardware:");
+    expect(result).not.toContain("Environment:");
+    expect(result).not.toContain("Hardware:");
   });
 
   test("agent name and description are always substituted", () => {

--- a/src/core/agent/agent-prompt-instructions.test.ts
+++ b/src/core/agent/agent-prompt-instructions.test.ts
@@ -52,6 +52,8 @@ describe("completion instructions injection", () => {
     expect(result).toContain("Do not stay stuck");
     expect(result).toContain("Do not dump a URL and stop");
     expect(result).toContain("Look up live docs");
+    expect(result).toContain("Do not invent a larger next job");
+    expect(result).not.toContain("brief offer of optional follow-up");
   });
 
   test("summarizer never receives the completion contract", () => {
@@ -70,6 +72,7 @@ describe("tool guidance injection", () => {
   test("tool selection guidance appears when tools are present", () => {
     const result = build("default", { toolNames: ["http_request"] });
     expect(result).toContain("# Tool usage");
+    expect(result).toContain("execute its playbook");
   });
 
   test("question guidance is gated on ask_user_question", () => {
@@ -81,6 +84,24 @@ describe("tool guidance injection", () => {
     expect(withTool).toContain("Permission to do work the user already requested");
     expect(withTool).toContain("A required CLI or account is not set up");
     expect(withTool).toContain("When TTY is no — there is no one to respond");
+  });
+});
+
+describe("skills playbook instructions", () => {
+  test("loaded skills are the playbook, not a suggestion", () => {
+    const result = build("default", {
+      knownSkills: [
+        {
+          name: "pr-description",
+          description: "Draft a PR body from the branch diff.",
+          path: "/skills/pr-description",
+        },
+      ],
+    });
+    expect(result).toContain("A loaded skill is the playbook");
+    expect(result).toContain("Do not ask whether to follow it");
+    expect(result).toContain("do not substitute a shorter path");
+    expect(result).not.toContain("Follow the loaded skill's step-by-step workflow");
   });
 });
 

--- a/src/core/agent/prompts/shared.ts
+++ b/src/core/agent/prompts/shared.ts
@@ -5,17 +5,8 @@
  * and so a new field is added in exactly one place. Rendered by filling the
  * placeholders with live values in AgentPromptBuilder.buildSystemPrompt.
  */
-export const ENVIRONMENT_TEMPLATE = `# Environment
-
-- Date: {currentDate}
-- OS: {osInfo}
-- Hardware: {hardware}
-- Shell: {shell}
-- Home: {homeDirectory}
-- Hostname: {hostname}
-- User: {username}
-- TTY: {tty}
-`;
+export const ENVIRONMENT_TEMPLATE =
+  "Environment: Date: {currentDate} | OS: {osInfo} | Hardware: {hardware} | Shell: {shell} | Home: {homeDirectory} | Hostname: {hostname} | User: {username} | TTY: {tty}";
 
 /**
  * Added only for models that cannot generate media themselves.
@@ -36,7 +27,7 @@ ask for that instead.
 export const SKILLS_INSTRUCTIONS = `
 Skills:
 1. If a request matches a skill in the index, load it with load_skill. Use find_skills when the index is not enough to decide.
-2. Follow the loaded skill's step-by-step workflow.
+2. A loaded skill is the playbook. Execute every step it names — including file writes and the exact tools it specifies. Do not ask whether to follow it, and do not substitute a shorter path.
 3. For complex skills, load referenced sections via load_skill_section (e.g. references/foo.md) only after load_skill.
 Note: Prefer skill workflows over ad-hoc handling for matched tasks. Do not load every skill.
 `;
@@ -76,13 +67,13 @@ export const COMPLETION_INSTRUCTIONS = `
 4. If a step fails, try a different approach before coming back. Look up current documentation (README, --help, upstream site), try another method, then continue. When you must report failure, say what you tried and the next step that would unblock you — never hand the user a menu of recovery options you could evaluate yourself.
 5. Never guess a value you can fetch. If a tool call can resolve a URL, an ID, a number, or a fact, make the call — a wrong guess costs more than one more tool call. Look up live docs instead of relying on training for how a CLI is installed or configured.
 6. When asked about something you did earlier, answer from the record — re-read the file, re-fetch the resource, check the actual tool results. Never reconstruct your own past actions from memory or from what seems plausible.
-7. Once the job is done and verified, a brief offer of optional follow-up work is fine. Asking permission to do the requested work is not.
+7. When the requested job is done, stop. Do not invent a larger next job or ask whether to expand the scope. If they want more, they will say so.
 `;
 
 export const TOOL_SELECTION_INSTRUCTIONS = `
 # Tool usage
 
-1. If a skill matches the task, load it and follow its workflow rather than improvising.
+1. If a skill matches the task, load it and execute its playbook.
 2. Prefer the most specific tool available; reach for a general shell command only when no dedicated tool covers the task.
 3. Call independent operations (searches, reads, status checks) in parallel in a single response. Sequence calls only when one result feeds the next.
 `;


### PR DESCRIPTION
## What & why
Agent replies that number items with `1)` no longer glue the first item onto the previous heading when the model skips a blank line. CommonMark allows that marker; we only treated `1.`, so those lists looked broken even though the markdown was fine.

Loaded skills are now the playbook, not a suggestion: execute the named steps instead of asking whether to follow them or substituting a shorter path. The environment block is one line, and once the requested job is done the agent stops instead of inventing follow-up work.

## How to verify
- Ask for a numbered list in the TUI (or replay a turn whose raw markdown is `Heading\n1) Item` with no blank line). The heading and `1)` should be on separate rows; nested `-` bullets should still indent under the item.
- Confirm a reply that already had a blank line before `1)` still looks the same, and that `1. Item` still renders as a `∙` bullet.
- Load a skill and check the agent follows its steps (including file writes) without asking permission to use the playbook or offering a shorter path.
- After a finished task, confirm there is no unsolicited “want me to also…?” expansion.