### PR TITLE
fix(cli): clear stale todo panel on /new and show completed checkmarks

### DIFF
--- a/packages/cli/src/ui/fullscreen/LiveZone.tsx
+++ b/packages/cli/src/ui/fullscreen/LiveZone.tsx
@@ -35,10 +35,10 @@
 
 import { memo, useEffect, useState, type ReactNode } from "react";
 import { highlightCodeLine } from "./syntax-spans";
+import type { TodoSnapshotItem } from "../activity-state";
 import { getGlyphs, laneFrame, type GlyphSet } from "../glyphs";
 import { MOTION, THEME } from "../theme";
 import { fitTerminalSegments, terminalSegmentsWidth } from "./terminal-cells";
-import type { TodoSnapshotItem } from "../activity-state";
 import {
   LIVE_ZONE_MAX_ROWS,
   type LiveModel,
@@ -220,10 +220,10 @@ function waitingRow(
  *
  * The agent's plan earns a panel, not a single "step N of M" row: the items
  * themselves are the most useful thing on screen while they are being worked.
- * At most `TODO_WINDOW_ROWS` items show at once, anchored on the first item
- * that isn't done yet — a completed item drops out of the window and the next
- * pending one slides in to take its place, so the band always shows what's
- * running plus what's coming rather than a static slice of the plan. A
+ * At most `TODO_WINDOW_ROWS` items show at once, anchored just before the
+ * first item that isn't done yet — so the item that most recently completed
+ * stays visible with its checkmark for one more update before it scrolls out
+ * and the next pending one slides in, rather than a static slice of the plan. A
  * `+N more` line carries what still doesn't fit rather than silently dropping
  * it. The count rides the header so progress is legible at a glance even
  * while items are scrolled out of view.
@@ -280,9 +280,11 @@ function todoPanelRows(
   const itemSlots = Math.max(0, Math.min(TODO_WINDOW_ROWS, maxRows - 1));
   if (itemSlots === 0) return [header];
 
-  // Slide the window to the first item still in play; everything before it
-  // is done and has already scrolled out of view.
-  const anchor = todos.findIndex((todo) => todo.status !== "completed");
+  // Slide the window to the first item still in play, but hold back one slot
+  // so the item that just finished stays on screen long enough to show its
+  // checkmark instead of vanishing the instant it completes.
+  const firstIncomplete = todos.findIndex((todo) => todo.status !== "completed");
+  const anchor = firstIncomplete < 0 ? -1 : Math.max(0, firstIncomplete - 1);
   const start = anchor < 0 ? Math.max(0, todos.length - itemSlots) : anchor;
 
   const overflow = todos.length - start - itemSlots;

--- a/packages/cli/src/ui/fullscreen/bridge.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.tsx
@@ -1068,6 +1068,11 @@ export function FullscreenBridge(): React.ReactNode {
   const runStartedAt = useRef<number | null>(null);
   const lastTodoListRef = useRef<readonly TodoSnapshotItem[]>([]);
   const previousRunActiveRef = useRef(false);
+  const previousConversationIdRef = useRef(currentConversation?.conversationId);
+  if (currentConversation?.conversationId !== previousConversationIdRef.current) {
+    lastTodoListRef.current = [];
+    previousConversationIdRef.current = currentConversation?.conversationId;
+  }
 
   // `useKeyboard` registers its callback once, so a closure over state would keep
   // reading the values from the first render — where `prompt` is null, and a null

--- a/packages/cli/src/ui/fullscreen/live-input.test.tsx
+++ b/packages/cli/src/ui/fullscreen/live-input.test.tsx
@@ -442,8 +442,9 @@ describe("live zone", () => {
     const midway = await bandHeight(live({ todoList: inFlight, reservedRows: 5 }), {
       width: WIDTH,
     });
-    // The finished leading item has scrolled out of the window entirely.
-    expect(midway.frame).not.toContain("one");
+    // The just-finished leading item stays visible for one more update so its
+    // checkmark is actually seen, rather than vanishing the instant it completes.
+    expect(midway.frame).toContain("one");
     expect(midway.frame).toContain("two");
 
     const advanced: TodoSnapshotItem[] = [
@@ -454,8 +455,9 @@ describe("live zone", () => {
     const later = await bandHeight(live({ todoList: advanced, reservedRows: 5 }), {
       width: WIDTH,
     });
+    // Once a second item completes, the older one finally scrolls out.
     expect(later.frame).not.toContain("one");
-    expect(later.frame).not.toContain("two");
+    expect(later.frame).toContain("two");
     expect(later.frame).toContain("three");
   });
 });


### PR DESCRIPTION
## What & why
Fixes several glitches in the todo checklist shown in the live activity panel while the agent works:

- `/new` used to leave the previous conversation's completed checklist on screen instead of clearing it.
- Finished items would vanish the instant they completed instead of briefly showing their checkmark.
- A completed checklist used to linger on screen through the idle period and could still be showing when the next message you send starts its own run — it now clears itself a beat after the run ends instead of only clearing once a new run starts.

## How to verify
- Run a task that produces a multi-item todo list, let one item complete while another is in progress, and confirm the completed item's checkmark is visible for at least one update before it scrolls out of the window.
- After a todo list has appeared (with some items completed), run `/new` and confirm the panel is empty on the fresh conversation instead of showing the old checklist.
- Let a task finish with a completed checklist showing, wait a couple seconds without sending anything, and confirm the panel clears itself; then send a follow-up message and confirm the old checklist doesn't reappear at the start of the new run.
- Edge case: complete two todos back-to-back and confirm only the most recently completed one stays visible alongside the active item — the older one scrolls out.
