### PR TITLE
feat(llm): configurable stream idle timeout via JAZZ_STREAM_IDLE_TIMEOUT_MS

### DIFF
--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -163,6 +163,13 @@ export interface LlamaCppProviderConfig {
 }
 
 export interface LLMConfig {
+  /**
+   * How long a provider stream may stay silent before jazz abandons it as dead,
+   * in milliseconds. Defaults to 120000, or JAZZ_STREAM_IDLE_TIMEOUT_MS when
+   * set. Local providers loading weights from disk on a cold start can
+   * legitimately exceed the default before their first streamed part.
+   */
+  readonly streamIdleTimeoutMs?: number;
   readonly ai_gateway?: LLMProviderConfig;
   readonly alibaba?: LLMProviderConfig;
   readonly anthropic?: LLMProviderConfig;

--- a/src/services/llm/ai-sdk-service.ts
+++ b/src/services/llm/ai-sdk-service.ts
@@ -1724,6 +1724,7 @@ class AISDKService implements LLMService {
                   {
                     providerName,
                     modelName: options.model,
+                    streamIdleTimeoutMs: this.config.llmConfig?.streamIdleTimeoutMs,
                     hasReasoningEnabled: !!(
                       options.reasoning_effort && options.reasoning_effort !== "disable"
                     ),

--- a/src/services/llm/stream-processor.test.ts
+++ b/src/services/llm/stream-processor.test.ts
@@ -610,18 +610,38 @@ describe("withIdleTimeout", () => {
 });
 
 describe("resolveStreamIdleTimeoutMs", () => {
-  it("defaults to two minutes when the env var is unset", () => {
-    expect(resolveStreamIdleTimeoutMs({})).toBe(120_000);
-    expect(resolveStreamIdleTimeoutMs({ JAZZ_STREAM_IDLE_TIMEOUT_MS: "" })).toBe(120_000);
+  it("defaults to two minutes when neither config nor env is set", () => {
+    expect(resolveStreamIdleTimeoutMs(undefined, {})).toBe(120_000);
+    expect(resolveStreamIdleTimeoutMs(undefined, { JAZZ_STREAM_IDLE_TIMEOUT_MS: "" })).toBe(
+      120_000,
+    );
   });
 
   it("honors JAZZ_STREAM_IDLE_TIMEOUT_MS for local cold starts", () => {
-    expect(resolveStreamIdleTimeoutMs({ JAZZ_STREAM_IDLE_TIMEOUT_MS: "300000" })).toBe(300_000);
+    expect(resolveStreamIdleTimeoutMs(undefined, { JAZZ_STREAM_IDLE_TIMEOUT_MS: "300000" })).toBe(
+      300_000,
+    );
+  });
+
+  it("prefers llm.streamIdleTimeoutMs from config.json over the env var", () => {
+    expect(resolveStreamIdleTimeoutMs(600_000, { JAZZ_STREAM_IDLE_TIMEOUT_MS: "300000" })).toBe(
+      600_000,
+    );
+  });
+
+  it("falls back to the env var when the configured value is not a usable budget", () => {
+    for (const value of [undefined, null, "300000", 0, -1, 1.5, Number.NaN]) {
+      expect(resolveStreamIdleTimeoutMs(value, { JAZZ_STREAM_IDLE_TIMEOUT_MS: "300000" })).toBe(
+        300_000,
+      );
+    }
   });
 
   it("falls back to the default on garbage rather than disabling the watchdog", () => {
     for (const value of ["zero", "-1", "0", "1.5", "Infinity", "NaN"]) {
-      expect(resolveStreamIdleTimeoutMs({ JAZZ_STREAM_IDLE_TIMEOUT_MS: value })).toBe(120_000);
+      expect(resolveStreamIdleTimeoutMs(undefined, { JAZZ_STREAM_IDLE_TIMEOUT_MS: value })).toBe(
+        120_000,
+      );
     }
   });
 });

--- a/src/services/llm/stream-processor.ts
+++ b/src/services/llm/stream-processor.ts
@@ -36,22 +36,27 @@ type StreamTextResult = ReturnType<typeof streamText>;
  * Local providers are different: before the first part arrives, the server may
  * still be loading model weights from disk and prefilling a long prompt, which
  * on a cold start can legitimately run past two minutes. That is what
- * JAZZ_STREAM_IDLE_TIMEOUT_MS raises; it does not change what the timeout is
- * for. Tool execution happens between streams, not inside one, so a slow tool
- * cannot trip this either way.
+ * `llm.streamIdleTimeoutMs` in config.json and JAZZ_STREAM_IDLE_TIMEOUT_MS
+ * raise; they do not change what the timeout is for. Tool execution happens
+ * between streams, not inside one, so a slow tool cannot trip this either way.
  */
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 
 /**
- * Resolve the stream idle budget, honoring `JAZZ_STREAM_IDLE_TIMEOUT_MS`.
+ * Resolve the stream idle budget: an explicit `llm.streamIdleTimeoutMs` from
+ * config.json wins, then `JAZZ_STREAM_IDLE_TIMEOUT_MS`, then the default.
  *
- * The env var sets the whole budget in milliseconds (not a delta), and must be
- * a positive integer — anything else falls back to the default rather than
- * silently disabling the watchdog or zeroing it.
+ * Both override paths set the whole budget in milliseconds (not a delta), and
+ * must be a positive integer — anything else falls back to the next source
+ * rather than silently disabling the watchdog or zeroing it.
  */
 export function resolveStreamIdleTimeoutMs(
+  configured: unknown,
   env: Record<string, string | undefined> = process.env,
 ): number {
+  if (typeof configured === "number" && Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
   const raw = env["JAZZ_STREAM_IDLE_TIMEOUT_MS"];
   if (raw === undefined || raw === "") return DEFAULT_STREAM_IDLE_TIMEOUT_MS;
   const parsed = Number(raw);
@@ -117,6 +122,8 @@ type EmitFunction = (
 interface StreamProcessorConfig {
   readonly providerName: string;
   readonly modelName: string;
+  /** `llm.streamIdleTimeoutMs` from config.json, when set — wins over the env var. */
+  readonly streamIdleTimeoutMs?: unknown;
   readonly hasReasoningEnabled: boolean;
   readonly startTime: number;
   readonly toolsDisabled?: boolean;
@@ -287,7 +294,10 @@ export class StreamProcessor {
    */
   private async processFullStream(result: StreamTextResult): Promise<void> {
     try {
-      for await (const part of withIdleTimeout(result.fullStream, resolveStreamIdleTimeoutMs())) {
+      for await (const part of withIdleTimeout(
+        result.fullStream,
+        resolveStreamIdleTimeoutMs(this.config.streamIdleTimeoutMs),
+      )) {
         // Stop if we've finished
         if (this.state.finishEventReceived) {
           break;


### PR DESCRIPTION
## What changes

The provider-stream idle watchdog (the thing that aborts a stream that stops sending without closing) was hardcoded to 120s. That budget assumed hosted providers, where the first streamed part arrives in seconds. Local providers — ollama, llama.cpp — spend their first minutes after a cold start loading weights from disk and prefilling the prompt, so a healthy stream can legitimately stay silent past two minutes and get killed as dead.

`JAZZ_STREAM_IDLE_TIMEOUT_MS` now sets the full budget in milliseconds. Unset/empty keeps the 120s default; garbage values (zero, negative, non-integer) fall back to the default rather than disabling the watchdog.

## Why

ksyl's PR reviews on lysk-server all failed with `Provider stream produced nothing for 120s` while the root cause lived below jazz (a GPU-pinning bug meant qwen could never load). The watchdog did its job converting an infinite queue into a fast, diagnosable failure — but once the infra issue is fixed, cold starts on local hardware should not flirt with the same tripwire. Raising the budget per-deployment beats removing the safety net.

## Verification

- `bun test src/services/llm/stream-processor.test.ts` — 23 pass, including new cases: default when unset, honored value, fallback on garbage.
- `bun run lint` clean.