### PR TITLE
docs(headless): document the read-only-container home-directory trap

### DIFF
--- a/docs/surfaces/ci-cd.md
+++ b/docs/surfaces/ci-cd.md
@@ -154,6 +154,7 @@ Because the answer is on stdout and the noise is on stderr, this composes with `
 | **Flaky provider**                | Jazz retries transient LLM failures with capped exponential backoff (up to 10 attempts, 15-minute ceiling for the whole call), so a single 429 doesn't fail your build.           |
 | **Reproducibility**               | Pin the model in the agent JSON. `latest` aliases move under you.                                                                                                                 |
 | **Provider choice**               | CI is where a cheap fast model usually wins. This is one field in the agent config.                                                                                               |
+| **Read-only sandbox**              | Don't bind-mount seed config straight at `JAZZ_HOME` read-only — jazz writes there too (personas, work state). See [Running in a read-only container](./headless.md#running-in-a-read-only-container). |
 
 ---
 

--- a/docs/surfaces/ci-cd.md
+++ b/docs/surfaces/ci-cd.md
@@ -154,7 +154,7 @@ Because the answer is on stdout and the noise is on stderr, this composes with `
 | **Flaky provider**                | Jazz retries transient LLM failures with capped exponential backoff (up to 10 attempts, 15-minute ceiling for the whole call), so a single 429 doesn't fail your build.           |
 | **Reproducibility**               | Pin the model in the agent JSON. `latest` aliases move under you.                                                                                                                 |
 | **Provider choice**               | CI is where a cheap fast model usually wins. This is one field in the agent config.                                                                                               |
-| **Securing a single-shot run**      | Don't bind-mount seed config straight at `JAZZ_HOME` read-only — jazz writes there too (personas, work state). See [Securing a single-shot run](./headless.md#securing-a-single-shot-run). |
+| **One-shot run in a sandbox**       | Don't bind-mount seed config straight at `JAZZ_HOME` read-only — jazz writes there too (personas, work state). See [One-shot run in a sandbox](./headless.md#one-shot-run-in-a-sandbox). |
 
 ---
 

--- a/docs/surfaces/ci-cd.md
+++ b/docs/surfaces/ci-cd.md
@@ -154,7 +154,7 @@ Because the answer is on stdout and the noise is on stderr, this composes with `
 | **Flaky provider**                | Jazz retries transient LLM failures with capped exponential backoff (up to 10 attempts, 15-minute ceiling for the whole call), so a single 429 doesn't fail your build.           |
 | **Reproducibility**               | Pin the model in the agent JSON. `latest` aliases move under you.                                                                                                                 |
 | **Provider choice**               | CI is where a cheap fast model usually wins. This is one field in the agent config.                                                                                               |
-| **Read-only sandbox**              | Don't bind-mount seed config straight at `JAZZ_HOME` read-only — jazz writes there too (personas, work state). See [Running in a read-only container](./headless.md#running-in-a-read-only-container). |
+| **Securing a single-shot run**      | Don't bind-mount seed config straight at `JAZZ_HOME` read-only — jazz writes there too (personas, work state). See [Securing a single-shot run](./headless.md#securing-a-single-shot-run). |
 
 ---
 

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -275,11 +275,16 @@ input from strangers means a prompt injection can run shell commands on that hos
 
 ---
 
-## Running in a read-only container
+## Securing a single-shot run
 
-A common pattern for a headless, single-task run — CI, a review bot, any service that spins up
-one ephemeral container per job — is to isolate the agent with a read-only root filesystem and
-seed its config from the host. The natural-looking way to do that is a read-only bind mount
+CI, a review bot, any service that spins up one ephemeral container per job — these all want
+the same guarantee: the agent can do whatever the task needs, but nothing it writes should
+outlive the container, and it shouldn't be able to tamper with the config it was seeded with.
+That's a security requirement, not a filesystem preference — a compromised or misbehaving task
+shouldn't be able to plant a persona, poison the model config, or otherwise leave something
+behind for the next run to pick up.
+
+The natural-looking way to get there is a read-only root filesystem with a read-only bind mount
 straight at `JAZZ_HOME`:
 
 ```bash
@@ -304,12 +309,15 @@ docker run --rm --read-only --tmpfs /tmp --tmpfs /home/jazz/.jazz:rw,mode=1777 \
   my-image sh -c 'cp -r /config/jazz/. /home/jazz/.jazz/ && exec jazz run --agent reviewer'
 ```
 
-The isolation guarantee — the agent can't tamper with its own durable config while doing
-whatever the task is — doesn't actually need a read-only permission bit on `JAZZ_HOME` itself.
-It only needs whatever the agent writes to be discarded, which `--rm` (or the container simply
-never being reused) already does. Copying the seed config into an ephemeral tmpfs at startup
-gets you that guarantee while jazz still gets one ordinary, fully-writable home directory —
-exactly like every other environment it runs in.
+The security guarantee this was after — the agent can't tamper with its own durable config, and
+nothing it writes survives past the job — doesn't actually need a read-only permission bit on
+`JAZZ_HOME` itself. It only needs whatever the agent writes to be discarded, which `--rm` (or
+the container simply never being reused) already does. Copying the seed config into an ephemeral
+tmpfs at startup gets you that guarantee while jazz still gets one ordinary, fully-writable home
+directory — exactly like every other environment it runs in. The container's read-only root
+filesystem is still doing real work here (nothing outside `/tmp` and the seeded tmpfs can be
+touched at all); it's specifically a read-only `JAZZ_HOME` that's the wrong tool for isolating
+this agent.
 
 If you'd rather not do the copy in the container's own entrypoint, `JAZZ_HOME` also just
 respects the environment variable of the same name, so a wrapper script or your own image's

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -275,6 +275,49 @@ input from strangers means a prompt injection can run shell commands on that hos
 
 ---
 
+## Running in a read-only container
+
+A common pattern for a headless, single-task run — CI, a review bot, any service that spins up
+one ephemeral container per job — is to isolate the agent with a read-only root filesystem and
+seed its config from the host. The natural-looking way to do that is a read-only bind mount
+straight at `JAZZ_HOME`:
+
+```bash
+docker run --rm --read-only --tmpfs /tmp \
+  -v /etc/myapp/jazz-config:/home/jazz/.jazz:ro \
+  my-image jazz run --agent reviewer
+```
+
+This breaks. `JAZZ_HOME` isn't read-only config — jazz writes there too: custom personas
+(`jazz persona create`), per-conversation work state and the compaction journal, cached model
+metadata. A live read-only mount at that path fails those writes, and depending on what's
+running, that shows up anywhere from a hard crash at startup (persona resolution falls through
+to listing `~/.jazz/personas`, which tries to create the directory) to a silently-dropped
+write nobody notices until task state that was supposed to survive compaction just isn't there.
+
+**Stage the config somewhere else, and copy it into a genuinely writable `JAZZ_HOME` on
+container start:**
+
+```bash
+docker run --rm --read-only --tmpfs /tmp --tmpfs /home/jazz/.jazz:rw,mode=1777 \
+  -v /etc/myapp/jazz-config:/config/jazz:ro \
+  my-image sh -c 'cp -r /config/jazz/. /home/jazz/.jazz/ && exec jazz run --agent reviewer'
+```
+
+The isolation guarantee — the agent can't tamper with its own durable config while doing
+whatever the task is — doesn't actually need a read-only permission bit on `JAZZ_HOME` itself.
+It only needs whatever the agent writes to be discarded, which `--rm` (or the container simply
+never being reused) already does. Copying the seed config into an ephemeral tmpfs at startup
+gets you that guarantee while jazz still gets one ordinary, fully-writable home directory —
+exactly like every other environment it runs in.
+
+If you'd rather not do the copy in the container's own entrypoint, `JAZZ_HOME` also just
+respects the environment variable of the same name, so a wrapper script or your own image's
+entrypoint can do the copy into any writable location and point `JAZZ_HOME` there instead of
+`~/.jazz`.
+
+---
+
 ## A complete bridge
 
 Everything above, in one function. This is genuinely the whole integration:

--- a/docs/surfaces/headless.md
+++ b/docs/surfaces/headless.md
@@ -275,7 +275,7 @@ input from strangers means a prompt injection can run shell commands on that hos
 
 ---
 
-## Securing a single-shot run
+## One-shot run in a sandbox
 
 CI, a review bot, any service that spins up one ephemeral container per job — these all want
 the same guarantee: the agent can do whatever the task needs, but nothing it writes should


### PR DESCRIPTION
## What changes

Adds a "Running in a read-only container" section to `docs/surfaces/headless.md`, with a cross-reference row in `docs/surfaces/ci-cd.md`'s practical-notes table.

## Why

Just spent a while chasing this exact bug in a real deployment (ksyl-bot): a live read-only bind mount straight at `JAZZ_HOME` looks like the obvious way to isolate a headless single-task run in a container, but jazz writes under `JAZZ_HOME` too — personas, per-conversation work state, the compaction journal — not just durable agent/skill config. That mount breaks those writes, and depending on what's running, that shows up anywhere from a hard crash at startup (#460) to a silently-dropped write nobody notices until state that was supposed to survive compaction just isn't there.

The fix — stage config elsewhere, copy it into a writable tmpfs on container start — isn't obvious from the error messages, and there was nothing in the docs pointing at it. Writing it down so the next person hits a doc instead of an afternoon of debugging.

## How to verify

- `bun run docs:check-links` — clean.
- `bun run docs:lint` — clean.