### PR TITLE
feat(events): name the agent on status and output lines

### DIFF
--- a/src/core/agent/execution/batch-executor.ts
+++ b/src/core/agent/execution/batch-executor.ts
@@ -87,7 +87,7 @@ export function executeWithoutStreaming(
           const showAgentStatus = (
             message: string,
             level: "info" | "success" | "warning" | "error" | "progress",
-          ) => presentationService.presentStatus(message, level);
+          ) => presentationService.presentStatus(message, level, agent.name);
 
           const retryAttemptRef = yield* Ref.make(0);
           const batchRetrySchedule = makeUserVisibleLlmRetrySchedule(

--- a/src/core/agent/execution/streaming-executor.ts
+++ b/src/core/agent/execution/streaming-executor.ts
@@ -121,7 +121,7 @@ export function executeWithStreaming(
           const showAgentStatus = (
             message: string,
             level: "info" | "success" | "warning" | "error" | "progress",
-          ) => presentationService.presentStatus(message, level);
+          ) => presentationService.presentStatus(message, level, agent.name);
 
           const retryAttemptRef = yield* Ref.make(0);
           const streamingRetrySchedule = makeUserVisibleLlmRetrySchedule(

--- a/src/core/agent/tools/subagent-tools.ts
+++ b/src/core/agent/tools/subagent-tools.ts
@@ -260,7 +260,7 @@ ${args.task}`;
           const maxLines = 10;
           const previewLines = fullResult.split("\n").slice(-maxLines).join("\n");
           const indentedLines = previewLines.split("\n").map((line) => `     ${line}`);
-          yield* presentation.writeOutput(indentedLines.join("\n"));
+          yield* presentation.writeOutput(indentedLines.join("\n"), subagentLabel);
 
           yield* logger.info("Sub-agent completed", {
             parentAgentId: parentAgent.id,

--- a/src/core/interfaces/presentation.ts
+++ b/src/core/interfaces/presentation.ts
@@ -144,9 +144,13 @@ export interface PresentationService {
   readonly emitsToolEventsViaRenderer?: () => boolean;
 
   /**
-   * Write output directly (for non-streaming mode)
+   * Write output directly (for non-streaming mode).
+   *
+   * @param agentName - Who produced the content, when the caller knows. Visual
+   *   implementations ignore it; the NDJSON emitter puts it on the line, so a
+   *   consumer can tell which of several concurrent sub-agents is speaking.
    */
-  readonly writeOutput: (message: string) => Effect.Effect<void, never>;
+  readonly writeOutput: (message: string, agentName?: string) => Effect.Effect<void, never>;
 
   /**
    * Write a blank line
@@ -166,10 +170,13 @@ export interface PresentationService {
    *
    * @param message - The status message to display
    * @param level - The type of status: info, success, warning, error, or progress
+   * @param agentName - Which agent the status is about, when the caller knows.
+   *   Carried on the NDJSON line for the same reason as {@link writeOutput}.
    */
   readonly presentStatus: (
     message: string,
     level: "info" | "success" | "warning" | "error" | "progress",
+    agentName?: string,
   ) => Effect.Effect<void, never>;
 
   /**

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -117,6 +117,40 @@ describe("OneShotPresentationService streaming renderer", () => {
     expect(parsed.agentName).toBe("komodo/roles verifier");
   });
 
+  it("names the agent on status and output lines when the caller knows it", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["text_chunk"]),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(
+      service.presentStatus("still waiting on the model", "progress", "airgap verifier"),
+    );
+    Effect.runSync(service.writeOutput("claim 6 holds", "airgap verifier"));
+
+    const [status, output] = captured.lines.map(
+      (line) => JSON.parse(line) as Record<string, unknown>,
+    );
+    expect(status?.["type"]).toBe("status");
+    expect(status?.["agentName"]).toBe("airgap verifier");
+    expect(output?.["type"]).toBe("output");
+    expect(output?.["agentName"]).toBe("airgap verifier");
+  });
+
+  it("omits agentName rather than guessing when the caller does not know it", () => {
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["text_chunk"]),
+    );
+
+    const captured = captureStderr();
+    Effect.runSync(service.presentStatus("connecting to the MCP server", "info"));
+
+    const status = JSON.parse(captured.lines[0] as string) as Record<string, unknown>;
+    expect("agentName" in status).toBe(false);
+  });
+
   it("returns a noop renderer that writes nothing when no types are selected", () => {
     const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
     const renderer = Effect.runSync(service.createStreamingRenderer(rendererConfig));

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -254,10 +254,14 @@ export class OneShotPresentationService implements PresentationService {
     return Effect.succeed(emittingRenderer);
   }
 
-  writeOutput(message: string): Effect.Effect<void, never> {
+  writeOutput(message: string, agentName?: string): Effect.Effect<void, never> {
     return Effect.sync(() => {
       if (this.eventsActive) {
-        this.emitNdjson({ type: "output", message });
+        this.emitNdjson({
+          type: "output",
+          message,
+          ...(agentName !== undefined ? { agentName } : {}),
+        });
         return;
       }
       process.stderr.write(message);
@@ -271,10 +275,16 @@ export class OneShotPresentationService implements PresentationService {
   presentStatus(
     message: string,
     level: "info" | "success" | "warning" | "error" | "progress",
+    agentName?: string,
   ): Effect.Effect<void, never> {
     return Effect.sync(() => {
       if (this.eventsActive) {
-        this.emitNdjson({ type: "status", level, message });
+        this.emitNdjson({
+          type: "status",
+          level,
+          message,
+          ...(agentName !== undefined ? { agentName } : {}),
+        });
         return;
       }
       const prefixes: Record<typeof level, string> = {


### PR DESCRIPTION
## What & why

`status` and `output` were the last NDJSON lines carrying no agent. A consumer could see which specialist called a tool or was mid-sentence, but not which one a relayed answer came from, nor which one a "still waiting on the model" notice was about — with several specialists in flight, both were guesses. A CI job trying to render a per-specialist view had to parse names out of prose.

`presentStatus` and `writeOutput` now take an optional agent name, passed by the three callers that know it: both executors, which already name the agent inside their own notices, and the sub-agent tool, whose `writeOutput` is the relay of a specialist's answer. Callers with no agent in scope — MCP connection progress, for instance — pass nothing, and the field stays absent rather than being guessed at. Visual implementations ignore the argument, so nothing changes in the TUI.

Depends on #435 for the ordering: merge that first, or `subagent_complete` keeps reporting the parent.

## How to verify

- Run a workflow whose agent spawns two sub-agents at once with `--json --events tools,reasoning,text,subagent`, and confirm each `output` line's `agentName` is the specialist that produced it, not the parent.
- Confirm a long model call's `status` line names the agent it is waiting on.
- Confirm a status with no agent in scope (start a run with an MCP server configured) still emits, with no `agentName` key at all.
- Run the same thing interactively and confirm the TUI is unchanged.
