### PR TITLE
fix(ci): publish npm packages with a token instead of OIDC alone

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -163,12 +163,22 @@ jobs:
 
       # Must publish before jazz-ai, whose optionalDependencies pin this exact version.
       - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          failed=()
           for dir in deploy/npm/jazz-ai-*/; do
-            echo "Publishing $(node -p "require('./${dir}package.json').name")..."
-            (cd "$dir" && npm publish)
+            name="$(node -p "require('./${dir}package.json').name")"
+            echo "Publishing $name..."
+            (cd "$dir" && npm publish) || failed+=("$name")
           done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::Failed to publish: ${failed[*]}"
+            exit 1
+          fi
 
       - name: Publish jazz-ai
         working-directory: deploy/npm/jazz-ai
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish


### PR DESCRIPTION
## What changes

Wires `NODE_AUTH_TOKEN` from a new `NPM_TOKEN` secret into both npm publish steps in `release-binaries.yml`, and makes the platform-package publish loop keep going on a single failure instead of aborting immediately.

## Why

`release-binaries.yml` relied on npm Trusted Publishing (OIDC via `id-token: write`), which `jazz-ai` already has configured on npmjs.com from before #450. The six `jazz-ai-<platform>` packages #450 added are brand new, and npm only lets you attach a Trusted Publisher to a package that already exists — there's no way to pre-register one for a name that's never been published. Every publish attempt for them failed with a 404 (v0.15.7 and v0.15.8 releases both hit this), and because the loop had no error handling, it aborted before `jazz-ai` itself — what `ksyl-bot`'s Dockerfile actually installs (`npm install -g jazz-ai@latest`) — got a chance to publish at all.

Token-based auth can create brand-new packages on first publish with no pre-registration needed, so this unblocks the six new packages. The loop change also means a single broken platform package no longer silently blocks every other package (including `jazz-ai`) from publishing.

## How to verify

Re-run `Release Binaries` for `v0.15.8` after this merges; `npm view jazz-ai version` should return `0.15.8`, and `npm view jazz-ai-darwin-arm64 version` (etc.) should resolve instead of 404.