### PR TITLE
fix(test): update stale sortModelsForPicker expectation

### DIFF
--- a/src/core/utils/provider-picker.test.ts
+++ b/src/core/utils/provider-picker.test.ts
@@ -11,13 +11,13 @@ const OPENROUTER_MODELS = [
 ] as never[];
 
 describe("sortModelsForPicker", () => {
-  it("pins every openrouter/* router model above plain models, in catalog order", () => {
+  it("pins openrouter/free and openrouter/auto first, then remaining router models in catalog order, above plain models", () => {
     expect(
       sortModelsForPicker("openrouter", OPENROUTER_MODELS, (m) => m.id).map((m) => m.id),
     ).toEqual([
-      "openrouter/fusion",
-      "openrouter/auto",
       "openrouter/free",
+      "openrouter/auto",
+      "openrouter/fusion",
       "anthropic/claude-sonnet-4-5",
       "deepseek/deepseek-v4",
       "openai/gpt-5",


### PR DESCRIPTION
## What & why
CI on main was red because a test still expected the old catalog-order sort for OpenRouter's router models. A prior fix intentionally pinned `openrouter/free` before `openrouter/auto` in the model picker, but the test's expected order was never updated to match, so it started failing as soon as that logic shipped. This updates the assertion to match the intended, already-shipped behavior — no production logic changes.

## How to verify
- `bun test src/core/utils/provider-picker.test.ts` passes.
- `bun test` full suite passes (0 fail).
- Confirm `openrouter/free` still sorts before `openrouter/auto`, with other router-prefixed models (e.g. `openrouter/fusion`) kept in catalog order above plain models.
