### PR TITLE
revert(ci): go back to OIDC-only npm publishing

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -163,8 +163,6 @@ jobs:
 
       # Must publish before jazz-ai, whose optionalDependencies pin this exact version.
       - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           failed=()
           for dir in deploy/npm/jazz-ai-*/; do
@@ -179,6 +177,4 @@ jobs:
 
       - name: Publish jazz-ai
         working-directory: deploy/npm/jazz-ai
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish


### PR DESCRIPTION
Reverts the `NODE_AUTH_TOKEN` wiring from #458. Token auth gets rejected now that the npm account has 2FA enabled — same restriction that blocked manual publishes until Trusted Publisher setup + a one-time bootstrap publish per new package. OIDC (already configured via `id-token: write`) is the correct long-term mechanism once each package has a Trusted Publisher registered on npmjs.com.