### PR TITLE
fix(agent): make double-Esc during a tool a clean stop

### DIFF
--- a/docs/internals/tools-and-approval.md
+++ b/docs/internals/tools-and-approval.md
@@ -213,7 +213,7 @@ flowchart TB
     META --> FORK["Fork all 6 as fibers<br/>≤10 running concurrently"]
     FORK --> JOIN{"Race"}
     JOIN -->|"all complete"| RESULTS(["6 results"])
-    JOIN -->|"interrupt signal<br/>(double-Esc)"| KILL["Interrupt every fiber<br/>→ GenerationInterruptedError"]
+    JOIN -->|"interrupt signal<br/>(double-Esc)"| KILL["Interrupt every fiber<br/>settle UI · stop the loop"]
 
     classDef act fill:#4f9d9d,stroke:#2f6d6d,color:#ffffff
     class FORK act
@@ -230,6 +230,11 @@ sees it, and the run continues. A tool that can't finish shouldn't take the whol
 
 Approval prompts are queued rather than raced, and re-checked at dequeue time — a parallel
 tool's "always approve" may have changed the answer while this one waited.
+
+Double-Esc during a running tool is a **clean stop**, not a crash. In-flight tools get a
+cancelled receipt, `execute_command`'s child process is killed, dangling `tool_calls` in
+the transcript get a matching tool-result so the next turn stays valid, and the loop
+exits the same way an LLM-stream interrupt does.
 
 ---
 

--- a/src/cli/presentation/ink-presentation-service.test.ts
+++ b/src/cli/presentation/ink-presentation-service.test.ts
@@ -528,6 +528,46 @@ describe("InkStreamingRenderer", () => {
       expect(toolPhases[0]!.tools[0]!.toolName).toBe("execute_bash");
     });
 
+    test("flush after a running tool returns activity to idle", async () => {
+      const renderer = createRenderer();
+      emitStreamStart(renderer);
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "tool_execution_start",
+          toolName: "execute_command",
+          toolCallId: "tc-1",
+        }),
+      );
+      Effect.runSync(renderer.flush());
+      await new Promise((r) => setTimeout(r, 0));
+
+      const last = setActivityCalls[setActivityCalls.length - 1];
+      expect(last!.phase).toBe("idle");
+    });
+
+    test("error after a running tool leaves activity in error, not tool-execution", async () => {
+      const renderer = createRenderer();
+      emitStreamStart(renderer);
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "tool_execution_start",
+          toolName: "execute_command",
+          toolCallId: "tc-1",
+        }),
+      );
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "error",
+          error: { code: "INTERRUPTED", message: "GenerationInterruptedError" },
+          recoverable: false,
+        } as never),
+      );
+      await new Promise((r) => setTimeout(r, 0));
+
+      const last = setActivityCalls[setActivityCalls.length - 1];
+      expect(last!.phase).toBe("error");
+    });
+
     test("tool_execution_complete transitions back to idle when last tool", async () => {
       const renderer = createRenderer();
       emitStreamStart(renderer);

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -408,6 +408,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       }
       this.pendingActivity = null;
       this.clearAllToolTimeouts();
+      this.acc.activeTools.clear();
       // Flush buffered deltas BEFORE collapsing the reasoning region so any
       // in-flight reasoning text lands in the panel before it collapses.
       this.flushStreamBuffer();
@@ -576,6 +577,10 @@ export class InkStreamingRenderer implements StreamingRenderer {
       if (event.type === "tool_execution_complete") {
         this.clearToolTimeout(event.toolCallId);
         this.storeExpandableDiff(completedToolName, event.result);
+      }
+      if (event.type === "error") {
+        this.clearAllToolTimeouts();
+        this.acc.activeTools.clear();
       }
 
       const result = reduceEvent(this.acc, event, ink);

--- a/src/core/agent/execution/agent-loop.test.ts
+++ b/src/core/agent/execution/agent-loop.test.ts
@@ -5,6 +5,7 @@ import { FileSystem } from "@effect/platform";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
+import { GenerationInterruptedError } from "@/core/types/errors";
 import type { ConversationMessages } from "@/core/types/message";
 import type { DisplayConfig } from "@/core/types/output";
 import { clearModelsDevCache } from "@/core/utils/models-dev";
@@ -691,6 +692,60 @@ describe("executeAgentLoop", () => {
     // rather than continuing on to further iterations.
     expect(calls).toContain("interrupted:test-agent");
     expect(getCompletionCalls).toBe(1);
+  });
+
+  it("treats a tool-phase GenerationInterruptedError as a clean interrupt", async () => {
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: {
+            id: "c1",
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_1",
+                type: "function" as const,
+                function: { name: "test_tool", arguments: "{}" },
+              },
+            ],
+          },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock(() =>
+      Effect.fail(new GenerationInterruptedError({ reason: "Tool execution interrupted by user" })),
+    );
+
+    const { observer, calls } = recordingObserver();
+
+    try {
+      const result = await Effect.runPromise(
+        executeAgentLoop(
+          makeOptions({ maxIterations: 5 }),
+          makeRunContext(),
+          displayConfig,
+          strategy,
+          observer,
+          runRecursive,
+        ).pipe(Effect.provide(TestLayer)),
+      );
+
+      expect(calls).toContain("interrupted:test-agent");
+      const toolMessage = result.messages?.find(
+        (message) => message.role === "tool" && message.tool_call_id === "call_1",
+      );
+      expect(toolMessage).toBeDefined();
+      expect(toolMessage?.content).toContain("interrupted");
+    } finally {
+      ToolExecutor.executeToolCalls = originalExecute;
+    }
   });
 
   it("should warn on empty response", async () => {

--- a/src/core/agent/execution/agent-loop.ts
+++ b/src/core/agent/execution/agent-loop.ts
@@ -15,7 +15,7 @@ import {
   type MessageAttachment,
 } from "@/core/types/attachment";
 import type { ChatCompletionResponse } from "@/core/types/chat";
-import { LLMRateLimitError } from "@/core/types/errors";
+import { GenerationInterruptedError, LLMRateLimitError } from "@/core/types/errors";
 import type { DisplayConfig } from "@/core/types/output";
 import type { StreamEvent } from "@/core/types/streaming";
 import { conversationLogGroup } from "@/core/utils/log-group";
@@ -349,10 +349,41 @@ function finalizeRun(
 }
 
 /**
+ * Close out assistant `tool_calls` that never got a `role: "tool"` result so the
+ * transcript stays valid for the next LLM request. Used when the user interrupts
+ * mid-batch: executeToolCalls fails before handleToolPhase can append results.
+ */
+function closeDanglingToolCalls(state: LoopState): void {
+  const lastAssistant = [...state.currentMessages]
+    .reverse()
+    .find((message) => message.role === "assistant" && (message.tool_calls?.length ?? 0) > 0);
+  if (lastAssistant?.tool_calls === undefined) return;
+
+  const existing = new Set(
+    state.currentMessages
+      .filter((message) => message.role === "tool" && message.tool_call_id !== undefined)
+      .map((message) => message.tool_call_id),
+  );
+
+  for (const toolCall of lastAssistant.tool_calls) {
+    if (existing.has(toolCall.id)) continue;
+    state.currentMessages.push({
+      role: "tool",
+      name: toolCall.function.name,
+      content: "Tool execution interrupted by user",
+      tool_call_id: toolCall.id,
+    });
+  }
+}
+
+/**
  * Handles the tool-call branch of a single loop iteration: executes the tool
  * calls, validates every call produced a result, appends tool-result messages,
  * runs meltdown detection/recovery injection, and applies budget/queued-message
  * handling. Mutates `state` in place (currentMessages, recentToolCalls, response).
+ *
+ * A user interrupt during tools returns `"interrupted"` instead of failing the
+ * run — the same clean stop as interrupting the LLM stream.
  */
 function handleToolPhase(
   state: LoopState,
@@ -361,7 +392,7 @@ function handleToolPhase(
   iterationIndex: number,
   deps: LoopDeps,
 ): Effect.Effect<
-  void,
+  "continue" | "interrupted",
   Error,
   ToolRegistry | LoggerService | AgentConfigService | ToolRequirements | PresentationService
 > {
@@ -376,6 +407,7 @@ function handleToolPhase(
     runMetrics,
     options,
     logger,
+    observer,
     provider,
     supportedAttachmentKinds,
   } = deps;
@@ -570,7 +602,23 @@ function handleToolPhase(
     if (queuedMessage) {
       state.currentMessages.push({ role: "user", content: queuedMessage });
     }
-  });
+  }).pipe(
+    Effect.as("continue" as const),
+    Effect.catchIf(
+      (error): error is GenerationInterruptedError => error instanceof GenerationInterruptedError,
+      () =>
+        Effect.gen(function* () {
+          closeDanglingToolCalls(state);
+          yield* observer.onInterrupted(agent.name);
+          const renderer = strategy.getRenderer();
+          if (renderer) {
+            yield* renderer.reset();
+          }
+          yield* logger.debug("Tool execution interrupted, breaking loop");
+          return "interrupted" as const;
+        }),
+    ),
+  );
 }
 
 type RunIterationResult = { kind: "continue" } | { kind: "final" } | { kind: "interrupted" };
@@ -834,7 +882,16 @@ function runIteration(
     }
 
     if (completion.toolCalls && completion.toolCalls.length > 0) {
-      yield* handleToolPhase(state, completion.toolCalls, completion.content, iterationIndex, deps);
+      const toolPhase = yield* handleToolPhase(
+        state,
+        completion.toolCalls,
+        completion.content,
+        iterationIndex,
+        deps,
+      );
+      if (toolPhase === "interrupted") {
+        return { kind: "interrupted" } as const;
+      }
       return { kind: "continue" } as const;
     }
 
@@ -1045,10 +1102,20 @@ export function executeAgentLoop(
         // person just gave already in hand — and only then does the loop start.
         if (options.pendingToolCalls !== undefined && options.pendingToolCalls.length > 0) {
           yield* Effect.sync(() => beginIteration(runMetrics, 1));
-          yield* handleToolPhase(state, [...options.pendingToolCalls], "", 0, deps);
+          const pendingPhase = yield* handleToolPhase(
+            state,
+            [...options.pendingToolCalls],
+            "",
+            0,
+            deps,
+          );
+          if (pendingPhase === "interrupted") {
+            finished = true;
+            interrupted = true;
+          }
         }
 
-        for (let i = 0; i < maxIterations; i++) {
+        for (let i = 0; i < maxIterations && !interrupted; i++) {
           yield* Effect.sync(() => beginIteration(runMetrics, i + 1));
           try {
             const step = yield* runIteration(state, i, deps);

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -385,7 +385,10 @@ export function executeWithStreaming(
       strategy,
       observer,
       runRecursive,
-    ).pipe(Effect.ensuring(renderer.setInterruptHandler(null)));
+    ).pipe(
+      Effect.tapError(() => renderer.reset()),
+      Effect.ensuring(renderer.setInterruptHandler(null)),
+    );
 
     return response;
   });

--- a/src/core/agent/execution/tool-executor.test.ts
+++ b/src/core/agent/execution/tool-executor.test.ts
@@ -1,6 +1,6 @@
 import { FileSystem } from "@effect/platform";
 import { describe, expect, it } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option } from "effect";
 import { ToolExecutor } from "./tool-executor";
 import { type SkillService, SkillServiceTag } from "../../../core/skills/skill-service";
 import type { AgentConfigService } from "../../interfaces/agent-config";
@@ -19,6 +19,7 @@ import type { TerminalService } from "../../interfaces/terminal";
 import { TerminalServiceTag } from "../../interfaces/terminal";
 import type { ToolRegistry } from "../../interfaces/tool-registry";
 import { ToolRegistryTag } from "../../interfaces/tool-registry";
+import { GenerationInterruptedError } from "../../types/errors";
 import type { DisplayConfig } from "../../types/output";
 import type { StreamEvent } from "../../types/streaming";
 import type { ApprovalRequest, ToolCall, ToolExecutionResult } from "../../types/tools";
@@ -337,6 +338,99 @@ describe("ToolExecutor.executeToolCalls", () => {
     expect(results).toHaveLength(2);
     expect(results[0]?.toolCallId).toBe("call_1");
     expect(results[1]?.toolCallId).toBe("call_2");
+  });
+
+  it("emits cancelled completes and fails when the interrupt signal fires", async () => {
+    const mockToolRegistry = {
+      getTool: () =>
+        Effect.succeed({
+          name: "slow_tool",
+          timeoutMs: 60_000,
+          longRunning: false,
+          approvalExecuteToolName: undefined,
+        }),
+      executeTool: () => Effect.never,
+    } as unknown as ToolRegistry;
+
+    const emittedEvents: StreamEvent[] = [];
+    const recordingRenderer: StreamingRenderer = {
+      handleEvent: (event) =>
+        Effect.sync(() => {
+          emittedEvents.push(event);
+        }),
+      setInterruptHandler: () => Effect.void,
+      reset: () => Effect.void,
+      flush: () => Effect.void,
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(FileSystem.FileSystem, emptyFs),
+      Layer.succeed(TerminalServiceTag, emptyTerminal),
+      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(LLMServiceTag, emptyLlm),
+      Layer.succeed(MCPServerManagerTag, emptyMcp),
+    );
+
+    const toolCalls: ToolCall[] = [
+      {
+        id: "call_slow",
+        type: "function",
+        function: { name: "slow_tool", arguments: "{}" },
+      },
+    ];
+
+    const program = Effect.gen(function* () {
+      const interruptDeferred = yield* Deferred.make<void>();
+      const fiber = yield* Effect.fork(
+        ToolExecutor.executeToolCalls(
+          toolCalls,
+          { agentId: "agent-1", conversationId: "sess-1" },
+          { showReasoning: false, showToolExecution: true, mode: "hybrid" as const },
+          recordingRenderer,
+          makeRunMetrics(),
+          "agent-1",
+          "conv-123",
+          "test-agent",
+          Deferred.await(interruptDeferred),
+        ),
+      );
+      yield* Effect.sleep("50 millis");
+      yield* Deferred.succeed(interruptDeferred, undefined);
+      return yield* Fiber.await(fiber);
+    });
+
+    const exit = await Effect.runPromise(
+      program.pipe(Effect.provide(testLayer)) as Effect.Effect<
+        Exit.Exit<
+          readonly { toolCallId: string; result: unknown; success: boolean; name: string }[],
+          unknown
+        >,
+        unknown,
+        never
+      >,
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const error = Cause.failureOption(exit.cause);
+      expect(Option.isSome(error)).toBe(true);
+      if (Option.isSome(error)) {
+        expect(error.value).toBeInstanceOf(GenerationInterruptedError);
+      }
+    }
+    expect(
+      emittedEvents.some(
+        (event) =>
+          event.type === "tool_execution_complete" &&
+          event.toolCallId === "call_slow" &&
+          event.success === false,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/core/agent/execution/tool-executor.ts
+++ b/src/core/agent/execution/tool-executor.ts
@@ -1,4 +1,4 @@
-import { Effect, Either, Fiber } from "effect";
+import { Effect, Either, Exit, Fiber, Option } from "effect";
 import { RunParkRequested } from "@/core/agent/run/park-signal";
 import { classifyCommandRisk, shouldClassifyExecuteCommand } from "@/core/agent/tools/command-risk";
 import { MAX_CONCURRENT_TOOLS, TOOL_TIMEOUT_MS } from "@/core/constants/agent";
@@ -720,6 +720,30 @@ export class ToolExecutor {
       );
 
       if (resultsOrInterrupt.type === "interrupt") {
+        // Settle the UI before waiting on fiber interrupt: execute_command used
+        // to wrap spawn in Effect.promise, which is uninterruptible, so this
+        // wait could block until the child exited — leaving the 30s "still
+        // running" timer armed across the next turn.
+        if (renderer && displayConfig.showToolExecution) {
+          for (let index = 0; index < toolFibers.length; index++) {
+            const fiber = toolFibers[index];
+            const toolCall = toolCalls[index];
+            if (fiber === undefined || toolCall === undefined || toolCall.type !== "function") {
+              continue;
+            }
+            const poll = yield* Fiber.poll(fiber);
+            if (Option.isNone(poll) || (Option.isSome(poll) && Exit.isInterrupted(poll.value))) {
+              yield* renderer.handleEvent({
+                type: "tool_execution_complete",
+                toolCallId: toolCall.id,
+                result: "Interrupted by user",
+                durationMs: 0,
+                success: false,
+                error: "Interrupted by user",
+              });
+            }
+          }
+        }
         yield* Effect.all(
           toolFibers.map((fiber) => Fiber.interrupt(fiber)),
           { concurrency: "unbounded" },

--- a/src/core/agent/tools/shell-tools.test.ts
+++ b/src/core/agent/tools/shell-tools.test.ts
@@ -1,7 +1,7 @@
 import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { describe, expect, it } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Effect, Fiber, Layer } from "effect";
 import { spawnOutputTruncationNotice } from "./capped-output";
 import { createShellCommandTools, EXECUTE_COMMAND_OUTPUT_CAP_BYTES } from "./shell-tools";
 import { createToolRegistryLayer } from "./tool-registry";
@@ -392,5 +392,47 @@ describe("Shell Tools", () => {
     );
     const payload = stderr.split("\n[truncated:")[0] ?? "";
     expect(Buffer.byteLength(payload, "utf8")).toBe(EXECUTE_COMMAND_OUTPUT_CAP_BYTES);
+  });
+
+  it("kills a running command when the effect is interrupted", async () => {
+    const tool = shellTools.execute;
+    // A duration no other process on the machine is plausibly sleeping for, so
+    // `ps` can tell this test's child apart from unrelated sleeps.
+    const uniqueSleepSeconds = "31.4159265";
+    const countLiveChildren = async (): Promise<number> => {
+      const listing = Bun.spawn(["ps", "-eo", "command"]);
+      const output = await new Response(listing.stdout).text();
+      return output.split("\n").filter((line) => line.trim() === `sleep ${uniqueSleepSeconds}`)
+        .length;
+    };
+
+    const waitForChildCount = async (expected: number): Promise<number> => {
+      const deadline = Date.now() + 5_000;
+      let count = await countLiveChildren();
+      while (count !== expected && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        count = await countLiveChildren();
+      }
+      return count;
+    };
+
+    const started = Date.now();
+    const program = tool
+      .execute(
+        {
+          command: `sleep ${uniqueSleepSeconds}`,
+          description: "Sleep long enough that interrupt must kill the child.",
+        },
+        { agentId: "test-agent", conversationId: "test-conversation" },
+      )
+      .pipe(Effect.provide(createTestLayer()));
+
+    const fiber = Effect.runFork(program);
+    expect(await waitForChildCount(1)).toBe(1);
+
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    expect(Date.now() - started).toBeLessThan(10_000);
+
+    expect(await waitForChildCount(0)).toBe(0);
   });
 });

--- a/src/core/agent/tools/shell-tools.test.ts
+++ b/src/core/agent/tools/shell-tools.test.ts
@@ -1,3 +1,5 @@
+import { existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { describe, expect, it } from "bun:test";
@@ -396,31 +398,40 @@ describe("Shell Tools", () => {
 
   it("kills a running command when the effect is interrupted", async () => {
     const tool = shellTools.execute;
-    // A duration no other process on the machine is plausibly sleeping for, so
-    // `ps` can tell this test's child apart from unrelated sleeps.
-    const uniqueSleepSeconds = "31.4159265";
-    const countLiveChildren = async (): Promise<number> => {
-      const listing = Bun.spawn(["ps", "-eo", "command"]);
-      const output = await new Response(listing.stdout).text();
-      return output.split("\n").filter((line) => line.trim() === `sleep ${uniqueSleepSeconds}`)
-        .length;
-    };
+    const pidFile = `${tmpdir()}/jazz-interrupt-pid-${process.pid}-${Date.now()}`;
 
-    const waitForChildCount = async (expected: number): Promise<number> => {
-      const deadline = Date.now() + 5_000;
-      let count = await countLiveChildren();
-      while (count !== expected && Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        count = await countLiveChildren();
+    const isAlive = (pid: number): boolean => {
+      try {
+        // Signal 0 checks for the process's existence without touching it.
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
       }
-      return count;
     };
 
-    const started = Date.now();
+    const pollUntil = async (condition: () => boolean): Promise<boolean> => {
+      const deadline = Date.now() + 10_000;
+      while (!condition() && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      return condition();
+    };
+
+    const readChildPid = async (): Promise<number> => {
+      const file = Bun.file(pidFile);
+      await pollUntil(() => existsSync(pidFile));
+      const pid = Number.parseInt((await file.text()).trim(), 10);
+      expect(Number.isInteger(pid)).toBe(true);
+      return pid;
+    };
+
+    // `exec` replaces the shell, so the pid recorded by `$$` is the pid of
+    // the sleep itself — the process the interrupt has to kill.
     const program = tool
       .execute(
         {
-          command: `sleep ${uniqueSleepSeconds}`,
+          command: `echo $$ > ${pidFile}; exec sleep 30`,
           description: "Sleep long enough that interrupt must kill the child.",
         },
         { agentId: "test-agent", conversationId: "test-conversation" },
@@ -428,11 +439,15 @@ describe("Shell Tools", () => {
       .pipe(Effect.provide(createTestLayer()));
 
     const fiber = Effect.runFork(program);
-    expect(await waitForChildCount(1)).toBe(1);
+    try {
+      const childPid = await readChildPid();
+      expect(await pollUntil(() => isAlive(childPid))).toBe(true);
 
-    await Effect.runPromise(Fiber.interrupt(fiber));
-    expect(Date.now() - started).toBeLessThan(10_000);
+      await Effect.runPromise(Fiber.interrupt(fiber));
 
-    expect(await waitForChildCount(0)).toBe(0);
-  });
+      expect(await pollUntil(() => !isAlive(childPid))).toBe(true);
+    } finally {
+      rmSync(pidFile, { force: true });
+    }
+  }, 30_000);
 });

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn, type ChildProcess } from "child_process";
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import { z } from "zod";
@@ -421,6 +421,89 @@ type ShellCommandDeps = FileSystem.FileSystem | FileSystemContextService | Logge
  */
 export const EXECUTE_COMMAND_OUTPUT_CAP_BYTES = DEFAULT_SPAWN_OUTPUT_CAP_BYTES;
 
+type ShellCommandOutput = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+};
+
+/**
+ * Spawn `sh -c command` in a way that Effect can interrupt. `Effect.promise`
+ * is uninterruptible, so a double-Esc during a long `sleep` (or any other
+ * hanging command) used to leave the child running and the UI stuck on
+ * "still running after 30s". Returning an interrupt finalizer from
+ * `Effect.async` SIGKILLs the child when the tool fiber is interrupted.
+ */
+function runShellCommand(input: {
+  readonly command: string;
+  readonly workingDir: string;
+  readonly timeoutMs: number;
+  readonly env: NodeJS.ProcessEnv;
+}): Effect.Effect<ShellCommandOutput, Error> {
+  return Effect.async((resume) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let child: ChildProcess | undefined;
+
+    const finish = (effect: Effect.Effect<ShellCommandOutput, Error>): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      resume(effect);
+    };
+
+    try {
+      child = spawn("sh", ["-c", input.command], {
+        cwd: input.workingDir,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: input.timeoutMs,
+        env: input.env,
+        detached: false,
+        uid: process.getuid ? process.getuid() : undefined,
+        gid: process.getgid ? process.getgid() : undefined,
+      });
+    } catch (spawnError) {
+      finish(Effect.fail(spawnError instanceof Error ? spawnError : new Error(String(spawnError))));
+      return;
+    }
+
+    const snapshot = bindCappedStdio(child.stdout, child.stderr, EXECUTE_COMMAND_OUTPUT_CAP_BYTES);
+
+    timeoutId = setTimeout(() => {
+      child?.kill("SIGKILL");
+      finish(Effect.fail(new Error(`Command timed out after ${input.timeoutMs}ms`)));
+    }, input.timeoutMs);
+
+    child.on("error", (error) => {
+      finish(Effect.fail(error));
+    });
+
+    child.on("close", (code) => {
+      const collected = snapshot();
+      finish(
+        Effect.succeed({
+          stdout: formatCappedStream(collected.stdout, "stdout", EXECUTE_COMMAND_OUTPUT_CAP_BYTES),
+          stderr: formatCappedStream(collected.stderr, "stderr", EXECUTE_COMMAND_OUTPUT_CAP_BYTES),
+          exitCode: code || 0,
+        }),
+      );
+    });
+
+    return Effect.sync(() => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      child?.kill("SIGKILL");
+    });
+  });
+}
+
 /**
  * Create shell command tools (approval + execution pair).
  *
@@ -507,86 +590,12 @@ This command will be executed on your system. Only approve commands you trust.`;
           const envAllowlist = context.parentAgent?.config.envAllowlist ?? [];
           const sanitizedEnv = createSanitizedEnv({}, envAllowlist);
 
-          const result = yield* Effect.promise<{
-            stdout: string;
-            stderr: string;
-            exitCode: number;
-          }>(
-            () =>
-              new Promise((resolve, reject) => {
-                let resolved = false;
-
-                let child;
-                try {
-                  child = spawn("sh", ["-c", command], {
-                    cwd: workingDir,
-                    stdio: ["ignore", "pipe", "pipe"],
-                    timeout: timeout,
-                    env: sanitizedEnv,
-                    // Additional security options
-                    detached: false,
-                    uid: process.getuid ? process.getuid() : undefined,
-                    gid: process.getgid ? process.getgid() : undefined,
-                  });
-                } catch (spawnError) {
-                  reject(spawnError instanceof Error ? spawnError : new Error(String(spawnError)));
-                  return;
-                }
-
-                const snapshot = bindCappedStdio(
-                  child.stdout,
-                  child.stderr,
-                  EXECUTE_COMMAND_OUTPUT_CAP_BYTES,
-                );
-
-                // Handle timeout
-                let timeoutId: NodeJS.Timeout | null = null;
-
-                const cleanup = (): void => {
-                  if (timeoutId) {
-                    clearTimeout(timeoutId);
-                    timeoutId = null;
-                  }
-                };
-
-                timeoutId = setTimeout(() => {
-                  if (!resolved) {
-                    child.kill("SIGKILL");
-                    resolved = true;
-                    reject(new Error(`Command timed out after ${timeout}ms`));
-                  }
-                }, timeout);
-
-                child.on("error", (error) => {
-                  cleanup();
-                  if (!resolved) {
-                    resolved = true;
-                    reject(error);
-                  }
-                });
-
-                child.on("close", (code) => {
-                  cleanup();
-                  if (!resolved) {
-                    resolved = true;
-                    const collected = snapshot();
-                    resolve({
-                      stdout: formatCappedStream(
-                        collected.stdout,
-                        "stdout",
-                        EXECUTE_COMMAND_OUTPUT_CAP_BYTES,
-                      ),
-                      stderr: formatCappedStream(
-                        collected.stderr,
-                        "stderr",
-                        EXECUTE_COMMAND_OUTPUT_CAP_BYTES,
-                      ),
-                      exitCode: code || 0,
-                    });
-                  }
-                });
-              }),
-          ).pipe(
+          const result = yield* runShellCommand({
+            command,
+            workingDir,
+            timeoutMs: timeout,
+            env: sanitizedEnv,
+          }).pipe(
             Effect.catchAll((error: unknown) =>
               Effect.succeed({
                 stdout: "",

--- a/src/core/presentation/error-handler.test.ts
+++ b/src/core/presentation/error-handler.test.ts
@@ -6,6 +6,7 @@ import {
   AgentAlreadyExistsError,
   AgentNotFoundError,
   ConfigurationError,
+  GenerationInterruptedError,
   ValidationError,
 } from "../types/errors";
 
@@ -123,6 +124,16 @@ describe("Error Handler", () => {
       expect(formatted).toContain("📚 Related Commands:");
       expect(formatted).toContain("jazz");
     });
+  });
+
+  it("formats GenerationInterruptedError as an interrupt, not an unknown crash", () => {
+    const formatted = formatError(
+      new GenerationInterruptedError({ reason: "Tool execution interrupted by user" }),
+    );
+
+    expect(formatted).toContain("❌ Interrupted");
+    expect(formatted).toContain("Tool execution interrupted by user");
+    expect(formatted).not.toContain("report this error to the development team");
   });
 });
 

--- a/src/core/presentation/error-handler.ts
+++ b/src/core/presentation/error-handler.ts
@@ -372,6 +372,14 @@ function generateSuggestions(error: JazzError): ErrorDisplay {
       };
     }
 
+    case "GenerationInterruptedError": {
+      return {
+        title: "Interrupted",
+        message: error.reason,
+        suggestion: "The run was stopped before it finished. Send another message to continue.",
+      };
+    }
+
     default: {
       // Surface actual error type and message for unhandled tagged errors (e.g. new error types)
       const tag = error._tag;

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -355,4 +355,5 @@ export type JazzError =
   | TelemetryError
   | TelemetryWriteError
   | PersonaNotFoundError
-  | PersonaAlreadyExistsError;
+  | PersonaAlreadyExistsError
+  | GenerationInterruptedError;

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -20,7 +20,12 @@ import {
   type ToolRequirements,
 } from "@/core/interfaces/tool-registry";
 import { getSkillIndexLine, SkillServiceTag, type SkillService } from "@/core/skills/skill-service";
-import { LLMAuthenticationError, LLMRateLimitError, LLMRequestError } from "@/core/types/errors";
+import {
+  GenerationInterruptedError,
+  LLMAuthenticationError,
+  LLMRateLimitError,
+  LLMRequestError,
+} from "@/core/types/errors";
 import type { Agent } from "@/core/types/index";
 import { type ChatMessage } from "@/core/types/message";
 import type { AutoApprovePolicy } from "@/core/types/tools";
@@ -537,6 +542,8 @@ export class ChatServiceImpl implements ChatService {
                       `   Run 'jazz config set llm.${error.provider}.api_key <key>' or 'jazz wizard' to fix.`,
                     );
                   }
+                } else if (error instanceof GenerationInterruptedError) {
+                  store.setActivity({ phase: "idle" });
                 } else {
                   yield* terminal.error(`Error: ${String(error)}`);
                 }


### PR DESCRIPTION
## What & why

Pressing Esc twice while a tool is running is now a clean stop instead of a crash. Previously it surfaced as an unhandled error, the spinner kept claiming the tool was still running, and a long-running `execute_command` kept its child process alive in the background after the run had visibly ended.

It also fixes a subtler failure: when the interrupt landed mid tool-batch, some tool calls never got a matching result, which left the conversation in a state the next request could reject.

## How to verify

- Ask the agent to run something slow (`sleep 30`), double-Esc while it runs, and confirm the run reports "Interrupted", the prompt returns immediately, and `ps` shows no orphaned `sleep`.
- Send another message straight after the interrupt and confirm the next turn goes through rather than erroring on the transcript.
- Interrupt during a batch of several parallel tools and confirm every one of them settles — none stay stuck on the 30s "still running" notice into the next turn.
- Interrupt during an approval prompt, and separately during the LLM stream, to confirm those paths still behave as before.
