### PR TITLE
fix(agent): stop stuck runs — stalled streams, phantom answers, and questions a bridge can actually ask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/**"
       - "scripts/**"
+      - "integrations/**"
       - "package.json"
       - "bun.lock"
       - "tsconfig*"
@@ -19,6 +20,7 @@ on:
     paths:
       - "src/**"
       - "scripts/**"
+      - "integrations/**"
       - "package.json"
       - "bun.lock"
       - "tsconfig*"
@@ -91,6 +93,14 @@ jobs:
 
       - name: Lint
         run: bun run lint --no-color
+
+      # Neither typechecker ran in CI, which is how both drifted: the test program
+      # had eighteen errors on main and nothing was failing.
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Typecheck tests
+        run: bun run test:typecheck
 
       - name: Build
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,6 @@ jobs:
       - name: Lint
         run: bun run lint --no-color
 
-      # Neither typechecker ran in CI, which is how both drifted: the test program
-      # had eighteen errors on main and nothing was failing.
       - name: Typecheck
         run: bun run typecheck
 

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -197,7 +197,7 @@ wherever it can be: **stdin being a terminal is enough on its own**, so running 
 by hand needs no flag — the question is printed and you answer by typing a line, either the
 number of an option or something of your own.
 
-```
+```text
 ❓ Which database?
   1) Postgres — the default
   2) SQLite

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -192,8 +192,21 @@ sees them, so it cannot spend a round on a question that will not be answered, a
 mistake a blank for a reply and act on it. A run in CI or cron that stopped to ask
 something would hang until its timeout for nobody's benefit.
 
-A caller that *can* put a question in front of a person passes `--interactive-stdin`. Then
-the tools are available, and a question becomes a line on the event stream:
+Where a human *is* reachable, the tools come back. That is detected rather than declared
+wherever it can be: **stdin being a terminal is enough on its own**, so running `jazz run`
+by hand needs no flag — the question is printed and you answer by typing a line, either the
+number of an option or something of your own.
+
+```
+❓ Which database?
+  1) Postgres — the default
+  2) SQLite
+Answer (number, or type your own; empty to skip):
+```
+
+A chat bridge is the case that cannot be detected: through a pipe it looks exactly like a
+cron job. It declares itself with `--interactive-stdin`, and the question then becomes a
+line on the event stream instead of a prompt:
 
 ```json
 {"type":"user_input_required","requestId":"ui-1","question":"When is your appointment?",
@@ -216,6 +229,10 @@ take as long as they like.
 The question is never truncated, unlike other event payloads — a clipped option is one
 nobody can meaningfully choose. Both shipped chat bridges pass this flag and render the
 suggestions as buttons.
+
+`CI=true` overrides the terminal check, since some runners allocate a pty and a job that
+stops to ask something would wait out its timeout for nobody. An explicit
+`--interactive-stdin` still wins there, for a bridge running inside a pipeline.
 
 ---
 

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -184,6 +184,41 @@ rather keep the batch path and take tool events only.
 
 ---
 
+## Asking the human something
+
+An unattended run has nobody to ask, so by default the tools that solicit an answer —
+`ask_user_question`, `ask_file_picker` — are **not offered to the model at all**. It never
+sees them, so it cannot spend a round on a question that will not be answered, and cannot
+mistake a blank for a reply and act on it. A run in CI or cron that stopped to ask
+something would hang until its timeout for nobody's benefit.
+
+A caller that *can* put a question in front of a person passes `--interactive-stdin`. Then
+the tools are available, and a question becomes a line on the event stream:
+
+```json
+{"type":"user_input_required","requestId":"ui-1","question":"When is your appointment?",
+ "suggestions":[{"value":"today","label":"Today"},{"value":"tomorrow","label":"Tomorrow"}],
+ "allowCustom":true}
+```
+
+The run blocks until you write the answer back on **stdin**, exactly as approvals work:
+
+```json
+{"type":"user_input_response","requestId":"ui-1","response":"tomorrow"}
+```
+
+`response` should be one of the suggestions' `value` fields, though any string is accepted
+when `allowCustom` is true. An empty response is treated as no answer: the tool reports
+that it could not ask and the model is told to state an assumption or put the question in
+its reply instead. Time spent waiting does not count against `--timeout`, so a human can
+take as long as they like.
+
+The question is never truncated, unlike other event payloads — a clipped option is one
+nobody can meaningfully choose. Both shipped chat bridges pass this flag and render the
+suggestions as buttons.
+
+---
+
 ## Autonomy
 
 Unattended runs have nobody to ask, so `--approval-policy` decides in advance. Tools

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -527,6 +527,9 @@ async function runJazz(
       "--json",
       "--events",
       "tools,reasoning,text,approval,subagent",
+      // This bridge relays the agent's questions as buttons and writes the answer
+      // back on stdin, so the tools that ask one are worth having here.
+      "--interactive-stdin",
       "--agent",
       agentIdForChannel(channelId),
       "--approval-policy",

--- a/integrations/discord-bot/bridge.ts
+++ b/integrations/discord-bot/bridge.ts
@@ -527,8 +527,6 @@ async function runJazz(
       "--json",
       "--events",
       "tools,reasoning,text,approval,subagent",
-      // This bridge relays the agent's questions as buttons and writes the answer
-      // back on stdin, so the tools that ask one are worth having here.
       "--interactive-stdin",
       "--agent",
       agentIdForChannel(channelId),

--- a/integrations/shared/auto-update.sh
+++ b/integrations/shared/auto-update.sh
@@ -25,9 +25,8 @@ REPO=$(cd -- "$BRIDGE_DIR/../.." && pwd)
 STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 DEPLOY_BRANCH=${JAZZ_DEPLOY_BRANCH:-main}
 
-# Cron has no reader. Anything a human must act on goes to the bridge itself:
-# in a logfile nobody opens, weeks of nightly failures are indistinguishable
-# from an update that never needed to run.
+# Cron has no reader. Anything a human must act on goes to the bridge itself: in a
+# logfile, a nightly failure is indistinguishable from an update that was not needed.
 notify() {
   echo "$STAMP $1"
   if [ -x "$BRIDGE_DIR/notify.sh" ]; then
@@ -107,10 +106,9 @@ rollback() {
   deploy || notify "auto-update: rollback to ${PREV} also failed to start — the bridge is DOWN"
 }
 
-# An `up -d --build` that exits non-zero used to abort the script outright,
-# leaving the checkout fast-forwarded to a commit that never deployed, with no
-# rollback and nothing said. A failed build is the common case here, not a rare
-# one, so it gets the same treatment as a failed health check.
+# Without this, `set -e` would abort with the checkout already fast-forwarded to a
+# commit that never deployed. A failed build gets the same treatment as a failed
+# health check.
 if ! deploy; then
   notify "auto-update: build/start of ${LATEST} failed — rolling back to ${PREV}"
   rollback

--- a/integrations/shared/bridge-config.ts
+++ b/integrations/shared/bridge-config.ts
@@ -25,9 +25,8 @@ function nestedObject(config: JsonObject, key: string): JsonObject {
 /**
  * Apply the bridge-managed keys to `existing`, returning a new object.
  *
- * Only the managed keys are touched; everything else the operator put in the
- * file is passed through, because the data volume outlives the container and
- * writing the file wholesale discarded their settings on every restart.
+ * Only the managed keys are touched; everything else the operator put in the file
+ * is passed through, since the data volume outlives the container.
  *
  * A managed key whose variable is unset is *removed* rather than left behind, so
  * turning an integration off in the environment actually takes effect instead of

--- a/integrations/shared/run-log.test.ts
+++ b/integrations/shared/run-log.test.ts
@@ -165,3 +165,30 @@ describe("createRunLog coalescing and retention", () => {
     expect(files.some((name) => name.includes("T13-29-00"))).toBe(true);
   });
 });
+
+describe("createRunLog flush timer", () => {
+  it("writes buffered deltas even when no further event arrives", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    // A run that streams and then hangs: nothing else will ever arrive.
+    log.event({ type: "text_chunk", delta: "partial answer" });
+    expect(readRecords(dataDir).map((record) => record["type"])).toEqual(["run_start"]);
+
+    await new Promise((resolve) => setTimeout(resolve, 2_400));
+
+    const records = readRecords(dataDir);
+    expect(records.map((record) => record["type"])).toEqual(["run_start", "text_chunk"]);
+    expect(records[1]).toMatchObject({ chunks: 1, characters: 14 });
+    log.finish({ ok: false, error: "timed out" });
+  });
+
+  it("stops flushing once the run has finished", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runlog-"));
+    const log = createRunLog(dataDir, "chat-1");
+    log.event({ type: "text_chunk", delta: "done" });
+    log.finish({ ok: true });
+    const afterFinish = readRecords(dataDir).length;
+    await new Promise((resolve) => setTimeout(resolve, 2_400));
+    expect(readRecords(dataDir)).toHaveLength(afterFinish);
+  });
+});

--- a/integrations/shared/run-log.ts
+++ b/integrations/shared/run-log.ts
@@ -1,14 +1,10 @@
 /**
- * @fileoverview Per-turn NDJSON record of what a bridge run actually did.
+ * @fileoverview Per-turn NDJSON record of what a bridge run did.
  *
- * A bridge already parses jazz's whole event stream to drive its progress
- * message and then discards it. That is fine until a run misbehaves: a 15-minute
- * agentic loop left one Telegram API error in `docker logs` and nothing about
- * the tool calls or model rounds that consumed it, and the conversation
- * transcript is only written when a run *completes*, so a run that times out
- * leaves no trace at all. Writing the stream we have already decoded costs one
- * append per event and is the difference between diagnosing a stuck run in one
- * command and reconstructing it from the model server's logs.
+ * The conversation transcript is only written once a run completes, so a run that
+ * hangs or times out leaves no other trace. The event stream is already decoded to
+ * drive the progress message; recording it costs one append per event and is what
+ * makes a stuck run diagnosable without the model server's logs.
  *
  * Appends are fire-and-forget: a logging failure must never interrupt a run, so
  * every error is swallowed after the first, which is reported once.
@@ -21,10 +17,10 @@ import { join } from "node:path";
 const OMITTED_FIELDS = ["accumulated", "previewDiff"] as const;
 
 /**
- * Deltas arrive one per token-ish chunk. Written individually they dominate the
- * file — a single runaway generation produced over nine thousand of them — for no
- * diagnostic gain, since what a reader needs is when the stream started, how much
- * came out and how long it took. They are counted and flushed as one line.
+ * Deltas arrive one per token-ish chunk, thousands to a long generation. Written
+ * individually they dominate the file for no diagnostic gain: a reader needs when
+ * the stream started, how much came out and how long it took. Counted and flushed
+ * as one line.
  */
 const COALESCED_TYPES = new Set(["thinking_chunk", "text_chunk"]);
 
@@ -34,9 +30,8 @@ const RUNS_RETAINED = 200;
 /**
  * How long a run of deltas may stay buffered before it is written anyway.
  *
- * Without this the buffer is only flushed by the *next* event, so a run that
- * hangs mid-stream — the exact case this log exists for — ends with the buffered
- * deltas never written and its last line naming the event before them. Two
+ * The next event would otherwise be the only thing that flushes them, which loses
+ * the tail of any run that stalls mid-stream — the case this log exists for. Two
  * seconds keeps a healthy run to a handful of lines while making a stall visible
  * within one.
  */

--- a/integrations/shared/run-log.ts
+++ b/integrations/shared/run-log.ts
@@ -31,10 +31,24 @@ const COALESCED_TYPES = new Set(["thinking_chunk", "text_chunk"]);
 /** Run logs to keep per bridge; older ones are removed as new runs start. */
 const RUNS_RETAINED = 200;
 
+/**
+ * How long a run of deltas may stay buffered before it is written anyway.
+ *
+ * Without this the buffer is only flushed by the *next* event, so a run that
+ * hangs mid-stream — the exact case this log exists for — ends with the buffered
+ * deltas never written and its last line naming the event before them. Two
+ * seconds keeps a healthy run to a handful of lines while making a stall visible
+ * within one.
+ */
+const FLUSH_INTERVAL_MS = 2_000;
+
 export interface RunLog {
   /** Record one event from the jazz stream. */
   event: (event: Record<string, unknown>) => void;
-  /** Record the run's outcome, including a timeout or crash. */
+  /**
+   * Record the run's outcome, including a timeout or crash. Also releases the
+   * flush timer, so this must be called exactly once per run.
+   */
   finish: (outcome: Record<string, unknown>) => void;
   /** Path written to, for a bridge that wants to mention it. */
   readonly path: string;
@@ -126,6 +140,11 @@ export function createRunLog(
     });
   };
 
+  // Unref'd so a bridge process is never held open by a log, and cleared in
+  // finish() so a long-lived bridge does not accumulate one timer per turn.
+  const flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
+  flushTimer.unref?.();
+
   return {
     path,
     event: (event) => {
@@ -151,6 +170,7 @@ export function createRunLog(
       append(record);
     },
     finish: (outcome) => {
+      clearInterval(flushTimer);
       flush();
       append({ ...now(), type: "run_finish", ...outcome });
     },

--- a/integrations/shared/write-bridge-config.ts
+++ b/integrations/shared/write-bridge-config.ts
@@ -1,9 +1,8 @@
 /**
  * @fileoverview Apply the bridge-managed keys to a bridge's `config.json`.
  *
- * The entrypoints used to write this file wholesale, which silently discarded
- * anything the operator had put there — the data volume outlives the container,
- * so a hand-added provider block or tool setting vanished on the next restart.
+ * Merged rather than written wholesale: the data volume outlives the container, so
+ * anything the operator added by hand must survive a restart.
  *
  * Usage: bun write-bridge-config.ts <path-to-config.json>
  */
@@ -41,10 +40,9 @@ function readExistingConfig(path: string): JsonObject {
   return parsed as JsonObject;
 }
 
-// Ollama unloads a model after 5 minutes by default, so the first message after
-// a quiet spell pays a full cold load — minutes on a CPU-bound host, during
-// which the run emits no events at all and a bridge's progress bubble sits at
-// "Working…". Operators pointing a bridge at a local Ollama want it pinned.
+// Ollama unloads a model after 5 minutes by default, so the first message after a
+// quiet spell pays a full cold load — minutes on a CPU-bound host, emitting no
+// events while it happens.
 const { config, applied } = mergeBridgeConfig(readExistingConfig(configPath), {
   braveApiKey: process.env["BRAVE_API_KEY"]?.trim(),
   ollamaKeepAlive: process.env["JAZZ_OLLAMA_KEEP_ALIVE"]?.trim(),

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -859,8 +859,6 @@ async function runJazz(
       "--json",
       "--events",
       "tools,reasoning,text,approval,subagent",
-      // This bridge relays the agent's questions as buttons and writes the answer
-      // back on stdin, so the tools that ask one are worth having here.
       "--interactive-stdin",
       "--agent",
       agentIdForChat(chatId),
@@ -1650,8 +1648,6 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
       callback_query_id: callback.id,
       text: `Answered: ${answer}`.slice(0, 200),
     });
-    // Keep the question visible but retire the buttons, so the thread still
-    // reads as a question that was answered.
     await callTelegram(config, "editMessageReplyMarkup", {
       chat_id: chatId,
       message_id: messageId,

--- a/integrations/telegram-bot/bridge.ts
+++ b/integrations/telegram-bot/bridge.ts
@@ -79,6 +79,16 @@ const activeRuns = new Map<
 // `commandKey` (set only for execute_command approvals) is the binary name an
 // "Always allow" tap persists to autoApprovedCommands — present only when we
 // could parse one out, since not every approval is a shell command.
+/**
+ * Questions the agent is blocked on, keyed by the id it minted. The run is
+ * parked on stdin until one of these buttons is tapped, so an entry left behind
+ * would be a run that never finishes — they are swept when the run ends.
+ */
+const pendingUserInputs = new Map<
+  string,
+  { chatId: number; messageId: number; runToken: string; options: readonly string[] }
+>();
+
 const pendingApprovals = new Map<
   string,
   { chatId: number; messageId: number; runToken: string; commandKey?: string }
@@ -552,6 +562,10 @@ interface JazzEvent {
   readonly toolCallId?: string;
   readonly message?: string;
   readonly previewDiff?: string;
+  // `user_input_required`: the agent is blocked on a question for the human.
+  readonly requestId?: string;
+  readonly question?: string;
+  readonly suggestions?: readonly { value: string; label?: string; description?: string }[];
 }
 
 /** Read a byte stream and invoke onLine for each newline-delimited line. */
@@ -777,6 +791,55 @@ async function sendApprovalRequest(
   }
 }
 
+/**
+ * Put the agent's question in front of the human with one button per option.
+ *
+ * A new message rather than an edit of the progress bubble: the bubble is
+ * overwritten every couple of seconds and replaced by the answer, so a question
+ * living there would vanish before it could be read.
+ */
+async function sendUserInputRequest(
+  config: BridgeConfig,
+  chatId: number,
+  runToken: string,
+  event: JazzEvent,
+): Promise<void> {
+  const requestId = event.requestId;
+  const question = event.question?.trim();
+  if (requestId === undefined || !question) return;
+
+  const suggestions = event.suggestions ?? [];
+  const lines = ["❓ <b>The agent needs an answer</b>", escapeHtml(question)];
+  for (const suggestion of suggestions) {
+    if (suggestion.description) {
+      lines.push(
+        `• <b>${escapeHtml(suggestion.label ?? suggestion.value)}</b> — ${escapeHtml(suggestion.description)}`,
+      );
+    }
+  }
+
+  // The value is what the agent gets back; the label is only ever shown. Sending
+  // an index keeps the callback payload inside Telegram's 64-byte limit however
+  // long the option text is.
+  const buttons = suggestions.map((suggestion, index) => ({
+    text: (suggestion.label ?? suggestion.value).slice(0, 60),
+    callback_data: `q:${requestId}:${index}`,
+  }));
+  const rows: Record<string, unknown>[][] = buttons.map((button) => [button]);
+
+  const messageId = await sendReply(config, chatId, lines.join("\n"), {
+    markup: { inline_keyboard: rows },
+  });
+  if (typeof messageId === "number") {
+    pendingUserInputs.set(requestId, {
+      chatId,
+      messageId,
+      runToken,
+      options: suggestions.map((suggestion) => suggestion.value),
+    });
+  }
+}
+
 // --- Jazz invocation ------------------------------------------------------
 
 async function runJazz(
@@ -796,6 +859,9 @@ async function runJazz(
       "--json",
       "--events",
       "tools,reasoning,text,approval,subagent",
+      // This bridge relays the agent's questions as buttons and writes the answer
+      // back on stdin, so the tools that ask one are worth having here.
+      "--interactive-stdin",
       "--agent",
       agentIdForChat(chatId),
       "--approval-policy",
@@ -834,6 +900,11 @@ async function runJazz(
       if (event.type === "approval_required" && event.toolCallId) {
         void sendApprovalRequest(config, chatId, runToken, event).catch((error) =>
           console.error(`Failed to send approval request for chat ${chatId}: ${String(error)}`),
+        );
+      }
+      if (event.type === "user_input_required" && event.requestId) {
+        void sendUserInputRequest(config, chatId, runToken, event).catch((error) =>
+          console.error(`Failed to send question for chat ${chatId}: ${String(error)}`),
         );
       }
     } catch {
@@ -1041,6 +1112,9 @@ async function handleMessage(config: BridgeConfig, chatId: number, text: string)
     // errored before a human tapped Accept/Reject).
     for (const [toolCallId, pending] of pendingApprovals) {
       if (pending.runToken === runToken) pendingApprovals.delete(toolCallId);
+    }
+    for (const [requestId, pending] of pendingUserInputs) {
+      if (pending.runToken === runToken) pendingUserInputs.delete(requestId);
     }
   }
 }
@@ -1545,6 +1619,44 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
         reply_markup: { inline_keyboard: [] },
       }).catch(() => undefined);
     }
+    return;
+  }
+
+  if (kind === "q") {
+    const requestId = parts[1] ?? "";
+    const optionIndex = Number.parseInt(parts[2] ?? "", 10);
+    const pending = pendingUserInputs.get(requestId);
+    const run = pending ? activeRuns.get(pending.runToken) : undefined;
+    const answer = pending?.options[optionIndex];
+    if (!pending || !run || answer === undefined) {
+      await callTelegram(config, "answerCallbackQuery", {
+        callback_query_id: callback.id,
+        text: "This question already expired or the run finished.",
+      });
+      return;
+    }
+    pendingUserInputs.delete(requestId);
+    try {
+      // The run is parked on stdin waiting for exactly this line; flush rather
+      // than let Bun's FileSink hold it until the buffer fills.
+      run.child.stdin.write(
+        `${JSON.stringify({ type: "user_input_response", requestId, response: answer })}\n`,
+      );
+      run.child.stdin.flush();
+    } catch (error) {
+      console.error(`Failed to write user input response: ${String(error)}`);
+    }
+    await callTelegram(config, "answerCallbackQuery", {
+      callback_query_id: callback.id,
+      text: `Answered: ${answer}`.slice(0, 200),
+    });
+    // Keep the question visible but retire the buttons, so the thread still
+    // reads as a question that was answered.
+    await callTelegram(config, "editMessageReplyMarkup", {
+      chat_id: chatId,
+      message_id: messageId,
+      reply_markup: { inline_keyboard: [] },
+    });
     return;
   }
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -13,7 +13,7 @@ Manage calendars using [khal](https://github.com/pimutils/khal) - a standards-ba
 
 **When using this skill as an agent**, run commands via `execute_command`. Prefer these patterns:
 
-1. **Sync before read**: Run `vdirsyncer sync` first to ensure local data is up to date, especially for remote calendars.
+1. **Sync before read**: Run `vdirsyncer sync` first to ensure local data is up to date, especially for remote calendars. **Skip this entirely for Google accounts** — gcalcli reads the live API, and a Google-only deployment has no working vdirsyncer pair to sync. If `khal printcalendars` errors or lists nothing, khal is not the path on this machine: check for gcalcli accounts (see [Google Calendar (gcalcli)](#google-calendar-gcalcli)) before reporting the calendar as unreachable.
 
 2. **Use `khal list`** for human-readable output, or `khal list --format "{start} {end} {title}" <date range>` for parsing. For machine parsing, `khal printcalendars -p` exports ICS.
 
@@ -298,6 +298,36 @@ XDG_DATA_HOME=~/.local/share/gcalcli-account-b gcalcli agenda
 XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli quick "Lunch with John tomorrow at noon"
 XDG_DATA_HOME=~/.local/share/gcalcli-account-b gcalcli add --title "Sprint Planning" --where "Room A" --when "2026-02-15 14:00" --duration 1h
 ```
+
+#### Date ranges: a bare number is a *date*, never a count of days
+
+`agenda` and `search` take `[start] [end]` as **dates**, not a window size. `gcalcli agenda 30`
+does not mean "the next 30 days" — dateutil parses `30` as *the 30th of the current month*, so
+the window starts there and silently hides everything before it. `agenda 120` is not a valid
+date at all and returns a bare `No Events Found...` rather than an error, which reads exactly
+like an empty calendar. Always give a real range:
+
+```bash
+XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli agenda today "120 days"
+XDG_DATA_HOME=~/.local/share/gcalcli-account-a gcalcli agenda 2026-08-25 2026-12-25
+```
+
+#### Search matches whole words, not substrings
+
+`search` forwards the query to Google's Calendar API, which tokenises event text and matches
+whole words — it is not `grep`. Searching a truncated stem finds nothing even when the event is
+right there: `gcalcli search podo` returns `No Events Found...` for an event titled
+`Rendez vous podologue`, while `gcalcli search podologue` finds it. Search the full word the
+event would actually contain, and if a search comes back empty, confirm against a date-ranged
+`agenda` before concluding the calendar is empty or unreachable.
+
+#### Run one plain command per account, not a shell loop
+
+Wrapping calls in `for account in a b; do … gcalcli …; done` defeats the `autoApprovedCommands`
+allowlist: approval keys off the *first* binary in the command, so the key becomes `for account`
+and never matches an allowlisted `gcalcli`, forcing a manual approval prompt on every turn. A
+leading `XDG_DATA_HOME=…` assignment is fine — env-var prefixes are skipped when the key is
+extracted. Issue one command per account instead.
 
 ---
 

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -134,6 +134,10 @@ function registerRunCommand(program: Command): void {
     )
     .option("--no-stream", "Disable streaming mode")
     .option(
+      "--interactive-stdin",
+      "This caller relays the agent's questions to a human and writes answers back on stdin (a chat bridge). Without it, tools that ask the user are withheld, so an unattended run never stops for an answer nobody will see.",
+    )
+    .option(
       "--ephemeral",
       "Skip persistence entirely: --conversation is ignored (no history load/save) and long-term memory writes are withheld. Nothing about this run touches disk.",
     )
@@ -161,6 +165,7 @@ function registerRunCommand(program: Command): void {
           conversation?: string;
           stream?: boolean;
           noStream?: boolean;
+          interactiveStdin?: boolean;
           ephemeral?: boolean;
           historyJson?: string;
           park?: boolean;
@@ -255,6 +260,7 @@ function registerRunCommand(program: Command): void {
                   ? { conversationId: options.conversation }
                   : {}),
                 ...resolveStreamOption(options, eventCategories),
+                ...(options.interactiveStdin === true ? { interactiveStdin: true } : {}),
                 ...(options.ephemeral === true ? { ephemeral: true } : {}),
                 ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
                 ...(options.park === true ? { park: true } : {}),

--- a/src/cli/cli-app.ts
+++ b/src/cli/cli-app.ts
@@ -135,7 +135,7 @@ function registerRunCommand(program: Command): void {
     .option("--no-stream", "Disable streaming mode")
     .option(
       "--interactive-stdin",
-      "This caller relays the agent's questions to a human and writes answers back on stdin (a chat bridge). Without it, tools that ask the user are withheld, so an unattended run never stops for an answer nobody will see.",
+      "Declare that this caller relays the agent's questions to a human and writes answers back on stdin (a chat bridge). Not needed on a terminal, where questions are asked directly. Without either, tools that ask the user are withheld so an unattended run never stops for an answer nobody will see.",
     )
     .option(
       "--ephemeral",

--- a/src/cli/commands/run/execute.ts
+++ b/src/cli/commands/run/execute.ts
@@ -4,7 +4,10 @@ import { getAgentByIdentifier } from "@/core/agent/agent-service";
 import { buildWorkStatePreamble } from "@/core/agent/context/work-state-preamble";
 import { RunParkRequested, isRunParkRequested } from "@/core/agent/run/park-signal";
 import { CommonSuggestions, getErrorMessage } from "@/core/presentation/error-handler";
-import { makeOneShotPresentationServiceLayer } from "@/core/presentation/oneshot-presentation-service";
+import {
+  detectInteractiveInput,
+  makeOneShotPresentationServiceLayer,
+} from "@/core/presentation/oneshot-presentation-service";
 import { AgentNotFoundError } from "@/core/types/errors";
 import type { ChatMessage } from "@/core/types/message";
 import type { StreamEvent } from "@/core/types/streaming";
@@ -121,8 +124,10 @@ export interface RunAgentOnceOptions {
   readonly stream?: boolean | undefined;
   /**
    * This caller will relay an `ask_user_question` to a human and write the answer
-   * back on stdin (a chat bridge). Without it the interactive tools are withheld
-   * entirely, so an unattended run cannot stop to ask something nobody will read.
+   * back on stdin (a chat bridge). Only needed where that cannot be detected: a
+   * terminal is recognised on its own. Without either, the interactive tools are
+   * withheld entirely, so an unattended run cannot stop to ask something nobody
+   * will read.
    */
   readonly interactiveStdin?: boolean | undefined;
   /**
@@ -243,6 +248,9 @@ export function runAgentOnceCommand(
   options: RunAgentOnceOptions,
 ) {
   const outputOptions: OneShotOutputOptions = { json: options.json };
+  // Resolved once and shared, so the toolset the model is offered and the way a
+  // question is delivered can never disagree about whether anyone is reachable.
+  const interactiveInput = detectInteractiveInput(options.interactiveStdin === true);
   // Deadline can be pushed out while blocked on a human approval decision (see
   // requestApproval in OneShotPresentationService) so waiting on a person
   // doesn't count against the same budget as the agent's own work.
@@ -345,9 +353,9 @@ export function runAgentOnceCommand(
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
       ...(options.stream !== undefined ? { stream: options.stream } : {}),
-      // Headless by default: only a caller that said it can relay a question
-      // keeps the tools that ask one.
-      ...(options.interactiveStdin === true ? {} : { withholdInteractiveTools: true }),
+      // Only a surface that can actually reach a human keeps the tools that ask
+      // one: a terminal, or a caller that declared it will relay the question.
+      ...(interactiveInput.interactive ? {} : { withholdInteractiveTools: true }),
       ...(ephemeral ? { disablePersistence: true } : {}),
       ...(options.park === true ? { parkWhenUnattended: true } : {}),
     });
@@ -453,7 +461,7 @@ export function runAgentOnceCommand(
         deadline && options.timeoutMs != null
           ? () => deadline.extend(options.timeoutMs!)
           : undefined,
-        options.interactiveStdin === true,
+        interactiveInput.interactive ? (interactiveInput.viaTty ? "tty" : "protocol") : "none",
       ),
     ),
   );

--- a/src/cli/commands/run/execute.ts
+++ b/src/cli/commands/run/execute.ts
@@ -120,6 +120,12 @@ export interface RunAgentOnceOptions {
    */
   readonly stream?: boolean | undefined;
   /**
+   * This caller will relay an `ask_user_question` to a human and write the answer
+   * back on stdin (a chat bridge). Without it the interactive tools are withheld
+   * entirely, so an unattended run cannot stop to ask something nobody will read.
+   */
+  readonly interactiveStdin?: boolean | undefined;
+  /**
    * Caller-supplied stable conversation key (e.g. a Telegram chat id). When
    * set, prior history for this conversation is loaded before the run and the
    * updated transcript is saved back after — giving stateless webhook bridges
@@ -339,6 +345,9 @@ export function runAgentOnceCommand(
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
       ...(options.stream !== undefined ? { stream: options.stream } : {}),
+      // Headless by default: only a caller that said it can relay a question
+      // keeps the tools that ask one.
+      ...(options.interactiveStdin === true ? {} : { withholdInteractiveTools: true }),
       ...(ephemeral ? { disablePersistence: true } : {}),
       ...(options.park === true ? { parkWhenUnattended: true } : {}),
     });
@@ -444,6 +453,7 @@ export function runAgentOnceCommand(
         deadline && options.timeoutMs != null
           ? () => deadline.extend(options.timeoutMs!)
           : undefined,
+        options.interactiveStdin === true,
       ),
     ),
   );

--- a/src/cli/commands/run/execute.ts
+++ b/src/cli/commands/run/execute.ts
@@ -353,8 +353,6 @@ export function runAgentOnceCommand(
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
       ...(options.stream !== undefined ? { stream: options.stream } : {}),
-      // Only a surface that can actually reach a human keeps the tools that ask
-      // one: a terminal, or a caller that declared it will relay the question.
       ...(interactiveInput.interactive ? {} : { withholdInteractiveTools: true }),
       ...(ephemeral ? { disablePersistence: true } : {}),
       ...(options.park === true ? { parkWhenUnattended: true } : {}),

--- a/src/cli/presentation/cli-presentation-service.ts
+++ b/src/cli/presentation/cli-presentation-service.ts
@@ -316,8 +316,8 @@ export class CLIPresentationService implements PresentationService {
 
       yield* this.writeOutput(`${separator}\n`);
 
-      // A terminal that cannot prompt has nobody to ask; one that can and comes
-      // back empty was answered with a shrug, which is the human's call to make.
+      // A terminal that cannot prompt has nobody to ask; an empty answer from one
+      // that can is the human declining.
       if (!this.interactive) return { kind: "unavailable" } as const;
       const response = yield* this.ask("Your response:", {});
       const answer = (response ?? "").trim();

--- a/src/cli/presentation/cli-presentation-service.ts
+++ b/src/cli/presentation/cli-presentation-service.ts
@@ -10,6 +10,7 @@ import type {
   PresentationService,
   StreamingRenderer,
   StreamingRendererConfig,
+  UserInputOutcome,
   UserInputRequest,
 } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
@@ -290,7 +291,7 @@ export class CLIPresentationService implements PresentationService {
     return Effect.void;
   }
 
-  requestUserInput(request: UserInputRequest): Effect.Effect<string, never> {
+  requestUserInput(request: UserInputRequest): Effect.Effect<UserInputOutcome, never> {
     return Effect.gen(this, function* () {
       const separator = chalk.dim(separatorLine(50));
 
@@ -315,9 +316,14 @@ export class CLIPresentationService implements PresentationService {
 
       yield* this.writeOutput(`${separator}\n`);
 
-      // Use the existing ask method
+      // A terminal that cannot prompt has nobody to ask; one that can and comes
+      // back empty was answered with a shrug, which is the human's call to make.
+      if (!this.interactive) return { kind: "unavailable" } as const;
       const response = yield* this.ask("Your response:", {});
-      return response ?? "";
+      const answer = (response ?? "").trim();
+      return answer.length > 0
+        ? ({ kind: "answered", response: answer } as const)
+        : ({ kind: "declined" } as const);
     });
   }
 

--- a/src/cli/presentation/cli-presentation-service.ts
+++ b/src/cli/presentation/cli-presentation-service.ts
@@ -316,8 +316,6 @@ export class CLIPresentationService implements PresentationService {
 
       yield* this.writeOutput(`${separator}\n`);
 
-      // A terminal that cannot prompt has nobody to ask; an empty answer from one
-      // that can is the human declining.
       if (!this.interactive) return { kind: "unavailable" } as const;
       const response = yield* this.ask("Your response:", {});
       const answer = (response ?? "").trim();

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -15,6 +15,7 @@ import type {
   StreamingRenderer,
   StreamingRendererConfig,
   StreamTarget,
+  UserInputOutcome,
   UserInputRequest,
 } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
@@ -987,7 +988,7 @@ interface QueuedApproval {
  */
 interface QueuedUserInput {
   request: UserInputRequest;
-  resume: (effect: Effect.Effect<string, never>) => void;
+  resume: (effect: Effect.Effect<UserInputOutcome, never>) => void;
 }
 
 /**
@@ -1439,7 +1440,7 @@ export class InkPresentationService implements PresentationService {
     });
   }
 
-  requestUserInput(request: UserInputRequest): Effect.Effect<string, never> {
+  requestUserInput(request: UserInputRequest): Effect.Effect<UserInputOutcome, never> {
     return Effect.async((resume) => {
       // Add to queue and process
       this.userInputQueue.push({ request, resume });
@@ -1504,19 +1505,25 @@ export class InkPresentationService implements PresentationService {
         allowMultiple: request.allowMultiple,
       },
       resolve: (value: unknown) => {
-        const response = String(value);
+        const response = String(value).trim();
         echoUserTurn(response);
         store.setPrompt(null);
         store.setApprovalRequest(null);
         this.isProcessingUserInput = false;
-        resume(Effect.succeed(response));
+        // Submitting nothing is a shrug, and a shrug is the human's answer: it
+        // says "not this", not "I was never here".
+        resume(
+          Effect.succeed(
+            response.length > 0 ? { kind: "answered", response } : { kind: "declined" },
+          ),
+        );
         this.processNextUserInput();
       },
       reject: () => {
         store.setPrompt(null);
         store.setApprovalRequest(null);
         this.isProcessingUserInput = false;
-        resume(Effect.succeed("")); // Return empty on cancel
+        resume(Effect.succeed({ kind: "declined" })); // Dismissed the prompt.
         this.processNextUserInput();
       },
     });

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -1510,7 +1510,6 @@ export class InkPresentationService implements PresentationService {
         store.setPrompt(null);
         store.setApprovalRequest(null);
         this.isProcessingUserInput = false;
-        // Submitting nothing says "not this", which is an answer, not an absence.
         resume(
           Effect.succeed(
             response.length > 0 ? { kind: "answered", response } : { kind: "declined" },

--- a/src/cli/presentation/ink-presentation-service.ts
+++ b/src/cli/presentation/ink-presentation-service.ts
@@ -1510,8 +1510,7 @@ export class InkPresentationService implements PresentationService {
         store.setPrompt(null);
         store.setApprovalRequest(null);
         this.isProcessingUserInput = false;
-        // Submitting nothing is a shrug, and a shrug is the human's answer: it
-        // says "not this", not "I was never here".
+        // Submitting nothing says "not this", which is an answer, not an absence.
         resume(
           Effect.succeed(
             response.length > 0 ? { kind: "answered", response } : { kind: "declined" },

--- a/src/cli/ui/fullscreen/bridge.test.tsx
+++ b/src/cli/ui/fullscreen/bridge.test.tsx
@@ -1111,7 +1111,7 @@ describe("fullscreen bridge", () => {
     await settleKeypress(rendered.flush, 100);
     await rendered.mockInput.pressKey("RETURN");
     await settleKeypress(rendered.flush, 100);
-    expect(await questionnaire).toBe("south");
+    expect(await questionnaire).toEqual({ kind: "answered", response: "south" });
 
     rendered.renderer.destroy();
   });

--- a/src/core/agent/agent-runner.test.ts
+++ b/src/core/agent/agent-runner.test.ts
@@ -387,8 +387,8 @@ describe("AgentRunner", () => {
         }),
       );
 
-      // Not offered rather than failing at call time: a run in CI that stops to
-      // ask something hangs until its timeout for nobody's benefit.
+      // Not offered rather than failing at call time: a CI run that stops to ask
+      // something hangs until its timeout for nobody.
       expect(lastRequestedToolNames()).not.toContain("ask_user_question");
       expect(lastRequestedToolNames()).not.toContain("ask_file_picker");
       expect(lastRequestedToolNames()).toContain("tool1");

--- a/src/core/agent/agent-runner.test.ts
+++ b/src/core/agent/agent-runner.test.ts
@@ -135,6 +135,20 @@ const mockToolRegistry = {
           parameters: {},
         },
       },
+      {
+        function: {
+          name: "ask_user_question",
+          description: "Ask the human a blocking question",
+          parameters: {},
+        },
+      },
+      {
+        function: {
+          name: "ask_file_picker",
+          description: "Show an interactive file picker",
+          parameters: {},
+        },
+      },
     ]),
   ),
 } as unknown as ToolRegistry;
@@ -344,6 +358,53 @@ describe("AgentRunner", () => {
       await runWithTestLayers(AgentRunner.run(options));
 
       expect(lastRequestedToolNames()).toContain("manage_memory");
+    });
+  });
+
+  describe("withholdInteractiveTools", () => {
+    const agentWithAskTool: Agent = {
+      ...mockAgent,
+      config: { ...mockAgent.config, tools: ["tool1", "ask_user_question", "ask_file_picker"] },
+    };
+
+    function lastRequestedToolNames(): string[] {
+      const streamingMock = mockLlmService.createStreamingChatCompletion as Mock<
+        LLMService["createStreamingChatCompletion"]
+      >;
+      const lastCall = streamingMock.mock.calls.at(-1);
+      const llmOptions = lastCall?.[1] as { tools?: { function: { name: string } }[] };
+      return (llmOptions.tools ?? []).map((tool) => tool.function.name);
+    }
+
+    it("withholds the soliciting tools when nobody can answer", async () => {
+      await runWithTestLayers(
+        AgentRunner.run({
+          ...defaultOptions,
+          agent: agentWithAskTool,
+          stream: true,
+          maxIterations: 1,
+          withholdInteractiveTools: true,
+        }),
+      );
+
+      // Not offered rather than failing at call time: a run in CI that stops to
+      // ask something hangs until its timeout for nobody's benefit.
+      expect(lastRequestedToolNames()).not.toContain("ask_user_question");
+      expect(lastRequestedToolNames()).not.toContain("ask_file_picker");
+      expect(lastRequestedToolNames()).toContain("tool1");
+    });
+
+    it("keeps them when the surface can relay a question", async () => {
+      await runWithTestLayers(
+        AgentRunner.run({
+          ...defaultOptions,
+          agent: agentWithAskTool,
+          stream: true,
+          maxIterations: 1,
+        }),
+      );
+
+      expect(lastRequestedToolNames()).toContain("ask_user_question");
     });
   });
 

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -306,9 +306,8 @@ function initializeAgentRun(
       combinedToolNames = combinedToolNames.filter((name) => name !== "manage_memory");
     }
 
-    // Same reasoning for the tools that solicit an answer from a human: a surface
-    // with nobody attached should not offer them at all. Failing the call at
-    // execution time costs a wasted round and invites the model to invent an
+    // Same reasoning for the tools that solicit an answer from a human. Failing the
+    // call at execution time costs a round and invites the model to invent an
     // answer; not having the tool leaves it no choice but to decide openly.
     if (options.withholdInteractiveTools === true) {
       combinedToolNames = combinedToolNames.filter(

--- a/src/core/agent/agent-runner.ts
+++ b/src/core/agent/agent-runner.ts
@@ -306,6 +306,16 @@ function initializeAgentRun(
       combinedToolNames = combinedToolNames.filter((name) => name !== "manage_memory");
     }
 
+    // Same reasoning for the tools that solicit an answer from a human: a surface
+    // with nobody attached should not offer them at all. Failing the call at
+    // execution time costs a wasted round and invites the model to invent an
+    // answer; not having the tool leaves it no choice but to decide openly.
+    if (options.withholdInteractiveTools === true) {
+      combinedToolNames = combinedToolNames.filter(
+        (name) => name !== "ask_user_question" && name !== "ask_file_picker",
+      );
+    }
+
     // Applied after personas resolve (earlier would let a child's persona re-add
     // a category the parent denied) and before the registry filter.
     if (options.toolAllowlist) {

--- a/src/core/agent/context/summarizer.test.ts
+++ b/src/core/agent/context/summarizer.test.ts
@@ -112,7 +112,7 @@ const mockPresentationService: PresentationService = {
   collapseEphemeralRegion: () => Effect.void,
   requestApproval: () => Effect.succeed({ approved: true }),
   signalToolExecutionStarted: () => Effect.void,
-  requestUserInput: () => Effect.succeed(""),
+  requestUserInput: () => Effect.succeed({ kind: "unavailable" as const }),
   requestFilePicker: () => Effect.succeed(""),
 };
 

--- a/src/core/agent/execution/tool-executor.test.ts
+++ b/src/core/agent/execution/tool-executor.test.ts
@@ -13,8 +13,10 @@ import type { LoggerService } from "../../interfaces/logger";
 import { LoggerServiceTag } from "../../interfaces/logger";
 import type { MCPServerManager } from "../../interfaces/mcp-server";
 import { MCPServerManagerTag } from "../../interfaces/mcp-server";
+import { type MemoryService, MemoryServiceTag } from "../../interfaces/memory-service";
 import type { PresentationService, StreamingRenderer } from "../../interfaces/presentation";
 import { PresentationServiceTag } from "../../interfaces/presentation";
+import { type ReminderService, ReminderServiceTag } from "../../interfaces/reminder-service";
 import type { TerminalService } from "../../interfaces/terminal";
 import { TerminalServiceTag } from "../../interfaces/terminal";
 import type { ToolRegistry } from "../../interfaces/tool-registry";
@@ -72,6 +74,10 @@ const emptyTerminal = {} as unknown as TerminalService;
 const emptyFsContext = {} as unknown as FileSystemContextService;
 const emptyLlm = {} as unknown as LLMService;
 const emptyMcp = {} as unknown as MCPServerManager;
+// Required by the tool pipeline's type but never reached by these tests; provided
+// so the requirement is genuinely discharged rather than cast away.
+const emptyMemory = {} as unknown as MemoryService;
+const emptyReminders = {} as unknown as ReminderService;
 
 function makeRunMetrics(): ReturnType<typeof createAgentRunMetrics> {
   return {
@@ -139,6 +145,8 @@ describe("ToolExecutor.executeTool", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const result = await Effect.runPromise(
@@ -173,6 +181,8 @@ describe("ToolExecutor.executeTool", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     // executeTool still works even if getTool fails for timeout lookup
@@ -215,6 +225,8 @@ describe("ToolExecutor.executeToolCall", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCall: ToolCall = {
@@ -253,6 +265,8 @@ describe("ToolExecutor.executeToolCall", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCall = {
@@ -303,6 +317,8 @@ describe("ToolExecutor.executeToolCalls", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCalls: ToolCall[] = [
@@ -374,6 +390,8 @@ describe("ToolExecutor.executeToolCalls", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCalls: ToolCall[] = [
@@ -491,6 +509,8 @@ describe("ToolExecutor.executeToolCall approval events", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, emptyLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCall: ToolCall = {
@@ -591,6 +611,8 @@ describe("ToolExecutor.executeToolCall approval events", () => {
       Layer.succeed(SkillServiceTag, mockSkillService),
       Layer.succeed(LLMServiceTag, classifyingLlm),
       Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
     );
 
     const toolCall: ToolCall = {

--- a/src/core/agent/metrics/agent-run-metrics.test.ts
+++ b/src/core/agent/metrics/agent-run-metrics.test.ts
@@ -160,11 +160,11 @@ describe("classifier usage", () => {
       ),
     );
 
-    expect(logged?.promptTokens).toBe(1000);
-    expect(logged?.completionTokens).toBe(50);
-    expect(logged?.classifierPromptTokens).toBe(82);
-    expect(logged?.classifierCompletionTokens).toBe(2);
-    expect(logged?.classifierRequests).toBe(2);
-    expect(logged?.classifierDurationMs).toBe(21);
+    expect(logged?.["promptTokens"]).toBe(1000);
+    expect(logged?.["completionTokens"]).toBe(50);
+    expect(logged?.["classifierPromptTokens"]).toBe(82);
+    expect(logged?.["classifierCompletionTokens"]).toBe(2);
+    expect(logged?.["classifierRequests"]).toBe(2);
+    expect(logged?.["classifierDurationMs"]).toBe(21);
   });
 });

--- a/src/core/agent/tools/base-tool.test.ts
+++ b/src/core/agent/tools/base-tool.test.ts
@@ -34,6 +34,7 @@ describe("defineTool", () => {
     const tool = defineTool({
       name: "echo_path",
       description: "Echo a path",
+      disclosure: "public",
       parameters: echoParameters,
       validate: makeZodValidator(echoParameters),
       handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
@@ -48,6 +49,7 @@ describe("defineTool", () => {
     const tool = defineTool({
       name: "echo_path",
       description: "Echo a path",
+      disclosure: "public",
       parameters: echoParameters,
       handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
     });
@@ -61,6 +63,7 @@ describe("defineTool", () => {
     const tool = defineTool({
       name: "echo_path",
       description: "Echo a path",
+      disclosure: "public",
       parameters: echoParameters,
       handler: () => Effect.succeed({ success: true, result: null }),
     });
@@ -73,6 +76,7 @@ describe("defineApprovalTool", () => {
     const pair = defineApprovalTool({
       name: "write_note",
       description: "Write a note",
+      disclosure: "public",
       parameters: echoParameters,
       approvalMessage: (args: EchoArgs) => Effect.succeed(`Write ${args.path}`),
       handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
@@ -97,6 +101,7 @@ describe("defineApprovalTool", () => {
     const pair = defineApprovalTool({
       name: "write_note",
       description: "Write a note",
+      disclosure: "public",
       parameters: echoParameters,
       approvalMessage: () =>
         Effect.succeed({

--- a/src/core/agent/tools/tool-registry.test.ts
+++ b/src/core/agent/tools/tool-registry.test.ts
@@ -15,6 +15,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: false,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -47,6 +48,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: false,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };
@@ -56,6 +58,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: true,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };
@@ -80,6 +83,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: false,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -107,6 +111,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: false,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -135,6 +140,7 @@ describe("ToolRegistry", () => {
       parameters: z.object({}),
       hidden: false,
       riskLevel: "read-only",
+      disclosure: "public",
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };

--- a/src/core/agent/tools/user-interaction-tools.test.ts
+++ b/src/core/agent/tools/user-interaction-tools.test.ts
@@ -5,13 +5,16 @@ import { userInteractionTools } from "./user-interaction-tools";
 
 const askUserQuestion = userInteractionTools.find((tool) => tool.name === "ask_user_question");
 
-function harness(response: string) {
+function harness(outcome: Record<string, unknown>) {
   return Layer.succeed(PresentationServiceTag, {
-    requestUserInput: () => Effect.succeed(response),
+    requestUserInput: () => Effect.succeed(outcome),
   } as never);
 }
 
-async function ask(response: string): Promise<{ success: boolean; result: string }> {
+async function ask(outcome: Record<string, unknown>): Promise<{
+  success: boolean;
+  result: string;
+}> {
   const effect = askUserQuestion!.execute(
     {
       question: "When is your appointment?",
@@ -23,7 +26,7 @@ async function ask(response: string): Promise<{ success: boolean; result: string
     { agentId: "a", conversationId: "c" },
   ) as never as Effect.Effect<{ success: boolean; result: string }, never, never>;
   return Effect.runPromise(
-    effect.pipe(Effect.provide(harness(response))) as Effect.Effect<
+    effect.pipe(Effect.provide(harness(outcome))) as Effect.Effect<
       { success: boolean; result: string },
       never,
       never
@@ -33,29 +36,36 @@ async function ask(response: string): Promise<{ success: boolean; result: string
 
 describe("ask_user_question", () => {
   it("passes a real answer through", async () => {
-    const outcome = await ask("next Tuesday at 3pm");
-    expect(outcome.success).toBe(true);
-    expect(outcome.result).toBe("User responded: next Tuesday at 3pm");
+    const result = await ask({ kind: "answered", response: "next Tuesday at 3pm" });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("User responded: next Tuesday at 3pm");
   });
 
-  it("reports failure when there is nobody to ask", async () => {
-    // Every non-interactive presentation answers with "".
-    const outcome = await ask("");
-    expect(outcome.success).toBe(false);
-    expect(outcome.result).toContain("No answer was given");
-    // The model must not read this as an answer it can act on.
-    expect(outcome.result).not.toContain("User responded");
+  it("reports a refusal as the human's decision, not a gap to fill", async () => {
+    const result = await ask({ kind: "declined" });
+    expect(result.success).toBe(false);
+    expect(result.result).toContain("declined to answer");
+    expect(result.result).toContain("do not pick an answer for them");
+    // Must not read as an answer, nor as nobody having been there.
+    expect(result.result).not.toContain("User responded");
+    expect(result.result).not.toContain("Nobody could be asked");
   });
 
-  it("treats whitespace as no answer too", async () => {
-    const outcome = await ask("   \n  ");
-    expect(outcome.success).toBe(false);
-    expect(outcome.result).toContain("No answer was given");
+  it("reports an absent human as something to decide around", async () => {
+    const result = await ask({ kind: "unavailable" });
+    expect(result.success).toBe(false);
+    expect(result.result).toContain("Nobody could be asked");
+    expect(result.result).toContain("state the assumption");
+    // The opposite instruction to a refusal: here the agent should proceed.
+    expect(result.result).not.toContain("declined");
   });
 
-  it("tells the model what to do instead of inventing one", async () => {
-    const outcome = await ask("");
-    expect(outcome.result).toContain("ask in your reply");
-    expect(outcome.result).toContain("assumption");
+  it("gives opposite guidance for the two failures", async () => {
+    const declined = await ask({ kind: "declined" });
+    const unavailable = await ask({ kind: "unavailable" });
+    // Refusal: do not decide for them. Absence: decide.
+    expect(declined.result).toContain("do not pick an answer");
+    expect(unavailable.result).toContain("Decide yourself");
+    expect(declined.result).not.toBe(unavailable.result);
   });
 });

--- a/src/core/agent/tools/user-interaction-tools.test.ts
+++ b/src/core/agent/tools/user-interaction-tools.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { PresentationServiceTag } from "@/core/interfaces/presentation";
+import { userInteractionTools } from "./user-interaction-tools";
+
+const askUserQuestion = userInteractionTools.find((tool) => tool.name === "ask_user_question");
+
+function harness(response: string) {
+  return Layer.succeed(PresentationServiceTag, {
+    requestUserInput: () => Effect.succeed(response),
+  } as never);
+}
+
+async function ask(response: string): Promise<{ success: boolean; result: string }> {
+  const effect = askUserQuestion!.execute(
+    {
+      question: "When is your appointment?",
+      suggested_responses: [
+        { value: "today", label: "Today" },
+        { value: "tomorrow", label: "Tomorrow" },
+      ],
+    },
+    { agentId: "a", conversationId: "c" },
+  ) as never as Effect.Effect<{ success: boolean; result: string }, never, never>;
+  return Effect.runPromise(
+    effect.pipe(Effect.provide(harness(response))) as Effect.Effect<
+      { success: boolean; result: string },
+      never,
+      never
+    >,
+  );
+}
+
+describe("ask_user_question", () => {
+  it("passes a real answer through", async () => {
+    const outcome = await ask("next Tuesday at 3pm");
+    expect(outcome.success).toBe(true);
+    expect(outcome.result).toBe("User responded: next Tuesday at 3pm");
+  });
+
+  it("reports failure when there is nobody to ask", async () => {
+    // Every non-interactive presentation answers with "".
+    const outcome = await ask("");
+    expect(outcome.success).toBe(false);
+    expect(outcome.result).toContain("No answer was given");
+    // The model must not read this as an answer it can act on.
+    expect(outcome.result).not.toContain("User responded");
+  });
+
+  it("treats whitespace as no answer too", async () => {
+    const outcome = await ask("   \n  ");
+    expect(outcome.success).toBe(false);
+    expect(outcome.result).toContain("No answer was given");
+  });
+
+  it("tells the model what to do instead of inventing one", async () => {
+    const outcome = await ask("");
+    expect(outcome.result).toContain("ask in your reply");
+    expect(outcome.result).toContain("assumption");
+  });
+});

--- a/src/core/agent/tools/user-interaction-tools.test.ts
+++ b/src/core/agent/tools/user-interaction-tools.test.ts
@@ -46,7 +46,6 @@ describe("ask_user_question", () => {
     expect(result.success).toBe(false);
     expect(result.result).toContain("declined to answer");
     expect(result.result).toContain("do not pick an answer for them");
-    // Must not read as an answer, nor as nobody having been there.
     expect(result.result).not.toContain("User responded");
     expect(result.result).not.toContain("Nobody could be asked");
   });
@@ -56,14 +55,12 @@ describe("ask_user_question", () => {
     expect(result.success).toBe(false);
     expect(result.result).toContain("Nobody could be asked");
     expect(result.result).toContain("state the assumption");
-    // The opposite instruction to a refusal: here the agent should proceed.
     expect(result.result).not.toContain("declined");
   });
 
   it("gives opposite guidance for the two failures", async () => {
     const declined = await ask({ kind: "declined" });
     const unavailable = await ask({ kind: "unavailable" });
-    // Refusal: do not decide for them. Absence: decide.
     expect(declined.result).toContain("do not pick an answer");
     expect(unavailable.result).toContain("Decide yourself");
     expect(declined.result).not.toBe(unavailable.result);

--- a/src/core/agent/tools/user-interaction-tools.ts
+++ b/src/core/agent/tools/user-interaction-tools.ts
@@ -79,10 +79,9 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
 
         const outcome = yield* presentation.requestUserInput(request);
 
-        // A refusal and an absence are different facts and lead somewhere
-        // different, so they are never collapsed into one message. Guessing after
-        // a refusal overrides a decision the human actually made; refusing to act
-        // after an absence strands a run nobody is watching.
+        // Never collapsed into one message: guessing after a refusal overrides a
+        // decision the human made, while refusing to act after an absence strands
+        // a run nobody is watching.
         if (outcome.kind === "declined") {
           return {
             success: false,

--- a/src/core/agent/tools/user-interaction-tools.ts
+++ b/src/core/agent/tools/user-interaction-tools.ts
@@ -61,7 +61,7 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
       "Ask the human one blocking question with 2–4 concrete options. Use this tool; do not bury the question in prose. " +
       "Ask only when you are actually blocked: a scope or approach decision with no clearly best option, a destructive action that needs explicit sign-off, or a secret or provider choice no tool can fetch. " +
       "Do not ask permission to do work they already requested, confirmation of safe reversible actions, anything already answered, or anything a tool can resolve. " +
-      "When there is no TTY (headless), do not call this — decide or fail. One decision per call.",
+      "Surfaces work anywhere a human is reachable, including chat bridges with no TTY; when nobody is, the tool says so and you must then decide on a stated assumption or ask in your reply. One decision per call.",
     parameters: askUserSchema,
     hidden: false,
     riskLevel: "read-only",

--- a/src/core/agent/tools/user-interaction-tools.ts
+++ b/src/core/agent/tools/user-interaction-tools.ts
@@ -79,6 +79,21 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
 
         const response = yield* presentation.requestUserInput(request);
 
+        // Every non-interactive presentation answers with an empty string: there
+        // is nobody at a TTY to ask. Reporting that as a successful answer is how
+        // an agent ends up acting on a decision the human never made — a bridge
+        // asked for an appointment date, got "", and set a reminder for 30
+        // minutes' time. Say plainly that no answer arrived so the model decides
+        // openly, or puts the question in its reply where a human will see it.
+        if (response.trim().length === 0) {
+          return {
+            success: false,
+            result:
+              "No answer was given — there is no interactive channel here, or the human dismissed the question. " +
+              "Do not treat this as an answer or invent one. Either proceed on a stated assumption, or ask in your reply.",
+          };
+        }
+
         return {
           success: true,
           result: `User responded: ${response}`,

--- a/src/core/agent/tools/user-interaction-tools.ts
+++ b/src/core/agent/tools/user-interaction-tools.ts
@@ -77,26 +77,34 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
           allowMultiple: args.allow_multiple === true,
         };
 
-        const response = yield* presentation.requestUserInput(request);
+        const outcome = yield* presentation.requestUserInput(request);
 
-        // Every non-interactive presentation answers with an empty string: there
-        // is nobody at a TTY to ask. Reporting that as a successful answer is how
-        // an agent ends up acting on a decision the human never made — a bridge
-        // asked for an appointment date, got "", and set a reminder for 30
-        // minutes' time. Say plainly that no answer arrived so the model decides
-        // openly, or puts the question in its reply where a human will see it.
-        if (response.trim().length === 0) {
+        // A refusal and an absence are different facts and lead somewhere
+        // different, so they are never collapsed into one message. Guessing after
+        // a refusal overrides a decision the human actually made; refusing to act
+        // after an absence strands a run nobody is watching.
+        if (outcome.kind === "declined") {
           return {
             success: false,
             result:
-              "No answer was given — there is no interactive channel here, or the human dismissed the question. " +
-              "Do not treat this as an answer or invent one. Either proceed on a stated assumption, or ask in your reply.",
+              "The human saw this question and declined to answer. Treat that as their decision, not as a gap to fill: " +
+              "do not pick an answer for them and do not ask again. Do only what is unambiguous without it, " +
+              "and say plainly what remains blocked and why.",
+          };
+        }
+
+        if (outcome.kind === "unavailable") {
+          return {
+            success: false,
+            result:
+              "Nobody could be asked — no human ever saw this question. Do not report it as unanswered or wait for a reply. " +
+              "Decide yourself, state the assumption you are proceeding on, and carry on.",
           };
         }
 
         return {
           success: true,
-          result: `User responded: ${response}`,
+          result: `User responded: ${outcome.response}`,
         };
       }),
   }),

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -107,9 +107,8 @@ export interface AgentRunnerOptions {
    * who isn't there.
    *
    * Interactive surfaces leave this off. A headless run sets it unless its caller
-   * has said it can relay a question and write the answer back, because a run in
-   * CI or cron that stops to ask something is a job that hangs until its timeout
-   * for no reason anyone will see.
+   * can relay a question and write the answer back: a CI or cron run that stops to
+   * ask something hangs until its timeout for nobody.
    */
   readonly withholdInteractiveTools?: boolean;
   /**

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -102,6 +102,17 @@ export interface AgentRunnerOptions {
    */
   readonly toolAllowlist?: readonly string[];
   /**
+   * Withhold the tools that solicit an answer from a human (`ask_user_question`,
+   * `ask_file_picker`), so the model is never offered a way to block on somebody
+   * who isn't there.
+   *
+   * Interactive surfaces leave this off. A headless run sets it unless its caller
+   * has said it can relay a question and write the answer back, because a run in
+   * CI or cron that stops to ask something is a job that hangs until its timeout
+   * for no reason anyone will see.
+   */
+  readonly withholdInteractiveTools?: boolean;
+  /**
    * Park instead of declining when a gated tool needs an approval this process cannot
    * obtain. Requires a durable `RunStore` in the layer, since the record is what a later
    * process resumes from. Off by default, and never set for sub-agent runs.

--- a/src/core/interfaces/presentation.ts
+++ b/src/core/interfaces/presentation.ts
@@ -18,11 +18,10 @@ export interface Suggestion {
 /**
  * What came back from asking the human.
  *
- * A bare string could not tell "nobody was there" apart from "they said no", and
- * those call for opposite behaviour: the first leaves the decision to the agent,
- * the second is the human's decision and must not be overridden by guessing. An
- * empty answer is a refusal, not an absence — someone was shown the question and
- * chose not to pick.
+ * "Nobody was there" and "they said no" call for opposite behaviour — the first
+ * leaves the decision to the agent, the second is the human's decision and must
+ * not be overridden by guessing — so they are distinct outcomes rather than one
+ * empty string. Submitting nothing is a refusal: the question was seen.
  */
 export type UserInputOutcome =
   /** They answered. `response` is non-empty. */

--- a/src/core/interfaces/presentation.ts
+++ b/src/core/interfaces/presentation.ts
@@ -16,6 +16,23 @@ export interface Suggestion {
 }
 
 /**
+ * What came back from asking the human.
+ *
+ * A bare string could not tell "nobody was there" apart from "they said no", and
+ * those call for opposite behaviour: the first leaves the decision to the agent,
+ * the second is the human's decision and must not be overridden by guessing. An
+ * empty answer is a refusal, not an absence — someone was shown the question and
+ * chose not to pick.
+ */
+export type UserInputOutcome =
+  /** They answered. `response` is non-empty. */
+  | { readonly kind: "answered"; readonly response: string }
+  /** They were asked and declined — dismissed the prompt or entered nothing. */
+  | { readonly kind: "declined" }
+  /** Nobody could be asked. No human ever saw this question. */
+  | { readonly kind: "unavailable" };
+
+/**
  * Request for user input with optional suggested responses.
  * Used by the ask_user tool to gather clarifications.
  */
@@ -267,7 +284,7 @@ export interface PresentationService {
    * @param request - The user input request with question and optional suggestions
    * @returns The user's response (either selected suggestion or custom text)
    */
-  readonly requestUserInput: (request: UserInputRequest) => Effect.Effect<string, never>;
+  readonly requestUserInput: (request: UserInputRequest) => Effect.Effect<UserInputOutcome, never>;
 
   /**
    * Request file selection from the user with fuzzy path filtering.

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -5,7 +5,7 @@ import { DEFAULT_DISPLAY_CONFIG } from "@/core/agent/types";
 import type { StreamingRendererConfig } from "@/core/interfaces/presentation";
 import type { StreamEvent } from "@/core/types/streaming";
 import type { ApprovalRequest } from "@/core/types/tools";
-import { OneShotPresentationService } from "./oneshot-presentation-service";
+import { detectInteractiveInput, OneShotPresentationService } from "./oneshot-presentation-service";
 
 function makeApprovalRequest(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
   return {
@@ -425,7 +425,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
       new Set<StreamEvent["type"]>(["tool_execution_start"]),
       stdin,
       undefined,
-      false,
+      "none",
     );
     const captured = captureStderr();
     const answer = await Effect.runPromise(service.requestUserInput(request));
@@ -446,7 +446,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
       new Set<StreamEvent["type"]>(["tool_execution_start"]),
       stdin,
       undefined,
-      true,
+      "protocol",
     );
     const captured = captureStderr();
     const pending = Effect.runPromise(service.requestUserInput(request));
@@ -483,7 +483,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
       new Set<StreamEvent["type"]>(["tool_execution_start"]),
       stdin,
       undefined,
-      true,
+      "protocol",
     );
     const captured = captureStderr();
     void Effect.runPromise(service.requestUserInput({ ...request, question: longQuestion }));
@@ -500,7 +500,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
       new Set<StreamEvent["type"]>(["tool_execution_start"]),
       stdin,
       undefined,
-      true,
+      "protocol",
     );
     captureStderr();
     const pending = Effect.runPromise(service.requestUserInput(request));
@@ -523,7 +523,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
       new Set<StreamEvent["type"]>(["tool_execution_start"]),
       stdin,
       undefined,
-      true,
+      "protocol",
     );
     const captured = captureStderr();
     const first = Effect.runPromise(service.requestUserInput(request));
@@ -541,5 +541,127 @@ describe("OneShotPresentationService.requestUserInput", () => {
     );
     expect(await first).toBe("first");
     expect(await second).toBe("second");
+  });
+});
+
+describe("detectInteractiveInput", () => {
+  it("recognises a terminal without being told", () => {
+    // The case that should not need a flag: someone running jazz by hand.
+    expect(detectInteractiveInput(false, {}, { isTTY: true })).toEqual({
+      interactive: true,
+      viaTty: true,
+    });
+  });
+
+  it("takes the caller's word when stdin is a pipe", () => {
+    // A bridge looks exactly like a cron job from here, so it has to say so.
+    expect(detectInteractiveInput(true, {}, { isTTY: false })).toEqual({
+      interactive: true,
+      viaTty: false,
+    });
+  });
+
+  it("is off for a pipe with nobody declared", () => {
+    expect(detectInteractiveInput(false, {}, { isTTY: false })).toEqual({
+      interactive: false,
+      viaTty: false,
+    });
+  });
+
+  it("ignores a TTY in CI, where a runner may allocate one anyway", () => {
+    expect(detectInteractiveInput(false, { CI: "true" }, { isTTY: true })).toEqual({
+      interactive: false,
+      viaTty: false,
+    });
+  });
+
+  it("still honours an explicit declaration in CI", () => {
+    // Someone wiring a bridge inside a pipeline meant it.
+    expect(detectInteractiveInput(true, { CI: "1" }, { isTTY: true }).interactive).toBe(true);
+  });
+});
+
+describe("OneShotPresentationService.requestUserInput on a terminal", () => {
+  const originalWrite = process.stderr.write;
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  function captureStderr(): { lines: string[] } {
+    const captured = { lines: [] as string[] };
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    return captured;
+  }
+
+  const request = {
+    question: "Which database?",
+    suggestions: [
+      { value: "postgres", label: "Postgres", description: "the default" },
+      { value: "sqlite", label: "SQLite" },
+    ],
+    allowCustom: true,
+  };
+
+  function ttyService(stdin: PassThrough) {
+    return new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set(),
+      stdin,
+      undefined,
+      "tty",
+    );
+  }
+
+  it("prints a readable prompt instead of NDJSON", async () => {
+    const stdin = new PassThrough();
+    const captured = captureStderr();
+    void Effect.runPromise(ttyService(stdin).requestUserInput(request));
+    await tick();
+    const prompt = captured.lines.join("");
+    expect(prompt).toContain("❓ Which database?");
+    expect(prompt).toContain("1) Postgres — the default");
+    expect(prompt).toContain("2) SQLite");
+    expect(prompt).not.toContain("user_input_required");
+  });
+
+  it("takes a typed line as the answer", async () => {
+    const stdin = new PassThrough();
+    captureStderr();
+    const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
+    await tick();
+    stdin.write("something of my own\n");
+    expect(await pending).toBe("something of my own");
+  });
+
+  it("maps a typed number onto the option it names", async () => {
+    const stdin = new PassThrough();
+    captureStderr();
+    const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
+    await tick();
+    stdin.write("2\n");
+    // The agent gets the option's value, not the digit the human typed.
+    expect(await pending).toBe("sqlite");
+  });
+
+  it("keeps a number that names no option as literal text", async () => {
+    const stdin = new PassThrough();
+    captureStderr();
+    const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
+    await tick();
+    stdin.write("2026\n");
+    expect(await pending).toBe("2026");
+  });
+
+  it("needs no --events, unlike the bridge protocol", async () => {
+    // A terminal run has no consumer parsing an event stream.
+    const stdin = new PassThrough();
+    captureStderr();
+    const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
+    await tick();
+    stdin.write("postgres\n");
+    expect(await pending).toBe("postgres");
   });
 });

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -391,3 +391,155 @@ describe("OneShotPresentationService requestApproval", () => {
     expect(await pendingA).toEqual({ approved: true });
   });
 });
+
+describe("OneShotPresentationService.requestUserInput", () => {
+  const originalWrite = process.stderr.write;
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  function captureStderr(): { lines: string[] } {
+    const captured = { lines: [] as string[] };
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    return captured;
+  }
+
+  const request = {
+    question: "When is your appointment?",
+    suggestions: [
+      { value: "today", label: "Today" },
+      { value: "tomorrow", label: "Tomorrow" },
+    ],
+    allowCustom: true,
+  };
+
+  it("answers empty without asking when the caller cannot relay a question", async () => {
+    // The CI case: --events is on so something is reading the stream, but nothing
+    // will ever write an answer back. Asking here would hang the job.
+    const stdin = new PassThrough();
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+      stdin,
+      undefined,
+      false,
+    );
+    const captured = captureStderr();
+    const answer = await Effect.runPromise(service.requestUserInput(request));
+    expect(answer).toBe("");
+    // Nothing was emitted, so no consumer is left waiting on a question either.
+    expect(captured.lines).toHaveLength(0);
+  });
+
+  it("answers empty with no events at all", async () => {
+    const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
+    expect(await Effect.runPromise(service.requestUserInput(request))).toBe("");
+  });
+
+  it("emits the question and resolves from a response line on stdin", async () => {
+    const stdin = new PassThrough();
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+      stdin,
+      undefined,
+      true,
+    );
+    const captured = captureStderr();
+    const pending = Effect.runPromise(service.requestUserInput(request));
+    await tick();
+
+    expect(captured.lines).toHaveLength(1);
+    const emitted = JSON.parse(captured.lines[0] as string) as {
+      type: string;
+      requestId: string;
+      question: string;
+      suggestions: { value: string }[];
+      allowCustom: boolean;
+    };
+    expect(emitted.type).toBe("user_input_required");
+    expect(emitted.question).toBe("When is your appointment?");
+    expect(emitted.suggestions.map((s) => s.value)).toEqual(["today", "tomorrow"]);
+    expect(emitted.allowCustom).toBe(true);
+
+    stdin.write(
+      `${JSON.stringify({
+        type: "user_input_response",
+        requestId: emitted.requestId,
+        response: "tomorrow",
+      })}\n`,
+    );
+    expect(await pending).toBe("tomorrow");
+  });
+
+  it("does not truncate a long question a human has to read", async () => {
+    const stdin = new PassThrough();
+    const longQuestion = `Which of these should I use? ${"x".repeat(500)}`;
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+      stdin,
+      undefined,
+      true,
+    );
+    const captured = captureStderr();
+    void Effect.runPromise(service.requestUserInput({ ...request, question: longQuestion }));
+    await tick();
+    const emitted = JSON.parse(captured.lines[0] as string) as { question: string };
+    expect(emitted.question).toBe(longQuestion);
+    expect(emitted.question).not.toContain("…");
+  });
+
+  it("ignores a response for a question it did not ask", async () => {
+    const stdin = new PassThrough();
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+      stdin,
+      undefined,
+      true,
+    );
+    captureStderr();
+    const pending = Effect.runPromise(service.requestUserInput(request));
+    await tick();
+    stdin.write(
+      `${JSON.stringify({ type: "user_input_response", requestId: "ui-999", response: "nope" })}\n`,
+    );
+    stdin.write("not json at all\n");
+    await tick();
+    stdin.write(
+      `${JSON.stringify({ type: "user_input_response", requestId: "ui-1", response: "today" })}\n`,
+    );
+    expect(await pending).toBe("today");
+  });
+
+  it("keeps concurrent questions apart", async () => {
+    const stdin = new PassThrough();
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["tool_execution_start"]),
+      stdin,
+      undefined,
+      true,
+    );
+    const captured = captureStderr();
+    const first = Effect.runPromise(service.requestUserInput(request));
+    const second = Effect.runPromise(
+      service.requestUserInput({ ...request, question: "And the other one?" }),
+    );
+    await tick();
+    const ids = captured.lines.map((line) => (JSON.parse(line) as { requestId: string }).requestId);
+    expect(new Set(ids).size).toBe(2);
+    stdin.write(
+      `${JSON.stringify({ type: "user_input_response", requestId: ids[1], response: "second" })}\n`,
+    );
+    stdin.write(
+      `${JSON.stringify({ type: "user_input_response", requestId: ids[0], response: "first" })}\n`,
+    );
+    expect(await first).toBe("first");
+    expect(await second).toBe("second");
+  });
+});

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -429,14 +429,16 @@ describe("OneShotPresentationService.requestUserInput", () => {
     );
     const captured = captureStderr();
     const answer = await Effect.runPromise(service.requestUserInput(request));
-    expect(answer).toBe("");
+    expect(answer).toEqual({ kind: "unavailable" });
     // Nothing was emitted, so no consumer is left waiting on a question either.
     expect(captured.lines).toHaveLength(0);
   });
 
   it("answers empty with no events at all", async () => {
     const service = new OneShotPresentationService(DEFAULT_DISPLAY_CONFIG, new Set());
-    expect(await Effect.runPromise(service.requestUserInput(request))).toBe("");
+    expect(await Effect.runPromise(service.requestUserInput(request))).toEqual({
+      kind: "unavailable",
+    });
   });
 
   it("emits the question and resolves from a response line on stdin", async () => {
@@ -472,7 +474,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
         response: "tomorrow",
       })}\n`,
     );
-    expect(await pending).toBe("tomorrow");
+    expect(await pending).toEqual({ kind: "answered", response: "tomorrow" });
   });
 
   it("does not truncate a long question a human has to read", async () => {
@@ -513,7 +515,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
     stdin.write(
       `${JSON.stringify({ type: "user_input_response", requestId: "ui-1", response: "today" })}\n`,
     );
-    expect(await pending).toBe("today");
+    expect(await pending).toEqual({ kind: "answered", response: "today" });
   });
 
   it("keeps concurrent questions apart", async () => {
@@ -539,8 +541,8 @@ describe("OneShotPresentationService.requestUserInput", () => {
     stdin.write(
       `${JSON.stringify({ type: "user_input_response", requestId: ids[0], response: "first" })}\n`,
     );
-    expect(await first).toBe("first");
-    expect(await second).toBe("second");
+    expect(await first).toEqual({ kind: "answered", response: "first" });
+    expect(await second).toEqual({ kind: "answered", response: "second" });
   });
 });
 
@@ -633,7 +635,7 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
     const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
     await tick();
     stdin.write("something of my own\n");
-    expect(await pending).toBe("something of my own");
+    expect(await pending).toEqual({ kind: "answered", response: "something of my own" });
   });
 
   it("maps a typed number onto the option it names", async () => {
@@ -643,7 +645,7 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
     await tick();
     stdin.write("2\n");
     // The agent gets the option's value, not the digit the human typed.
-    expect(await pending).toBe("sqlite");
+    expect(await pending).toEqual({ kind: "answered", response: "sqlite" });
   });
 
   it("keeps a number that names no option as literal text", async () => {
@@ -652,7 +654,7 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
     const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
     await tick();
     stdin.write("2026\n");
-    expect(await pending).toBe("2026");
+    expect(await pending).toEqual({ kind: "answered", response: "2026" });
   });
 
   it("needs no --events, unlike the bridge protocol", async () => {
@@ -662,6 +664,6 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
     const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
     await tick();
     stdin.write("postgres\n");
-    expect(await pending).toBe("postgres");
+    expect(await pending).toEqual({ kind: "answered", response: "postgres" });
   });
 });

--- a/src/core/presentation/oneshot-presentation-service.test.ts
+++ b/src/core/presentation/oneshot-presentation-service.test.ts
@@ -417,8 +417,7 @@ describe("OneShotPresentationService.requestUserInput", () => {
   };
 
   it("answers empty without asking when the caller cannot relay a question", async () => {
-    // The CI case: --events is on so something is reading the stream, but nothing
-    // will ever write an answer back. Asking here would hang the job.
+    // --events is on, so something reads the stream — but nothing answers.
     const stdin = new PassThrough();
     const service = new OneShotPresentationService(
       DEFAULT_DISPLAY_CONFIG,
@@ -430,7 +429,6 @@ describe("OneShotPresentationService.requestUserInput", () => {
     const captured = captureStderr();
     const answer = await Effect.runPromise(service.requestUserInput(request));
     expect(answer).toEqual({ kind: "unavailable" });
-    // Nothing was emitted, so no consumer is left waiting on a question either.
     expect(captured.lines).toHaveLength(0);
   });
 
@@ -548,7 +546,6 @@ describe("OneShotPresentationService.requestUserInput", () => {
 
 describe("detectInteractiveInput", () => {
   it("recognises a terminal without being told", () => {
-    // The case that should not need a flag: someone running jazz by hand.
     expect(detectInteractiveInput(false, {}, { isTTY: true })).toEqual({
       interactive: true,
       viaTty: true,
@@ -644,7 +641,6 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
     const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));
     await tick();
     stdin.write("2\n");
-    // The agent gets the option's value, not the digit the human typed.
     expect(await pending).toEqual({ kind: "answered", response: "sqlite" });
   });
 
@@ -658,7 +654,6 @@ describe("OneShotPresentationService.requestUserInput on a terminal", () => {
   });
 
   it("needs no --events, unlike the bridge protocol", async () => {
-    // A terminal run has no consumer parsing an event stream.
     const stdin = new PassThrough();
     captureStderr();
     const pending = Effect.runPromise(ttyService(stdin).requestUserInput(request));

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -7,6 +7,7 @@ import type {
   PresentationService,
   StreamingRenderer,
   StreamingRendererConfig,
+  UserInputOutcome,
   UserInputRequest,
 } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
@@ -169,8 +170,8 @@ export class OneShotPresentationService implements PresentationService {
      *    answered by typing a line.
      *  - `"protocol"`: a consumer relays it and writes back a
      *    `user_input_response` line (a chat bridge).
-     *  - `"none"`: nobody. `requestUserInput` answers empty and the calling tool
-     *    reports that it could not ask.
+     *  - `"none"`: nobody. `requestUserInput` reports `unavailable`, which the
+     *    calling tool must not confuse with a human declining.
      */
     private readonly askMode: "tty" | "protocol" | "none" = "none",
   ) {}
@@ -434,10 +435,13 @@ export class OneShotPresentationService implements PresentationService {
    * answer, so this returns empty and the calling tool reports that it could not
    * ask rather than treating a blank as an answer.
    */
-  requestUserInput(request: UserInputRequest): Effect.Effect<string, never> {
-    if (this.askMode === "none") return Effect.succeed("");
+  requestUserInput(request: UserInputRequest): Effect.Effect<UserInputOutcome, never> {
+    if (this.askMode === "none") return Effect.succeed({ kind: "unavailable" });
     // The protocol needs a consumer parsing the event stream; a terminal does not.
-    if (this.askMode === "protocol" && !this.eventsActive) return Effect.succeed("");
+    // Declared but not wired up is a misconfiguration, not a human saying no.
+    if (this.askMode === "protocol" && !this.eventsActive) {
+      return Effect.succeed({ kind: "unavailable" });
+    }
 
     this.userInputSequence += 1;
     const requestId = `ui-${this.userInputSequence}`;
@@ -484,10 +488,17 @@ export class OneShotPresentationService implements PresentationService {
       }
       return answer;
     };
-    return Effect.async<string, never>((resume) => {
-      pendingUserInputs.set(requestId, (response) =>
-        resume(Effect.succeed(resolveChoice(response))),
-      );
+    return Effect.async<UserInputOutcome, never>((resume) => {
+      pendingUserInputs.set(requestId, (response) => {
+        // Someone was shown the question and sent nothing back: a refusal, and
+        // reported as one so the agent does not answer it on their behalf.
+        const answer = resolveChoice(response).trim();
+        resume(
+          Effect.succeed(
+            answer.length > 0 ? { kind: "answered", response: answer } : { kind: "declined" },
+          ),
+        );
+      });
       return Effect.sync(() => {
         pendingUserInputs.delete(requestId);
       });

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -435,7 +435,6 @@ export class OneShotPresentationService implements PresentationService {
    */
   requestUserInput(request: UserInputRequest): Effect.Effect<UserInputOutcome, never> {
     if (this.askMode === "none") return Effect.succeed({ kind: "unavailable" });
-    // The protocol needs a consumer parsing the event stream; a terminal does not.
     // Declared but not wired up is a misconfiguration, not a human saying no.
     if (this.askMode === "protocol" && !this.eventsActive) {
       return Effect.succeed({ kind: "unavailable" });
@@ -487,7 +486,6 @@ export class OneShotPresentationService implements PresentationService {
     };
     return Effect.async<UserInputOutcome, never>((resume) => {
       pendingUserInputs.set(requestId, (response) => {
-        // Nothing sent back is a refusal, not an absence: the question was seen.
         const answer = resolveChoice(response).trim();
         resume(
           Effect.succeed(

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -50,6 +50,28 @@ interface ApprovalDecisionLine {
   readonly approved: boolean;
 }
 
+/**
+ * Can this process put a question in front of a human and get an answer back?
+ *
+ * Two shapes qualify, which is what makes this worth detecting rather than
+ * demanding a flag for. A person at a terminal answers by typing, so a TTY on
+ * stdin is enough on its own. A chat bridge answers over the event protocol, and
+ * nothing about its environment distinguishes it from a cron job — pipes either
+ * way — so that case stays an explicit `--interactive-stdin`.
+ *
+ * `CI` wins over the TTY check: some runners allocate one, and a job that stops
+ * to ask something waits out its timeout for nobody.
+ */
+export function detectInteractiveInput(
+  declared: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+  stdin: { isTTY?: boolean } = process.stdin,
+): { interactive: boolean; viaTty: boolean } {
+  if (env["CI"] === "true" || env["CI"] === "1") return { interactive: declared, viaTty: false };
+  if (stdin.isTTY === true) return { interactive: true, viaTty: true };
+  return { interactive: declared, viaTty: false };
+}
+
 /** Shape of a line written back to `stdinStream` to answer a pending question. */
 interface UserInputResponseLine {
   readonly type: "user_input_response";
@@ -142,12 +164,15 @@ export class OneShotPresentationService implements PresentationService {
     private readonly stdinStream: NodeJS.ReadableStream = process.stdin,
     private readonly onApprovalWaitStart?: () => void,
     /**
-     * The consumer on stdin will relay a question to a human and write the answer
-     * back. Off unless the caller says so: `--events` alone only means something
-     * is reading the stream, and a CI job reading it for progress would otherwise
-     * park the run on a question nobody will ever see.
+     * How a question reaches a human, if one is reachable at all.
+     *  - `"tty"`: somebody is at a terminal. The question is printed for them and
+     *    answered by typing a line.
+     *  - `"protocol"`: a consumer relays it and writes back a
+     *    `user_input_response` line (a chat bridge).
+     *  - `"none"`: nobody. `requestUserInput` answers empty and the calling tool
+     *    reports that it could not ask.
      */
-    private readonly canAskUser: boolean = false,
+    private readonly askMode: "tty" | "protocol" | "none" = "none",
   ) {}
 
   /**
@@ -169,6 +194,17 @@ export class OneShotPresentationService implements PresentationService {
         buffer = buffer.slice(newlineIndex + 1);
         newlineIndex = buffer.indexOf("\n");
         if (line.length === 0) continue;
+        // A person types prose, not JSON. Any line that is not one of the two
+        // protocol shapes answers the question that has been waiting longest.
+        if (this.askMode === "tty" && !line.startsWith("{")) {
+          const [requestId] = this.pendingUserInputs.keys();
+          if (requestId !== undefined) {
+            const resolveTyped = this.pendingUserInputs.get(requestId);
+            this.pendingUserInputs.delete(requestId);
+            resolveTyped?.(line);
+          }
+          continue;
+        }
         const decision = parseApprovalDecisionLine(line);
         if (decision) {
           const resolveApproval = this.pendingApprovals.get(decision.toolCallId);
@@ -399,30 +435,59 @@ export class OneShotPresentationService implements PresentationService {
    * ask rather than treating a blank as an answer.
    */
   requestUserInput(request: UserInputRequest): Effect.Effect<string, never> {
-    if (!this.eventsActive || !this.canAskUser) return Effect.succeed("");
+    if (this.askMode === "none") return Effect.succeed("");
+    // The protocol needs a consumer parsing the event stream; a terminal does not.
+    if (this.askMode === "protocol" && !this.eventsActive) return Effect.succeed("");
 
     this.userInputSequence += 1;
     const requestId = `ui-${this.userInputSequence}`;
-    // Not truncated: the whole point is that a human reads the question and its
-    // options, and a clipped option is an option they cannot choose meaningfully.
-    process.stderr.write(
-      `${JSON.stringify({
-        type: "user_input_required",
-        requestId,
-        question: request.question,
-        suggestions: request.suggestions,
-        allowCustom: request.allowCustom,
-        ...(request.allowMultiple === true ? { allowMultiple: true } : {}),
-      })}\n`,
-    );
+    if (this.askMode === "tty") {
+      // Written to stderr like every other human-facing line here, so stdout stays
+      // the machine-readable payload even while somebody is being asked something.
+      const lines = [`\n❓ ${request.question}`];
+      request.suggestions.forEach((suggestion, index) => {
+        const label = suggestion.label ?? suggestion.value;
+        const description = suggestion.description ? ` — ${suggestion.description}` : "";
+        lines.push(`  ${index + 1}) ${label}${description}`);
+      });
+      lines.push("Answer (number, or type your own; empty to skip): ");
+      process.stderr.write(lines.join("\n"));
+    } else {
+      // Not truncated: the whole point is that a human reads the question and its
+      // options, and a clipped option is an option they cannot choose meaningfully.
+      process.stderr.write(
+        `${JSON.stringify({
+          type: "user_input_required",
+          requestId,
+          question: request.question,
+          suggestions: request.suggestions,
+          allowCustom: request.allowCustom,
+          ...(request.allowMultiple === true ? { allowMultiple: true } : {}),
+        })}\n`,
+      );
+    }
 
     // Waiting on a person must not spend the agent's own time budget, same as an
     // approval.
     this.onApprovalWaitStart?.();
     this.ensureStdinReaderStarted();
     const pendingUserInputs = this.pendingUserInputs;
+    const suggestions = request.suggestions;
+    // "2" means the second option, not the literal string. Only a bare index is
+    // treated this way, so an answer that happens to be a number still works when
+    // it is not in range.
+    const resolveChoice = (answer: string): string => {
+      const index = Number.parseInt(answer.trim(), 10);
+      if (!Number.isNaN(index) && `${index}` === answer.trim()) {
+        const chosen = suggestions[index - 1];
+        if (chosen) return chosen.value;
+      }
+      return answer;
+    };
     return Effect.async<string, never>((resume) => {
-      pendingUserInputs.set(requestId, (response) => resume(Effect.succeed(response)));
+      pendingUserInputs.set(requestId, (response) =>
+        resume(Effect.succeed(resolveChoice(response))),
+      );
       return Effect.sync(() => {
         pendingUserInputs.delete(requestId);
       });
@@ -460,7 +525,7 @@ export class OneShotPresentationService implements PresentationService {
 export function makeOneShotPresentationServiceLayer(
   emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
   onApprovalWaitStart?: () => void,
-  canAskUser = false,
+  askMode: "tty" | "protocol" | "none" = "none",
 ) {
   return Layer.effect(
     PresentationServiceTag,
@@ -474,7 +539,7 @@ export function makeOneShotPresentationServiceLayer(
         emitEventTypes,
         undefined,
         onApprovalWaitStart,
-        canAskUser,
+        askMode,
       );
     }),
   );

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -54,14 +54,12 @@ interface ApprovalDecisionLine {
 /**
  * Can this process put a question in front of a human and get an answer back?
  *
- * Two shapes qualify, which is what makes this worth detecting rather than
- * demanding a flag for. A person at a terminal answers by typing, so a TTY on
- * stdin is enough on its own. A chat bridge answers over the event protocol, and
- * nothing about its environment distinguishes it from a cron job — pipes either
- * way — so that case stays an explicit `--interactive-stdin`.
+ * A person at a terminal answers by typing, so a TTY on stdin settles it. A chat
+ * bridge answers over the event protocol but is indistinguishable from a cron job
+ * through a pipe, so it must declare itself.
  *
- * `CI` wins over the TTY check: some runners allocate one, and a job that stops
- * to ask something waits out its timeout for nobody.
+ * `CI` overrides the TTY check, since some runners allocate one and a job that
+ * stops to ask something waits out its timeout for nobody.
  */
 export function detectInteractiveInput(
   declared: boolean,
@@ -446,8 +444,7 @@ export class OneShotPresentationService implements PresentationService {
     this.userInputSequence += 1;
     const requestId = `ui-${this.userInputSequence}`;
     if (this.askMode === "tty") {
-      // Written to stderr like every other human-facing line here, so stdout stays
-      // the machine-readable payload even while somebody is being asked something.
+      // stderr like every other human-facing line, so stdout stays the payload.
       const lines = [`\n❓ ${request.question}`];
       request.suggestions.forEach((suggestion, index) => {
         const label = suggestion.label ?? suggestion.value;
@@ -490,8 +487,7 @@ export class OneShotPresentationService implements PresentationService {
     };
     return Effect.async<UserInputOutcome, never>((resume) => {
       pendingUserInputs.set(requestId, (response) => {
-        // Someone was shown the question and sent nothing back: a refusal, and
-        // reported as one so the agent does not answer it on their behalf.
+        // Nothing sent back is a refusal, not an absence: the question was seen.
         const answer = resolveChoice(response).trim();
         resume(
           Effect.succeed(

--- a/src/core/presentation/oneshot-presentation-service.ts
+++ b/src/core/presentation/oneshot-presentation-service.ts
@@ -7,6 +7,7 @@ import type {
   PresentationService,
   StreamingRenderer,
   StreamingRendererConfig,
+  UserInputRequest,
 } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import { resolveDisplayConfig } from "@/core/presentation/display-config";
@@ -49,6 +50,13 @@ interface ApprovalDecisionLine {
   readonly approved: boolean;
 }
 
+/** Shape of a line written back to `stdinStream` to answer a pending question. */
+interface UserInputResponseLine {
+  readonly type: "user_input_response";
+  readonly requestId: string;
+  readonly response: string;
+}
+
 function parseApprovalDecisionLine(line: string): ApprovalDecisionLine | undefined {
   let parsed: unknown;
   try {
@@ -72,6 +80,29 @@ function parseApprovalDecisionLine(line: string): ApprovalDecisionLine | undefin
   return undefined;
 }
 
+function parseUserInputResponseLine(line: string): UserInputResponseLine | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    candidate["type"] === "user_input_response" &&
+    typeof candidate["requestId"] === "string" &&
+    typeof candidate["response"] === "string"
+  ) {
+    return {
+      type: "user_input_response",
+      requestId: candidate["requestId"],
+      response: candidate["response"],
+    };
+  }
+  return undefined;
+}
+
 /**
  * Presentation service for headless, one-shot agent runs (`jazz run`).
  *
@@ -87,13 +118,22 @@ function parseApprovalDecisionLine(line: string): ApprovalDecisionLine | undefin
  *    `autoApprovePolicy` already auto-approved everything it was allowed to;
  *    anything still asking is above the policy threshold and is refused
  *    rather than blanket-approved or left hanging forever,
- *  - user-input / file-picker requests return empty.
+ *  - user-input requests are relayed as a `user_input_required` event and wait
+ *    for a `user_input_response` line, but only when the caller declared it can
+ *    answer them; otherwise they return empty and the calling tool reports that
+ *    it could not ask,
+ *  - file-picker requests return empty.
  *
  * This differs from QuietPresentationService, which blanket-approves every tool
  * and is meant for trusted background runs.
  */
 export class OneShotPresentationService implements PresentationService {
   private readonly pendingApprovals = new Map<string, (outcome: ApprovalOutcome) => void>();
+  private readonly pendingUserInputs = new Map<string, (response: string) => void>();
+  // Questions have no id of their own the way a tool call does, so one is minted
+  // here. Only ever compared against ids this process emitted, so a counter is
+  // enough — it does not need to be unguessable or unique across runs.
+  private userInputSequence = 0;
   private stdinReaderStarted = false;
 
   constructor(
@@ -101,6 +141,13 @@ export class OneShotPresentationService implements PresentationService {
     private readonly emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
     private readonly stdinStream: NodeJS.ReadableStream = process.stdin,
     private readonly onApprovalWaitStart?: () => void,
+    /**
+     * The consumer on stdin will relay a question to a human and write the answer
+     * back. Off unless the caller says so: `--events` alone only means something
+     * is reading the stream, and a CI job reading it for progress would otherwise
+     * park the run on a question nobody will ever see.
+     */
+    private readonly canAskUser: boolean = false,
   ) {}
 
   /**
@@ -123,11 +170,20 @@ export class OneShotPresentationService implements PresentationService {
         newlineIndex = buffer.indexOf("\n");
         if (line.length === 0) continue;
         const decision = parseApprovalDecisionLine(line);
-        if (!decision) continue;
-        const resolve = this.pendingApprovals.get(decision.toolCallId);
-        if (!resolve) continue;
-        this.pendingApprovals.delete(decision.toolCallId);
-        resolve({ approved: decision.approved });
+        if (decision) {
+          const resolveApproval = this.pendingApprovals.get(decision.toolCallId);
+          if (!resolveApproval) continue;
+          this.pendingApprovals.delete(decision.toolCallId);
+          resolveApproval({ approved: decision.approved });
+          continue;
+        }
+        const answer = parseUserInputResponseLine(line);
+        if (answer) {
+          const resolveInput = this.pendingUserInputs.get(answer.requestId);
+          if (!resolveInput) continue;
+          this.pendingUserInputs.delete(answer.requestId);
+          resolveInput(answer.response);
+        }
       }
     });
   }
@@ -333,8 +389,44 @@ export class OneShotPresentationService implements PresentationService {
     return Effect.void;
   }
 
-  requestUserInput(): Effect.Effect<string, never> {
-    return Effect.succeed("");
+  /**
+   * Ask the human a question, when something is listening.
+   *
+   * Mirrors `requestApproval`: with `--events` a consumer (a chat bridge) sees the
+   * `user_input_required` line, puts the question in front of a person, and writes
+   * a `user_input_response` line back on stdin. Without events nobody could
+   * answer, so this returns empty and the calling tool reports that it could not
+   * ask rather than treating a blank as an answer.
+   */
+  requestUserInput(request: UserInputRequest): Effect.Effect<string, never> {
+    if (!this.eventsActive || !this.canAskUser) return Effect.succeed("");
+
+    this.userInputSequence += 1;
+    const requestId = `ui-${this.userInputSequence}`;
+    // Not truncated: the whole point is that a human reads the question and its
+    // options, and a clipped option is an option they cannot choose meaningfully.
+    process.stderr.write(
+      `${JSON.stringify({
+        type: "user_input_required",
+        requestId,
+        question: request.question,
+        suggestions: request.suggestions,
+        allowCustom: request.allowCustom,
+        ...(request.allowMultiple === true ? { allowMultiple: true } : {}),
+      })}\n`,
+    );
+
+    // Waiting on a person must not spend the agent's own time budget, same as an
+    // approval.
+    this.onApprovalWaitStart?.();
+    this.ensureStdinReaderStarted();
+    const pendingUserInputs = this.pendingUserInputs;
+    return Effect.async<string, never>((resume) => {
+      pendingUserInputs.set(requestId, (response) => resume(Effect.succeed(response)));
+      return Effect.sync(() => {
+        pendingUserInputs.delete(requestId);
+      });
+    });
   }
 
   requestFilePicker(): Effect.Effect<string, never> {
@@ -368,6 +460,7 @@ export class OneShotPresentationService implements PresentationService {
 export function makeOneShotPresentationServiceLayer(
   emitEventTypes: ReadonlySet<StreamEvent["type"]> = new Set(),
   onApprovalWaitStart?: () => void,
+  canAskUser = false,
 ) {
   return Layer.effect(
     PresentationServiceTag,
@@ -381,6 +474,7 @@ export function makeOneShotPresentationServiceLayer(
         emitEventTypes,
         undefined,
         onApprovalWaitStart,
+        canAskUser,
       );
     }),
   );

--- a/src/core/presentation/quiet-presentation-service.ts
+++ b/src/core/presentation/quiet-presentation-service.ts
@@ -7,6 +7,7 @@ import type {
   PresentationService,
   StreamingRenderer,
   StreamingRendererConfig,
+  UserInputOutcome,
 } from "@/core/interfaces/presentation";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import { resolveDisplayConfig } from "@/core/presentation/display-config";
@@ -123,9 +124,9 @@ class QuietPresentationService implements PresentationService {
     return Effect.void;
   }
 
-  // Quiet mode cannot ask user — return empty string
-  requestUserInput(): Effect.Effect<string, never> {
-    return Effect.succeed("");
+  // Quiet mode has nobody to ask; the caller must not read this as a refusal.
+  requestUserInput(): Effect.Effect<UserInputOutcome, never> {
+    return Effect.succeed({ kind: "unavailable" });
   }
 
   // Quiet mode cannot show file picker — return empty string

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import { Chunk, Effect } from "effect";
 import { selectParser } from "./reasoning";
-import { StreamProcessor } from "./stream-processor";
+import { StreamIdleTimeoutError, StreamProcessor, withIdleTimeout } from "./stream-processor";
 import { type LoggerService } from "../../core/interfaces/logger";
 
 describe("StreamProcessor", () => {
@@ -534,5 +534,72 @@ describe("StreamProcessor", () => {
       expect(thinkingChunks.map((c) => c.content).join("")).toContain("partial thought");
       expect(finalContent).toBe("visible");
     });
+  });
+});
+
+describe("withIdleTimeout", () => {
+  async function* never(): AsyncGenerator<number> {
+    yield 1;
+    // Stalls without closing — the shape of a provider that stops sending.
+    await new Promise(() => {});
+  }
+
+  async function* slowButAlive(): AsyncGenerator<number> {
+    for (const value of [1, 2, 3]) {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      yield value;
+    }
+  }
+
+  it("passes a healthy stream through untouched", async () => {
+    const seen: number[] = [];
+    for await (const value of withIdleTimeout(slowButAlive(), 1_000)) seen.push(value);
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("does not fail a stream that is slow but still producing", async () => {
+    // Each gap is under the budget even though the total exceeds it.
+    const seen: number[] = [];
+    for await (const value of withIdleTimeout(slowButAlive(), 50)) seen.push(value);
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("abandons a stream that stalls without closing", async () => {
+    const seen: number[] = [];
+    const drain = async (): Promise<void> => {
+      for await (const value of withIdleTimeout(never(), 60)) seen.push(value);
+    };
+    await expect(drain()).rejects.toThrow(StreamIdleTimeoutError);
+    // The part that did arrive was still delivered.
+    expect(seen).toEqual([1]);
+  });
+
+  it("names the idle budget in the error, so a log says what happened", async () => {
+    const drain = async (): Promise<void> => {
+      for await (const _value of withIdleTimeout(never(), 60)) {
+        // drain
+      }
+    };
+    await expect(drain()).rejects.toThrow(/produced nothing for/);
+  });
+
+  it("closes the underlying iterator when it gives up", async () => {
+    let returned = false;
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => new Promise<IteratorResult<number>>(() => {}),
+        return: async () => {
+          returned = true;
+          return { done: true as const, value: undefined };
+        },
+      }),
+    };
+    const drain = async (): Promise<void> => {
+      for await (const _value of withIdleTimeout(source, 40)) {
+        // drain
+      }
+    };
+    await expect(drain()).rejects.toThrow(StreamIdleTimeoutError);
+    expect(returned).toBe(true);
   });
 });

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -23,6 +23,70 @@ import { extractReasoningParts } from "./reasoning-parts";
 type StreamTextResult = ReturnType<typeof streamText>;
 
 /**
+ * How long the stream may go without producing anything before it is treated as
+ * dead.
+ *
+ * `for await` over a provider stream waits forever if the server stops sending
+ * without closing the connection, and nothing below this layer notices: the
+ * process sits in epoll with an idle GPU until whatever wall-clock timeout the
+ * caller set fires, which for an unattended bridge was fifteen minutes of a chat
+ * showing "Working…". Two minutes is far longer than any real gap between parts —
+ * generation on a loaded 27B model still emits tens of tokens a second, and the
+ * slowest observed wait for a first part was under twenty seconds — while turning
+ * an indefinite hang into a normal failure the caller can report and retry.
+ *
+ * Tool execution happens between streams, not inside one, so a slow tool cannot
+ * trip this.
+ */
+const STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+/** Raised when a provider stream stops producing without closing. */
+export class StreamIdleTimeoutError extends Error {
+  constructor(readonly idleMs: number) {
+    super(
+      `Provider stream produced nothing for ${Math.round(idleMs / 1000)}s and was abandoned. ` +
+        `The connection stalled without closing.`,
+    );
+    this.name = "StreamIdleTimeoutError";
+  }
+}
+
+/**
+ * Re-yield `source`, failing if any single step takes longer than `idleMs`.
+ *
+ * The timer is per part rather than for the whole stream: a long answer is
+ * healthy, a long *silence* is not.
+ */
+export async function* withIdleTimeout<T>(
+  source: AsyncIterable<T>,
+  idleMs: number,
+): AsyncGenerator<T> {
+  const iterator = source[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const idle = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new StreamIdleTimeoutError(idleMs)), idleMs);
+      });
+      let step: IteratorResult<T>;
+      try {
+        step = await Promise.race([iterator.next(), idle]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+      if (step.done === true) return;
+      yield step.value;
+    }
+  } finally {
+    // Signal the provider we are done so a stalled connection is torn down, but
+    // never wait for it: `return()` on an iterator suspended mid-await resolves
+    // only when that await does, so awaiting here would hang on exactly the
+    // stream this function exists to escape.
+    void iterator.return?.()?.catch(() => undefined);
+  }
+}
+
+/**
  * Emit function type for Effect streams
  */
 type EmitFunction = (
@@ -205,7 +269,7 @@ export class StreamProcessor {
    */
   private async processFullStream(result: StreamTextResult): Promise<void> {
     try {
-      for await (const part of result.fullStream) {
+      for await (const part of withIdleTimeout(result.fullStream, STREAM_IDLE_TIMEOUT_MS)) {
         // Stop if we've finished
         if (this.state.finishEventReceived) {
           break;

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -26,14 +26,11 @@ type StreamTextResult = ReturnType<typeof streamText>;
  * How long the stream may go without producing anything before it is treated as
  * dead.
  *
- * `for await` over a provider stream waits forever if the server stops sending
- * without closing the connection, and nothing below this layer notices: the
- * process sits in epoll with an idle GPU until whatever wall-clock timeout the
- * caller set fires, which for an unattended bridge was fifteen minutes of a chat
- * showing "Working…". Two minutes is far longer than any real gap between parts —
- * generation on a loaded 27B model still emits tens of tokens a second, and the
- * slowest observed wait for a first part was under twenty seconds — while turning
- * an indefinite hang into a normal failure the caller can report and retry.
+ * A provider that stops sending without closing the connection would otherwise
+ * block `for await` indefinitely, which no layer below the caller's wall-clock
+ * timeout can detect. Two minutes exceeds any legitimate gap between parts —
+ * generation emits tens of tokens a second, and first-part latency stays under
+ * twenty — so exceeding it means the connection is dead, not slow.
  *
  * Tool execution happens between streams, not inside one, so a slow tool cannot
  * trip this.


### PR DESCRIPTION
## What & why

A Telegram run sat at "Working…" for the full fifteen minutes of its timeout, with
the GPU idle at 14W, no request in flight at the model server, and the process
asleep in `epoll`. Unpicking that turned up three defects and one missing feature.

**A stalled provider stream is now abandoned rather than waited on.** `for await`
over the stream never returns if the server stops sending without closing, and
nothing below the caller's wall-clock timeout notices. Each step races a two-minute
idle budget — per part, so a long answer stays healthy and only a long silence
fails.

**The agent can now actually ask you something.** `ask_user_question` was unusable
from a bridge and quietly harmful: every non-interactive presentation answers with
an empty string, and the tool reported that as `User responded: ` with success — so
asked for an appointment date, the agent got a blank, treated it as an answer, and
set a reminder for thirty minutes' time. A question is now a `user_input_required`
event answered by a `user_input_response` line on stdin, the same mechanism
approvals already use, and both bridges render the suggestions as buttons.

**Interactive tools are only offered to interactive surfaces.** The capability is
opt-in via `--interactive-stdin`; without it the soliciting tools are withheld from
the model entirely. `--events` alone was too weak a signal — it means something is
*reading* the stream, not that anything will answer — so gating on it would have
parked a CI job that passes `--events` for progress on a question nobody will see.

**The run log no longer hides a hang.** Coalesced token deltas were flushed only by
the next event, so a run that stalled mid-stream never wrote them — the failure
mode the log exists for was the one it could not describe.

## Breaking changes / migration

None. `--interactive-stdin` is new and off by default, which is the safe direction:
an existing headless caller loses the ability to be asked a question it could never
have answered anyway.

## How to verify

- Kill a model server mid-generation: the run should fail within ~2 minutes with a
  stream-idle error instead of hanging to the wall clock. Confirm a long but healthy
  answer still completes — the budget is per part, not per stream.
- Run without `--interactive-stdin` and ask the agent to call `ask_user_question`:
  the tool should be absent from its toolset and the run should finish promptly,
  not block.
- Run with `--interactive-stdin`, watch for `user_input_required` on stderr, write
  `{"type":"user_input_response","requestId":"…","response":"…"}` to stdin, and
  confirm the tool returns `User responded: …`.
- On a bridge, ask something ambiguous and confirm buttons arrive as a separate
  message, tapping one unblocks the run, and the buttons retire afterwards.
- Stall a run and check the newest file in `<JAZZ_HOME>/logs/runs/` — buffered
  deltas should appear within ~2s rather than being lost.