### PR TITLE
fix(cli): unify pickers and render capability descriptions in standard mode

### DIFF
--- a/src/cli/ui/components/Questionnaire.tsx
+++ b/src/cli/ui/components/Questionnaire.tsx
@@ -1,9 +1,10 @@
 import { Box, Text } from "ink";
-import React, { useState } from "react";
+import React, { useMemo } from "react";
 import type { Suggestion } from "@/core/interfaces/presentation";
 import { THEME } from "../theme";
 import { TextInput } from "./TextInput";
 import { useInputHandler, InputPriority, InputResults } from "../hooks/use-input-service";
+import { usePicker, type PickerChoice } from "../prompt-core";
 
 interface QuestionnaireProps {
   suggestions: readonly Suggestion[];
@@ -13,11 +14,21 @@ interface QuestionnaireProps {
   onCancel?: () => void;
 }
 
+function toPickerChoice(suggestion: Suggestion): PickerChoice {
+  return {
+    label: suggestion.label ?? suggestion.value,
+    value: suggestion.value,
+    ...(suggestion.description === undefined ? {} : { description: suggestion.description }),
+  };
+}
+
 /**
- * Questionnaire component that displays suggested responses and an inline custom input.
- * Supports both single-select (radio) and multi-select (checkbox) modes.
- * The custom input is the last option and can be typed into directly when selected.
- * When there are no suggestions, only the custom text input is shown so the user is never blocked.
+ * Suggested-responses picker. Selection, multi-select and custom-input state
+ * come from the shared picker core; this component maps suggestions into core
+ * choices, feeds `useInputHandler` actions into intents, and paints the view.
+ * The inline custom text field keeps its own `TextInput` (which submits
+ * directly) — the core only owns the suggestion list and selection.
+ * See `prompt-core/picker-core.ts`.
  */
 export function Questionnaire({
   suggestions,
@@ -26,58 +37,45 @@ export function Questionnaire({
   onSubmit,
   onCancel,
 }: QuestionnaireProps): React.ReactElement {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
-  const [customValue] = useState("");
-
-  // When no suggestions, always show custom input so the user can type (never blocked)
+  const choices = useMemo(() => suggestions.map(toPickerChoice), [suggestions]);
   const effectiveAllowCustom = allowCustom || suggestions.length === 0;
-  const totalItems = effectiveAllowCustom ? suggestions.length + 1 : suggestions.length;
   const customOptionIndex = suggestions.length;
+
+  const picker = usePicker({
+    type: "questionnaire",
+    choices,
+    allowMultiple,
+    allowCustom: effectiveAllowCustom,
+    onResolve: (resolution) => {
+      if (resolution.kind === "single") {
+        onSubmit(resolution.value);
+      } else if (resolution.kind === "multi") {
+        onSubmit(resolution.values.join(", "));
+      }
+    },
+    onCancel,
+  });
+
+  const { view, state, dispatch } = picker;
 
   useInputHandler({
     id: "questionnaire-nav",
     priority: InputPriority.PROMPT,
     onInput: (action) => {
       if (action.type === "up") {
-        setSelectedIndex((i) => Math.max(0, i - 1));
+        dispatch({ kind: "move", delta: -1 });
         return InputResults.consumed();
       }
       if (action.type === "down") {
-        setSelectedIndex((i) => Math.min(totalItems - 1, i + 1));
+        dispatch({ kind: "move", delta: 1 });
         return InputResults.consumed();
       }
       if (action.type === "submit") {
-        if (allowMultiple) {
-          // In multiselect mode, Enter submits all selected items
-          if (selectedIndices.size > 0) {
-            const selectedValues = Array.from(selectedIndices)
-              .sort((a, b) => a - b)
-              .map((i) => suggestions[i]?.value)
-              .filter(Boolean) as string[];
-            onSubmit(selectedValues.join(", "));
-            return InputResults.consumed();
-          }
-          // If nothing selected, select the current item and submit
-          if (selectedIndex < suggestions.length) {
-            const suggestion = suggestions[selectedIndex];
-            if (suggestion) {
-              onSubmit(suggestion.value);
-              return InputResults.consumed();
-            }
-          }
-        } else {
-          // Single-select mode: submit the current selection
-          if (selectedIndex < suggestions.length) {
-            const suggestion = suggestions[selectedIndex];
-            if (suggestion) {
-              onSubmit(suggestion.value);
-              return InputResults.consumed();
-            }
-          }
+        if (state.cursor === customOptionIndex && effectiveAllowCustom) {
+          return InputResults.ignored();
         }
-        // If on custom input, TextInput component handles the submit
-        return InputResults.ignored();
+        dispatch({ kind: "submit" });
+        return InputResults.consumed();
       }
       if (action.type === "escape") {
         if (onCancel) {
@@ -86,132 +84,87 @@ export function Questionnaire({
         }
       }
       if (action.type === "char") {
-        // Space toggles selection in multiselect mode
-        if (allowMultiple && action.char === " " && selectedIndex < suggestions.length) {
-          setSelectedIndices((prev) => {
-            const next = new Set(prev);
-            if (next.has(selectedIndex)) {
-              next.delete(selectedIndex);
-            } else {
-              next.add(selectedIndex);
-            }
-            return next;
-          });
+        if (allowMultiple && action.char === " " && state.cursor < suggestions.length) {
+          dispatch({ kind: "toggle" });
           return InputResults.consumed();
         }
-
-        // Quick select by number key (only if not currently typing in the input field)
-        const isTyping = selectedIndex === customOptionIndex && effectiveAllowCustom;
+        const isTyping = state.cursor === customOptionIndex && effectiveAllowCustom;
         if (!isTyping && action.char >= "1" && action.char <= "9") {
           const index = parseInt(action.char, 10) - 1;
           if (index < suggestions.length) {
-            const suggestion = suggestions[index];
-            if (suggestion) {
-              if (allowMultiple) {
-                // Toggle selection in multiselect mode
-                setSelectedIndices((prev) => {
-                  const next = new Set(prev);
-                  if (next.has(index)) {
-                    next.delete(index);
-                  } else {
-                    next.add(index);
-                  }
-                  return next;
-                });
-                setSelectedIndex(index);
-              } else {
-                onSubmit(suggestion.value);
-              }
-              return InputResults.consumed();
-            }
+            dispatch({ kind: "quickPick", index });
+            if (!allowMultiple) dispatch({ kind: "submit" });
+            return InputResults.consumed();
           }
         }
       }
       return InputResults.ignored();
     },
-    deps: [
-      selectedIndex,
-      selectedIndices,
-      suggestions,
-      effectiveAllowCustom,
-      allowMultiple,
-      onSubmit,
-      onCancel,
-    ],
+    deps: [state, suggestions, effectiveAllowCustom, allowMultiple, onSubmit, onCancel],
   });
 
-  const renderIndicator = (index: number) => {
+  const renderIndicator = (row: (typeof view.rows)[number]) => {
     if (allowMultiple) {
-      const isSelected = selectedIndices.has(index);
-      const isFocused = index === selectedIndex;
       return (
-        <Text color={isFocused ? THEME.selected : THEME.secondary}>
-          {isFocused ? "› " : "  "}
-          <Text color={isSelected ? THEME.selected : "gray"}>{isSelected ? "[✓]" : "[ ]"}</Text>
+        <Text color={row.active ? THEME.selected : THEME.secondary}>
+          {row.active ? "› " : "  "}
+          <Text color={row.selected ? THEME.selected : "gray"}>{row.selected ? "[✓]" : "[ ]"}</Text>
         </Text>
       );
     }
     return (
       <Text
-        color={index === selectedIndex ? THEME.selected : THEME.secondary}
-        bold={index === selectedIndex}
+        color={row.active ? THEME.selected : THEME.secondary}
+        bold={row.active}
       >
-        {index === selectedIndex ? "› " : "  "}
+        {row.active ? "› " : "  "}
       </Text>
     );
   };
 
   return (
     <Box flexDirection="column">
-      {/* Suggested responses */}
-      {suggestions.map((suggestion, i) => {
-        const label = suggestion.label ?? suggestion.value;
-        const description = suggestion.description;
-        const isFocused = i === selectedIndex;
-
+      {view.rows.map((row, i) => {
+        const isFocused = i === view.cursor;
         return (
           <Box
-            key={i}
+            key={row.originalIndex}
             flexDirection="column"
           >
             <Box>
-              {renderIndicator(i)}
+              {renderIndicator(row)}
               <Text color={isFocused ? THEME.selected : THEME.primary}> {i + 1}.</Text>
               <Text
                 color={isFocused ? THEME.selected : THEME.secondary}
                 bold={isFocused}
               >
                 {" "}
-                {label}
+                {row.label}
               </Text>
             </Box>
-            {description && (
+            {row.description ? (
               <Box paddingLeft={5}>
-                <Text dimColor>{description}</Text>
+                <Text dimColor>{row.description}</Text>
               </Box>
-            )}
+            ) : null}
           </Box>
         );
       })}
 
-      {/* Inline Custom input */}
       {effectiveAllowCustom && (
         <Box marginTop={suggestions.length > 0 ? 1 : 0}>
           <Box>
             <Text
-              color={selectedIndex === customOptionIndex ? THEME.selected : "gray"}
-              bold={selectedIndex === customOptionIndex}
+              color={state.cursor === customOptionIndex ? THEME.selected : "gray"}
+              bold={state.cursor === customOptionIndex}
             >
-              {selectedIndex === customOptionIndex ? "› " : "  "}
+              {state.cursor === customOptionIndex ? "› " : "  "}
             </Text>
-            {selectedIndex === customOptionIndex ? (
+            {state.cursor === customOptionIndex ? (
               <TextInput
                 inputId="questionnaire-inline-custom"
-                defaultValue={customValue}
                 onSubmit={(value) => {
-                  if (value.trim()) {
-                    onSubmit(value.trim());
-                  }
+                  if (value.trim()) onSubmit(value.trim());
                 }}
               />
             ) : (
@@ -221,7 +174,6 @@ export function Questionnaire({
         </Box>
       )}
 
-      {/* Keyboard hints */}
       <Box marginTop={1}>
         <Text dimColor>
           {allowMultiple

--- a/src/cli/ui/components/ScrollableMultiSelect.tsx
+++ b/src/cli/ui/components/ScrollableMultiSelect.tsx
@@ -1,6 +1,8 @@
 import { Box, Text, useInput } from "ink";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { getGlyphs } from "../glyphs";
+import { pickerWindowStart } from "../picker-window";
+import { originalValuesFromPicker, toPickerChoices, usePicker } from "../prompt-core";
 import { THEME } from "../theme";
 import type { Choice } from "../types";
 
@@ -11,6 +13,7 @@ interface ScrollableMultiSelectProps<T = unknown> {
   readonly defaultSelected?: T | readonly T[];
   readonly pageSize?: number;
   readonly onSubmit: (selectedValues: readonly T[]) => void;
+  readonly onCancel?: () => void;
 }
 
 function normalizeDefaultSelected<T>(defaultSelected: T | readonly T[] | undefined): readonly T[] {
@@ -19,125 +22,68 @@ function normalizeDefaultSelected<T>(defaultSelected: T | readonly T[] | undefin
   return [defaultSelected as T];
 }
 
-function buildDefaultSelectedIndexSet<T>(
-  options: readonly Choice<T>[],
-  defaultSelected: readonly T[],
-): ReadonlySet<number> {
-  if (defaultSelected.length === 0 || options.length === 0) return new Set<number>();
-
-  const selected = new Set<number>();
-  for (let i = 0; i < options.length; i++) {
-    const value = options[i]!.value;
-    if (defaultSelected.includes(value)) selected.add(i);
-  }
-  return selected;
-}
-
+/**
+ * Multi-select checkbox list. Behaviour comes from the shared picker core;
+ * this component translates ink keys into intents and paints the derived view.
+ * See `prompt-core/picker-core.ts`.
+ */
 export function ScrollableMultiSelect<T = unknown>({
   options,
   defaultSelected,
   pageSize = 10,
   onSubmit,
+  onCancel,
 }: ScrollableMultiSelectProps<T>): React.ReactElement {
-  const normalizedDefaultSelected = useMemo(
-    () => normalizeDefaultSelected(defaultSelected),
-    [defaultSelected],
-  );
+  const choices = useMemo(() => toPickerChoices(options), [options]);
+  const defaultChecked = useMemo(() => {
+    const values = new Set(normalizeDefaultSelected(defaultSelected).map(String));
+    return choices
+      .map((choice, index) => (values.has(choice.value) ? index : -1))
+      .filter((i) => i >= 0);
+  }, [choices, defaultSelected]);
 
-  const [cursorIndex, setCursorIndex] = useState(0);
-  const [windowStart, setWindowStart] = useState(0);
-  const [selectedIndexes, setSelectedIndexes] = useState<ReadonlySet<number>>(() =>
-    buildDefaultSelectedIndexSet(options, normalizedDefaultSelected),
-  );
+  const picker = usePicker({
+    type: "checkbox",
+    choices,
+    allowMultiple: true,
+    defaultChecked,
+    onResolve: (resolution) => {
+      if (resolution.kind === "multi") {
+        onSubmit(originalValuesFromPicker(options, resolution.values));
+      }
+    },
+    onCancel,
+  });
 
-  const effectivePageSize = Math.max(1, Math.min(pageSize, options.length || 1));
-  const windowEndExclusive = Math.min(options.length, windowStart + effectivePageSize);
-  const hasMoreAbove = windowStart > 0;
-  const hasMoreBelow = windowEndExclusive < options.length;
-
-  // React can keep this component mounted between prompts; ensure state resets.
-  useEffect(() => {
-    setCursorIndex(0);
-    setWindowStart(0);
-    setSelectedIndexes(buildDefaultSelectedIndexSet(options, normalizedDefaultSelected));
-  }, [options, normalizedDefaultSelected]);
-
-  function clampCursor(nextIndex: number): number {
-    if (options.length === 0) return 0;
-    return Math.max(0, Math.min(options.length - 1, nextIndex));
-  }
-
-  function ensureCursorVisible(nextCursor: number): void {
-    if (options.length <= effectivePageSize) {
-      setWindowStart(0);
-      return;
-    }
-
-    if (nextCursor < windowStart) {
-      setWindowStart(nextCursor);
-      return;
-    }
-
-    const endInclusive = windowStart + effectivePageSize - 1;
-    if (nextCursor > endInclusive) {
-      setWindowStart(Math.max(0, nextCursor - (effectivePageSize - 1)));
-    }
-  }
-
-  function moveCursor(delta: number): void {
-    const nextCursor = clampCursor(cursorIndex + delta);
-    setCursorIndex(nextCursor);
-    ensureCursorVisible(nextCursor);
-  }
-
-  function toggleSelected(index: number): void {
-    setSelectedIndexes((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index);
-      else next.add(index);
-      return next;
-    });
-  }
-
-  function submit(): void {
-    const selected = Array.from(selectedIndexes).sort((a, b) => a - b);
-    const values: T[] = [];
-    for (const idx of selected) {
-      const choice = options[idx];
-      if (choice) values.push(choice.value);
-    }
-    onSubmit(values);
-  }
+  const { view, dispatch } = picker;
 
   useInput((input, key) => {
+    if (key.escape) {
+      onCancel?.();
+      return;
+    }
     if (key.upArrow || input === "k") {
-      moveCursor(-1);
+      dispatch({ kind: "move", delta: -1 });
       return;
     }
-
     if (key.downArrow || input === "j") {
-      moveCursor(1);
+      dispatch({ kind: "move", delta: 1 });
       return;
     }
-
     if (input === " ") {
-      if (options.length > 0) toggleSelected(cursorIndex);
+      dispatch({ kind: "toggle" });
       return;
     }
-
     if (key.return) {
-      submit();
+      dispatch({ kind: "submit" });
     }
   });
 
-  if (options.length === 0) {
-    return (
-      <Box flexDirection="column">
-        <Text dimColor>(No options)</Text>
-        <Text dimColor>Press Enter to submit.</Text>
-      </Box>
-    );
-  }
+  const effectivePageSize = Math.max(1, Math.min(pageSize, view.rows.length || 1));
+  const windowStart = pickerWindowStart(view.cursor, view.rows.length, effectivePageSize);
+  const windowEndExclusive = Math.min(view.rows.length, windowStart + effectivePageSize);
+  const hasMoreAbove = windowStart > 0;
+  const hasMoreBelow = windowEndExclusive < view.rows.length;
 
   return (
     <Box flexDirection="column">
@@ -149,29 +95,30 @@ export function ScrollableMultiSelect<T = unknown>({
 
       {hasMoreAbove && <Text dimColor>↑ more</Text>}
 
-      {options.slice(windowStart, windowEndExclusive).map((choice, localIndex) => {
-        const absoluteIndex = windowStart + localIndex;
-        const isActive = absoluteIndex === cursorIndex;
-        const isSelected = selectedIndexes.has(absoluteIndex);
-
-        return (
-          <Box key={absoluteIndex}>
+      {view.rows.length === 0 ? (
+        <Box flexDirection="column">
+          <Text dimColor>(No options)</Text>
+          <Text dimColor>Press Enter to submit.</Text>
+        </Box>
+      ) : (
+        view.rows.slice(windowStart, windowEndExclusive).map((row) => (
+          <Box key={row.originalIndex}>
             <Text
               color={THEME.primary}
               bold
             >
-              {isActive ? G.rail : " "}
+              {row.active ? G.rail : " "}
             </Text>
             <Text
-              color={isActive ? THEME.selected : THEME.secondary}
-              bold={isActive}
+              color={row.active ? THEME.selected : THEME.secondary}
+              bold={row.active}
             >
               {" "}
-              [{isSelected ? "x" : " "}] {choice.label}
+              [{row.selected ? "x" : " "}] {row.label}
             </Text>
           </Box>
-        );
-      })}
+        ))
+      )}
 
       {hasMoreBelow && <Text dimColor>↓ more</Text>}
 

--- a/src/cli/ui/components/ScrollableSelect.tsx
+++ b/src/cli/ui/components/ScrollableSelect.tsx
@@ -1,7 +1,8 @@
 import { Box, Text, useInput } from "ink";
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import { getGlyphs } from "../glyphs";
-import { PICKER_WINDOW_SIZE, pickerWindowStart, wrapIndex } from "../picker-window";
+import { PICKER_WINDOW_SIZE, pickerWindowStart } from "../picker-window";
+import { originalValueFromPicker, toPickerChoices, usePicker } from "../prompt-core";
 import { THEME } from "../theme";
 import type { Choice } from "../types";
 
@@ -16,9 +17,9 @@ interface ScrollableSelectProps<T = unknown> {
 }
 
 /**
- * ScrollableSelect - a scrollable select component with pagination.
- * Uses arrow keys to navigate, Enter to select, Escape to cancel.
- * Shows 10 items at a time with scroll indicators.
+ * Scrollable single-select (also used for `confirm`). Behaviour comes from the
+ * shared picker core; this component translates ink keys into intents and
+ * paints the derived view. See `prompt-core/picker-core.ts`.
  */
 export function ScrollableSelect<T = unknown>({
   options,
@@ -27,127 +28,92 @@ export function ScrollableSelect<T = unknown>({
   onSelect,
   onCancel,
 }: ScrollableSelectProps<T>): React.ReactElement {
-  const effectivePageSize = Math.max(1, Math.min(pageSize, options.length || 1));
+  const choices = useMemo(() => toPickerChoices(options), [options]);
+  const picker = usePicker({
+    type: "select",
+    choices,
+    initialCursor: initialIndex,
+    onResolve: (resolution) => {
+      if (resolution.kind === "single") {
+        const value = originalValueFromPicker(options, resolution.value);
+        if (value !== undefined) onSelect(value);
+      }
+    },
+    onCancel,
+  });
 
-  const clampedInitialIndex = Math.max(0, Math.min(Math.max(0, options.length - 1), initialIndex));
-  const [cursorIndex, setCursorIndex] = useState(clampedInitialIndex);
-  const windowStart = pickerWindowStart(cursorIndex, options.length, effectivePageSize);
-
-  const windowEndExclusive = Math.min(options.length, windowStart + effectivePageSize);
-  const hasMoreAbove = windowStart > 0;
-  const hasMoreBelow = windowEndExclusive < options.length;
-
-  useEffect(() => {
-    setCursorIndex(clampedInitialIndex);
-  }, [options, clampedInitialIndex]);
-
-  function findNextEnabledIndex(from: number, direction: 1 | -1): number {
-    if (options.length === 0) return 0;
-    let index = from;
-    for (let step = 0; step < options.length; step += 1) {
-      index = wrapIndex(index + direction, options.length);
-      if (options[index]?.disabled !== true) return index;
-    }
-    return from;
-  }
-
-  function moveCursor(delta: number): void {
-    const direction = delta > 0 ? 1 : -1;
-    setCursorIndex(findNextEnabledIndex(cursorIndex, direction));
-  }
-
-  function submit(): void {
-    const selected = options[cursorIndex];
-    if (selected && !selected.disabled) {
-      onSelect(selected.value);
-    }
-  }
+  const { view, dispatch } = picker;
 
   useInput((input, key) => {
-    // Handle escape for cancellation
     if (key.escape) {
       onCancel?.();
       return;
     }
-
-    // Navigation
     if (key.upArrow || input === "k") {
-      moveCursor(-1);
+      dispatch({ kind: "move", delta: -1 });
       return;
     }
-
     if (key.downArrow || input === "j") {
-      moveCursor(1);
+      dispatch({ kind: "move", delta: 1 });
       return;
     }
-
-    // Selection
     if (key.return) {
-      submit();
+      dispatch({ kind: "submit" });
     }
   });
 
-  if (options.length === 0) {
-    return (
-      <Box flexDirection="column">
-        <Text dimColor>(No options)</Text>
-      </Box>
-    );
-  }
+  const effectivePageSize = Math.max(1, Math.min(pageSize, view.rows.length || 1));
+  const windowStart = pickerWindowStart(view.cursor, view.rows.length, effectivePageSize);
+  const windowEndExclusive = Math.min(view.rows.length, windowStart + effectivePageSize);
+  const hasMoreAbove = windowStart > 0;
+  const hasMoreBelow = windowEndExclusive < view.rows.length;
 
   return (
     <Box flexDirection="column">
-      {/* Results count */}
       {(hasMoreAbove || hasMoreBelow) && (
         <Box>
-          <Text dimColor>{options.length} options (↑/↓ to scroll)</Text>
+          <Text dimColor>{view.totalCount} options (↑/↓ to scroll)</Text>
         </Box>
       )}
 
-      {/* Scroll indicator - top */}
       {hasMoreAbove && <Text dimColor>↑ more</Text>}
 
-      {/* Options list */}
-      {options.slice(windowStart, windowEndExclusive).map((choice, localIndex) => {
-        const absoluteIndex = windowStart + localIndex;
-        const isActive = absoluteIndex === cursorIndex;
-        const isDisabled = choice.disabled ?? false;
-
-        // Disabled items: dimmed, cannot be selected
-        if (isDisabled) {
+      {view.rows.length === 0 ? (
+        <Text dimColor>(No options)</Text>
+      ) : (
+        view.rows.slice(windowStart, windowEndExclusive).map((row) => {
+          if (row.disabled) {
+            return (
+              <Text
+                key={row.originalIndex}
+                dimColor
+              >
+                {"  "}
+                {row.label}
+              </Text>
+            );
+          }
           return (
-            <Text
-              key={absoluteIndex}
-              dimColor
-            >
-              {"  "}
-              {choice.label}
-            </Text>
+            <Box key={row.originalIndex}>
+              <Text
+                color={THEME.primary}
+                bold
+              >
+                {row.active ? `${G.rail} ` : "  "}
+              </Text>
+              <Text
+                color={row.active ? THEME.selected : THEME.secondary}
+                bold={row.active}
+              >
+                {row.label}
+              </Text>
+            </Box>
           );
-        }
+        })
+      )}
 
-        return (
-          <Box key={absoluteIndex}>
-            <Text
-              color={THEME.primary}
-              bold
-            >
-              {isActive ? `${G.rail} ` : "  "}
-            </Text>
-            <Text
-              color={isActive ? THEME.selected : THEME.secondary}
-              bold={isActive}
-            >
-              {choice.label}
-            </Text>
-          </Box>
-        );
-      })}
-
-      {/* Scroll indicator - bottom */}
       {hasMoreBelow && <Text dimColor>↓ more</Text>}
 
-      {/* Help text */}
       <Box marginTop={1}>
         <Text dimColor>↑/↓ navigate · Enter select · Esc cancel</Text>
       </Box>

--- a/src/cli/ui/components/SearchSelect.tsx
+++ b/src/cli/ui/components/SearchSelect.tsx
@@ -1,12 +1,13 @@
 import { Box, Text, useInput } from "ink";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { getGlyphs } from "../glyphs";
+import { PICKER_WINDOW_SIZE, pickerWindowStart } from "../picker-window";
 import {
-  PICKER_WINDOW_SIZE,
-  pickerWindowStart,
-  rankPickerMatches,
-  wrapIndex,
-} from "../picker-window";
+  originalValueFromPicker,
+  toPickerChoices,
+  usePicker,
+  type PickerView,
+} from "../prompt-core";
 import { THEME } from "../theme";
 import type { Choice } from "../types";
 
@@ -21,8 +22,9 @@ interface SearchSelectProps<T = unknown> {
 }
 
 /**
- * SearchSelect - a searchable select component with filtering and pagination.
- * Type to filter options, use arrow keys to navigate, Enter to select, Escape to cancel.
+ * Searchable picker. Behaviour (filtering, ranking, cursor, resolution) comes
+ * from the shared picker core; this component only translates ink keys into
+ * intents and paints the derived view. See `prompt-core/picker-core.ts`.
  */
 export function SearchSelect<T = unknown>({
   options,
@@ -31,77 +33,59 @@ export function SearchSelect<T = unknown>({
   onSelect,
   onCancel,
 }: SearchSelectProps<T>): React.ReactElement {
-  const [query, setQuery] = useState("");
-  const [cursorIndex, setCursorIndex] = useState(0);
+  const choices = useMemo(() => toPickerChoices(options), [options]);
+  const picker = usePicker({
+    type: "search",
+    choices,
+    onResolve: (resolution) => {
+      if (resolution.kind === "single") {
+        const value = originalValueFromPicker(options, resolution.value);
+        if (value !== undefined) onSelect(value);
+      } else if (resolution.kind === "custom") {
+        const value = originalValueFromPicker(options, resolution.value);
+        if (value !== undefined) onSelect(value);
+      }
+    },
+    onCancel,
+  });
 
-  const filteredOptions = useMemo(() => rankPickerMatches(options, query), [options, query]);
-
-  const effectivePageSize = Math.max(1, Math.min(pageSize, filteredOptions.length || 1));
-  const windowStart = pickerWindowStart(cursorIndex, filteredOptions.length, effectivePageSize);
-  const windowEndExclusive = Math.min(filteredOptions.length, windowStart + effectivePageSize);
-  const hasMoreAbove = windowStart > 0;
-  const hasMoreBelow = windowEndExclusive < filteredOptions.length;
-
-  useEffect(() => {
-    setCursorIndex(0);
-  }, [query]);
-
-  useEffect(() => {
-    setQuery("");
-    setCursorIndex(0);
-  }, [options]);
-
-  function moveCursor(delta: number): void {
-    if (filteredOptions.length === 0) return;
-    setCursorIndex(wrapIndex(cursorIndex + delta, filteredOptions.length));
-  }
-
-  function submit(): void {
-    const selected = filteredOptions[cursorIndex];
-    if (selected) {
-      onSelect(selected.item.value);
-    }
-  }
+  const { view, state, dispatch } = picker;
+  const query = state.query;
 
   useInput((input, key) => {
-    // Handle escape for cancellation
     if (key.escape) {
       onCancel?.();
       return;
     }
-
-    // Navigation
     if (key.upArrow) {
-      moveCursor(-1);
+      dispatch({ kind: "move", delta: -1 });
       return;
     }
-
     if (key.downArrow) {
-      moveCursor(1);
+      dispatch({ kind: "move", delta: 1 });
       return;
     }
-
-    // Selection
     if (key.return) {
-      submit();
+      dispatch({ kind: "submit" });
       return;
     }
-
-    // Backspace handling
     if (key.backspace || key.delete) {
-      setQuery((prev) => prev.slice(0, -1));
+      dispatch({ kind: "setQuery", query: query.slice(0, -1) });
       return;
     }
-
-    // Text input - only printable characters
     if (input && !key.ctrl && !key.meta) {
-      setQuery((prev) => prev + input);
+      dispatch({ kind: "setQuery", query: query + input });
     }
   });
 
+  const effectivePageSize = Math.max(1, Math.min(pageSize, view.rows.length || 1));
+  const windowStart = pickerWindowStart(view.cursor, view.rows.length, effectivePageSize);
+  const windowEndExclusive = Math.min(view.rows.length, windowStart + effectivePageSize);
+  const hasMoreAbove = windowStart > 0;
+  const hasMoreBelow = windowEndExclusive < view.rows.length;
+
   return (
     <Box flexDirection="column">
-      {/* Search input */}
       <Box>
         <Text color={THEME.muted}>Search: </Text>
         {query.length === 0 ? (
@@ -120,70 +104,77 @@ export function SearchSelect<T = unknown>({
         )}
       </Box>
 
-      {/* Results count */}
       <Box marginTop={1}>
         <Text dimColor>
-          {filteredOptions.length} of {options.length} results
+          {view.filteredCount} of {view.totalCount} results
           {hasMoreAbove || hasMoreBelow ? " (↑/↓ to scroll)" : ""}
         </Text>
       </Box>
 
-      {/* Scroll indicator - top */}
       {hasMoreAbove && <Text dimColor>↑ more</Text>}
 
-      {/* Options list */}
-      {filteredOptions.length === 0 ? (
+      {view.rows.length === 0 ? (
         <Text dimColor>(No matching options)</Text>
       ) : (
-        filteredOptions.slice(windowStart, windowEndExclusive).map((entry, localIndex) => {
-          const absoluteIndex = windowStart + localIndex;
-          const isActive = absoluteIndex === cursorIndex;
-          const { item: option, matchIndex } = entry;
-          const queryLength = query.trim().length;
-          const labelColor = isActive ? THEME.selected : THEME.secondary;
-
-          return (
-            <Box key={absoluteIndex}>
-              <Text
-                color={THEME.primary}
-                bold
-              >
-                {isActive ? `${G.rail} ` : "  "}
-              </Text>
-              {matchIndex >= 0 && queryLength > 0 ? (
-                <Text
-                  color={labelColor}
-                  bold={isActive}
-                >
-                  {option.label.slice(0, matchIndex)}
-                  <Text
-                    color={THEME.primary}
-                    bold
-                  >
-                    {option.label.slice(matchIndex, matchIndex + queryLength)}
-                  </Text>
-                  {option.label.slice(matchIndex + queryLength)}
-                </Text>
-              ) : (
-                <Text
-                  color={labelColor}
-                  bold={isActive}
-                >
-                  {option.label}
-                </Text>
-              )}
-            </Box>
-          );
-        })
+        view.rows.slice(windowStart, windowEndExclusive).map((row) => (
+          <PickerRowLine
+            key={row.originalIndex}
+            row={row}
+            query={query}
+          />
+        ))
       )}
 
-      {/* Scroll indicator - bottom */}
       {hasMoreBelow && <Text dimColor>↓ more</Text>}
 
-      {/* Help text */}
       <Box marginTop={1}>
         <Text dimColor>Type to filter · ↑/↓ navigate · Enter select · Esc cancel</Text>
       </Box>
+    </Box>
+  );
+}
+
+function PickerRowLine({
+  row,
+  query,
+}: {
+  readonly row: PickerView["rows"][number];
+  readonly query: string;
+}): React.ReactElement {
+  const queryLength = query.trim().length;
+  const labelColor = row.active ? THEME.selected : THEME.secondary;
+
+  return (
+    <Box flexDirection="row">
+      <Text
+        color={THEME.primary}
+        bold
+      >
+        {row.active ? `${G.rail} ` : "  "}
+      </Text>
+      {row.matchIndex >= 0 && queryLength > 0 ? (
+        <Text
+          color={labelColor}
+          bold={row.active}
+        >
+          {row.label.slice(0, row.matchIndex)}
+          <Text
+            color={THEME.primary}
+            bold
+          >
+            {row.label.slice(row.matchIndex, row.matchIndex + queryLength)}
+          </Text>
+          {row.label.slice(row.matchIndex + queryLength)}
+        </Text>
+      ) : (
+        <Text
+          color={labelColor}
+          bold={row.active}
+        >
+          {row.label}
+        </Text>
+      )}
+      {row.description ? <Text color={THEME.muted}>{`  ${row.description}`}</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/fullscreen/bridge.tsx
+++ b/src/cli/ui/fullscreen/bridge.tsx
@@ -29,7 +29,8 @@ import {
   resolveFilePickerPath,
   scanFilePickerEntries,
 } from "../file-picker-files";
-import { pickerItemMatches, wrapIndex } from "../picker-window";
+import { wrapIndex } from "../picker-window";
+import { filterAndRank, type PickerChoice } from "../prompt-core";
 import { composeRecalledBuffer, isCursorOnFirstLine, isCursorOnLastLine } from "../queue-recall";
 import {
   store,
@@ -182,16 +183,16 @@ function firstEnabledChoice(choices: readonly { readonly disabled?: boolean }[])
   return index < 0 ? 0 : index;
 }
 
-function choiceMatchesFilter(choice: Choice, filter: string): boolean {
-  return pickerItemMatches(choice, filter);
-}
-
 function promptIsFilterable(prompt: PromptState): boolean {
   return prompt.type === "search" || prompt.type === "select";
 }
 
 function matchingChoiceIndices(choices: readonly Choice[], filter: string): number[] {
-  return choices.flatMap((choice, index) => (choiceMatchesFilter(choice, filter) ? [index] : []));
+  // Route through the shared core so fullscreen ranks choices identically to
+  // the standard (ink) renderer — this ends the two-mode divergence.
+  return filterAndRank(choices as readonly PickerChoice[], filter).map(
+    (ranked) => ranked.originalIndex,
+  );
 }
 
 function choicesAtIndices(choices: readonly Choice[], indices: readonly number[]): Choice[] {
@@ -1191,10 +1192,17 @@ export function FullscreenBridge(): React.ReactNode {
 
   const tools = useMemo(() => liveToolsFrom(activity, Date.now()), [activity, elapsedMs]);
   const step = useMemo(() => stepFrom(activity), [activity]);
+  const todoList =
+    activity.phase === "tool-execution" && activity.todoSnapshot !== undefined
+      ? activity.todoSnapshot.filter((todo) => todo.status !== "cancelled")
+      : [];
   const waitingNow = activity.phase === "awaiting" || activity.phase === "thinking";
   const neededRows = Math.min(
     LIVE_ZONE_MAX_ROWS,
-    tools.length + (waitingNow ? 1 : 0) + (step === undefined ? 0 : 1),
+    tools.length +
+      (waitingNow ? 1 : 0) +
+      (step === undefined ? 0 : 1) +
+      (todoList.length > 0 ? 1 + todoList.length : 0),
   );
 
   useEffect(() => {
@@ -1334,7 +1342,10 @@ export function FullscreenBridge(): React.ReactNode {
           const sourceChoices = choicesForQuestion(active, suggestions);
           updatePromptQuestion((state) => {
             const filter = state.filter + flat;
-            const choices = sourceChoices.filter((choice) => choiceMatchesFilter(choice, filter));
+            const choices = choicesAtIndices(
+              sourceChoices,
+              matchingChoiceIndices(sourceChoices, filter),
+            );
             return { ...state, filter, selected: firstEnabledChoice(choices) };
           });
           return true;
@@ -1692,7 +1703,10 @@ export function FullscreenBridge(): React.ReactNode {
         if (promptIsFilterable(active) && name === "backspace") {
           updatePromptQuestion((state) => {
             const filter = [...state.filter].slice(0, -1).join("");
-            const choices = sourceChoices.filter((choice) => choiceMatchesFilter(choice, filter));
+            const choices = choicesAtIndices(
+              sourceChoices,
+              matchingChoiceIndices(sourceChoices, filter),
+            );
             return { ...state, filter, selected: firstEnabledChoice(choices) };
           });
           return true;
@@ -1746,7 +1760,10 @@ export function FullscreenBridge(): React.ReactNode {
         if (promptIsFilterable(active) && isPrintableSequence(sequence, ctrl, superKey)) {
           updatePromptQuestion((state) => {
             const filter = state.filter + sequence;
-            const choices = sourceChoices.filter((choice) => choiceMatchesFilter(choice, filter));
+            const choices = choicesAtIndices(
+              sourceChoices,
+              matchingChoiceIndices(sourceChoices, filter),
+            );
             return { ...state, filter, selected: firstEnabledChoice(choices) };
           });
           return true;
@@ -2163,6 +2180,7 @@ export function FullscreenBridge(): React.ReactNode {
       tools,
       hiddenTools: [],
       ...(step === undefined ? {} : { step }),
+      ...(todoList.length === 0 ? {} : { todoList }),
       ...(waitingNow
         ? {
             waiting: WAITING[
@@ -2174,7 +2192,7 @@ export function FullscreenBridge(): React.ReactNode {
       reservedRows,
       ...(reasoningElapsedMs === undefined ? {} : { reasoningElapsedMs }),
     };
-  }, [tools, step, waitingNow, elapsedMs, reservedRows, regions]);
+  }, [tools, step, todoList, waitingNow, elapsedMs, reservedRows, regions]);
 
   const view = useMemo<ViewModel>(
     () => ({

--- a/src/cli/ui/prompt-core/index.ts
+++ b/src/cli/ui/prompt-core/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Shared interaction core for choice-based prompts.
+ *
+ * Re-exports the pure picker core and the ink binding so both renderers import
+ * from one place. See `picker-core.ts` for the architecture and the drift
+ * contract.
+ */
+
+export * from "./picker-core";
+export * from "./use-picker";
+export * from "./picker-adapter";

--- a/src/cli/ui/prompt-core/picker-adapter.ts
+++ b/src/cli/ui/prompt-core/picker-adapter.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Adapter between the store's `Choice<T>` and the core's
+ * `PickerChoice`.
+ *
+ * The core is intentionally value-agnostic (values are strings); the store
+ * carries `value: T`. These helpers convert on the way in and resolve the
+ * original `T` on the way out, so components keep their typed `onSelect`.
+ */
+
+import type { Choice } from "../types";
+import type { PickerChoice } from "./picker-core";
+
+export function toPickerChoices<T>(choices: readonly Choice<T>[]): readonly PickerChoice[] {
+  return choices.map((choice) => ({
+    label: choice.label,
+    value: String(choice.value),
+    ...(choice.description === undefined ? {} : { description: choice.description }),
+    ...(choice.disabled === true ? { disabled: true } : {}),
+  }));
+}
+
+export function originalValueFromPicker<T>(
+  choices: readonly Choice<T>[],
+  pickerValue: string,
+): T | undefined {
+  const match = choices.find((choice) => String(choice.value) === pickerValue);
+  return match?.value;
+}
+
+export function originalValuesFromPicker<T>(
+  choices: readonly Choice<T>[],
+  pickerValues: readonly string[],
+): T[] {
+  return pickerValues
+    .map((value) => originalValueFromPicker(choices, value))
+    .filter((value): value is T => value !== undefined);
+}

--- a/src/cli/ui/prompt-core/picker-core.test.ts
+++ b/src/cli/ui/prompt-core/picker-core.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createPickerState,
+  derivePickerView,
+  filterAndRank,
+  reducePicker,
+  resolvePicker,
+  type PickerChoice,
+} from "./picker-core";
+
+const CHOICES: readonly PickerChoice[] = [
+  { label: "Alpha", value: "a", description: "first" },
+  { label: "Beta", value: "b", description: "second", disabled: true },
+  { label: "Gamma", value: "g", description: "third" },
+  { label: "Delta", value: "d" },
+];
+
+describe("filterAndRank", () => {
+  it("returns every choice when the query is empty, preserving order", () => {
+    const ranked = filterAndRank(CHOICES, "");
+    expect(ranked.map((r) => r.originalIndex)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("ranks matches by label position, not just membership", () => {
+    const ranked = filterAndRank(
+      [
+        { label: "Zeta model", value: "z" },
+        { label: "Alpha model", value: "a" },
+      ],
+      "model",
+    );
+    // Both match at a word boundary; the tie-break is the lower match index,
+    // so "Zeta model" (index 5) sorts before "Alpha model" (index 6).
+    expect(ranked[0]?.originalIndex).toBe(0);
+    expect(ranked[1]?.originalIndex).toBe(1);
+  });
+
+  it("reports the match offset inside the label", () => {
+    const ranked = filterAndRank([{ label: "Alpha model", value: "a" }], "model");
+    expect(ranked[0]?.matchIndex).toBe(6);
+  });
+});
+
+describe("derivePickerView", () => {
+  it("marks the cursor row active and carries the description", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES, initialCursor: 2 });
+    const view = derivePickerView(state);
+    expect(view.rows[2]?.active).toBe(true);
+    expect(view.rows[0]?.active).toBe(false);
+    expect(view.rows[2]?.description).toBe("third");
+    expect(view.filteredCount).toBe(4);
+  });
+
+  it("reflects the checked set for multi-select", () => {
+    const state = createPickerState({
+      type: "checkbox",
+      choices: CHOICES,
+      allowMultiple: true,
+      defaultChecked: [0, 2],
+    });
+    const view = derivePickerView(state);
+    expect(view.rows[0]?.selected).toBe(true);
+    expect(view.rows[1]?.selected).toBe(false);
+    expect(view.rows[2]?.selected).toBe(true);
+  });
+});
+
+describe("reducePicker", () => {
+  it("resets the cursor when the query changes", () => {
+    const state = createPickerState({ type: "search", choices: CHOICES, initialCursor: 3 });
+    const next = reducePicker(state, { kind: "setQuery", query: "a" });
+    expect(next.query).toBe("a");
+    expect(next.cursor).toBe(0);
+  });
+
+  it("skips disabled rows when moving", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES, initialCursor: 0 });
+    // From Alpha (0) moving down should land on Gamma (2), skipping Beta (1, disabled).
+    const next = reducePicker(state, { kind: "move", delta: 1 });
+    expect(next.cursor).toBe(2);
+  });
+
+  it("toggles the checked set on toggle for multi-select", () => {
+    const state = createPickerState({
+      type: "checkbox",
+      choices: CHOICES,
+      allowMultiple: true,
+      initialCursor: 2,
+    });
+    const toggled = reducePicker(state, { kind: "toggle" });
+    expect(toggled.checked.has(2)).toBe(true);
+    const untoggled = reducePicker(toggled, { kind: "toggle" });
+    expect(untoggled.checked.has(2)).toBe(false);
+  });
+
+  it("ignores toggle outside multi-select", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES, initialCursor: 0 });
+    expect(reducePicker(state, { kind: "toggle" })).toBe(state);
+  });
+
+  it("jumps to a valid quick-pick index and ignores disabled/out-of-range", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES });
+    expect(reducePicker(state, { kind: "quickPick", index: 2 }).cursor).toBe(2);
+    expect(reducePicker(state, { kind: "quickPick", index: 99 }).cursor).toBe(0);
+  });
+});
+
+describe("resolvePicker", () => {
+  it("resolves the active single choice", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES, initialCursor: 2 });
+    expect(resolvePicker(state)).toEqual({ kind: "single", value: "g" });
+  });
+
+  it("resolves all checked values for multi-select, in original order", () => {
+    const state = createPickerState({
+      type: "checkbox",
+      choices: CHOICES,
+      allowMultiple: true,
+      defaultChecked: [2, 0],
+    });
+    expect(resolvePicker(state)).toEqual({ kind: "multi", values: ["a", "g"] });
+  });
+
+  it("falls back to the custom value when allowed and nothing is active", () => {
+    const state = createPickerState({
+      type: "select",
+      choices: CHOICES,
+      allowCustom: true,
+      customValue: "typed",
+      // A query that matches nothing leaves no active row to resolve.
+      query: "zzz-no-match",
+    });
+    expect(resolvePicker(state)).toEqual({ kind: "custom", value: "typed" });
+  });
+
+  it("resolves none when there is nothing to select", () => {
+    const state = createPickerState({ type: "select", choices: CHOICES, initialCursor: 1 });
+    // Cursor on a disabled row with no custom fallback.
+    expect(resolvePicker(state).kind).toBe("none");
+  });
+});

--- a/src/cli/ui/prompt-core/picker-core.ts
+++ b/src/cli/ui/prompt-core/picker-core.ts
@@ -1,0 +1,271 @@
+/**
+ * @fileoverview Shared interaction core for choice-based prompts.
+ *
+ * Every interactive picker in Jazz — `select`, `search`, `checkbox`,
+ * `questionnaire` and the `confirm` variant — behaves the same way underneath:
+ * a list of choices, an optional filter query, a cursor, an optional checked
+ * set, and a resolution step. Until now that behaviour was implemented twice,
+ * once for the ink (standard) renderer and once for the OpenTUI (fullscreen)
+ * renderer, which is how the two modes drifted apart (fullscreen filtered
+ * without ranking while standard ranked; standard dropped the description
+ * line that fullscreen painted).
+ *
+ * This module is the single source of that behaviour. It is pure — no React,
+ * no ink, no `@opentui` import — so both renderers can drive it from key
+ * events and paint the `PickerView` it derives. Renderers keep only their
+ * visual layout (card vs free list, alignment, colours), which is the part
+ * that is supposed to differ between hosts.
+ *
+ * The contract that prevents drift: a renderer must produce its rows from
+ * `derivePickerView`, and must move state through `reducePicker`. Any future
+ * change to filtering, ranking, cursor, selection or resolution touches one
+ * function here, not two components.
+ */
+
+import { rankPickerMatches } from "../picker-window";
+
+/** A single choice as the core sees it. Hosts map their domain choices to this. */
+export interface PickerChoice {
+  readonly label: string;
+  readonly value: string;
+  readonly description?: string;
+  readonly disabled?: boolean;
+}
+
+export type PickerType = "select" | "search" | "checkbox" | "questionnaire";
+
+/** All mutable interaction state for a choice-based prompt. */
+export interface PickerState {
+  readonly type: PickerType;
+  readonly choices: readonly PickerChoice[];
+  /** Incremental filter text (empty means "show all"). */
+  readonly query: string;
+  /** Cursor index into the *filtered* list, not the original choices. */
+  readonly cursor: number;
+  /** Original-choice indices that are checked (checkbox / multi-select). */
+  readonly checked: ReadonlySet<number>;
+  /** Questionnaire / checkbox multi-select mode. */
+  readonly allowMultiple?: boolean;
+  /** A free-text row the user can type into when nothing matches. */
+  readonly allowCustom?: boolean;
+  /** The free-text value, when `allowCustom` is set. */
+  readonly customValue?: string;
+  /** Original-choice indices checked by default. */
+  readonly defaultChecked?: readonly number[];
+}
+
+/** Options for {@link createPickerState}. Optional fields accept `undefined`
+ *  explicitly so callers can forward `maybeDefined ?? undefined` under
+ *  `exactOptionalPropertyTypes`. */
+export interface CreatePickerStateOptions {
+  readonly type: PickerType;
+  readonly choices: readonly PickerChoice[];
+  readonly query?: string | undefined;
+  readonly allowMultiple?: boolean | undefined;
+  readonly allowCustom?: boolean | undefined;
+  readonly customValue?: string | undefined;
+  readonly defaultChecked?: readonly number[] | undefined;
+  readonly initialCursor?: number | undefined;
+}
+
+/** A choice paired with its position in the original list, after filtering/ranking. */
+export interface RankedChoice {
+  readonly originalIndex: number;
+  readonly choice: PickerChoice;
+  /** Offset of the query match inside the label, or -1 when there is no query. */
+  readonly matchIndex: number;
+}
+
+/**
+ * Filter and rank `choices` against `query`.
+ *
+ * Shares `rankPickerMatches` with the rest of the UI so the ranking order is
+ * identical everywhere — this is the function that ended the fullscreen-vs-
+ * standard ranking divergence. Returns original indices so cursors and checked
+ * sets stay stable across re-filtering.
+ */
+export function filterAndRank(
+  choices: readonly PickerChoice[],
+  query: string,
+): readonly RankedChoice[] {
+  const ranked = rankPickerMatches(choices, query);
+  return ranked.map((entry) => ({
+    // Original array index, not the filtered position: callers map a ranked
+    // choice back to its source via this index.
+    originalIndex: choices.indexOf(entry.item),
+    choice: entry.item,
+    matchIndex: entry.matchIndex,
+  }));
+}
+
+/** Build the initial picker state from prompt data. */
+export function createPickerState(options: CreatePickerStateOptions): PickerState {
+  const checked = new Set<number>(options.defaultChecked ?? []);
+  return {
+    type: options.type,
+    choices: options.choices,
+    query: options.query ?? "",
+    cursor: options.initialCursor ?? 0,
+    checked,
+    allowMultiple: options.allowMultiple ?? false,
+    allowCustom: options.allowCustom ?? false,
+    customValue: options.customValue ?? "",
+    defaultChecked: options.defaultChecked ?? [],
+  };
+}
+
+/** A row the renderer paints — derived, never stored. */
+export interface PickerRow {
+  readonly originalIndex: number;
+  readonly label: string;
+  readonly description?: string;
+  readonly disabled: boolean;
+  readonly active: boolean;
+  readonly selected: boolean;
+  /** Offset of the active query inside the label, or -1 when there is no query. */
+  readonly matchIndex: number;
+}
+
+/** The complete derived view for a picker at its current state. */
+export interface PickerView {
+  readonly rows: readonly PickerRow[];
+  readonly totalCount: number;
+  readonly filteredCount: number;
+  readonly cursor: number;
+  readonly query: string;
+  readonly checked: ReadonlySet<number>;
+}
+
+/**
+ * Derive the paint-ready view from state. Renderers window this (both already
+ * window by height/width) but the *content* — order, labels, descriptions,
+ * which row is active, which are checked — is single-sourced here.
+ */
+export function derivePickerView(state: PickerState): PickerView {
+  const ranked = filterAndRank(state.choices, state.query);
+  const rows: PickerRow[] = ranked.map((entry, index) => ({
+    originalIndex: entry.originalIndex,
+    label: entry.choice.label,
+    ...(entry.choice.description === undefined ? {} : { description: entry.choice.description }),
+    disabled: entry.choice.disabled === true,
+    active: index === state.cursor,
+    selected: state.checked.has(entry.originalIndex),
+    matchIndex: entry.matchIndex,
+  }));
+  return {
+    rows,
+    totalCount: state.choices.length,
+    filteredCount: ranked.length,
+    cursor: state.cursor,
+    query: state.query,
+    checked: state.checked,
+  };
+}
+
+/** Intent the drivers feed in. Host-agnostic: ink keys and OpenTUI actions both map to these. */
+export type PickerIntent =
+  | { readonly kind: "setQuery"; readonly query: string }
+  | { readonly kind: "move"; readonly delta: number }
+  | { readonly kind: "first" }
+  | { readonly kind: "last" }
+  | { readonly kind: "toggle" }
+  | { readonly kind: "quickPick"; readonly index: number }
+  | { readonly kind: "submit" };
+
+function clampCursor(cursor: number, length: number): number {
+  if (length <= 0) return 0;
+  return Math.max(0, Math.min(length - 1, cursor));
+}
+
+/**
+ * Move the cursor by `delta` through the filtered list, skipping disabled rows.
+ * Skipping mirrors the standard `ScrollableSelect` rule and keeps disabled
+ * choices unselectable without special-casing in the renderer.
+ */
+function moveCursor(filtered: readonly RankedChoice[], cursor: number, delta: number): number {
+  if (filtered.length === 0) return 0;
+  const direction = delta > 0 ? 1 : -1;
+  let next = cursor;
+  for (let step = 0; step < filtered.length; step += 1) {
+    next = clampCursor(next + direction, filtered.length);
+    if (!filtered[next]?.choice.disabled) return next;
+  }
+  return cursor;
+}
+
+/**
+ * Pure state transition. The renderer calls this on every key intent and
+ * repaints from `derivePickerView`. Resolution (what value a submit yields) is
+ * a separate pure step, `resolvePicker`, so drivers and tests can inspect the
+ * outcome without a renderer.
+ */
+export function reducePicker(state: PickerState, intent: PickerIntent): PickerState {
+  const filtered = filterAndRank(state.choices, state.query);
+
+  switch (intent.kind) {
+    case "setQuery": {
+      return { ...state, query: intent.query, cursor: 0 };
+    }
+    case "move": {
+      return { ...state, cursor: moveCursor(filtered, state.cursor, intent.delta) };
+    }
+    case "first": {
+      return { ...state, cursor: moveCursor(filtered, -1, filtered.length) };
+    }
+    case "last": {
+      return { ...state, cursor: moveCursor(filtered, filtered.length, filtered.length) };
+    }
+    case "toggle": {
+      if (state.type !== "checkbox" && state.type !== "questionnaire") return state;
+      if (!state.allowMultiple) return state;
+      const current = filtered[state.cursor];
+      if (current === undefined) return state;
+      const next = new Set(state.checked);
+      if (next.has(current.originalIndex)) next.delete(current.originalIndex);
+      else next.add(current.originalIndex);
+      return { ...state, checked: next };
+    }
+    case "quickPick": {
+      const target = intent.index;
+      if (target < 0 || target >= filtered.length) return state;
+      if (filtered[target]?.choice.disabled) return state;
+      return { ...state, cursor: target };
+    }
+    case "submit": {
+      return state;
+    }
+  }
+}
+
+export type PickerResolution =
+  | { readonly kind: "single"; readonly value: string }
+  | { readonly kind: "multi"; readonly values: readonly string[] }
+  | { readonly kind: "custom"; readonly value: string }
+  | { readonly kind: "none" };
+
+/**
+ * What a submit produces, derived purely from state. Hosts call this when the
+ * user confirms, so the "what gets resolved" rule lives here too.
+ */
+export function resolvePicker(state: PickerState): PickerResolution {
+  const filtered = filterAndRank(state.choices, state.query);
+
+  if (state.type === "checkbox" || (state.type === "questionnaire" && state.allowMultiple)) {
+    const values = [...state.checked]
+      .sort((left, right) => left - right)
+      .map((index) => state.choices[index]?.value)
+      .filter((value): value is string => value !== undefined);
+    return { kind: "multi", values };
+  }
+
+  const current = filtered[state.cursor];
+  if (current !== undefined && !current.choice.disabled) {
+    return { kind: "single", value: current.choice.value };
+  }
+
+  if (state.allowCustom && (state.customValue ?? "").length > 0) {
+    return { kind: "custom", value: state.customValue ?? "" };
+  }
+
+  return { kind: "none" };
+}

--- a/src/cli/ui/prompt-core/use-picker.ts
+++ b/src/cli/ui/prompt-core/use-picker.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview React hook binding the pure picker core to component state.
+ *
+ * Ink (standard) components share this hook so their *state, transitions and
+ * derived view* all come from `picker-core` — the only place left to them is
+ * translating ink key events into `PickerIntent`s and painting the view. The
+ * fullscreen renderer drives the same pure functions from its external
+ * controls, so both hosts agree on behaviour by construction.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  createPickerState,
+  derivePickerView,
+  reducePicker,
+  resolvePicker,
+  type PickerChoice,
+  type PickerIntent,
+  type PickerResolution,
+  type PickerState,
+  type PickerType,
+  type PickerView,
+} from "./picker-core";
+
+export interface UsePickerOptions {
+  readonly type: PickerType;
+  readonly choices: readonly PickerChoice[];
+  readonly allowMultiple?: boolean;
+  readonly allowCustom?: boolean;
+  readonly defaultChecked?: readonly number[];
+  readonly initialCursor?: number;
+  /** Called when the user confirms; receives the resolved value(s). */
+  readonly onResolve: (resolution: PickerResolution) => void;
+  /** Called when the user cancels (escape). */
+  readonly onCancel?: (() => void) | undefined;
+}
+
+export interface UsePicker {
+  readonly state: PickerState;
+  readonly view: PickerView;
+  readonly dispatch: (intent: PickerIntent) => void;
+  readonly resolve: () => PickerResolution;
+  readonly setCustomValue: (value: string) => void;
+}
+
+export function usePicker(options: UsePickerOptions): UsePicker {
+  const [state, setState] = useState<PickerState>(() =>
+    createPickerState({
+      type: options.type,
+      choices: options.choices,
+      allowMultiple: options.allowMultiple ?? false,
+      allowCustom: options.allowCustom ?? false,
+      defaultChecked: options.defaultChecked ?? [],
+      initialCursor: options.initialCursor ?? 0,
+    }),
+  );
+
+  const dispatch = useCallback(
+    (intent: PickerIntent) => {
+      if (intent.kind === "submit") {
+        const resolution = resolvePicker(state);
+        // A non-resolvable row (e.g. cursor on a disabled choice) is ignored,
+        // not cancelled — escape is the only cancel path.
+        if (resolution.kind !== "none") {
+          options.onResolve(resolution);
+        }
+        return;
+      }
+      setState((previous) => reducePicker(previous, intent));
+    },
+    [state, options],
+  );
+
+  const setCustomValue = useCallback((value: string) => {
+    setState((previous) => ({ ...previous, customValue: value }));
+  }, []);
+
+  const view = useMemo(() => derivePickerView(state), [state]);
+
+  const resolve = useCallback(() => resolvePicker(state), [state]);
+
+  return { state, view, dispatch, resolve, setCustomValue };
+}

--- a/src/core/utils/provider-picker.ts
+++ b/src/core/utils/provider-picker.ts
@@ -67,16 +67,19 @@ const PINNED_MODELS_BY_PROVIDER: Readonly<Record<string, readonly string[]>> = {
 /**
  * OpenRouter's own ids (`openrouter/free`, `openrouter/auto`, `openrouter/fusion`, …)
  * are router meta-models — the reason to pick this provider at all — so the whole
- * prefix pins above its hundreds of plain catalog entries.
+ * prefix pins above its hundreds of plain catalog entries. `free` leads the group
+ * since it's the entry point with no cost attached.
  */
 const ROUTER_MODEL_PREFIX = "openrouter/";
+const ROUTER_MODEL_ORDER = ["openrouter/free", "openrouter/auto"] as const;
 
 function pinnedModelRank(providerId: string, modelId: string): number {
   if (
     canonicalizeProviderId(providerId) === "openrouter" &&
     modelId.startsWith(ROUTER_MODEL_PREFIX)
   ) {
-    return 0;
+    const routerRank = ROUTER_MODEL_ORDER.indexOf(modelId as (typeof ROUTER_MODEL_ORDER)[number]);
+    return routerRank === -1 ? 0 : routerRank - ROUTER_MODEL_ORDER.length;
   }
   const pinned = PINNED_MODELS_BY_PROVIDER[canonicalizeProviderId(providerId)];
   const rank = pinned?.indexOf(modelId) ?? -1;


### PR DESCRIPTION
## What & why
Standard (non-fullscreen) pickers didn't show the input/output capability and
price lines that fullscreen showed for model selection (added in #444) — so the
same prompt looked different and lost information depending on which renderer was
active. Worse, the two renderers had quietly diverged: fullscreen filtered
choices unranked while standard ranked them.

We extracted a shared, host-agnostic picker core (`src/cli/ui/prompt-core/`) that
owns selection, filtering, ranking, multi-select, custom input, and cursor
movement. Both the ink (standard) components and the fullscreen bridge now drive
the same core, so the modes behave identically and can't drift again.

## How to verify
- In standard mode, open a model/provider picker and confirm each option shows
  its capability + price description line, with the typed query substring
  highlighted in the label.
- In fullscreen mode, open the same picker and confirm the ordering/ranking for
  a given query now matches standard mode (both rank).
- Edge: in a select/confirm with custom input allowed, type a query that matches
  nothing — the custom row appears, and submitting it returns the typed text.
- Edge: checkbox/multi-select — Space toggles, Enter submits all checked values.
- `bun test ./src/cli/ui/prompt-core/` (14 tests) and the fullscreen
  `prompts`/`bridge` suites stay green.
