### PR TITLE
fix(events): name the sub-agent on subagent_complete

### DIFF
--- a/src/core/agent/tools/subagent-tools.test.ts
+++ b/src/core/agent/tools/subagent-tools.test.ts
@@ -133,6 +133,40 @@ describe("spawn_subagent auto-approve inheritance", () => {
   });
 });
 
+describe("spawn_subagent event bracket", () => {
+  it("names the sub-agent on both events so a consumer can pair them", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation(
+      () =>
+        Effect.succeed({
+          content: "done",
+          conversationId: "conv-test",
+          messages: [],
+        }) as ReturnType<typeof AgentRunner.runRecursive>,
+    );
+
+    try {
+      const { presentation } = createPresentationHarness();
+      await runSpawn(presentation, {
+        emitEvent: (event: Record<string, unknown>) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+      });
+
+      const start = events.find((event) => event["type"] === "subagent_start");
+      const complete = events.find((event) => event["type"] === "subagent_complete");
+      expect(start?.["agentName"]).toBeDefined();
+      // Without this the complete event reaches the stream through the parent's
+      // renderer and gets attributed to the parent instead of the specialist.
+      expect(complete?.["agentName"]).toBe(start?.["agentName"]);
+      expect(typeof complete?.["durationMs"]).toBe("number");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("spawn_subagent persona handling", () => {
   it("passes the persona through as config rather than restating it in the task", async () => {
     let captured: Omit<AgentRunnerOptions, "internal"> | undefined;

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -214,7 +214,16 @@ ${args.task}`;
             ),
             // Bracket the sub-run for --events consumers, whatever the outcome.
             Effect.ensuring(
-              context.emitEvent ? context.emitEvent({ type: "subagent_complete" }) : Effect.void,
+              context.emitEvent
+                ? Effect.suspend(
+                    () =>
+                      context.emitEvent?.({
+                        type: "subagent_complete",
+                        agentName: subagentLabel,
+                        durationMs: Date.now() - startedAt,
+                      }) ?? Effect.void,
+                  )
+                : Effect.void,
             ),
           );
 

--- a/src/core/types/streaming.ts
+++ b/src/core/types/streaming.ts
@@ -134,7 +134,13 @@ export type StreamEvent =
 
   // Sub-agent lifecycle (delegated spawn_subagent runs)
   | { type: "subagent_start"; task?: string; agentName?: string }
-  | { type: "subagent_complete" };
+  /**
+   * Emitted whatever the outcome, so a consumer can close the bracket it opened on
+   * `subagent_start`. It carries the sub-agent's own name because several run at once
+   * and the event reaches the stream through the *parent's* renderer, which would
+   * otherwise attribute it to the parent.
+   */
+  | { type: "subagent_complete"; agentName?: string; durationMs?: number };
 
 export interface StreamingResult {
   readonly stream: Stream.Stream<StreamEvent, LLMError>;


### PR DESCRIPTION
## What & why

`subagent_complete` was a bare `{ type }` tag. It reaches the event stream through the *parent's* renderer, so since #433 stamped an `agentName` on every emitted line, a specialist finishing was reported as the parent finishing. A consumer watching a run with several concurrent specialists could not tell which one had closed.

It now carries the sub-agent's own name, and how long the sub-run took — which is also what a consumer needs to render a per-specialist roster without keeping its own clock.

## How to verify

- Run any agent that spawns sub-agents with `--json --events subagent`, and confirm each `subagent_complete` line's `agentName` matches the `subagent_start` that opened it, with a plausible `durationMs`.
- On a run with two specialists in flight at once, confirm neither completion is attributed to the parent.
