### PR TITLE
fix(bridges): make auto-update recover from a parked checkout, and speak up

### DIFF
--- a/integrations/discord-bot/README.md
+++ b/integrations/discord-bot/README.md
@@ -139,6 +139,11 @@ While a message is processing, the progress message carries a **⏹ Cancel**
 button that kills the run. Each answer gets follow-up buttons (`🔍 Go deeper`,
 `✂️ Shorter`, …) that upgrade to contextual ones a beat later; set
 `JAZZ_DISCORD_DYNAMIC_CTA=0` to keep only the static ones.
+The 💭 line on the progress message is only the tail of the model's current
+thought, and that message is replaced when the answer lands — so the full
+reasoning follows the answer as **Reasoning** spoilers you click to reveal.
+Very long runs are split across a few spoilers, and the last one says how much
+was left out; set `JAZZ_DISCORD_SHOW_REASONING=0` to drop them.
 Set `JAZZ_DAILY_COST_CAP_USD` to cap known spend per UTC day (0 = no cap).
 If a completed run has no pricing metadata, its exact cost cannot be capped;
 the bot records it as unpriced and pauses later requests until the next UTC day.

--- a/integrations/discord-bot/README.md
+++ b/integrations/discord-bot/README.md
@@ -221,12 +221,21 @@ cd integrations/discord-bot && docker compose -p jazz-discord up -d --build
 ```
 
 **Nightly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
-rebuilds only if it changed, and rolls back if the new build isn't healthy.
-Install it (as the deploy user):
+rebuilds only if it changed, and rolls back if the new build fails to build or
+isn't healthy. Install it (as the deploy user):
 
 ```sh
 (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/discord-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
+
+Anything needing a human is also sent to the bridge's own chat via `notify.sh`,
+because a nightly cron failure that only appends to a logfile is invisible: a
+checkout left on a feature branch silently skipped every update for over two
+weeks before anyone noticed. If the checkout isn't on `main`, the script parks it
+back there — stashing tracked edits (untracked files such as a local
+`docker-compose.override.yml` are left alone) and reporting both the stash and any
+commits left behind on the old branch by name, so nothing goes quietly missing.
+Set `JAZZ_DEPLOY_BRANCH` to track something other than `main`.
 
 ## Security notes
 

--- a/integrations/discord-bot/README.md
+++ b/integrations/discord-bot/README.md
@@ -233,6 +233,13 @@ isn't healthy. Install it (as the deploy user):
 (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/discord-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
 
+**Run logs:** every turn appends an NDJSON record of the jazz event stream to
+`<JAZZ_HOME>/logs/runs/<conversation>-<timestamp>.ndjson`, written as the run
+happens rather than when it finishes — so a run that times out still leaves a
+trace. Each line carries elapsed time, token deltas are collapsed into one line
+per stream with a character count and duration, and the last line is the outcome
+with the number of model rounds. The newest 200 runs per bridge are kept.
+
 Anything needing a human is also sent to the bridge's own chat via `notify.sh`,
 because a nightly cron failure that only appends to a logfile is invisible: a
 checkout left on a feature branch silently skipped every update for over two

--- a/integrations/discord-bot/auto-update.sh
+++ b/integrations/discord-bot/auto-update.sh
@@ -1,52 +1,9 @@
 #!/bin/sh
-# Nightly auto-update for the Jazz Discord bridge.
-#
-# Fast-forwards the checkout to the latest origin/main, rebuilds only if it
-# actually changed, and rolls back to the previous commit if the new build
-# doesn't come up healthy. Safe to run from cron. Install (as the deploy user):
+# Nightly auto-update for the Jazz Discord bridge. The logic is shared with the
+# other bridges; this only names which one. Install (as the deploy user):
 #
 #   (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/discord-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 #
 set -eu
-
-PATH=/usr/local/bin:/usr/bin:/bin
-export PATH
-
 DIR=$(cd -- "$(dirname -- "$0")" && pwd)
-REPO=$(cd -- "$DIR/../.." && pwd)
-PROJECT=jazz-discord
-STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-cd "$REPO"
-git fetch -q origin main
-PREV=$(git rev-parse HEAD)
-LATEST=$(git rev-parse origin/main)
-
-if [ "$PREV" = "$LATEST" ]; then
-  echo "$STAMP up-to-date ($PREV)"
-  exit 0
-fi
-
-echo "$STAMP updating ${PREV} -> ${LATEST}"
-git merge --ff-only origin/main
-
-cd "$DIR"
-docker compose -p "$PROJECT" up -d --build
-
-attempt=0
-while [ "$attempt" -lt 12 ]; do
-  status=$(docker inspect -f '{{.State.Health.Status}}' "$PROJECT" 2>/dev/null || echo none)
-  if [ "$status" = "healthy" ]; then
-    echo "$STAMP updated to ${LATEST} (healthy)"
-    exit 0
-  fi
-  attempt=$((attempt + 1))
-  sleep 5
-done
-
-echo "$STAMP update to ${LATEST} did not become healthy — rolling back to ${PREV}"
-cd "$REPO"
-git reset --hard "$PREV"
-cd "$DIR"
-docker compose -p "$PROJECT" up -d --build
-exit 1
+exec "$DIR/../shared/auto-update.sh" "$DIR" jazz-discord

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -82,7 +82,11 @@ import { conversationKey, isIncognito, setIncognito, startNewConversation } from
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
 import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
 import { reasoningSnippet, splitReasoning } from "../shared/reasoning";
+import { createRunLog, type RunLog } from "../shared/run-log";
 
+// The text the progress message is created with. The reporter starts from it so
+// its first render is not sent as an edit to identical content.
+const PROGRESS_INITIAL_TEXT = "🤔 **Working…**";
 const PROGRESS_MIN_INTERVAL_MS = 2_000;
 const PROGRESS_MAX_TOOLS_SHOWN = 8;
 // The reasoning log goes out inside a spoiler, which costs four characters;
@@ -367,18 +371,20 @@ function createProgressReporter(
   channelId: string,
   messageId: string,
   runToken: string,
+  runLog: RunLog,
 ) {
   const tools: string[] = [];
   const subagents: string[] = [];
   const declined: string[] = [];
   let reasoning = "";
   let writing = false;
-  let lastText = "";
+  let rounds = 0;
+  let lastText = PROGRESS_INITIAL_TEXT;
   let lastEditAt = 0;
   let editing = false;
 
   const render = (): string => {
-    const lines = ["🤔 **Working…**"];
+    const lines = [PROGRESS_INITIAL_TEXT];
     const thought = reasoningSnippet(reasoning);
     if (thought) lines.push(`💭 ${thought}`);
     for (const tool of tools.slice(-PROGRESS_MAX_TOOLS_SHOWN)) {
@@ -390,6 +396,9 @@ function createProgressReporter(
     for (const tool of declined) {
       lines.push(`⛔ \`${tool}\` declined (needs approval)`);
     }
+    // A run that goes round and round looks identical to a slow one from the
+    // outside; the count is what makes a loop visible without reading logs.
+    if (rounds > 1) lines.push(`↻ round ${rounds}`);
     if (writing) lines.push("✍️ writing the answer…");
     return neutralizeBroadcastMentions(lines.join("\n"));
   };
@@ -408,7 +417,12 @@ function createProgressReporter(
 
   return {
     onEvent(event: JazzEvent): void {
+      runLog.event(event as unknown as Record<string, unknown>);
       switch (event.type) {
+        case "tools_detected":
+          // One per model response that asked for tools, so one per loop round.
+          rounds += 1;
+          break;
         case "thinking_chunk":
           if (typeof event.content === "string") reasoning += event.content;
           break;
@@ -434,6 +448,7 @@ function createProgressReporter(
     },
     finish: (summary: string): Promise<void> => edit(summary, []),
     toolsUsed: (): string[] => [...new Set(tools)],
+    rounds: (): number => rounds,
     // The progress bubble only ever showed a rolling tail; this is everything
     // the model thought, for the spoiler log attached to the answer.
     reasoningLog: (): string => reasoning,
@@ -649,19 +664,23 @@ async function handleMessage(
   const runToken = newRunToken();
   let messageId = progressMessageId;
   if (messageId === undefined) {
-    const sent = await sendMessage(config.botToken, channelId, "🤔 **Working…**", {
+    const sent = await sendMessage(config.botToken, channelId, PROGRESS_INITIAL_TEXT, {
       components: cancelComponents(runToken),
     });
     messageId = sent?.id;
   } else {
-    await editMessage(config.botToken, channelId, messageId, "🤔 **Working…**", {
+    await editMessage(config.botToken, channelId, messageId, PROGRESS_INITIAL_TEXT, {
       components: cancelComponents(runToken),
     });
   }
 
+  // Opened before the run so a crash or timeout still leaves a record: the
+  // conversation transcript is only written once a run completes.
+  const runLog = createRunLog(config.jazzHome, conversationKey(config.jazzHome, channelId));
+  let runLogged = false;
   const reporter =
     messageId !== undefined
-      ? createProgressReporter(config, channelId, messageId, runToken)
+      ? createProgressReporter(config, channelId, messageId, runToken, runLog)
       : undefined;
 
   try {
@@ -673,6 +692,14 @@ async function handleMessage(
       runToken,
     );
     const cancelled = activeRuns.get(runToken)?.cancelled ?? false;
+    runLog.finish({
+      ok: envelope.ok,
+      cancelled,
+      rounds: reporter?.rounds() ?? 0,
+      toolsUsed: reporter?.toolsUsed() ?? [],
+      ...(envelope.ok ? {} : { error: envelope.error }),
+    });
+    runLogged = true;
 
     if (cancelled) {
       await reporter?.finish("⏹ **Cancelled**");
@@ -721,6 +748,16 @@ async function handleMessage(
       await sendReply(config, channelId, `⚠️ ${envelope.error}`);
     }
   } finally {
+    // A throw anywhere above would otherwise leave the log with no outcome line,
+    // which is exactly the run someone will come looking for.
+    if (!runLogged) {
+      runLog.finish({
+        ok: false,
+        error: "handler threw before the run reported an outcome",
+        rounds: reporter?.rounds() ?? 0,
+        toolsUsed: reporter?.toolsUsed() ?? [],
+      });
+    }
     activeRuns.delete(runToken);
     for (const [token, pending] of pendingApprovals) {
       if (pending.runToken === runToken) pendingApprovals.delete(token);

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -71,15 +71,27 @@ import {
   triggerTyping,
   type SlashCommand,
 } from "./discord";
-import { neutralizeBroadcastMentions, splitForDiscord, threadNameFromPrompt } from "./discord-md";
+import {
+  neutralizeBroadcastMentions,
+  spoilerBlock,
+  splitForDiscord,
+  threadNameFromPrompt,
+} from "./discord-md";
 import { startReminderSweep } from "./reminders";
 import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
 import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
+import { reasoningSnippet, splitReasoning } from "../shared/reasoning";
 
 const PROGRESS_MIN_INTERVAL_MS = 2_000;
 const PROGRESS_MAX_TOOLS_SHOWN = 8;
-const PROGRESS_REASONING_CHARS = 180;
+// The reasoning log goes out inside a spoiler, which costs four characters;
+// budget under the 1900 the answer splitter uses so a part plus its heading
+// stays clear of Discord's 2000 hard limit without splitting mid-spoiler.
+const REASONING_PART_CHARS = 1_700;
+// A long agentic run would otherwise post a wall of spoilers; past this the
+// tail is dropped and the final part says how much.
+const REASONING_MAX_PARTS = 4;
 const BRIDGE_STARTED_AT = Date.now();
 
 const activeRuns = new Map<
@@ -114,6 +126,12 @@ interface BridgeConfig extends AccessConfig {
   readonly port: number;
   readonly dailyCostCapUsd: number;
   readonly dynamicCta: boolean;
+  /**
+   * Attach the run's full reasoning under the answer as click-to-reveal
+   * spoilers. The live progress line only ever shows a rolling tail, and that
+   * message is overwritten when the answer lands.
+   */
+  readonly showReasoning: boolean;
   readonly publicBaseUrl: string | undefined;
 }
 
@@ -206,6 +224,7 @@ function loadConfig(): BridgeConfig {
     port: Number.parseInt(process.env["PORT"]?.trim() || "8080", 10),
     dailyCostCapUsd: Number.parseFloat(process.env["JAZZ_DAILY_COST_CAP_USD"]?.trim() || "0") || 0,
     dynamicCta: envFlag("JAZZ_DISCORD_DYNAMIC_CTA", true),
+    showReasoning: envFlag("JAZZ_DISCORD_SHOW_REASONING", true),
     publicBaseUrl: process.env["DISCORD_PUBLIC_BASE_URL"]?.trim() || undefined,
   };
 }
@@ -343,15 +362,6 @@ async function streamLines(
   }
 }
 
-function reasoningSnippet(reasoning: string): string {
-  const normalized = reasoning.replace(/\s+/g, " ").trim();
-  if (normalized.length <= PROGRESS_REASONING_CHARS) return normalized;
-  let tail = normalized.slice(-PROGRESS_REASONING_CHARS).trimStart();
-  const firstSpace = tail.indexOf(" ");
-  if (firstSpace > 0 && firstSpace < 40) tail = tail.slice(firstSpace + 1);
-  return `… ${tail}`;
-}
-
 function createProgressReporter(
   config: BridgeConfig,
   channelId: string,
@@ -424,11 +434,34 @@ function createProgressReporter(
     },
     finish: (summary: string): Promise<void> => edit(summary, []),
     toolsUsed: (): string[] => [...new Set(tools)],
+    // The progress bubble only ever showed a rolling tail; this is everything
+    // the model thought, for the spoiler log attached to the answer.
+    reasoningLog: (): string => reasoning,
   };
 }
 
 const APPROVAL_MESSAGE_MAX_CHARS = 500;
 const APPROVAL_PREVIEW_DIFF_MAX_CHARS = 500;
+
+/**
+ * Attach a run's full reasoning under the answer as click-to-reveal spoilers.
+ * Sent as its own messages rather than appended to the answer so the answer
+ * keeps its follow-up buttons and its own splitting untouched.
+ */
+async function sendReasoningLog(
+  config: BridgeConfig,
+  channelId: string,
+  reasoning: string,
+): Promise<void> {
+  const parts = splitReasoning(reasoning, {
+    budget: REASONING_PART_CHARS,
+    maxParts: REASONING_MAX_PARTS,
+  });
+  for (const [index, part] of parts.entries()) {
+    const counter = parts.length > 1 ? ` (${index + 1}/${parts.length})` : "";
+    await sendReply(config, channelId, `💭 **Reasoning**${counter}\n${spoilerBlock(part)}`);
+  }
+}
 
 async function sendApprovalRequest(
   config: BridgeConfig,
@@ -676,6 +709,9 @@ async function handleMessage(
       });
       if (config.dynamicCta && answerMessageId !== undefined) {
         void upgradeToDynamicCtas(config, channelId, answerMessageId, text, envelope.answer);
+      }
+      if (config.showReasoning) {
+        await sendReasoningLog(config, channelId, reporter?.reasoningLog() ?? "");
       }
       if (envelope.webApp) {
         await deliverWebApp(config, channelId, envelope.webApp);

--- a/integrations/discord-bot/discord-md.test.ts
+++ b/integrations/discord-bot/discord-md.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { neutralizeBroadcastMentions, splitForDiscord, threadNameFromPrompt } from "./discord-md";
+import {
+  neutralizeBroadcastMentions,
+  spoilerBlock,
+  splitForDiscord,
+  threadNameFromPrompt,
+} from "./discord-md";
 
 describe("splitForDiscord", () => {
   it("returns a placeholder for empty input", () => {
@@ -40,5 +45,18 @@ describe("threadNameFromPrompt", () => {
 
   it("falls back when the prompt is empty", () => {
     expect(threadNameFromPrompt("   ")).toBe("Jazz");
+  });
+});
+
+describe("spoilerBlock", () => {
+  it("wraps text so Discord hides it until clicked", () => {
+    expect(spoilerBlock("thinking out loud")).toBe("||thinking out loud||");
+  });
+
+  it("keeps a literal pipe pair from closing the spoiler early", () => {
+    const wrapped = spoilerBlock("a || b");
+    expect(wrapped.startsWith("||")).toBe(true);
+    expect(wrapped.endsWith("||")).toBe(true);
+    expect(wrapped.slice(2, -2)).not.toContain("||");
   });
 });

--- a/integrations/discord-bot/discord-md.ts
+++ b/integrations/discord-bot/discord-md.ts
@@ -38,3 +38,13 @@ export function threadNameFromPrompt(prompt: string): string {
   if (cleaned.length === 0) return "Jazz";
   return `Jazz · ${cleaned}`.slice(0, 100);
 }
+
+/**
+ * Wrap plain text in a spoiler — Discord's only click-to-reveal container, and
+ * the closest analogue to Telegram's expandable quote. A literal `||` in the
+ * text would close the spoiler early, so pipe pairs are separated by a
+ * zero-width space; the text still reads the same.
+ */
+export function spoilerBlock(text: string): string {
+  return `||${text.replace(/\|\|/g, "|​|")}||`;
+}

--- a/integrations/discord-bot/notify.sh
+++ b/integrations/discord-bot/notify.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Send one operational message to the bridge's own Discord channel.
+#
+# Called by auto-update.sh so a failed or surprising deploy reaches a human
+# instead of only a logfile. Needs DISCORD_ALLOWED_CHANNEL_IDS: a bot can post
+# to a channel without the extra DM-open round trip a user id would need.
+set -eu
+
+DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+MESSAGE=${1:?usage: notify.sh <message>}
+ENV_FILE="${DIR}/.env"
+
+[ -f "$ENV_FILE" ] || { echo "notify: no ${ENV_FILE}" >&2; exit 1; }
+
+token=$(sed -n 's/^DISCORD_BOT_TOKEN=//p' "$ENV_FILE" | tail -1 | tr -d '"'"'"' \r')
+channel=$(sed -n 's/^DISCORD_ALLOWED_CHANNEL_IDS=//p' "$ENV_FILE" | tail -1 |
+  tr -d '"'"'"' \r' | cut -d, -f1)
+
+[ -n "$token" ] || { echo "notify: DISCORD_BOT_TOKEN not set" >&2; exit 1; }
+[ -n "$channel" ] || { echo "notify: DISCORD_ALLOWED_CHANNEL_IDS not set" >&2; exit 1; }
+
+# jq is not a given on a deploy box, so build the one JSON string by hand:
+# escape backslashes, quotes and newlines, which is all this payload can contain.
+escaped=$(printf '%s' "🛠 ${MESSAGE}" |
+  sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | awk 'BEGIN{ORS=""} {print sep $0; sep="\\n"}')
+
+curl -sS -o /dev/null -m 20 -X POST \
+  "https://discord.com/api/v10/channels/${channel}/messages" \
+  -H "Authorization: Bot ${token}" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: DiscordBot (https://github.com/lvndry/jazz, 1.0)" \
+  -d "{\"content\":\"${escaped}\"}"

--- a/integrations/shared/auto-update.sh
+++ b/integrations/shared/auto-update.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Nightly auto-update for a Jazz chat bridge, shared by every bridge.
+#
+# Fast-forwards the checkout to the latest origin/main, rebuilds only if it
+# actually changed, and rolls back to the previous commit if the new build does
+# not come up healthy.
+#
+# Usage (from a bridge's own auto-update.sh):
+#   exec "$DIR/../shared/auto-update.sh" "$DIR" jazz-telegram
+#
+# A bridge may sit next to an executable `notify.sh` taking one message
+# argument; it is called on every outcome a human needs to see. Failure to
+# notify never fails the update.
+set -eu
+
+# Cron runs with a minimal PATH, so name the standard locations first — but keep
+# whatever was inherited on the end, or a docker installed outside them
+# (rootless, snap, Homebrew) is invisible to an otherwise working deploy.
+PATH=/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}
+export PATH
+
+BRIDGE_DIR=${1:?usage: auto-update.sh <bridge-dir> <compose-project>}
+PROJECT=${2:?usage: auto-update.sh <bridge-dir> <compose-project>}
+REPO=$(cd -- "$BRIDGE_DIR/../.." && pwd)
+STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+DEPLOY_BRANCH=${JAZZ_DEPLOY_BRANCH:-main}
+
+# Cron has no reader. Anything a human must act on goes to the bridge itself:
+# in a logfile nobody opens, weeks of nightly failures are indistinguishable
+# from an update that never needed to run.
+notify() {
+  echo "$STAMP $1"
+  if [ -x "$BRIDGE_DIR/notify.sh" ]; then
+    "$BRIDGE_DIR/notify.sh" "$1" || echo "$STAMP (notify failed)"
+  fi
+}
+
+die() {
+  notify "$1"
+  exit 1
+}
+
+cd "$REPO"
+
+# Park the checkout back on the deploy branch rather than attempting a merge
+# that cannot succeed. Only tracked modifications are stashed: untracked files
+# are deliberate local config (a docker-compose.override.yml publishing a port,
+# a .env) and stashing them would silently change how the bridge deploys.
+# Nothing is discarded — commits stay on the branch they were made on and the
+# stash is left for a human, both reported below.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "$DEPLOY_BRANCH" ]; then
+  # Resolve to a sha before moving: on a detached HEAD there is no branch name
+  # to diff against afterwards, and those commits are the easiest to lose.
+  PRIOR_HEAD=$(git rev-parse HEAD)
+  STASHED=no
+  if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    git stash push -m "auto-update ${STAMP} (was on ${CURRENT_BRANCH})" >/dev/null
+    STASHED=yes
+  fi
+  git checkout -q "$DEPLOY_BRANCH" ||
+    die "auto-update: cannot check out ${DEPLOY_BRANCH} from ${CURRENT_BRANCH}; left as-is"
+
+  message="auto-update: moved the checkout from ${CURRENT_BRANCH} to ${DEPLOY_BRANCH}"
+  # Commits only ever reachable from the old branch are not lost, but they are
+  # now invisible to anyone looking at the deploy — so say so by name.
+  orphans=$(git log --oneline "${DEPLOY_BRANCH}..${PRIOR_HEAD}" 2>/dev/null || true)
+  if [ -n "$orphans" ]; then
+    message="${message}
+Commits left behind on ${CURRENT_BRANCH} (push them or they stay only on this box):
+${orphans}"
+  fi
+  if [ "$STASHED" = yes ]; then
+    message="${message}
+Local edits were stashed — recover with: git -C ${REPO} stash list"
+  fi
+  notify "$message"
+fi
+
+git fetch -q origin "$DEPLOY_BRANCH"
+PREV=$(git rev-parse HEAD)
+LATEST=$(git rev-parse "origin/${DEPLOY_BRANCH}")
+
+if [ "$PREV" = "$LATEST" ]; then
+  echo "$STAMP up-to-date ($PREV)"
+  exit 0
+fi
+
+echo "$STAMP updating ${PREV} -> ${LATEST}"
+# Fast-forward only: never silently discard local commits. Reaching here with a
+# non-fast-forwardable branch means someone committed to the deploy branch on
+# this box, which a cron job must not resolve on their behalf.
+git merge --ff-only "origin/${DEPLOY_BRANCH}" 2>/dev/null ||
+  die "auto-update: ${DEPLOY_BRANCH} has local commits that block a fast-forward to ${LATEST}. Push or drop them; the bridge is still on ${PREV}."
+
+deploy() {
+  cd "$BRIDGE_DIR"
+  docker compose -p "$PROJECT" up -d --build
+}
+
+# Put the checkout and the running container back on the commit that worked.
+# Reached from two different failures, so it must not assume the new build even
+# started: `up -d` on the old tree is what actually restores service.
+rollback() {
+  cd "$REPO"
+  git reset --hard "$PREV"
+  deploy || notify "auto-update: rollback to ${PREV} also failed to start — the bridge is DOWN"
+}
+
+# An `up -d --build` that exits non-zero used to abort the script outright,
+# leaving the checkout fast-forwarded to a commit that never deployed, with no
+# rollback and nothing said. A failed build is the common case here, not a rare
+# one, so it gets the same treatment as a failed health check.
+if ! deploy; then
+  notify "auto-update: build/start of ${LATEST} failed — rolling back to ${PREV}"
+  rollback
+  die "auto-update: rolled back to ${PREV}; ${LATEST} does not build and needs a look"
+fi
+
+# Health gate — give it up to a minute to report healthy.
+attempt=0
+while [ "$attempt" -lt 12 ]; do
+  status=$(docker inspect -f '{{.State.Health.Status}}' "$PROJECT" 2>/dev/null || echo none)
+  if [ "$status" = "healthy" ]; then
+    echo "$STAMP updated to ${LATEST} (healthy)"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
+notify "auto-update: ${LATEST} did not become healthy — rolling back to ${PREV}"
+rollback
+die "auto-update: rolled back to ${PREV}; ${LATEST} is unhealthy and needs a look"

--- a/integrations/shared/reasoning.test.ts
+++ b/integrations/shared/reasoning.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PROGRESS_REASONING_CHARS,
+  reasoningSnippet,
+  splitReasoning,
+  tidyReasoning,
+} from "./reasoning";
+
+describe("reasoningSnippet", () => {
+  test("renders a short thought whole, on one line", () => {
+    expect(reasoningSnippet("  I need\n the duration.  ")).toBe("I need the duration.");
+  });
+
+  test("returns empty for whitespace-only reasoning so no 💭 line is drawn", () => {
+    expect(reasoningSnippet("   \n\t ")).toBe("");
+  });
+
+  test("shows the tail, not the head, of a long thought", () => {
+    const reasoning = `${"a".repeat(500)} and finally the newest thought`;
+    const snippet = reasoningSnippet(reasoning);
+    expect(snippet.startsWith("… ")).toBe(true);
+    expect(snippet.endsWith("and finally the newest thought")).toBe(true);
+    expect(snippet.length).toBeLessThan(reasoning.length);
+  });
+
+  test("drops a chopped-off leading word fragment", () => {
+    const reasoning = `${"x".repeat(400)}fragment ${"word ".repeat(30)}`;
+    expect(reasoningSnippet(reasoning)).not.toContain("fragment");
+  });
+
+  test("keeps a long leading run rather than eating a real word", () => {
+    const tail = `${"y".repeat(60)} ${"word ".repeat(20)}`;
+    const snippet = reasoningSnippet(`${"z".repeat(400)} ${tail}`);
+    expect(snippet).toContain("y".repeat(60));
+  });
+
+  test("stays within the advertised budget plus the ellipsis marker", () => {
+    const snippet = reasoningSnippet("word ".repeat(500));
+    expect(snippet.length).toBeLessThanOrEqual(PROGRESS_REASONING_CHARS + 2);
+  });
+});
+
+describe("tidyReasoning", () => {
+  test("keeps paragraph breaks but collapses longer blank runs", () => {
+    expect(tidyReasoning("one\n\n\n\ntwo")).toBe("one\n\ntwo");
+  });
+
+  test("normalises carriage returns and strips trailing spaces", () => {
+    expect(tidyReasoning("one   \r\ntwo\t\r\n")).toBe("one\ntwo");
+  });
+});
+
+describe("splitReasoning", () => {
+  const options = { budget: 100, maxParts: 3 };
+
+  test("returns nothing for empty reasoning", () => {
+    expect(splitReasoning("   \n  ", options)).toEqual([]);
+  });
+
+  test("returns a single part when it fits", () => {
+    expect(splitReasoning("short thought", options)).toEqual(["short thought"]);
+  });
+
+  test("keeps every part within budget", () => {
+    for (const part of splitReasoning("word ".repeat(50), options)) {
+      expect(part.length).toBeLessThanOrEqual(options.budget);
+    }
+  });
+
+  test("prefers a line break in the back half of the window", () => {
+    const reasoning = `${"a".repeat(80)}\n${"b".repeat(80)}`;
+    const parts = splitReasoning(reasoning, options);
+    expect(parts[0]).toBe("a".repeat(80));
+    expect(parts[1]).toBe("b".repeat(80));
+  });
+
+  test("loses no text when it splits", () => {
+    const reasoning = "word ".repeat(40).trim();
+    const parts = splitReasoning(reasoning, options);
+    expect(parts.length).toBeGreaterThan(1);
+    expect(parts.join(" ")).toBe(reasoning);
+  });
+
+  test("says how much it dropped rather than truncating silently", () => {
+    const parts = splitReasoning("word ".repeat(500), options);
+    expect(parts).toHaveLength(options.maxParts);
+    expect(parts.at(-1)).toMatch(/\[… [\d,]+ more characters of reasoning not shown\]$/);
+  });
+
+  test("adds no dropped note when the last part lands exactly on the cap", () => {
+    const reasoning = `${"a".repeat(90)}\n${"b".repeat(90)}`;
+    const parts = splitReasoning(reasoning, { budget: 100, maxParts: 2 });
+    expect(parts).toHaveLength(2);
+    expect(parts.at(-1)).toBe("b".repeat(90));
+  });
+
+  test("splits unbroken text that offers no word boundary at all", () => {
+    const parts = splitReasoning("a".repeat(250), options);
+    expect(parts.join("")).toBe("a".repeat(250));
+  });
+});

--- a/integrations/shared/reasoning.ts
+++ b/integrations/shared/reasoning.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Shared rules for surfacing a run's model reasoning in a chat bridge.
+ *
+ * Both bridges consume the same `thinking_chunk` stream and face the same two
+ * conflicting needs: a live progress bubble that has to stay one line (it is
+ * edited in place every couple of seconds, under a platform edit rate limit)
+ * and a post-run record that should keep everything the model actually thought.
+ * The rules live here rather than in either bridge so the two can't drift apart
+ * on cap sizes, word boundaries or truncation wording.
+ */
+
+/** How much of the accumulated thought the live progress line shows, as a tail. */
+export const PROGRESS_REASONING_CHARS = 180;
+
+/**
+ * Cutting a tail at a fixed offset usually lands mid-word. A leading run shorter
+ * than this is treated as that fragment and dropped; a longer one is plausibly a
+ * real word and kept.
+ */
+const WORD_FRAGMENT_CHARS = 40;
+
+/**
+ * Show the latest slice of a streaming thought. Short thoughts render whole;
+ * longer ones show the tail from a word boundary with a leading ellipsis, so
+ * the line reads as a continuation rather than a chopped-off first word.
+ */
+export function reasoningSnippet(reasoning: string): string {
+  const normalized = reasoning.replace(/\s+/g, " ").trim();
+  if (normalized.length <= PROGRESS_REASONING_CHARS) return normalized;
+  let tail = normalized.slice(-PROGRESS_REASONING_CHARS).trimStart();
+  const firstSpace = tail.indexOf(" ");
+  if (firstSpace > 0 && firstSpace < WORD_FRAGMENT_CHARS) tail = tail.slice(firstSpace + 1);
+  return `… ${tail}`;
+}
+
+/**
+ * Tidy the accumulated reasoning for the post-run record. Unlike the progress
+ * snippet this keeps line structure — the full log is read as prose, and the
+ * model's own paragraph breaks are most of what makes it readable.
+ */
+export function tidyReasoning(reasoning: string): string {
+  return reasoning
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export interface ReasoningSplitOptions {
+  /** Characters each part may hold, before any platform wrapper is added. */
+  readonly budget: number;
+  /** Ceiling on parts, so one very long run can't flood a channel. */
+  readonly maxParts: number;
+}
+
+/**
+ * Split tidied reasoning into parts that each fit a platform's per-message
+ * budget, preferring line breaks over hard cuts. If the text needs more parts
+ * than `maxParts`, the last part says how much was dropped — a silent cut here
+ * would read as "this is all the model thought", which is the one thing the
+ * full log exists to disprove.
+ */
+export function splitReasoning(reasoning: string, options: ReasoningSplitOptions): string[] {
+  const tidied = tidyReasoning(reasoning);
+  if (tidied.length === 0) return [];
+
+  const parts: string[] = [];
+  let remaining = tidied;
+  while (remaining.length > options.budget) {
+    const window = remaining.slice(0, options.budget);
+    const lastNewline = window.lastIndexOf("\n");
+    const lastSpace = window.lastIndexOf(" ");
+    // Prefer a break in the back half of the window; a break near the very start
+    // would emit a near-empty part and make no progress on the remainder.
+    const halfway = options.budget * 0.5;
+    let splitAt = window.length;
+    if (lastNewline > halfway) splitAt = lastNewline;
+    else if (lastSpace > halfway) splitAt = lastSpace;
+    parts.push(window.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+
+    if (parts.length === options.maxParts) {
+      return withDroppedNote(parts, remaining.length);
+    }
+  }
+  if (remaining.length > 0) parts.push(remaining);
+  return parts;
+}
+
+function withDroppedNote(parts: string[], droppedChars: number): string[] {
+  if (droppedChars === 0) return parts;
+  const note = `\n\n[… ${droppedChars.toLocaleString("en-US")} more characters of reasoning not shown]`;
+  const last = parts[parts.length - 1];
+  if (last !== undefined) parts[parts.length - 1] = `${last}${note}`;
+  return parts;
+}

--- a/integrations/shared/run-log.test.ts
+++ b/integrations/shared/run-log.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { createRunLog, nullRunLog } from "./run-log";
+
+function readRecords(dataDir: string): Record<string, unknown>[] {
+  const directory = join(dataDir, "logs", "runs");
+  const file = readdirSync(directory)[0];
+  expect(file).toBeDefined();
+  return readFileSync(join(directory, file as string), "utf8")
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("createRunLog", () => {
+  it("records a start line, each event and the outcome", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    log.event({ type: "tools_detected", toolNames: ["add_reminder"] });
+    log.event({ type: "tool_execution_start", toolName: "add_reminder" });
+    log.finish({ ok: false, error: "timed out", rounds: 7 });
+
+    const records = readRecords(dataDir);
+    expect(records.map((record) => record["type"])).toEqual([
+      "run_start",
+      "tools_detected",
+      "tool_execution_start",
+      "run_finish",
+    ]);
+    expect(records.at(-1)).toMatchObject({ ok: false, error: "timed out", rounds: 7 });
+  });
+
+  it("stamps every record with elapsed time so a slow round is visible", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1", new Date(Date.now() - 5_000));
+    log.event({ type: "tool_execution_start", toolName: "add_reminder" });
+    const elapsed = readRecords(dataDir).map((record) => record["elapsedMs"] as number);
+    expect(elapsed[0]).toBe(0);
+    expect(elapsed[1]).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it("drops the bulky fields that other lines already cover", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    log.event({
+      type: "approval_required",
+      toolName: "run_shell",
+      message: "rm -rf build",
+      previewDiff: "d".repeat(10_000),
+    });
+    const record = readRecords(dataDir)[1] as Record<string, unknown>;
+    expect(record["message"]).toBe("rm -rf build");
+    expect(record).not.toHaveProperty("previewDiff");
+  });
+
+  it("keeps a conversation's turns sorted and never collides", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    createRunLog(dataDir, "chat-1", new Date("2026-08-24T10:00:00Z")).finish({ ok: true });
+    createRunLog(dataDir, "chat-1", new Date("2026-08-24T11:00:00Z")).finish({ ok: true });
+    const files = readdirSync(join(dataDir, "logs", "runs")).sort();
+    expect(files).toHaveLength(2);
+    expect(files[0]).toContain("10-00-00");
+    expect(files[1]).toContain("11-00-00");
+    // Nothing a shell would need quoting for.
+    for (const file of files) expect(file).not.toContain(":");
+  });
+
+  it("sanitises a conversation key that is not filename-safe", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    createRunLog(dataDir, "../../etc/passwd").finish({ ok: true });
+    const files = readdirSync(join(dataDir, "logs", "runs"));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toStartWith("______etc_passwd-");
+  });
+
+  it("never throws when the directory cannot be created", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    // A file where the log directory needs to be.
+    const log = createRunLog(
+      join(dataDir, "logs", "runs", "blocked", "..", "..", "..", "\0bad"),
+      "chat-1",
+    );
+    expect(() => {
+      log.event({ type: "tools_detected" });
+      log.finish({ ok: true });
+    }).not.toThrow();
+  });
+});
+
+describe("nullRunLog", () => {
+  it("accepts everything and writes nothing", () => {
+    const log = nullRunLog();
+    expect(() => {
+      log.event({ type: "anything" });
+      log.finish({ ok: true });
+    }).not.toThrow();
+    expect(log.path).toBe("");
+  });
+});
+
+describe("createRunLog coalescing and retention", () => {
+  it("collapses a run of deltas into one line with counts", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    for (const word of ["Let", " me", " check", " the", " time"]) {
+      log.event({ type: "thinking_chunk", content: word });
+    }
+    log.event({ type: "tool_execution_start", toolName: "add_reminder" });
+    log.finish({ ok: true });
+
+    const records = readRecords(dataDir);
+    expect(records.map((record) => record["type"])).toEqual([
+      "run_start",
+      "thinking_chunk",
+      "tool_execution_start",
+      "run_finish",
+    ]);
+    expect(records[1]).toMatchObject({ chunks: 5, characters: 21 });
+    expect(records[1]).toHaveProperty("streamedMs");
+  });
+
+  it("keeps separate runs of deltas separate, in arrival order", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    log.event({ type: "thinking_chunk", content: "aa" });
+    log.event({ type: "text_chunk", delta: "b" });
+    log.event({ type: "thinking_chunk", content: "cc" });
+    log.finish({ ok: true });
+    const records = readRecords(dataDir);
+    expect(records.map((record) => record["type"])).toEqual([
+      "run_start",
+      "thinking_chunk",
+      "text_chunk",
+      "thinking_chunk",
+      "run_finish",
+    ]);
+    expect(records[2]).toMatchObject({ chunks: 1, characters: 1 });
+  });
+
+  it("a runaway generation costs one line, not thousands", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    for (let index = 0; index < 9_190; index += 1) {
+      log.event({ type: "thinking_chunk", content: "tok" });
+    }
+    log.finish({ ok: false, error: "timed out" });
+    const records = readRecords(dataDir);
+    expect(records).toHaveLength(3);
+    expect(records[1]).toMatchObject({ chunks: 9_190, characters: 27_570 });
+  });
+
+  it("prunes old runs so a long-lived deploy does not grow without bound", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const base = Date.parse("2026-08-24T10:00:00Z");
+    for (let index = 0; index < 210; index += 1) {
+      createRunLog(dataDir, "chat-1", new Date(base + index * 60_000)).finish({ ok: true });
+    }
+    const files = readdirSync(join(dataDir, "logs", "runs"));
+    expect(files.length).toBeLessThanOrEqual(201);
+    // The newest survives, the oldest is gone.
+    expect(files.some((name) => name.includes("T10-00-00"))).toBe(false);
+    // 209 minutes after 10:00 is 13:29.
+    expect(files.some((name) => name.includes("T13-29-00"))).toBe(true);
+  });
+});

--- a/integrations/shared/run-log.ts
+++ b/integrations/shared/run-log.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview Per-turn NDJSON record of what a bridge run actually did.
+ *
+ * A bridge already parses jazz's whole event stream to drive its progress
+ * message and then discards it. That is fine until a run misbehaves: a 15-minute
+ * agentic loop left one Telegram API error in `docker logs` and nothing about
+ * the tool calls or model rounds that consumed it, and the conversation
+ * transcript is only written when a run *completes*, so a run that times out
+ * leaves no trace at all. Writing the stream we have already decoded costs one
+ * append per event and is the difference between diagnosing a stuck run in one
+ * command and reconstructing it from the model server's logs.
+ *
+ * Appends are fire-and-forget: a logging failure must never interrupt a run, so
+ * every error is swallowed after the first, which is reported once.
+ */
+
+import { appendFileSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Events whose payload is bulky and already summarised by other lines. */
+const OMITTED_FIELDS = ["accumulated", "previewDiff"] as const;
+
+/**
+ * Deltas arrive one per token-ish chunk. Written individually they dominate the
+ * file — a single runaway generation produced over nine thousand of them — for no
+ * diagnostic gain, since what a reader needs is when the stream started, how much
+ * came out and how long it took. They are counted and flushed as one line.
+ */
+const COALESCED_TYPES = new Set(["thinking_chunk", "text_chunk"]);
+
+/** Run logs to keep per bridge; older ones are removed as new runs start. */
+const RUNS_RETAINED = 200;
+
+export interface RunLog {
+  /** Record one event from the jazz stream. */
+  event: (event: Record<string, unknown>) => void;
+  /** Record the run's outcome, including a timeout or crash. */
+  finish: (outcome: Record<string, unknown>) => void;
+  /** Path written to, for a bridge that wants to mention it. */
+  readonly path: string;
+}
+
+/** A no-op log, so callers never branch on whether logging is enabled. */
+export function nullRunLog(): RunLog {
+  return { event: () => {}, finish: () => {}, path: "" };
+}
+
+/**
+ * Drop the oldest logs beyond the retention count. Names are timestamped, so a
+ * lexical sort is chronological and no file needs to be stat-ed.
+ */
+function pruneOldRuns(directory: string): void {
+  try {
+    const files = readdirSync(directory)
+      .filter((name) => name.endsWith(".ndjson"))
+      .sort();
+    for (const name of files.slice(0, Math.max(0, files.length - RUNS_RETAINED))) {
+      rmSync(join(directory, name), { force: true });
+    }
+  } catch {
+    // Retention is housekeeping; failing to prune must not fail a run.
+  }
+}
+
+/**
+ * Open a run log under `<dataDir>/logs/runs/`. The name carries the
+ * conversation and the start time so a chat's turns sort chronologically and
+ * two concurrent runs in the same chat cannot collide.
+ */
+export function createRunLog(
+  dataDir: string,
+  conversationKey: string,
+  startedAt: Date = new Date(),
+): RunLog {
+  const directory = join(dataDir, "logs", "runs");
+  // Colons are legal on the filesystems this runs on but awkward to type in a
+  // shell, and this path exists to be opened by a human in a hurry.
+  const stamp = startedAt.toISOString().replace(/[:.]/g, "-");
+  const safeKey = conversationKey.replace(/[^A-Za-z0-9_-]/g, "_");
+  const path = join(directory, `${safeKey}-${stamp}.ndjson`);
+
+  let broken = false;
+  const append = (record: Record<string, unknown>): void => {
+    if (broken) return;
+    try {
+      appendFileSync(path, `${JSON.stringify(record)}\n`);
+    } catch (error) {
+      broken = true;
+      console.error(`Run log ${path} disabled after write failure: ${String(error)}`);
+    }
+  };
+
+  try {
+    mkdirSync(directory, { recursive: true });
+  } catch (error) {
+    console.error(`Run log directory ${directory} unavailable: ${String(error)}`);
+    return nullRunLog();
+  }
+
+  pruneOldRuns(directory);
+
+  const startedMs = startedAt.getTime();
+  append({ at: startedAt.toISOString(), elapsedMs: 0, type: "run_start", conversationKey });
+
+  // The run of deltas currently being counted, flushed when anything else
+  // happens so the file keeps the order the events arrived in.
+  let pending: { type: string; chunks: number; characters: number; firstMs: number } | undefined;
+
+  const now = (): Record<string, unknown> => ({
+    at: new Date().toISOString(),
+    elapsedMs: Date.now() - startedMs,
+  });
+
+  const flush = (): void => {
+    if (pending === undefined) return;
+    const { type, chunks, characters, firstMs } = pending;
+    pending = undefined;
+    append({
+      ...now(),
+      type,
+      chunks,
+      characters,
+      // How long the model spent streaming this run of deltas, which is the
+      // number that tells a slow round apart from a long one.
+      streamedMs: Date.now() - firstMs,
+    });
+  };
+
+  return {
+    path,
+    event: (event) => {
+      const type = typeof event["type"] === "string" ? (event["type"] as string) : "unknown";
+      if (COALESCED_TYPES.has(type)) {
+        const delta = event["content"] ?? event["delta"];
+        const length = typeof delta === "string" ? delta.length : 0;
+        if (pending?.type === type) {
+          pending.chunks += 1;
+          pending.characters += length;
+        } else {
+          flush();
+          pending = { type, chunks: 1, characters: length, firstMs: Date.now() };
+        }
+        return;
+      }
+      flush();
+      const record: Record<string, unknown> = now();
+      for (const [key, value] of Object.entries(event)) {
+        if ((OMITTED_FIELDS as readonly string[]).includes(key)) continue;
+        record[key] = value;
+      }
+      append(record);
+    },
+    finish: (outcome) => {
+      flush();
+      append({ ...now(), type: "run_finish", ...outcome });
+    },
+  };
+}

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -290,12 +290,21 @@ cd integrations/telegram-bot && docker compose -p jazz-telegram up -d --build
 ```
 
 **Nightly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
-rebuilds only if it changed, and rolls back if the new build isn't healthy.
-Install it (as the deploy user):
+rebuilds only if it changed, and rolls back if the new build fails to build or
+isn't healthy. Install it (as the deploy user):
 
 ```sh
 (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/telegram-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
+
+Anything needing a human is also sent to the bridge's own chat via `notify.sh`,
+because a nightly cron failure that only appends to a logfile is invisible: a
+checkout left on a feature branch silently skipped every update for over two
+weeks before anyone noticed. If the checkout isn't on `main`, the script parks it
+back there — stashing tracked edits (untracked files such as a local
+`docker-compose.override.yml` are left alone) and reporting both the stash and any
+commits left behind on the old branch by name, so nothing goes quietly missing.
+Set `JAZZ_DEPLOY_BRANCH` to track something other than `main`.
 
 It tracks `main` (bleeding edge); the health-gated rollback guards against a bad
 commit. Check `~/jazz-autoupdate.log` for the run history.

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -302,6 +302,13 @@ isn't healthy. Install it (as the deploy user):
 (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/telegram-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
 
+**Run logs:** every turn appends an NDJSON record of the jazz event stream to
+`<JAZZ_HOME>/logs/runs/<conversation>-<timestamp>.ndjson`, written as the run
+happens rather than when it finishes — so a run that times out still leaves a
+trace. Each line carries elapsed time, token deltas are collapsed into one line
+per stream with a character count and duration, and the last line is the outcome
+with the number of model rounds. The newest 200 runs per bridge are kept.
+
 Anything needing a human is also sent to the bridge's own chat via `notify.sh`,
 because a nightly cron failure that only appends to a logfile is invisible: a
 checkout left on a feature branch silently skipped every update for over two

--- a/integrations/telegram-bot/README.md
+++ b/integrations/telegram-bot/README.md
@@ -85,6 +85,11 @@ the nearest pharmacy" → "🧭 Directions", "🕒 Opening hours", "🔍 Go deep
 one sends it as your next message. Answers appear instantly with static
 `🔍 Go deeper` / `✂️ Shorter` buttons that upgrade to the contextual set a beat
 later; set `JAZZ_TELEGRAM_DYNAMIC_CTA=0` to keep only the static ones.
+The 💭 line on the progress bubble is only the tail of the model's current
+thought, and that bubble is replaced when the answer lands — so the full
+reasoning follows the answer as collapsed **Reasoning** quotes you tap to
+expand. Very long runs are split across a few quotes, and the last one says
+how much was left out; set `JAZZ_TELEGRAM_SHOW_REASONING=0` to drop them.
 Set `JAZZ_DAILY_COST_CAP_USD` to cap known spend per UTC day (0 = no cap).
 If a completed run has no pricing metadata, its exact cost cannot be capped;
 the bot records it as unpriced and pauses later requests until the next UTC day.

--- a/integrations/telegram-bot/auto-update.sh
+++ b/integrations/telegram-bot/auto-update.sh
@@ -1,56 +1,11 @@
 #!/bin/sh
-# Nightly auto-update for the Jazz Telegram bridge.
-#
-# Fast-forwards the checkout to the latest origin/main, rebuilds only if it
-# actually changed, and rolls back to the previous commit if the new build
-# doesn't come up healthy. Safe to run from cron. Install (as the deploy user):
+# Nightly auto-update for the Jazz Telegram bridge. The logic is shared with the
+# other bridges; this only names which one. Install (as the deploy user):
 #
 #   (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/integrations/telegram-bot/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 #
 # Paths are derived from the script's own location, so it works wherever the
 # repo lives.
 set -eu
-
-PATH=/usr/local/bin:/usr/bin:/bin
-export PATH
-
 DIR=$(cd -- "$(dirname -- "$0")" && pwd)
-REPO=$(cd -- "$DIR/../.." && pwd)
-PROJECT=jazz-telegram
-STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-cd "$REPO"
-git fetch -q origin main
-PREV=$(git rev-parse HEAD)
-LATEST=$(git rev-parse origin/main)
-
-if [ "$PREV" = "$LATEST" ]; then
-  echo "$STAMP up-to-date ($PREV)"
-  exit 0
-fi
-
-echo "$STAMP updating ${PREV} -> ${LATEST}"
-# Fast-forward only: never silently discard local commits/divergence.
-git merge --ff-only origin/main
-
-cd "$DIR"
-docker compose -p "$PROJECT" up -d --build
-
-# Health gate — give it up to a minute to report healthy.
-attempt=0
-while [ "$attempt" -lt 12 ]; do
-  status=$(docker inspect -f '{{.State.Health.Status}}' "$PROJECT" 2>/dev/null || echo none)
-  if [ "$status" = "healthy" ]; then
-    echo "$STAMP updated to ${LATEST} (healthy)"
-    exit 0
-  fi
-  attempt=$((attempt + 1))
-  sleep 5
-done
-
-echo "$STAMP update to ${LATEST} did not become healthy — rolling back to ${PREV}"
-cd "$REPO"
-git reset --hard "$PREV"
-cd "$DIR"
-docker compose -p "$PROJECT" up -d --build
-exit 1
+exec "$DIR/../shared/auto-update.sh" "$DIR" jazz-telegram

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -45,12 +45,17 @@ import {
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
 import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
 import { reasoningSnippet, splitReasoning } from "../shared/reasoning";
+import { createRunLog, type RunLog } from "../shared/run-log";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const GETUPDATES_TIMEOUT_SECONDS = 30;
 const POLL_ERROR_BACKOFF_MS = 5_000;
 const ALLOWED_UPDATES = ["message", "callback_query"];
 // Telegram rate-limits message edits; don't refresh the progress bubble faster.
+// The text the progress bubble is created with. The reporter starts from it so
+// its first render is not sent as an edit to identical content, which Telegram
+// rejects with a 400 on essentially every run.
+const PROGRESS_INITIAL_TEXT = "🤔 <b>Working…</b>";
 const PROGRESS_MIN_INTERVAL_MS = 2_000;
 const PROGRESS_MAX_TOOLS_SHOWN = 8;
 // The reasoning log is HTML-escaped into an expandable quote before it is
@@ -605,13 +610,15 @@ function createProgressReporter(
   chatId: number,
   messageId: number,
   runToken: string,
+  runLog: RunLog,
 ) {
   const tools: string[] = [];
   const subagents: string[] = [];
   const declined: string[] = [];
   let reasoning = "";
   let writing = false;
-  let lastText = "";
+  let rounds = 0;
+  let lastText = PROGRESS_INITIAL_TEXT;
   let lastEditAt = 0;
   let editing = false;
 
@@ -628,6 +635,9 @@ function createProgressReporter(
     for (const tool of declined) {
       lines.push(`⛔ <code>${escapeHtml(tool)}</code> declined (needs approval)`);
     }
+    // A run that goes round and round looks identical to a slow one from the
+    // outside; the count is what makes a loop visible without reading logs.
+    if (rounds > 1) lines.push(`↻ round ${rounds}`);
     if (writing) lines.push("✍️ writing the answer…");
     return lines.join("\n");
   };
@@ -653,7 +663,12 @@ function createProgressReporter(
 
   return {
     onEvent(event: JazzEvent): void {
+      runLog.event(event as unknown as Record<string, unknown>);
       switch (event.type) {
+        case "tools_detected":
+          // One per model response that asked for tools, so one per loop round.
+          rounds += 1;
+          break;
         case "thinking_chunk":
           // Accumulate raw so a lone-space chunk isn't trimmed away (which would
           // glue the surrounding words); normalization happens at render time.
@@ -682,6 +697,7 @@ function createProgressReporter(
     // Final edit drops the Cancel button (empty keyboard).
     finish: (summary: string): Promise<void> => edit(summary, { inline_keyboard: [] }),
     toolsUsed: (): string[] => [...new Set(tools)],
+    rounds: (): number => rounds,
     // The progress bubble only ever showed a rolling tail; this is everything
     // the model thought, for the expandable log attached to the answer.
     reasoningLog: (): string => reasoning,
@@ -925,14 +941,18 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
   // sent as a *new* message so it pushes a notification (edits don't).
   const sent = (await callTelegram(config, "sendMessage", {
     chat_id: chatId,
-    text: "🤔 <b>Working…</b>",
+    text: PROGRESS_INITIAL_TEXT,
     parse_mode: "HTML",
     reply_markup: cancelKeyboard(runToken),
   })) as { result?: { message_id?: number } } | undefined;
   const messageId = sent?.result?.message_id;
+  // Opened before the run so a crash or timeout still leaves a record: the
+  // conversation transcript is only written once a run completes.
+  const runLog = createRunLog(config.jazzHome, conversationKey(config.jazzHome, chatId));
+  let runLogged = false;
   const reporter =
     typeof messageId === "number"
-      ? createProgressReporter(config, chatId, messageId, runToken)
+      ? createProgressReporter(config, chatId, messageId, runToken, runLog)
       : undefined;
 
   try {
@@ -944,6 +964,14 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       runToken,
     );
     const cancelled = activeRuns.get(runToken)?.cancelled ?? false;
+    runLog.finish({
+      ok: envelope.ok,
+      cancelled,
+      rounds: reporter?.rounds() ?? 0,
+      toolsUsed: reporter?.toolsUsed() ?? [],
+      ...(envelope.ok ? {} : { error: envelope.error }),
+    });
+    runLogged = true;
 
     if (cancelled) {
       await reporter?.finish("⏹ <b>Cancelled</b>");
@@ -997,6 +1025,16 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       await sendReply(config, chatId, `⚠️ ${escapeHtml(envelope.error)}`);
     }
   } finally {
+    // A throw anywhere above would otherwise leave the log with no outcome line,
+    // which is exactly the run someone will come looking for.
+    if (!runLogged) {
+      runLog.finish({
+        ok: false,
+        error: "handler threw before the run reported an outcome",
+        rounds: reporter?.rounds() ?? 0,
+        toolsUsed: reporter?.toolsUsed() ?? [],
+      });
+    }
     // Always release the run slot, even if runJazz or a reply throws.
     activeRuns.delete(runToken);
     // Sweep any approvals left pending for this run (e.g. the run finished or

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -36,9 +36,15 @@ import { buildMediaPrompt, downloadTelegramFile, type TelegramFileRef } from "./
 import { withReplyContext } from "./quotes";
 import { startReminderSweep } from "./reminders";
 import { conversationKey, isIncognito, setIncognito, startNewConversation } from "./sessions";
-import { escapeHtml, markdownToTelegramHtml, splitForTelegram } from "./telegram-html";
+import {
+  escapeHtml,
+  expandableBlockquote,
+  markdownToTelegramHtml,
+  splitForTelegram,
+} from "./telegram-html";
 import { formatWhen, hasChatTz, isValidTimeZone, setTzForChat, tzForChat } from "./timezone";
 import { dailyCostCapBlockReason, recordUsage, todayUsage } from "./usage";
+import { reasoningSnippet, splitReasoning } from "../shared/reasoning";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const GETUPDATES_TIMEOUT_SECONDS = 30;
@@ -47,7 +53,14 @@ const ALLOWED_UPDATES = ["message", "callback_query"];
 // Telegram rate-limits message edits; don't refresh the progress bubble faster.
 const PROGRESS_MIN_INTERVAL_MS = 2_000;
 const PROGRESS_MAX_TOOLS_SHOWN = 8;
-const PROGRESS_REASONING_CHARS = 180;
+// The reasoning log is HTML-escaped into an expandable quote before it is
+// sent. Reasoning is model prose, so escaping adds a few percent at most, but
+// budget under the 3500 the answer splitter uses to keep the escaped message
+// clear of Telegram's 4096 hard limit without needing to split mid-tag.
+const REASONING_PART_CHARS = 2_800;
+// A long agentic run would otherwise post a wall of collapsed quotes; past
+// this the tail is dropped and the final part says how much.
+const REASONING_MAX_PARTS = 4;
 
 const BRIDGE_STARTED_AT = Date.now();
 // In-flight runs keyed by a per-run token, so the ⏹ Cancel button can kill the
@@ -95,6 +108,12 @@ interface BridgeConfig {
   readonly geocodeUrl: string;
   /** Generate contextual follow-up CTAs per answer (a second short LLM call). */
   readonly dynamicCta: boolean;
+  /**
+   * Attach the run's full reasoning under the answer as collapsed,
+   * tap-to-expand quotes. The live progress line only ever shows a rolling
+   * tail, and that bubble is overwritten when the answer lands.
+   */
+  readonly showReasoning: boolean;
   /**
    * Public HTTPS origin this bridge's own HTTP server is reachable at, used to
    * build Web App button URLs for `create_web_app`'s "interactive" mode (e.g.
@@ -195,6 +214,9 @@ function loadConfig(): BridgeConfig {
     geocodeUrl: process.env["NOMINATIM_BASE_URL"]?.trim() ?? "https://nominatim.openstreetmap.org",
     dynamicCta: !["0", "false", "off"].includes(
       process.env["JAZZ_TELEGRAM_DYNAMIC_CTA"]?.trim().toLowerCase() ?? "",
+    ),
+    showReasoning: !["0", "false", "off"].includes(
+      process.env["JAZZ_TELEGRAM_SHOW_REASONING"]?.trim().toLowerCase() ?? "",
     ),
     webAppBaseUrl,
   };
@@ -578,20 +600,6 @@ function formatUsageLines(usage: JazzSuccessEnvelope["tokenUsage"]): string | un
   ].join("\n");
 }
 
-/**
- * Show the latest slice of a streaming thought. Short thoughts render whole;
- * longer ones show the tail from a word boundary with a leading ellipsis, so
- * the line reads as a continuation rather than a chopped-off first word.
- */
-function reasoningSnippet(reasoning: string): string {
-  const normalized = reasoning.replace(/\s+/g, " ").trim();
-  if (normalized.length <= PROGRESS_REASONING_CHARS) return normalized;
-  let tail = normalized.slice(-PROGRESS_REASONING_CHARS).trimStart();
-  const firstSpace = tail.indexOf(" ");
-  if (firstSpace > 0 && firstSpace < 40) tail = tail.slice(firstSpace + 1);
-  return `… ${tail}`;
-}
-
 function createProgressReporter(
   config: BridgeConfig,
   chatId: number,
@@ -674,7 +682,45 @@ function createProgressReporter(
     // Final edit drops the Cancel button (empty keyboard).
     finish: (summary: string): Promise<void> => edit(summary, { inline_keyboard: [] }),
     toolsUsed: (): string[] => [...new Set(tools)],
+    // The progress bubble only ever showed a rolling tail; this is everything
+    // the model thought, for the expandable log attached to the answer.
+    reasoningLog: (): string => reasoning,
   };
+}
+
+/**
+ * Attach a run's full reasoning under the answer as collapsed, tap-to-expand
+ * quotes. Sent as its own messages rather than appended to the answer so the
+ * answer keeps its follow-up buttons and its own splitting, and sent through
+ * callTelegram rather than sendReply so the answer splitter can never cut one
+ * of these in the middle of a blockquote tag.
+ */
+async function sendReasoningLog(
+  config: BridgeConfig,
+  chatId: number,
+  reasoning: string,
+): Promise<void> {
+  const parts = splitReasoning(reasoning, {
+    budget: REASONING_PART_CHARS,
+    maxParts: REASONING_MAX_PARTS,
+  });
+  for (const [index, part] of parts.entries()) {
+    const counter = parts.length > 1 ? ` (${index + 1}/${parts.length})` : "";
+    const rendered = await callTelegram(config, "sendMessage", {
+      chat_id: chatId,
+      text: `💭 <b>Reasoning</b>${counter}\n${expandableBlockquote(part)}`,
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+    if (!isOkResponse(rendered)) {
+      // Older Bot API versions reject `expandable`; the thinking still matters
+      // more than the affordance, so fall back to plain text.
+      await callTelegram(config, "sendMessage", {
+        chat_id: chatId,
+        text: `💭 Reasoning${counter}\n${part}`,
+      });
+    }
+  }
 }
 
 // --- Human approval --------------------------------------------------------
@@ -939,6 +985,9 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
       });
       if (config.dynamicCta && answerMessageId !== undefined) {
         void upgradeToDynamicCtas(config, chatId, answerMessageId, text, envelope.answer);
+      }
+      if (config.showReasoning) {
+        await sendReasoningLog(config, chatId, reporter?.reasoningLog() ?? "");
       }
       if (envelope.webApp) {
         await deliverWebApp(config, chatId, envelope.webApp);

--- a/integrations/telegram-bot/notify.sh
+++ b/integrations/telegram-bot/notify.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Send one operational message to the bridge's own Telegram chat.
+#
+# Called by auto-update.sh so a failed or surprising deploy reaches a human
+# instead of only a logfile. Reads the same .env the bridge runs on, and exits
+# non-zero on any problem so the caller can note it without aborting.
+set -eu
+
+DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+MESSAGE=${1:?usage: notify.sh <message>}
+ENV_FILE="${DIR}/.env"
+
+[ -f "$ENV_FILE" ] || { echo "notify: no ${ENV_FILE}" >&2; exit 1; }
+
+# Read the two keys directly rather than sourcing: .env holds secrets with
+# characters a shell would happily interpret.
+token=$(sed -n 's/^TELEGRAM_BOT_TOKEN=//p' "$ENV_FILE" | tail -1 | tr -d '"'"'"' \r')
+# The first allowed chat is the operator's; the bot cannot message anyone else.
+chat=$(sed -n 's/^TELEGRAM_ALLOWED_CHAT_IDS=//p' "$ENV_FILE" | tail -1 |
+  tr -d '"'"'"' \r' | cut -d, -f1)
+
+[ -n "$token" ] || { echo "notify: TELEGRAM_BOT_TOKEN not set" >&2; exit 1; }
+[ -n "$chat" ] || { echo "notify: TELEGRAM_ALLOWED_CHAT_IDS not set" >&2; exit 1; }
+
+# --data-urlencode keeps newlines and any markup in the message intact, and no
+# parse_mode is sent so nothing in it can be read as broken formatting.
+curl -sS -o /dev/null -m 20 -X POST \
+  "https://api.telegram.org/bot${token}/sendMessage" \
+  --data-urlencode "chat_id=${chat}" \
+  --data-urlencode "text=🛠 ${MESSAGE}" \
+  --data-urlencode "disable_notification=false"

--- a/integrations/telegram-bot/telegram-html.test.ts
+++ b/integrations/telegram-bot/telegram-html.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { expandableBlockquote } from "./telegram-html";
+
+describe("expandableBlockquote", () => {
+  it("wraps text in a collapsed, tap-to-expand quote", () => {
+    expect(expandableBlockquote("thinking out loud")).toBe(
+      "<blockquote expandable>thinking out loud</blockquote>",
+    );
+  });
+
+  it("escapes markup so reasoning about HTML can't break the message", () => {
+    const wrapped = expandableBlockquote("use <b> & </blockquote>");
+    expect(wrapped).toBe(
+      "<blockquote expandable>use &lt;b&gt; &amp; &lt;/blockquote&gt;</blockquote>",
+    );
+  });
+});

--- a/integrations/telegram-bot/telegram-html.ts
+++ b/integrations/telegram-bot/telegram-html.ts
@@ -91,3 +91,13 @@ export function splitForTelegram(text: string): string[] {
   chunks.push(remaining);
   return chunks.map((chunk) => chunk.trim()).filter((chunk) => chunk.length > 0);
 }
+
+/**
+ * Wrap already-plain text in a collapsed, tap-to-expand quote (Bot API 7.4+).
+ * Telegram shows the first few lines and hides the rest behind an "expand"
+ * affordance, which is what makes it safe to attach a long reasoning log to a
+ * chat without it dominating the conversation.
+ */
+export function expandableBlockquote(text: string): string {
+  return `<blockquote expandable>${escapeHtml(text)}</blockquote>`;
+}


### PR DESCRIPTION
## What & why

Three things that all came out of one incident: a Telegram run spent fifteen
minutes looping on "remind me to bring shoes to my podologue appointment" and
almost nothing about it was recoverable afterwards.

**The deploy box had been serving stale code for over two weeks.** The nightly
updater fast-forwarded whatever branch was checked out; parked on a feature
branch that can never succeed, `set -eu` aborted, and the only trace was a line in
a logfile. It now parks the checkout back on the deploy branch and reports
anything surprising to the bridge's own chat through a new per-bridge
`notify.sh` — a cron job's stdout has no reader. Nothing is discarded: only
tracked edits are stashed, and commits left behind on the old branch are named in
the message. Two more silent failures are fixed alongside — a failed
`docker compose up` used to abort *after* the fast-forward with no rollback and no
message, and `PATH` was replaced rather than extended, hiding a `docker` installed
outside the standard directories.

**Runs are now recorded.** Both bridges decoded jazz's whole event stream to drive
their progress message and then discarded it, and the conversation transcript is
only written when a run *completes* — so a run that times out left nothing at all.
Each turn now appends the stream to `<JAZZ_HOME>/logs/runs/`, opened before the run
so a timeout still lands an outcome line. Token deltas collapse to one line per
stream with a character count and duration, because written individually a single
runaway generation produced over nine thousand lines; the newest 200 runs are kept.
Logging never interrupts a run.

**Loops are visible in the chat.** The progress message counts model rounds and
shows them past the first, so going round and round no longer looks identical to
being slow. The full reasoning is also kept and attached to the answer instead of
being truncated to a 180-character tail.

## Breaking changes / migration

None required — the per-bridge `auto-update.sh` paths are unchanged, so existing
crontab entries keep working. For failure notifications the bridge's `.env` needs
credentials it already has (`TELEGRAM_ALLOWED_CHAT_IDS`, or
`DISCORD_ALLOWED_CHANNEL_IDS`); without them the update still runs and just logs.
`JAZZ_DEPLOY_BRANCH` overrides the tracked branch.

One deploy note: this cannot reach a stuck box *through* auto-update, since the
broken copy is the one that runs. That checkout needs moving to `main` by hand once.

## How to verify

- On a checkout parked on a feature branch with an unpushed commit, run
  `auto-update.sh`: it should land on `main` and name that commit as left behind.
- Repeat with an untracked `docker-compose.override.yml` present — it must survive,
  or the deploy loses whatever it configures.
- Repeat with uncommitted tracked edits: recoverable from `git stash list`, not gone.
- Point it at a commit that fails to build: it should roll back and say so, not exit
  with the checkout already moved.
- Send a bridge a message and check `<JAZZ_HOME>/logs/runs/` — one file, ~10 lines
  for a normal turn, ending in `run_finish` with a round count.
- Send something that makes the agent loop and confirm the progress message starts
  showing `↻ round N`.
