### PR TITLE
feat(chat): add ! shell escape for interactive terminal

### DIFF
--- a/docs/internals/tools-and-approval.md
+++ b/docs/internals/tools-and-approval.md
@@ -14,6 +14,17 @@ Source:
 
 ## The lifecycle of one tool call
 
+### Operator shell escapes
+
+Interactive terminal users can explicitly run a command with `! <command>`. This path runs
+before the model turn and feeds the bounded result back as tagged command context. It shares
+the shell executor's working-directory resolution, sanitized environment, timeout, interruption
+handling, denylist, and stdout/stderr caps. Because the operator authored the command directly,
+the `!` path is an explicit operator action rather than a model-issued approval request; it does
+not make the command safe or weaken the denylist. Shell output is untrusted data and must be
+treated as context, not as instructions. This syntax is available only in the interactive
+terminal; headless and remote surfaces retain their own authorization contracts.
+
 ```mermaid
 flowchart TD
     IN(["Model emits a tool call"]) --> PARSE{"Arguments<br/>valid JSON?"}
@@ -49,7 +60,7 @@ flowchart TD
 ## Two-phase execution
 
 A gated tool doesn't act when the model calls it. It returns a description of what it
-*would* do:
+_would_ do:
 
 ```mermaid
 sequenceDiagram
@@ -73,10 +84,10 @@ sequenceDiagram
 
 **Why a pair rather than a `dangerous: true` flag.** You cannot show a useful preview
 without doing the work — computing a diff means reading the target and resolving the path.
-Two phases let the propose step do real work and *still* not mutate anything, which is what
+Two phases let the propose step do real work and _still_ not mutate anything, which is what
 makes "here is the exact diff, approve?" possible.
 
-**What it buys.** Interactive and unattended runs go down the *same* path. The only
+**What it buys.** Interactive and unattended runs go down the _same_ path. The only
 difference is who answers the gate. There is no separate headless mode to drift out of sync
 with the interactive one.
 
@@ -156,7 +167,7 @@ Fail closed: timeouts, provider errors, empty replies, and anything other than t
 token `read-only` or `low-risk` stay `high-risk`. A clearly mutating command stays
 `high-risk` regardless of context.
 
-**What the classifier is allowed to read.** The command, always. Plus the last five *user*
+**What the classifier is allowed to read.** The command, always. Plus the last five _user_
 requests (hard-capped at 800 characters) when the session is interactive, so an ambiguous
 command can be lowered only when the person at the keyboard asked for that milder action.
 Two exclusions are deliberate:
@@ -245,7 +256,7 @@ exits the same way an LLM-stream interrupt does.
 
 ### A 56-pattern denylist
 
-Commands are matched against a denylist *before* execution — privilege escalation (`sudo`,
+Commands are matched against a denylist _before_ execution — privilege escalation (`sudo`,
 `su`), filesystem destruction (`rm -rf /`), remote code execution (`curl … | sh`),
 power/runlevel changes (`shutdown`), and reads or copies of `/etc/passwd`, `/etc/shadow`,
 `/etc/sudoers`. A blocked command returns the specific reason, so the agent learns why rather
@@ -267,7 +278,7 @@ worth reading before you rely on the denylist for anything.
 
 ### Environment sanitization
 
-Shell commands do not inherit your full environment. Variables whose *names* match
+Shell commands do not inherit your full environment. Variables whose _names_ match
 `API|KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH` (case-insensitive), plus everything prefixed
 `SSH_`, are stripped before the command runs — so a command that echoes its environment cannot
 exfiltrate your provider keys.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -126,12 +126,12 @@ See [Integrations → MCP](../integrations/mcp.md).
 Inspect runs still in flight — including your own parked ones, and, once a daemon started
 one, runs begun from somewhere else entirely.
 
-| Command                    | Purpose                                                             |
-| --------------------------- | -------------------------------------------------------------------- |
-| `jazz runs list`           | List unfinished runs, newest first. `--agent`, `--conversation`, `--all` (include finished, with cost), `--json` |
-| `jazz runs show <runId>`   | Show one run, including what it's waiting for. `--json`             |
-| `jazz runs approve <runId>` | Approve what a parked run is waiting for; blocks until it finishes  |
-| `jazz runs reject <runId>` | Refuse what it's waiting for; `--note <text>` tells it why           |
+| Command                     | Purpose                                                                                                          |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `jazz runs list`            | List unfinished runs, newest first. `--agent`, `--conversation`, `--all` (include finished, with cost), `--json` |
+| `jazz runs show <runId>`    | Show one run, including what it's waiting for. `--json`                                                          |
+| `jazz runs approve <runId>` | Approve what a parked run is waiting for; blocks until it finishes                                               |
+| `jazz runs reject <runId>`  | Refuse what it's waiting for; `--note <text>` tells it why                                                       |
 
 A run parks when it hits something needing your approval and nobody is there to give it — see
 [Daemon](#jazz-daemon) for answering one from a different process than the one that started it.
@@ -145,11 +145,11 @@ Serves runs over HTTP: start one, poll it, approve or reject what a parked one i
 began it. Runs in the foreground; supervision (restart on crash, start on boot) is the host's
 job, not the daemon's.
 
-| Flag                    | Purpose                                                                                          |
-| ------------------------ | -------------------------------------------------------------------------------------------------- |
-| `--port <n>`            | Port to listen on. Default `4747`                                                                 |
-| `--host <address>`      | Interface to bind. Default `127.0.0.1`. Anything else requires `$JAZZ_DAEMON_TOKEN`               |
-| `--serve-peers <agentId>` | Also answer questions from configured peers, using this agent. Off unless given                 |
+| Flag                      | Purpose                                                                             |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `--port <n>`              | Port to listen on. Default `4747`                                                   |
+| `--host <address>`        | Interface to bind. Default `127.0.0.1`. Anything else requires `$JAZZ_DAEMON_TOKEN` |
+| `--serve-peers <agentId>` | Also answer questions from configured peers, using this agent. Off unless given     |
 
 `$JAZZ_DAEMON_TOKEN` authenticates the operator routes (`/runs`, `/health`); it is read from
 the environment, never a flag, so it never lands in `ps` output or shell history. `/peer/ask`
@@ -165,11 +165,11 @@ See [Setting up peers](../guide/peers-setup.md) for a full walkthrough, and
 
 Other people's agents this machine talks to, and what has been said to or by them.
 
-| Command                          | Purpose                                                                          |
-| ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `jazz peers list`                | List configured peers and what each may learn. `--json`                          |
-| `jazz peers set-token <name>`    | Store a peer's token, read from `$JAZZ_PEER_TOKEN` (or `--from-env <VAR>`)        |
-| `jazz peers forget-token <name>` | Remove a peer's stored token                                                     |
+| Command                          | Purpose                                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `jazz peers list`                | List configured peers and what each may learn. `--json`                                  |
+| `jazz peers set-token <name>`    | Store a peer's token, read from `$JAZZ_PEER_TOKEN` (or `--from-env <VAR>`)               |
+| `jazz peers forget-token <name>` | Remove a peer's stored token                                                             |
 | `jazz peers log`                 | Everything said to and by a peer, newest first. `--peer <name>`, `--limit <n>`, `--json` |
 
 Peers themselves are added by editing `~/.jazz/config.json` directly, not through a command —
@@ -213,7 +213,7 @@ See [Configuration](./configuration.md).
 
 ---
 
-## In-chat slash commands
+## In-chat commands
 
 Available inside an interactive session. Type `/help` for the current list.
 
@@ -233,6 +233,24 @@ Available inside an interactive session. Type `/help` for the current list.
 
 **Keys:** double-Escape interrupts generation or a running tool. Shift+Tab cycles the
 approval policy. Shift+Enter inserts a newline in the composer; Enter sends.
+
+### Shell escapes
+
+In the interactive terminal, type `! <command>` when the agent asks you to run a command
+yourself. Jazz executes the command in the current session directory and sends its bounded
+stdout, stderr, and exit code to the agent as context for the next response:
+
+```text
+> ! ssh user@test rm -r folder
+> Did that remove the folder successfully?
+```
+
+The command is executed because you entered it explicitly; it does not wait for the model to
+call `execute_command`. The built-in shell denylist, sanitized environment, timeout, process
+interruption, and 256 KiB per-stream output cap still apply. Output is treated as command data,
+not as instructions. A non-zero exit code is still passed to the agent so it can explain or
+suggest the next step. `!` is an interactive terminal feature and is not interpreted by
+`jazz run`, scheduled jobs, CI, or chat bridges.
 
 ---
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -66,11 +66,11 @@ nothing, `write_file` changes the machine and reveals nothing at all.
 Every tool declares both. The field is required, with no default anywhere, so a new tool
 cannot be added without someone deciding.
 
-| Level        | Safe to tell                                                              | Tools |
-| ------------ | ------------------------------------------------------------------------- | ----- |
-| `public`     | safe to tell anyone                                                       | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file` |
-| `internal`   | the shape of this machine — paths, names, what is installed               | `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `ls`, `pdf_page_count`, `pwd`, `stat` |
-| `private`    | your own material — file contents, memory, schedule, transcript           | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory` |
+| Level      | Safe to tell                                                    | Tools                                                                                                                                                                                                                                                                                  |
+| ---------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `public`   | safe to tell anyone                                             | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file`                                                                                                                                                                                                     |
+| `internal` | the shape of this machine — paths, names, what is installed     | `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `ls`, `pdf_page_count`, `pwd`, `stat`                                                                                                                                                                        |
+| `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory` |
 
 A tool spanning two levels takes the more sensitive one — `edit_file` writes, but its approval
 message carries a diff of your file, so it is `private`. `http_request` reaches private
@@ -114,6 +114,11 @@ of "unknown" is the most restrictive one.
 | ----------------- | --------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `execute_command` | `unknown` | `execute_execute_command` | Run a shell command when no dedicated tool exists. Each command is classified `read-only`, `low-risk`, or `high-risk`, and the active tier then applies to that verdict. Stdout/stderr capped at 256 KB each. |
 
+In the interactive terminal, an operator can also type `! <command>`. That explicit shell escape
+uses the same cwd resolution, environment sanitization, denylist, timeout, interruption, and
+output caps as `execute_command`, then gives the result to the agent as context. It is not
+available through `jazz run` or remote chat surfaces.
+
 ### Web Search
 
 | Tool         | Risk        | Approval pair | What it does                              |
@@ -155,11 +160,11 @@ Opt-in per agent (like File Management) rather than always-on — see [Memory](.
 
 Opt-in per agent. Reminders persist on disk and fire later on the same surface that scheduled them — see [Reminders](../internals/reminders.md).
 
-| Tool              | Risk        | Approval pair | What it does                                                                            |
-| ----------------- | ----------- | ------------- | --------------------------------------------------------------------------------------- |
+| Tool              | Risk        | Approval pair | What it does                                                                                                                                     |
+| ----------------- | ----------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `add_reminder`    | `low-risk`  | —             | Schedule a reminder from a duration (`30m`), clock time (`18:00`), `tomorrow HH:MM`, a weekday (`tue 20:00`), or an absolute `2026-08-25 20:00`. |
-| `list_reminders`  | `read-only` | —             | List this person's pending reminders, including their id, fire time, and text.          |
-| `cancel_reminder` | `low-risk`  | —             | Cancel a pending reminder by id (get the id from list_reminders first).                 |
+| `list_reminders`  | `read-only` | —             | List this person's pending reminders, including their id, fire time, and text.                                                                   |
+| `cancel_reminder` | `low-risk`  | —             | Cancel a pending reminder by id (get the id from list_reminders first).                                                                          |
 
 ### Context
 
@@ -193,7 +198,7 @@ Opt-in per agent via `tools`. Used by chat bridges that can render a Mini App or
 
 ---
 
-## What is *not* a built-in tool
+## What is _not_ a built-in tool
 
 A common and consequential misreading. These capabilities exist, but **not as built-in
 tools** — they are [skills](../concepts/skills.md) that shell out through
@@ -206,7 +211,7 @@ tools** — they are [skills](../concepts/skills.md) that shell out through
 | Obsidian vault writes       | `obsidian` skill → CLI via `execute_command`, or `write_file`                              | `unknown` / `high-risk` |
 
 So a scheduled workflow set to `autoApprove: low-risk` **cannot archive an email** — every
-himalaya invocation is declined. The fix is usually *not* to raise the whole tier to
+himalaya invocation is declined. The fix is usually _not_ to raise the whole tier to
 `high-risk` (which also unlocks `rm` and `git push`), but to allowlist the specific binary:
 
 ```json
@@ -222,8 +227,8 @@ That keeps the tier low while letting the one command through. Matching is on a 
 
 ## Notes
 
-- **`find` vs `grep`** — `find` locates files by name, glob, or path pattern. `grep` searches *inside* file contents. Non-overlapping on purpose.
-- **`execute_command` classifier**. The tool is `unknown`, so a harness-model classifier labels each command `read-only`, `low-risk`, or `high-risk` and the active tier judges that verdict: `--approval-policy read-only` auto-approves an inspect-only command, an interactive session skips its prompt, yolo skips the classifier entirely. The live zone shows `classifying` while it runs, and the verdict is printed on the settled receipt. It sees the last five *user* requests (800 characters) on an interactive session and the command alone everywhere else — never the assistant's own turns. Timeouts and ambiguous replies stay `high-risk`. See [Tools & approval](../internals/tools-and-approval.md#command-classifier).
+- **`find` vs `grep`** — `find` locates files by name, glob, or path pattern. `grep` searches _inside_ file contents. Non-overlapping on purpose.
+- **`execute_command` classifier**. The tool is `unknown`, so a harness-model classifier labels each command `read-only`, `low-risk`, or `high-risk` and the active tier judges that verdict: `--approval-policy read-only` auto-approves an inspect-only command, an interactive session skips its prompt, yolo skips the classifier entirely. The live zone shows `classifying` while it runs, and the verdict is printed on the settled receipt. It sees the last five _user_ requests (800 characters) on an interactive session and the command alone everywhere else — never the assistant's own turns. Timeouts and ambiguous replies stay `high-risk`. See [Tools & approval](../internals/tools-and-approval.md#command-classifier).
 - **`http_request` is `read-only`** by risk classification even though it can issue POSTs. It reaches whatever URL the agent targets; network policy belongs at the firewall, not the tier. Treat it accordingly on surfaces that accept untrusted input.
 - **Timeouts** — 3 minutes by default per tool. `ask_user_question` and `ask_file_picker` are `longRunning` and never time out, because waiting for a human is not a hang.
 - **Concurrency** — up to 10 tools execute in parallel per iteration.

--- a/docs/surfaces/index.md
+++ b/docs/surfaces/index.md
@@ -1,6 +1,6 @@
 # Where it runs
 
-This page helps you decide how Jazz fits into *your* setup.
+This page helps you decide how Jazz fits into _your_ setup.
 
 Most agent CLIs are one thing: a terminal REPL. Jazz is a runtime that happens to ship
 with a terminal REPL. The same agent — same tools, same config, same memory — also runs
@@ -14,8 +14,8 @@ want.
 
 ## The surface matrix
 
-| Surface                                                                              | Entry point                        | Human in the loop?             | Status                        |
-| ------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------ | ----------------------------- |
+| Surface                                                                              | Entry point                        | Human in the loop?             | Status                         |
+| ------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------ | ------------------------------ |
 | **[Terminal](../guide/quick-start.md)** — interactive TUI, streaming, slash commands | `jazz`                             | Yes, per tool call             | ✅ Shipped                     |
 | **[Headless](./headless.md)** — one-shot, clean stdout, JSON envelope                | `jazz run`                         | Optional (`--approval-policy`) | ✅ Shipped                     |
 | **[Scheduled](./scheduled.md)** — launchd / cron, with catch-up for missed slots     | `jazz workflow schedule`           | No                             | ✅ Shipped                     |
@@ -32,6 +32,10 @@ want.
 ---
 
 ## One primitive, many surfaces
+
+The `! <command>` shell escape is intentionally a terminal-chat affordance. It is not parsed
+as a command by `jazz run`, scheduled workflows, CI, or chat bridges; those surfaces must use
+their configured approval and authorization policies.
 
 Everything above is the same agent core reached through a different front door. Only two
 of those doors are interactive; the rest all funnel through `jazz run`.
@@ -125,7 +129,7 @@ flag, and it means the same thing everywhere. See
 Because surfaces are front doors rather than forks, all of this is identical no matter
 how the run started:
 
-- **Agent definitions** — `~/.jazz/agents/*.json`. The Telegram bridge, the Discord bridge, your CI job, and your terminal can all run the *same* agent, or different ones.
+- **Agent definitions** — `~/.jazz/agents/*.json`. The Telegram bridge, the Discord bridge, your CI job, and your terminal can all run the _same_ agent, or different ones.
 - **Tools, skills, and MCP servers** — one registry. A skill you add is available headless.
 - **Approval model** — the same two-phase propose/execute path, with a policy dial instead of a prompt when unattended. There is no separate "unattended mode" to drift out of sync.
 - **Conversation history** — `~/.jazz/history/`, keyed by conversation id. A bridge passes its chat id and gets memory for free.

--- a/src/cli/ui/fullscreen/Input.tsx
+++ b/src/cli/ui/fullscreen/Input.tsx
@@ -257,6 +257,9 @@ export function inputRows(
   const width = Math.max(1, viewport.width);
   const contentWidth = Math.max(1, width - GUTTER_CELLS);
   const live = focused && !model.disabled;
+  // A leading "!" hands the line to the shell instead of the model — the rail
+  // and marker pick up the warning hue so that is visible before Enter is hit.
+  const shellCommand = live && model.value.trimStart().startsWith("!");
   const empty = model.value.length === 0;
   const valueCodePoints = [...model.value].length;
   const caretAt = Math.max(0, Math.min(model.caret ?? valueCodePoints, valueCodePoints));
@@ -346,11 +349,14 @@ export function inputRows(
   visible.forEach((line, index) => {
     const rail: InputSegment = {
       text: `${glyphs.rail} `,
-      fg: live ? THEME.primary : THEME.border,
+      fg: shellCommand ? THEME.warning : live ? THEME.primary : THEME.border,
     };
     const marker: InputSegment =
       index === 0
-        ? { text: `${glyphs.promptCursor} `, fg: live ? THEME.prompt : THEME.muted }
+        ? {
+            text: `${glyphs.promptCursor} `,
+            fg: shellCommand ? THEME.warning : live ? THEME.prompt : THEME.muted,
+          }
         : { text: "  ", fg: THEME.muted };
 
     const body: InputSegment[] = [];

--- a/src/core/agent/tools/shell-tools.ts
+++ b/src/core/agent/tools/shell-tools.ts
@@ -421,7 +421,7 @@ type ShellCommandDeps = FileSystem.FileSystem | FileSystemContextService | Logge
  */
 export const EXECUTE_COMMAND_OUTPUT_CAP_BYTES = DEFAULT_SPAWN_OUTPUT_CAP_BYTES;
 
-type ShellCommandOutput = {
+export type ShellCommandOutput = {
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: number;
@@ -434,7 +434,7 @@ type ShellCommandOutput = {
  * "still running after 30s". Returning an interrupt finalizer from
  * `Effect.async` SIGKILLs the child when the tool fiber is interrupted.
  */
-function runShellCommand(input: {
+export function runShellCommand(input: {
   readonly command: string;
   readonly workingDir: string;
   readonly timeoutMs: number;

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -273,7 +273,8 @@ export class ChatServiceImpl implements ChatService {
         if (
           conversationTitle === null &&
           trimmedMessage.length > 0 &&
-          !trimmedMessage.startsWith("/")
+          !trimmedMessage.startsWith("/") &&
+          !trimmedMessage.startsWith("!")
         ) {
           conversationTitle = trimmedMessage.slice(0, 80);
         }
@@ -281,10 +282,11 @@ export class ChatServiceImpl implements ChatService {
         let messageForAgent = userMessage;
 
         // A message with interior newlines (multi-line composition or a
-        // multi-line queued entry) is prose even when it starts with "/" —
+        // multi-line queued entry) is prose even when it starts with "/" or
+        // "!" —
         // command parsing would silently discard everything after line one.
         if (
-          trimmedMessage.startsWith("/") &&
+          (trimmedMessage.startsWith("/") || trimmedMessage.startsWith("!")) &&
           !drainedMultipleEntries &&
           !trimmedMessage.includes("\n")
         ) {
@@ -422,6 +424,10 @@ export class ChatServiceImpl implements ChatService {
               // message instead of prompting again.
               messageForAgent = commandResult.resendMessage;
               yield* terminal.user(messageForAgent);
+            } else if (commandResult.messageForAgent !== undefined) {
+              // A leading `!` executes locally first; only the command result is
+              // sent into the model turn, not the shell escape syntax itself.
+              messageForAgent = commandResult.messageForAgent;
             } else {
               continue;
             }

--- a/src/services/chat/commands/handler.test.ts
+++ b/src/services/chat/commands/handler.test.ts
@@ -6,9 +6,11 @@ import { NodeFileSystem } from "@effect/platform-node";
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { JazzStateServiceTag, type JazzStateService } from "@/core/interfaces/jazz-state";
+import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
 import type { Agent } from "@/core/types/agent";
 import type { ChatMessage } from "@/core/types/message";
+import { createFileSystemContextServiceLayer } from "@/services/fs";
 import { saveConversation } from "@/services/history/conversation-history-service";
 import { handleSpecialCommand } from "./handler";
 import type { CommandContext, CommandResult } from "./types";
@@ -154,5 +156,75 @@ describe("handleSpecialCommand resume", () => {
 
     expect(result).toEqual({ shouldContinue: true });
     expect(info).toHaveBeenCalled();
+  });
+});
+
+describe("handleSpecialCommand shell escape", () => {
+  test("executes the command and returns its bounded result as agent context", async () => {
+    const output: string[] = [];
+    const mockTerminal: Partial<TerminalService> = {
+      log: mock((message: string) => {
+        output.push(message);
+        return Effect.succeed(undefined);
+      }) as TerminalService["log"],
+      error: mock(() => Effect.void),
+    };
+    const mockLogger: Partial<LoggerService> = {
+      info: mock(() => Effect.void),
+    };
+    const fsContextLayer = createFileSystemContextServiceLayer().pipe(
+      Layer.provide(NodeFileSystem.layer),
+    );
+    const layers = Layer.mergeAll(
+      Layer.succeed(TerminalServiceTag, mockTerminal as TerminalService),
+      Layer.succeed(LoggerServiceTag, mockLogger as LoggerService),
+      fsContextLayer,
+    );
+
+    const result = await Effect.runPromise(
+      handleSpecialCommand(
+        { type: "shell", args: ["printf 'alpha'"] },
+        {
+          agent: testAgent,
+          conversationHistory: [],
+          conversationId: "test-session",
+          sessionUsage: { promptTokens: 0, completionTokens: 0 },
+          sessionStartedAt: new Date(),
+        },
+      ).pipe(Effect.provide(layers)) as Effect.Effect<CommandResult, unknown, never>,
+    );
+
+    expect(output).toEqual(["alpha"]);
+    expect(result.messageForAgent).toContain("Exit code: 0");
+    expect(result.messageForAgent).toContain("alpha");
+  });
+
+  test("does not execute a denylisted command", async () => {
+    const error = mock(() => Effect.void);
+    const mockTerminal: Partial<TerminalService> = { error };
+    const fsContextLayer = createFileSystemContextServiceLayer().pipe(
+      Layer.provide(NodeFileSystem.layer),
+    );
+    const layers = Layer.mergeAll(
+      Layer.succeed(TerminalServiceTag, mockTerminal as TerminalService),
+      Layer.succeed(LoggerServiceTag, { info: () => Effect.void } as LoggerService),
+      fsContextLayer,
+    );
+
+    const result = await Effect.runPromise(
+      handleSpecialCommand(
+        { type: "shell", args: ["rm -rf /"] },
+        {
+          agent: testAgent,
+          conversationHistory: [],
+          conversationId: "test-session",
+          sessionUsage: { promptTokens: 0, completionTokens: 0 },
+          sessionStartedAt: new Date(),
+        },
+      ).pipe(Effect.provide(layers)) as Effect.Effect<CommandResult, unknown, never>,
+    );
+
+    expect(error).toHaveBeenCalled();
+    expect(result.messageForAgent).toContain("blocked");
   });
 });

--- a/src/services/chat/commands/handler.ts
+++ b/src/services/chat/commands/handler.ts
@@ -12,6 +12,7 @@ import { resolveEffectiveContextWindow } from "@/core/agent/context/effective-co
 import { DEFAULT_TOKEN_COUNTER } from "@/core/agent/context/token-counter";
 import { clearWorkState, readJournal, workStateSizeBytes } from "@/core/agent/context/work-journal";
 import { formatWorkState, readWorkState } from "@/core/agent/context/work-state";
+import { matchForbiddenCommand, runShellCommand } from "@/core/agent/tools/shell-tools";
 import { WEB_SEARCH_PROVIDERS } from "@/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import type { ProviderName } from "@/core/constants/models";
@@ -20,7 +21,7 @@ import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interface
 import { AgentServiceTag, type AgentService } from "@/core/interfaces/agent-service";
 import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
 import { LLMServiceTag, type LLMService } from "@/core/interfaces/llm";
-import type { LoggerService } from "@/core/interfaces/logger";
+import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
 import {
   MCPServerManagerTag,
   isHttpConfig,
@@ -41,6 +42,7 @@ import type { ChatMessage } from "@/core/types/message";
 import type { AutoApprovePolicy } from "@/core/types/tools";
 import { generateConversationId } from "@/core/utils/conversation-id";
 import { describeCronSchedule } from "@/core/utils/cron";
+import { createSanitizedEnv } from "@/core/utils/env";
 import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import type { WorkflowMetadata } from "@/core/workflows/workflow-service";
 import { WorkflowServiceTag, type WorkflowService } from "@/core/workflows/workflow-service";
@@ -158,6 +160,9 @@ export function handleSpecialCommand(
       case "retry":
         return yield* handleRetryCommand(terminal, conversationHistory);
 
+      case "shell":
+        return yield* handleShellCommand(command.args[0] ?? "", context);
+
       case "clear":
         return yield* handleClearCommand(terminal, agent);
 
@@ -173,6 +178,89 @@ export function handleSpecialCommand(
       default:
         return { shouldContinue: true };
     }
+  });
+}
+
+/**
+ * Execute a command explicitly entered by the operator with a leading `!`.
+ *
+ * This is intentionally outside the model tool loop: the operator authored the
+ * command and its output is then handed to the model as context. It still uses
+ * the shell tool's denylist, sanitized environment, cwd resolution, timeout,
+ * and output cap so the two shell entry points share the same host boundary.
+ */
+function handleShellCommand(
+  command: string,
+  context: CommandContext,
+): Effect.Effect<CommandResult, never, FileSystemContextService | LoggerService | TerminalService> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const shell = yield* FileSystemContextServiceTag;
+    const logger = yield* LoggerServiceTag;
+    const trimmedCommand = command.trim();
+
+    if (!trimmedCommand) {
+      yield* terminal.error("Usage: ! <shell command>");
+      return { shouldContinue: true };
+    }
+
+    const forbidden = matchForbiddenCommand(trimmedCommand);
+    if (forbidden) {
+      const error = `Command blocked by the built-in safety denylist: ${forbidden.reason}`;
+      yield* terminal.error(error);
+      return {
+        shouldContinue: true,
+        messageForAgent: `The operator tried to run this shell command with \`!\`, but Jazz blocked it: ${error}`,
+      };
+    }
+
+    const workingDirectory = yield* shell.getCwd({
+      agentId: context.agent.id,
+      conversationId: context.conversationId,
+    });
+    const result = yield* runShellCommand({
+      command: trimmedCommand,
+      workingDir: workingDirectory,
+      timeoutMs: 900_000,
+      env: createSanitizedEnv({}, context.agent.config.envAllowlist ?? []),
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.succeed({
+          stdout: "",
+          stderr: error.message,
+          exitCode: -1,
+        }),
+      ),
+    );
+
+    const combinedOutput = [result.stdout, result.stderr ? `stderr:\n${result.stderr}` : ""]
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    yield* logger.info("Interactive shell escape completed", {
+      exitCode: result.exitCode,
+      workingDirectory,
+    });
+    yield* terminal.log(
+      combinedOutput || `(command exited with code ${result.exitCode}; no output)`,
+    );
+
+    return {
+      shouldContinue: true,
+      messageForAgent: [
+        `The operator ran this command with \`!\` in ${workingDirectory}:`,
+        "",
+        "```sh",
+        trimmedCommand,
+        "```",
+        "",
+        `Exit code: ${result.exitCode}`,
+        "",
+        combinedOutput ? `Command output:\n${combinedOutput}` : "Command output: (none)",
+        "",
+        "Use this command result as context for your response. Do not claim to have run the command yourself.",
+      ].join("\n"),
+    };
   });
 }
 
@@ -421,6 +509,9 @@ function handleHelpCommand(
           34,
         ),
       ).join("\n"),
+    );
+    yield* terminal.log(
+      fmt.commandRow("! <command>", "Run a shell command and give its output to the agent", 34),
     );
     yield* terminal.log(fmt.blank());
     yield* terminal.log(fmt.heading("Keyboard Shortcuts"));

--- a/src/services/chat/commands/parser.test.ts
+++ b/src/services/chat/commands/parser.test.ts
@@ -167,6 +167,26 @@ describe("parseSpecialCommand", () => {
     });
   });
 
+  describe("shell escapes", () => {
+    it("preserves the complete command after a leading !", () => {
+      expect(parseSpecialCommand("! ssh user@test rm -r folder")).toEqual({
+        type: "shell",
+        args: ["ssh user@test rm -r folder"],
+      });
+    });
+
+    it("allows whitespace before the shell escape", () => {
+      expect(parseSpecialCommand("  ! ls -la  ")).toEqual({
+        type: "shell",
+        args: ["ls -la"],
+      });
+    });
+
+    it("does not treat a bare ! as a shell command", () => {
+      expect(parseSpecialCommand("!").type).toBe("unknown");
+    });
+  });
+
   describe("skill commands", () => {
     afterEach(() => {
       setSkillCommands([]);

--- a/src/services/chat/commands/parser.ts
+++ b/src/services/chat/commands/parser.ts
@@ -4,11 +4,17 @@ import type { SpecialCommand } from "./types";
 /**
  * Parse special commands from user input.
  *
- * Special commands start with "/" and may have arguments.
- * Examples: /new, /help, /switch agent-name
+ * Slash commands start with "/" and may have arguments. A leading "!" is
+ * preserved as a shell escape whose complete command is kept in one argument.
+ * Examples: /new, /help, /switch agent-name, ! git status
  */
 export function parseSpecialCommand(input: string): SpecialCommand {
   const trimmed = input.trim();
+
+  if (trimmed.startsWith("!")) {
+    const command = trimmed.slice(1).trim();
+    return command.length > 0 ? { type: "shell", args: [command] } : { type: "unknown", args: [] };
+  }
 
   if (!trimmed.startsWith("/")) {
     return { type: "unknown", args: [] };

--- a/src/services/chat/commands/types.ts
+++ b/src/services/chat/commands/types.ts
@@ -29,6 +29,7 @@ export type CommandType =
   | "theme"
   | "export"
   | "retry"
+  | "shell"
   | "runSkill"
   | "runMcpPrompt"
   | "unknown";
@@ -65,6 +66,8 @@ export interface CommandResult {
   resetStartedAt?: boolean;
   /** Message to re-send to the agent immediately (set by /retry) */
   resendMessage?: string;
+  /** Message to send to the agent after a user-side command has completed. */
+  messageForAgent?: string;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */


### PR DESCRIPTION
## What & why
Adds a `! <command>` shell escape to the interactive terminal. Instead of asking the agent to run a command and waiting on approval, an operator can type `! ssh user@host rm -r folder` directly — Jazz runs it right away and feeds the bounded output (stdout, stderr, exit code) back to the agent as context for its next reply. It reuses the same cwd resolution, sanitized environment, denylist, timeout, and output caps as `execute_command`, so the safety boundary is shared rather than duplicated.

The composer also turns amber (rail + prompt marker) as soon as the draft starts with `!`, so it's visually clear a line is about to be executed locally rather than sent to the model.

`!` is scoped to the interactive terminal only — `jazz run`, scheduled workflows, and chat bridges are unaffected and keep their own authorization contracts.

## How to verify
- In `jazz` interactively, type `! ls` and confirm it runs immediately, prints output, and the composer border/marker goes amber while typing.
- Ask a follow-up referencing the command's output and confirm the agent can see it.
- Type `! rm -rf /` (or another denylisted pattern) and confirm it's blocked with a clear reason, and the agent is told it was blocked.
- Confirm `/help` lists `! <command>` and that a `!`-prefixed message with no command (just `!`) shows a usage hint instead of running anything.
