### PR TITLE
feat(events): deliver reasoning and text to headless callers

### DIFF
--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -140,8 +140,13 @@ jazz workflow run email-cleanup --agent research-bot
 # --json prints exactly one JSON envelope { ok, answer, costUSD, tokenUsage, toolCalls }
 # on stdout (ok:false + non-zero exit on failure), suppressing all terminal chatter.
 # --timeout aborts the run cleanly after the given milliseconds.
-# --events streams event categories as NDJSON to stderr while stdout stays clean.
+# --events streams event categories as NDJSON to stderr while stdout stays clean; every
+# line carries the agentName that produced it, so concurrent sub-agents stay apart.
 jazz workflow run email-cleanup --auto-approve --json --timeout 1200000 --events tools
+
+# Reasoning and answer text exist only on the streaming path, which auto-disables when
+# stdout is a pipe — asking for those categories turns it back on (--no-stream opts out).
+jazz workflow run email-cleanup --auto-approve --json --events tools,reasoning,text
 ```
 
 **Note for headless runs**: `--json` implies non-interactive — if the agent is missing

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -100,7 +100,7 @@ interpret that fallback as a free run.
 | `--reasoning <effort>`     | `low` \| `medium` \| `high` \| `disable`. Overrides the agent's config for this run.                                                               |
 | `--timeout <ms>`           | Abort the run after this many milliseconds.                                                                                                        |
 | `--max-iterations <n>`     | Cap the agent's reasoning iterations (default 100).                                                                                                 |
-| `--stream` / `--no-stream` | Force streaming on/off. Streaming auto-disables for non-TTY stdout, which also suppresses `--events` — pass `--stream` to re-enable it in scripts. |
+| `--stream` / `--no-stream` | Force streaming on/off. Streaming auto-disables for non-TTY stdout; `--events reasoning`/`text` re-enable it on their own, since those events exist only on the streaming path. |
 
 ---
 
@@ -176,8 +176,11 @@ jazz run --json --stream --events tools,subagent --agent dev "audit this repo" \
 `error` events are **always** included regardless of what you select, so a failure can
 never be invisible on the live stream.
 
-> `--events` needs streaming. stdout being a pipe auto-disables streaming, so pass
-> `--stream` explicitly in scripts and webhooks.
+Streaming auto-disables when stdout is a pipe, which is every headless caller. Tool,
+approval and subagent events survive that — the batch path routes them through the same
+renderer — but `reasoning` and `text` deltas exist only on the streaming path. Asking for
+either category therefore turns streaming back on for you; pass `--no-stream` if you would
+rather keep the batch path and take tool events only.
 
 ---
 

--- a/integrations/discord-bot/entrypoint.sh
+++ b/integrations/discord-bot/entrypoint.sh
@@ -9,15 +9,15 @@ AGENT_TEMPLATE="/app/integrations/discord-bot/agent.discord.json"
 
 mkdir -p "${JAZZ_HOME}/agents"
 
-# Streaming is required so `jazz run --events` emits live-progress events
-# (non-TTY runs otherwise fall back to batch mode and emit nothing).
+# The bridge asks for reasoning and text events, and jazz selects the streaming path
+# for those on its own — nothing here needs to force it.
 if [ -n "${BRAVE_API_KEY:-}" ]; then
   cat > "${JAZZ_HOME}/config.json" <<JSON
-{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
+{"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
 JSON
   echo "Configured Brave web search"
 else
-  printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+  printf '{}\n' > "${JAZZ_HOME}/config.json"
 fi
 
 sed -e "s#__JAZZ_PROVIDER__#${JAZZ_DISCORD_PROVIDER}#g" \

--- a/integrations/telegram-bot/entrypoint.sh
+++ b/integrations/telegram-bot/entrypoint.sh
@@ -20,17 +20,17 @@ mkdir -p "${XDG_CONFIG_HOME:-/data/xdg-config}" "${XDG_DATA_HOME:-/data/xdg-data
 mkdir -p "${GNUPGHOME:-/data/gnupg}"
 chmod 700 "${GNUPGHOME:-/data/gnupg}"
 
-# Write config.json. Streaming is required so `jazz run --events` emits
-# live-progress events (non-TTY runs otherwise fall back to batch mode and emit
-# nothing). When BRAVE_API_KEY is set, also configure Brave as the web_search
+# Write config.json. When BRAVE_API_KEY is set, configure Brave as the web_search
 # provider — the key comes from the environment so it's never baked into the image.
+# Nothing here needs to force streaming: the bridge asks for reasoning and text
+# events, and jazz selects the streaming path for those on its own.
 if [ -n "${BRAVE_API_KEY:-}" ]; then
   cat > "${JAZZ_HOME}/config.json" <<JSON
-{"output":{"streaming":{"enabled":true}},"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
+{"web_search":{"provider":"brave","brave":{"api_key":"${BRAVE_API_KEY}"}}}
 JSON
   echo "Configured Brave web search"
 else
-  printf '{"output":{"streaming":{"enabled":true}}}\n' > "${JAZZ_HOME}/config.json"
+  printf '{}\n' > "${JAZZ_HOME}/config.json"
 fi
 
 # Seed / refresh the template agent that per-chat agents are cloned from.

--- a/src/cli/cli-app.test.ts
+++ b/src/cli/cli-app.test.ts
@@ -40,6 +40,16 @@ describe("createCLIApp help path", () => {
     expect(specifiers).not.toContain("./commands/run/lifecycle");
   });
 
+  it("offers --stream on `workflow run`, as headless reasoning events depend on it", () => {
+    const program = createCLIApp();
+    const workflow = program.commands.find((command) => command.name() === "workflow");
+    const run = workflow?.commands.find((command) => command.name() === "run");
+    const flags = run?.options.map((option) => option.flags) ?? [];
+    expect(flags).toContain("--stream");
+    expect(flags).toContain("--no-stream");
+    expect(flags).toContain("--events <categories>");
+  });
+
   it("registers the public command families", () => {
     const program = createCLIApp();
     const names = program.commands.map((command) => command.name());

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -4,6 +4,7 @@ import {
   isApprovalPolicyFlag,
   isReasoningEffortFlag,
   parseEventCategories,
+  resolveStreamOption,
 } from "./commands/run/flags";
 import { parsePositiveInt } from "./utils/option-parsers";
 import { setCurrentCommandName } from "../core/utils/current-command";
@@ -253,11 +254,7 @@ function registerRunCommand(program: Command): void {
                 ...(options.conversation !== undefined
                   ? { conversationId: options.conversation }
                   : {}),
-                ...(options.noStream === true
-                  ? { stream: false }
-                  : options.stream === true
-                    ? { stream: true }
-                    : {}),
+                ...resolveStreamOption(options, eventCategories),
                 ...(options.ephemeral === true ? { ephemeral: true } : {}),
                 ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
                 ...(options.park === true ? { park: true } : {}),
@@ -901,6 +898,11 @@ function registerWorkflowCommands(program: Command): void {
       "--events <categories>",
       "With --json: emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,subagent,all). stdout stays the clean payload.",
     )
+    .option(
+      "--stream",
+      "Force streaming mode. Required for --events to emit reasoning and text in non-TTY contexts (CI, containers), where streaming is otherwise auto-disabled and only tool events survive.",
+    )
+    .option("--no-stream", "Disable streaming mode")
     .action(
       (
         name: string,
@@ -912,6 +914,8 @@ function registerWorkflowCommands(program: Command): void {
           json?: boolean;
           timeout?: number;
           events?: string;
+          stream?: boolean;
+          noStream?: boolean;
         },
         command: Command,
       ) => {
@@ -950,6 +954,7 @@ function registerWorkflowCommands(program: Command): void {
                 ...options,
                 ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
                 ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
+                ...resolveStreamOption(options, eventCategories),
               }),
             ),
           cliRuntimeOptions(program),

--- a/src/cli/commands/run/flags.test.ts
+++ b/src/cli/commands/run/flags.test.ts
@@ -152,6 +152,8 @@ describe("resolveStreamOption", () => {
   });
 
   it("lets an explicit --no-stream win over the events request", () => {
+    // Commander folds `--no-stream` into `stream: false`; both shapes must opt out.
+    expect(resolveStreamOption({ stream: false }, reasoning)).toEqual({ stream: false });
     expect(resolveStreamOption({ noStream: true }, reasoning)).toEqual({ stream: false });
   });
 

--- a/src/cli/commands/run/flags.test.ts
+++ b/src/cli/commands/run/flags.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { StreamEvent } from "@/core/types/streaming";
-import { isApprovalPolicyFlag, isReasoningEffortFlag, parseEventCategories } from "./flags";
+import {
+  eventsRequireStreaming,
+  isApprovalPolicyFlag,
+  isReasoningEffortFlag,
+  parseEventCategories,
+  resolveStreamOption,
+} from "./flags";
 
 describe("isApprovalPolicyFlag", () => {
   it("accepts the three risk levels", () => {
@@ -109,5 +115,51 @@ describe("isReasoningEffortFlag", () => {
     expect(isReasoningEffortFlag("none")).toBe(false);
     expect(isReasoningEffortFlag("")).toBe(false);
     expect(isReasoningEffortFlag("HIGH")).toBe(false);
+  });
+});
+
+describe("eventsRequireStreaming", () => {
+  it("is true for categories the batch path cannot produce", () => {
+    for (const category of ["reasoning", "text", "all", "tools,reasoning"]) {
+      const result = parseEventCategories(category);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(eventsRequireStreaming(result.types)).toBe(true);
+    }
+  });
+
+  it("is false for categories the batch path routes through the renderer", () => {
+    for (const category of ["tools", "approval", "subagent", "tools,subagent"]) {
+      const result = parseEventCategories(category);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(eventsRequireStreaming(result.types)).toBe(false);
+    }
+  });
+});
+
+describe("resolveStreamOption", () => {
+  const reasoning = parseEventCategories("tools,reasoning,text");
+  const toolsOnly = parseEventCategories("tools");
+
+  it("turns streaming on when the requested events only exist there", () => {
+    expect(resolveStreamOption({}, reasoning)).toEqual({ stream: true });
+  });
+
+  it("leaves the TTY heuristic alone for events the batch path can produce", () => {
+    expect(resolveStreamOption({}, toolsOnly)).toEqual({});
+    expect(resolveStreamOption({}, undefined)).toEqual({});
+  });
+
+  it("lets an explicit --no-stream win over the events request", () => {
+    expect(resolveStreamOption({ noStream: true }, reasoning)).toEqual({ stream: false });
+  });
+
+  it("honours an explicit --stream with no events at all", () => {
+    expect(resolveStreamOption({ stream: true }, undefined)).toEqual({ stream: true });
+  });
+
+  it("ignores an unparseable --events value rather than forcing a mode on it", () => {
+    expect(resolveStreamOption({}, parseEventCategories("bogus"))).toEqual({});
   });
 });

--- a/src/cli/commands/run/flags.ts
+++ b/src/cli/commands/run/flags.ts
@@ -103,12 +103,16 @@ export function eventsRequireStreaming(types: ReadonlySet<StreamEvent["type"]>):
  * Resolve a run's streaming mode from the `--stream` / `--no-stream` pair, defaulting to
  * streaming when the requested `--events` categories can only be produced there. An
  * explicit `--no-stream` still wins: the caller is then choosing tool events only.
+ *
+ * Commander folds `--no-stream` into `stream: false` because a positive `--stream` is
+ * declared alongside it, so that is the shape actually seen at runtime; `noStream` is
+ * accepted too rather than trusting one library's negation rules to stay put.
  */
 export function resolveStreamOption(
   options: { stream?: boolean | undefined; noStream?: boolean | undefined },
   eventCategories: ReturnType<typeof parseEventCategories> | undefined,
 ): { stream?: boolean } {
-  if (options.noStream === true) return { stream: false };
+  if (options.noStream === true || options.stream === false) return { stream: false };
   if (options.stream === true) return { stream: true };
   if (eventCategories?.ok === true && eventsRequireStreaming(eventCategories.types)) {
     return { stream: true };

--- a/src/cli/commands/run/flags.ts
+++ b/src/cli/commands/run/flags.ts
@@ -78,3 +78,40 @@ export function parseEventCategories(
 
   return { ok: true, types };
 }
+
+/**
+ * Do the selected event types only exist on the streaming path?
+ *
+ * Reasoning and text deltas are produced by the streaming stream-processor; the batch
+ * executor re-routes tool lifecycle events to the renderer but never produces these.
+ * Streaming auto-disables when stdout is not a TTY, which is exactly where `--events`
+ * consumers live (CI, containers, webhooks) — so a caller asking for these categories
+ * there would get a silent tool-only stream. Callers use this to turn streaming back on
+ * rather than leave the request unmet.
+ */
+export function eventsRequireStreaming(types: ReadonlySet<StreamEvent["type"]>): boolean {
+  return (
+    types.has("thinking_chunk") ||
+    types.has("thinking_start") ||
+    types.has("thinking_complete") ||
+    types.has("text_chunk") ||
+    types.has("text_start")
+  );
+}
+
+/**
+ * Resolve a run's streaming mode from the `--stream` / `--no-stream` pair, defaulting to
+ * streaming when the requested `--events` categories can only be produced there. An
+ * explicit `--no-stream` still wins: the caller is then choosing tool events only.
+ */
+export function resolveStreamOption(
+  options: { stream?: boolean | undefined; noStream?: boolean | undefined },
+  eventCategories: ReturnType<typeof parseEventCategories> | undefined,
+): { stream?: boolean } {
+  if (options.noStream === true) return { stream: false };
+  if (options.stream === true) return { stream: true };
+  if (eventCategories?.ok === true && eventsRequireStreaming(eventCategories.types)) {
+    return { stream: true };
+  }
+  return {};
+}

--- a/src/cli/commands/workflow.test.ts
+++ b/src/cli/commands/workflow.test.ts
@@ -256,6 +256,41 @@ describe("runWorkflowCommand", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("forwards --stream to the agent run so --events can emit reasoning off a TTY", async () => {
+    let runOptions: Record<string, unknown> | undefined;
+    AgentRunner.run = mock((options: Record<string, unknown>) => {
+      runOptions = options;
+      return Effect.succeed({ content: "ok" });
+    }) as unknown as typeof AgentRunner.run;
+
+    const program = runWorkflowCommand("code-review", {
+      autoApprove: true,
+      agent: "ci-reviewer",
+      stream: true,
+    });
+    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+
+    await Effect.runPromiseExit(runnable);
+
+    expect(runOptions?.["stream"]).toBe(true);
+  });
+
+  it("leaves stream unset when neither --stream nor --no-stream is given", async () => {
+    let runOptions: Record<string, unknown> | undefined;
+    AgentRunner.run = mock((options: Record<string, unknown>) => {
+      runOptions = options;
+      return Effect.succeed({ content: "ok" });
+    }) as unknown as typeof AgentRunner.run;
+
+    const program = runWorkflowCommand("code-review", { autoApprove: true, agent: "ci-reviewer" });
+    const runnable = program.pipe(Effect.provide(testLayer)) as Effect.Effect<void, unknown, never>;
+
+    await Effect.runPromiseExit(runnable);
+
+    expect(runOptions).toBeDefined();
+    expect("stream" in (runOptions ?? {})).toBe(false);
+  });
+
   it("leaves the exit code untouched when the agent run succeeds", async () => {
     AgentRunner.run = mock(() =>
       Effect.succeed({ content: "ok" }),

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -202,6 +202,12 @@ export function runWorkflowCommand(
     timeoutMs?: number;
     /** Stream these event types as NDJSON to stderr during the run (json mode only). */
     eventTypes?: ReadonlySet<StreamEvent["type"]>;
+    /**
+     * Force streaming on/off. Streaming auto-disables when stdout is not a TTY, and the
+     * batch path never produces reasoning or text events — so a headless consumer asking
+     * for `--events reasoning,text` gets tool events only unless this forces it back on.
+     */
+    stream?: boolean;
   },
 ) {
   const jsonMode = options?.json === true;
@@ -384,6 +390,7 @@ export function runWorkflowCommand(
       conversationId: generateConversationId(`workflow-${workflowName}`),
       ...(resolvedMaxIterations != null ? { maxIterations: resolvedMaxIterations } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
+      ...(options?.stream !== undefined ? { stream: options.stream } : {}),
     });
     const runResult = yield* (
       options?.timeoutMs != null

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -77,6 +77,46 @@ describe("OneShotPresentationService streaming renderer", () => {
     expect(parsed.type).toBe("tool_execution_start");
   });
 
+  it("stamps the renderer's agent name on events that carry none", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["text_chunk"]),
+    );
+    const renderer = Effect.runSync(
+      service.createStreamingRenderer({ ...rendererConfig, agentName: "airgap verifier" }),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(renderer.handleEvent(textChunkEvent));
+
+    const parsed = JSON.parse(captured.lines[0] as string) as { agentName: string; delta: string };
+    expect(parsed.agentName).toBe("airgap verifier");
+    expect(parsed.delta).toBe("hello");
+  });
+
+  it("keeps an event's own agent name rather than the renderer's", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tools_detected"]),
+    );
+    const renderer = Effect.runSync(
+      service.createStreamingRenderer({ ...rendererConfig, agentName: "parent" }),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(
+      renderer.handleEvent({
+        type: "tools_detected",
+        toolNames: ["grep"],
+        toolsRequiringApproval: [],
+        agentName: "komodo/roles verifier",
+      }),
+    );
+
+    const parsed = JSON.parse(captured.lines[0] as string) as { agentName: string };
+    expect(parsed.agentName).toBe("komodo/roles verifier");
+  });
+
   it("returns a noop renderer that writes nothing when no types are selected", () => {
     const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
     const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -219,7 +219,7 @@ export class OneShotPresentationService implements PresentationService {
   }
 
   createStreamingRenderer(
-    _config: StreamingRendererConfig,
+    config: StreamingRendererConfig,
   ): Effect.Effect<StreamingRenderer, never> {
     if (this.emitEventTypes.size === 0) {
       const noopRenderer: StreamingRenderer = {
@@ -232,13 +232,19 @@ export class OneShotPresentationService implements PresentationService {
     }
 
     const emitEventTypes = this.emitEventTypes;
+    // A renderer is created per agent run, so the name it was built with is the one
+    // authoring these events. Stamping it on every line is what lets a consumer keep
+    // concurrent sub-agents apart: reasoning and text deltas carry no agent of their
+    // own, and several specialists streaming at once are otherwise unattributable.
+    const agentName = config.agentName;
     const emittingRenderer: StreamingRenderer = {
       handleEvent: (event: StreamEvent) =>
         Effect.sync(() => {
           if (emitEventTypes.has(event.type)) {
             // Don't truncate what a human is being asked to approve.
             const replacer = event.type === "approval_required" ? undefined : truncateLongStrings;
-            process.stderr.write(`${JSON.stringify(event, replacer)}\n`);
+            const attributed = "agentName" in event ? event : { ...event, agentName };
+            process.stderr.write(`${JSON.stringify(attributed, replacer)}\n`);
           }
         }),
       setInterruptHandler: (_handler: (() => void) | null) => Effect.void,


### PR DESCRIPTION
## What & why

`--events reasoning,text` silently returned tool events only for every headless caller. Streaming auto-disables when stdout is not a TTY — which is every script, container and CI job — and the batch path cannot produce reasoning or answer deltas at all, so the request was dropped with no error and no way for a consumer to tell. A CI job watching a 40-minute run saw a list of file reads and nothing about what the model was thinking between them.

Asking for a category that only exists on the streaming path now selects that path, so the declared intent decides the execution mode instead of a TTY guess. `--no-stream` is the explicit opt-out for a caller who would rather keep batch and take tool events only. `jazz workflow run` also gains the `--stream`/`--no-stream` pair it was missing, and every emitted NDJSON line now carries the `agentName` of the run that produced it — reasoning and text deltas carry no agent of their own, so a consumer watching concurrent sub-agents previously had three specialists interleaved with no way to separate them.

The Telegram and Discord bridges were hand-writing `output.streaming.enabled` into `config.json` at container start for exactly this reason; that workaround is removed, so they stop overwriting a key the operator may be using themselves. Both build jazz from the repo source, so there is no version skew.

## Breaking changes / migration

- A headless run passing `--events reasoning`, `text` or `all` now streams where it used to batch. Pass `--no-stream` to keep the old path.
- `--no-stream` now actually disables streaming. It was read from a key commander never sets, so it had been a silent no-op — a run relying on that accident to stay streaming should drop the flag.

## How to verify

- `jazz workflow run <name> --agent <agent> --auto-approve --json --events tools,reasoning,text 2>events.log`, redirecting stdout to a file so there is no TTY: `events.log` carries `thinking_chunk` and `text_chunk` lines, each with an `agentName`.
- Add `--no-stream` to the same command and confirm only tool events come back.
- `--events tools` alone still takes the batch path (no thinking or text lines), so existing tool-only consumers are untouched.
- On a workflow that spawns parallel sub-agents, confirm each specialist's reasoning lines carry its own name rather than the parent's.
