### PR TITLE
fix(build): fetch the native libraries a cross-compile needs

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import manifest from "../package.json" with { type: "json" };
+import { ensureNativeLibrariesForTarget } from "./opentui-natives";
 
 type SpawnResult = {
   readonly exitCode: number | null;
@@ -350,6 +351,8 @@ async function buildStandaloneBinary(compileTarget: string): Promise<string> {
   const targetPlatform = compileTarget.split("-")[1] ?? "";
   const generatedAssets = generateEmbeddedAssetsModule(targetPlatform);
   const outfile = path.join("binaries", outputName);
+
+  await ensureNativeLibrariesForTarget(compileTarget);
 
   // Matches the reasoning in buildNpmBundle: the bundler picks the JSX runtime
   // from NODE_ENV at build time, and the dev runtime is unusable at runtime.

--- a/scripts/opentui-natives.test.ts
+++ b/scripts/opentui-natives.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { nativePackagesForTarget, readNativeVersions } from "./opentui-natives";
+
+const AVAILABLE = [
+  "@opentui/core-darwin-x64",
+  "@opentui/core-darwin-arm64",
+  "@opentui/core-linux-x64",
+  "@opentui/core-linux-arm64",
+  "@opentui/core-win32-x64",
+  "@opentui/core-win32-arm64",
+  "@opentui/core-linux-x64-musl",
+  "@opentui/core-linux-arm64-musl",
+];
+
+// The targets scripts/build.ts compiles for. A release matrix that cannot resolve one
+// of these fails the whole job, which is what this mapping exists to prevent.
+const COMPILE_TARGETS = [
+  "bun-darwin-arm64",
+  "bun-darwin-x64",
+  "bun-linux-arm64",
+  "bun-linux-x64",
+  "bun-linux-arm64-musl",
+  "bun-linux-x64-musl",
+];
+
+describe("nativePackagesForTarget", () => {
+  it("resolves a native library for every target a release builds", () => {
+    for (const target of COMPILE_TARGETS) {
+      expect(nativePackagesForTarget(target, AVAILABLE).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("pulls both libc variants for linux, which bun does not prune by libc", () => {
+    expect(nativePackagesForTarget("bun-linux-arm64", AVAILABLE)).toEqual([
+      "@opentui/core-linux-arm64",
+      "@opentui/core-linux-arm64-musl",
+    ]);
+    expect(nativePackagesForTarget("bun-linux-arm64-musl", AVAILABLE)).toEqual([
+      "@opentui/core-linux-arm64",
+      "@opentui/core-linux-arm64-musl",
+    ]);
+  });
+
+  it("takes only the matching architecture, never a sibling", () => {
+    expect(nativePackagesForTarget("bun-darwin-x64", AVAILABLE)).toEqual([
+      "@opentui/core-darwin-x64",
+    ]);
+    expect(nativePackagesForTarget("bun-linux-x64", AVAILABLE)).not.toContain(
+      "@opentui/core-linux-arm64",
+    );
+  });
+
+  it("returns nothing for a triple it cannot read, rather than guessing", () => {
+    expect(nativePackagesForTarget("bun", AVAILABLE)).toEqual([]);
+    expect(nativePackagesForTarget("bun-freebsd-riscv64", AVAILABLE)).toEqual([]);
+  });
+
+  it("defaults to what the installed @opentui/core declares", () => {
+    const declared = Object.keys(readNativeVersions());
+    expect(declared).toContain(`@opentui/core-${process.platform}-${process.arch}`);
+    expect(nativePackagesForTarget(`bun-${process.platform}-${process.arch}`)).toContain(
+      `@opentui/core-${process.platform}-${process.arch}`,
+    );
+  });
+});

--- a/scripts/opentui-natives.ts
+++ b/scripts/opentui-natives.ts
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Downloads the platform-specific `@opentui/core` libraries a
+ * cross-compile needs.
+ *
+ * The fullscreen interface reaches a native Zig library that ships as one optional
+ * dependency per platform, and an install only unpacks the one matching the machine
+ * doing the installing — every other one is skipped by its `os`/`cpu` fields, however
+ * explicitly it is asked for. The standalone build bundles `@opentui/core` rather than
+ * leaving it external, so the bundler walks the platform switch inside it and has to
+ * resolve the library for the target being compiled. Building `bun-linux-arm64` on an
+ * x64 runner therefore failed on a package that is correctly absent, which took out
+ * every non-native target in the release matrix.
+ *
+ * Fetching the tarball straight from the registry sidesteps the `os`/`cpu` gate that a
+ * package manager is right to enforce. Bun imports the library as a file asset and
+ * embeds it in the binary, so a foreign platform's copy is inert until it runs there.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const REGISTRY_BASE_URL = process.env["npm_config_registry"] ?? "https://registry.npmjs.org";
+const CORE_MANIFEST_PATH = "node_modules/@opentui/core/package.json";
+
+/** The installed `@opentui/core`, which pins the version of each native package. */
+export function readNativeVersions(): Record<string, string> {
+  if (!fs.existsSync(CORE_MANIFEST_PATH)) {
+    throw new Error(`${CORE_MANIFEST_PATH} is missing — run \`bun install\` before compiling.`);
+  }
+  const coreManifest = JSON.parse(fs.readFileSync(CORE_MANIFEST_PATH, "utf8")) as {
+    optionalDependencies?: Record<string, string>;
+  };
+  return coreManifest.optionalDependencies ?? {};
+}
+
+/**
+ * Which native packages the bundler will try to resolve for one compile target.
+ *
+ * Bun prunes the platform switch by the target's platform and architecture but not by
+ * its libc, so a musl target and its glibc sibling each pull in both.
+ *
+ * @param compileTarget - A Bun target triple, e.g. `bun-linux-arm64-musl`.
+ * @param availablePackages - Native package names to choose from; defaults to the ones
+ *   the installed `@opentui/core` declares.
+ */
+export function nativePackagesForTarget(
+  compileTarget: string,
+  availablePackages: readonly string[] = Object.keys(readNativeVersions()),
+): string[] {
+  const [, platform, architecture] = compileTarget.split("-");
+  if (platform === undefined || architecture === undefined) return [];
+  const prefix = `@opentui/core-${platform}-${architecture}`;
+  return availablePackages.filter((name) => name === prefix || name.startsWith(`${prefix}-`));
+}
+
+async function downloadNativePackage(packageName: string, version: string): Promise<void> {
+  const installedPath = path.join("node_modules", ...packageName.split("/"));
+  if (fs.existsSync(path.join(installedPath, "package.json"))) return;
+
+  const bareName = packageName.split("/")[1] as string;
+  const tarballUrl = `${REGISTRY_BASE_URL}/${packageName}/-/${bareName}-${version}.tgz`;
+  const response = await fetch(tarballUrl);
+  if (!response.ok) {
+    throw new Error(`Could not download ${packageName}@${version}: HTTP ${response.status}`);
+  }
+
+  fs.mkdirSync(installedPath, { recursive: true });
+  const archivePath = path.join(".build", `${bareName}-${version}.tgz`);
+  fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+  fs.writeFileSync(archivePath, new Uint8Array(await response.arrayBuffer()));
+
+  const extraction = Bun.spawnSync(
+    ["tar", "-xzf", archivePath, "-C", installedPath, "--strip-components=1"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  fs.rmSync(archivePath, { force: true });
+  if (extraction.exitCode !== 0) {
+    throw new Error(
+      `Could not unpack ${packageName}@${version}: ${new TextDecoder().decode(extraction.stderr).trim()}`,
+    );
+  }
+  process.stdout.write(`  fetched ${packageName}@${version}\n`);
+}
+
+/** Makes every native library the given target's bundle references resolvable. */
+export async function ensureNativeLibrariesForTarget(compileTarget: string): Promise<void> {
+  const versions = readNativeVersions();
+  for (const packageName of nativePackagesForTarget(compileTarget, Object.keys(versions))) {
+    const version = versions[packageName];
+    if (version === undefined) continue;
+    await downloadNativePackage(packageName, version);
+  }
+}


### PR DESCRIPTION
## What & why

`Release Binaries` has failed for every non-native target since v0.15.0, so v0.15.0, v0.15.1 and v0.15.2 all reached npm with no binaries attached to the GitHub release — anyone installing via `install.sh` instead of npm has had nothing to download for three releases.

The fullscreen interface's native Zig library ships as one optional dependency per platform, and an install only unpacks the one matching the machine doing the installing; the rest are skipped by their `os`/`cpu` fields however explicitly they are asked for (`bun add @opentui/core-linux-x64` on a Mac reports "installed" and unpacks nothing). The standalone build bundles `@opentui/core` rather than leaving it external, so the bundler walks the platform switch inside it and has to resolve the library for the target being compiled — `bun-linux-arm64` on an x64 runner failed on a package that was correctly absent.

The compile step now fetches the tarball for the target's library straight from the registry. That lives in `scripts/build.ts` rather than the release workflow, so a contributor cross-compiling locally is fixed too. The list of platforms comes from what the installed `@opentui/core` declares, so it does not rot when opentui adds one.

## How to verify

- On an arm64 Mac, `bun run scripts/build.ts --compile --target bun-darwin-x64` — previously "Could not resolve @opentui/core-darwin-x64", now fetches it and produces the binary. Same for `bun-linux-arm64` and `bun-linux-x64-musl`.
- Confirm the library is really embedded, not just linked: the 21 MB `libopentui.so` from `@opentui/core-linux-arm64` appears verbatim inside `binaries/jazz-linux-arm64`.
- Build the runner's own target and confirm nothing is fetched (its library is already installed) and the binary still passes the smoke test — `--version` and `persona list`.
- Re-run the workflow for an existing tag with `workflow_dispatch` and confirm all three jobs go green and binaries attach.
