### PR TITLE
docs: add README for bot-shared and runtime packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Read the READMEs:
 - `packages/core/README.md` - Core package patterns
 - `packages/adapters/README.md` - Adapter implementations
 - `packages/cli/README.md` - CLI commands
-- `docs/ARCHITECTURE.md` - System architecture
+- `docs/reference/architecture.md` - System architecture
 - `docs/FAQ.md` - Common patterns
 
 ## Key Best Practices

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -242,6 +242,6 @@ Uses Node.js `fs` with Effect-TS `@effect/platform` for:
 
 - **Core**: See `@jazz/core/README.md` for interface definitions
 - **CLI**: See `@jazz/cli/README.md` for how adapters are used
-- **Architecture**: See `docs/ARCHITECTURE.md` for system-wide architecture
+- **Architecture**: See `docs/reference/architecture.md` for system-wide architecture
 
 **Critical Rule**: Adapters import from `@jazz/core/`, never the other way around. Adapters implement core interfaces.

--- a/packages/bot-shared/README.md
+++ b/packages/bot-shared/README.md
@@ -1,0 +1,29 @@
+# `@jazz/bot-shared`
+
+Small helpers shared by the two chat-bridge packages (`@jazz/telegram-bot`, `@jazz/discord-bot`)
+so they can't drift apart on formatting/config rules that both bridges must apply identically.
+
+Depends only on `@jazz/core`.
+
+## Key files
+
+- **`reasoning.ts`** — rules for surfacing a run's model reasoning in a chat bridge. Both bridges
+  consume the same `thinking_chunk` stream and face the same two conflicting needs: a live
+  progress bubble that must stay one line (edited in place under a platform edit rate limit) and
+  a post-run record that keeps everything the model actually thought.
+- **`bridge-config.ts`** — the merge rule for a bridge's `config.json`: which keys the bridge
+  owns, and what happens when their backing environment variables go away. Kept pure and
+  filesystem-free so it's testable without touching disk.
+- **`write-bridge-config.ts`** — the entrypoint script (`bun write-bridge-config.ts
+  <path-to-config.json>`) that applies `bridge-config.ts`'s merge rule to a real file, run at
+  container startup. Merges rather than overwrites, since the data volume outlives the container
+  and anything an operator added by hand must survive a restart.
+- **`run-log.ts`** — per-turn NDJSON record of what a bridge run did, written to
+  `<dataDir>/logs/runs/`. The conversation transcript is only written once a run completes, so a
+  run that hangs or times out would otherwise leave no trace to diagnose.
+
+## Related documentation
+
+- **Telegram bridge**: `packages/telegram-bot/README.md`
+- **Discord bridge**: `packages/discord-bot/README.md`
+- **Core**: `packages/core/README.md`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -315,4 +315,4 @@ Test full command flows with:
 
 - **Core**: See `@jazz/core/README.md` for agent execution logic
 - **Adapters**: See `@jazz/adapters/README.md` for adapter implementations
-- **Architecture**: See `docs/ARCHITECTURE.md` for system-wide architecture
+- **Architecture**: See `docs/reference/architecture.md` for system-wide architecture

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -132,7 +132,7 @@ function myLogic(): Effect.Effect<Result, Error, LLMService | LoggerService> {
 
 - **`@jazz/adapters`**: see `packages/adapters/README.md` for interface implementations
 - **`@jazz/cli`**: see `packages/cli/README.md` for how commands use core
-- **Architecture**: see `docs/ARCHITECTURE.md` for system-wide architecture
+- **Architecture**: see `docs/reference/architecture.md` for system-wide architecture
 
 **Critical rule**: `@jazz/core` never imports from `@jazz/adapters`, `@jazz/cli`, or
 `@jazz/runtime`. All dependencies point inward, and `tsc -b` enforces it.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,61 @@
+# `@jazz/runtime`
+
+The composition root: wires `@jazz/core`, `@jazz/adapters`, and `@jazz/cli` together into the
+running `jazz` CLI, and is what `scripts/build.ts` compiles into the standalone binary.
+
+## Role in the system
+
+```
+┌─────────────┐
+│   User      │
+└──────┬──────┘
+       │
+┌──────▼──────────────────────────────────┐
+│  @jazz/runtime                           │
+│  - Process bootstrap (entry.ts)          │
+│  - Commander.js program (cli-app.ts)     │
+│  - Effect Layer composition (app-layer)  │
+└──────┬──────────────────────────────────┘
+       │ provides layers to
+┌──────▼──────────────────────────────────┐
+│  @jazz/cli                               │
+└──────┬──────────────────────────────────┘
+       │ calls
+┌──────▼──────────────────────────────────┐
+│  @jazz/core                              │
+└──────▲──────────────────────────────────┘
+       │ implements
+┌──────┴──────────────────────────────────┐
+│  @jazz/adapters                          │
+└───────────────────────────────────────────┘
+```
+
+`@jazz/runtime` is the only package allowed to depend on all three of `core`, `adapters`, and
+`cli` at once — everywhere else, the dependency rule points inward (see
+`docs/internals/code-map.md`).
+
+## Key files
+
+- **`entry.ts`** — process-level bootstrap (suppresses noisy deprecation warnings) before the
+  rest of the app loads. This is the binary's actual entrypoint.
+- **`main.ts`** — second-stage entrypoint imported by `entry.ts`; builds the Commander program
+  and parses `argv`. Also routes the `ai` SDK's warning logger to stderr, since `jazz run --json`
+  requires stdout to be JSON-only.
+- **`cli-app.ts`** — Commander.js setup and command registration for every `jazz <command>`.
+- **`app-layer.ts`** — builds the Effect `Layer` that wires every adapter (storage, LLM,
+  terminal, presentation, telemetry, ...) behind `@jazz/core`'s service tags, then runs a
+  command's effect against it. This is where a new service's `Layer` gets registered.
+
+## Adding a new command
+
+1. Implement it in `@jazz/cli/commands/<name>.ts` (see `packages/cli/README.md`).
+2. Register it in `cli-app.ts`'s Commander program.
+3. If it needs a new service, define the contract in `@jazz/core/interfaces/`, implement it in
+   `@jazz/adapters/`, and add its `Layer` to `app-layer.ts`'s `createAppLayer()`.
+
+## Related documentation
+
+- **Core**: `packages/core/README.md`
+- **Adapters**: `packages/adapters/README.md`
+- **CLI**: `packages/cli/README.md`
+- **Architecture**: `docs/reference/architecture.md`


### PR DESCRIPTION
## What & why
Every package under `packages/*` now has a README — adds the two that were missing (`bot-shared`, `runtime`) so a contributor can orient themselves in any package without reading source first.

Also fixes a dead `docs/ARCHITECTURE.md` link (the file actually lives at `docs/reference/architecture.md`) that four other package READMEs and `CONTRIBUTING.md` already carried.

## How to verify
- `bun run docs:check-links` passes.
- Every relative link in the new/edited READMEs resolves (`packages/*/README.md`, `docs/reference/architecture.md`).