### PR TITLE
fix(shell): give child processes the run's timezone

### DIFF
--- a/src/core/agent/tools/shell-tools.test.ts
+++ b/src/core/agent/tools/shell-tools.test.ts
@@ -10,7 +10,7 @@ import { createToolRegistryLayer } from "./tool-registry";
 import { FileSystemContextServiceTag, type FileSystemContextService } from "../../interfaces/fs";
 import { LoggerServiceTag, type LoggerService } from "../../interfaces/logger";
 import { TerminalServiceTag, type TerminalService } from "../../interfaces/terminal";
-import type { Agent, ToolExecutionResult } from "../../types";
+import type { Agent, ToolExecutionContext, ToolExecutionResult } from "../../types";
 
 describe("Shell Tools", () => {
   const createTestLayer = () => {
@@ -338,6 +338,55 @@ describe("Shell Tools", () => {
         : "";
     expect(stdout).toBe("test output");
     expect(stdout).not.toContain("[truncated:");
+  });
+
+  describe("timezone", () => {
+    async function runDate(context: ToolExecutionContext): Promise<string> {
+      const result: ToolExecutionResult = await Effect.runPromise(
+        Effect.provide(
+          shellTools.execute.execute(
+            { command: "date +%Z", description: "Report the shell's timezone." },
+            context,
+          ),
+          createTestLayer(),
+        ),
+      );
+      return result.result && typeof result.result === "object" && "stdout" in result.result
+        ? String(result.result.stdout).trim()
+        : "";
+    }
+
+    it("gives a child process the run's timezone", async () => {
+      // Tokyo has no daylight saving and shares an abbreviation with nowhere else
+      // a CI runner is likely to sit, so this cannot pass by coincidence.
+      expect(await runDate({ agentId: "a", conversationId: "c", timezone: "Asia/Tokyo" })).toBe(
+        "JST",
+      );
+    });
+
+    it("distinguishes two zones in the same run", async () => {
+      const tokyo = await runDate({ agentId: "a", conversationId: "c", timezone: "Asia/Tokyo" });
+      const utc = await runDate({ agentId: "a", conversationId: "c", timezone: "UTC" });
+      expect(tokyo).toBe("JST");
+      expect(utc).toBe("UTC");
+    });
+
+    it("leaves the host default alone when no timezone is set", async () => {
+      const withoutZone = await runDate({ agentId: "a", conversationId: "c" });
+      const hostZone = new Intl.DateTimeFormat("en-US", { timeZoneName: "short" })
+        .formatToParts(new Date())
+        .find((part) => part.type === "timeZoneName")?.value;
+      expect(withoutZone.length).toBeGreaterThan(0);
+      // Whatever the host reports, an absent zone must not silently become UTC.
+      if (hostZone !== undefined && !hostZone.startsWith("GMT")) {
+        expect(withoutZone).not.toBe("JST");
+      }
+    });
+
+    it("ignores an empty timezone rather than exporting a blank TZ", async () => {
+      const blank = await runDate({ agentId: "a", conversationId: "c", timezone: "" });
+      expect(blank.length).toBeGreaterThan(0);
+    });
   });
 
   it("caps stdout while collecting and tells the model it was truncated", async () => {

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -588,7 +588,16 @@ This command will be executed on your system. Only approve commands you trust.`;
           // Sanitize environment variables for security, exempting any
           // agent-configured allowlist from the sensitive-name scrub.
           const envAllowlist = context.parentAgent?.config.envAllowlist ?? [];
-          const sanitizedEnv = createSanitizedEnv({}, envAllowlist);
+          // The run's zone governs child processes too. `date`, `khal` and
+          // `gcalcli` read TZ, not the agent's notion of "now", so without this a
+          // caller in Europe/Rome is shown their own calendar in whatever zone the
+          // host happens to be set to.
+          const sanitizedEnv = createSanitizedEnv(
+            typeof context.timezone === "string" && context.timezone.length > 0
+              ? { TZ: context.timezone }
+              : {},
+            envAllowlist,
+          );
 
           const result = yield* runShellCommand({
             command,


### PR DESCRIPTION
## What & why

Asking the Telegram bot about your calendar showed it in **UTC** rather than your
own zone — two hours out, with nothing on screen to indicate it.

`--timezone` was threaded into jazz's own time-aware tools (`add_reminder`,
context) but not into the shell. `execute_command` builds a curated environment
for its children and `TZ` was not in it, so `date`, `khal` and `gcalcli` fell back
to the host's zone — UTC in a container.

The run's zone is now exported as `TZ` to shell children, so every tool agrees
about what time it is. It comes from the run rather than the host, so a single
container serving several chats stays correct for each one.

## How to verify

```sh
jazz run --json --agent <a> --approval-policy high-risk --timezone Asia/Tokyo \
  "Run exactly: date +'%Z %H:%M' — reply with only its raw output"
```

- Should report `JST` and a time nine hours ahead of UTC, regardless of the host's
  zone. `America/New_York` should report `EDT`.
- Omit `--timezone` and the terminal's own zone should still apply — an absent
  zone must not become UTC.
- On a bridge, ask what is on your calendar today and confirm the times match your
  phone's.