### PR TITLE
fix(bots): install after full COPY so Bun links workspace packages

### DIFF
--- a/packages/discord-bot/src/Dockerfile
+++ b/packages/discord-bot/src/Dockerfile
@@ -12,9 +12,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 COPY package.json bun.lock bunfig.toml ./
-RUN bun install --frozen-lockfile
 
+# A workspace monorepo: bun needs every packages/*/package.json on disk to
+# link @jazz/* symlinks in node_modules, so installing before the rest of the
+# source is copied would silently skip them (every @jazz/* import then fails
+# at runtime, not at build time). Copy everything first and pay for a full
+# install on every source change instead — this repo's install is ~2s.
 COPY . .
+RUN bun install --frozen-lockfile
 
 RUN printf '#!/bin/sh\nexec bun /app/packages/runtime/src/entry.ts "$@"\n' > /usr/local/bin/jazz \
     && chmod +x /usr/local/bin/jazz \

--- a/packages/discord-bot/src/Dockerfile
+++ b/packages/discord-bot/src/Dockerfile
@@ -13,11 +13,8 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 COPY package.json bun.lock bunfig.toml ./
 
-# A workspace monorepo: bun needs every packages/*/package.json on disk to
-# link @jazz/* symlinks in node_modules, so installing before the rest of the
-# source is copied would silently skip them (every @jazz/* import then fails
-# at runtime, not at build time). Copy everything first and pay for a full
-# install on every source change instead — this repo's install is ~2s.
+# Workspace packages must be on disk before install, or bun skips their
+# node_modules/@jazz/* symlinks.
 COPY . .
 RUN bun install --frozen-lockfile
 

--- a/packages/telegram-bot/src/Dockerfile
+++ b/packages/telegram-bot/src/Dockerfile
@@ -55,14 +55,8 @@ ENV XDG_CONFIG_HOME=/data/xdg-config \
 
 COPY package.json bun.lock bunfig.toml ./
 
-# Jazz runs from source under Bun; it locates built-in personas/skills by
-# walking up to the package.json named "jazz-ai", so the whole tree is copied.
-#
-# A workspace monorepo: bun needs every packages/*/package.json on disk to
-# link @jazz/* symlinks in node_modules, so installing before the rest of the
-# source is copied would silently skip them (every @jazz/* import then fails
-# at runtime, not at build time). Copy everything first and pay for a full
-# install on every source change instead — this repo's install is ~2s.
+# Workspace packages must be on disk before install, or bun skips their
+# node_modules/@jazz/* symlinks.
 COPY . .
 RUN bun install --frozen-lockfile
 

--- a/packages/telegram-bot/src/Dockerfile
+++ b/packages/telegram-bot/src/Dockerfile
@@ -53,13 +53,18 @@ ENV XDG_CONFIG_HOME=/data/xdg-config \
     GNUPGHOME=/data/gnupg \
     PASSWORD_STORE_DIR=/data/password-store
 
-# Dependencies first so the install layer caches across source edits.
 COPY package.json bun.lock bunfig.toml ./
-RUN bun install --frozen-lockfile
 
 # Jazz runs from source under Bun; it locates built-in personas/skills by
 # walking up to the package.json named "jazz-ai", so the whole tree is copied.
+#
+# A workspace monorepo: bun needs every packages/*/package.json on disk to
+# link @jazz/* symlinks in node_modules, so installing before the rest of the
+# source is copied would silently skip them (every @jazz/* import then fails
+# at runtime, not at build time). Copy everything first and pay for a full
+# install on every source change instead — this repo's install is ~2s.
 COPY . .
+RUN bun install --frozen-lockfile
 
 RUN printf '#!/bin/sh\nexec bun /app/packages/runtime/src/entry.ts "$@"\n' > /usr/local/bin/jazz \
     && chmod +x /usr/local/bin/jazz \


### PR DESCRIPTION
## What & why
Both bot Dockerfiles copied only the root `package.json` before `bun install --frozen-lockfile`, then copied the rest of the source afterward. In this Bun workspace monorepo, that means the `packages/*/package.json` files aren't on disk yet at install time, so Bun never creates the `node_modules/@jazz/*` symlinks — every `@jazz/*` import then fails at container startup ("Cannot find module"), not at build time. This never surfaced because the multi-package layout (from #455 and the earlier `packages/*` split) had never actually been deployed anywhere until today.

## How to verify
Confirmed live on lysk-server: deploying with the old Dockerfile crash-looped `jazz-telegram` with exactly that error; installing after the full `COPY . .` instead fixed it immediately, and both `jazz-telegram` and `jazz-discord` are now healthy on current `main`.