### PR TITLE
fix(context): pin a workflow's task message against compaction

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -391,6 +391,7 @@ export function runWorkflowCommand(
       agent,
       userInput: workflow.prompt,
       conversationId: generateConversationId(`workflow-${workflowName}`),
+      pinInitialMessage: true,
       ...(resolvedMaxIterations != null ? { maxIterations: resolvedMaxIterations } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options?.stream !== undefined ? { stream: options.stream } : {}),

--- a/packages/core/src/agent/agent-prompt.ts
+++ b/packages/core/src/agent/agent-prompt.ts
@@ -135,6 +135,14 @@ export interface AgentPromptOptions {
    * explanatory note; they are already resolved, so no path scanning touches them.
    */
   readonly initialAttachments?: readonly MessageAttachment[];
+  /**
+   * True when `userInput` carries a literal task contract (exact output format, step
+   * ordering) rather than an ordinary conversational turn — e.g. a workflow's prompt.
+   * The initial user message it becomes is tagged `kind: "task"` so compaction pins
+   * it instead of summarizing it away, which an LLM-generated summary is not obliged
+   * to preserve verbatim.
+   */
+  readonly pinInitialMessage?: boolean;
 }
 
 /**
@@ -501,6 +509,7 @@ ${triggeredBlock}`;
                 ? `${effectiveUserContent}\n\n${ingested.notes.join("\n")}`
                 : effectiveUserContent,
             ...(attachments.length > 0 ? { attachments } : {}),
+            ...(options.pinInitialMessage === true ? { kind: "task" } : {}),
           });
         }
 

--- a/packages/core/src/agent/agent-runner.test.ts
+++ b/packages/core/src/agent/agent-runner.test.ts
@@ -360,6 +360,47 @@ describe("AgentRunner", () => {
     });
   });
 
+  describe("pinInitialMessage", () => {
+    function lastRequestedMessages(): { role: string; kind?: string; content?: string }[] {
+      const streamingMock = mockLlmService.createStreamingChatCompletion as Mock<
+        LLMService["createStreamingChatCompletion"]
+      >;
+      const lastCall = streamingMock.mock.calls.at(-1);
+      const llmOptions = lastCall?.[1] as {
+        messages?: { role: string; kind?: string; content?: string }[];
+      };
+      return llmOptions.messages ?? [];
+    }
+
+    it("tags the initial user message kind: task when set", async () => {
+      const options = {
+        ...defaultOptions,
+        userInput: "Emit exactly two fenced blocks, nothing before or after them.",
+        stream: true,
+        maxIterations: 1,
+        pinInitialMessage: true,
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      const initialUserMessage = lastRequestedMessages().find((message) => message.role === "user");
+      expect(initialUserMessage?.kind).toBe("task");
+    });
+
+    it("leaves the initial user message untagged for an ordinary turn", async () => {
+      const options = {
+        ...defaultOptions,
+        stream: true,
+        maxIterations: 1,
+      };
+
+      await runWithTestLayers(AgentRunner.run(options));
+
+      const initialUserMessage = lastRequestedMessages().find((message) => message.role === "user");
+      expect(initialUserMessage?.kind).toBeUndefined();
+    });
+  });
+
   describe("withholdInteractiveTools", () => {
     const agentWithAskTool: Agent = {
       ...mockAgent,

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -418,6 +418,7 @@ function initializeAgentRun(
         }),
         ...(triggeredSkillNames.length > 0 && { triggeredSkillNames }),
         ...(projectInstructions.length > 0 && { projectInstructions }),
+        ...(options.pinInitialMessage === true ? { pinInitialMessage: true } : {}),
       },
       resolvedPersonaService,
     );

--- a/packages/core/src/agent/context/summarizer.test.ts
+++ b/packages/core/src/agent/context/summarizer.test.ts
@@ -591,6 +591,56 @@ describe("Summarizer", () => {
       expect(result.length).toBeLessThan(messages.length);
       expect(result.some((message) => message.role === "user")).toBe(true);
     });
+
+    it("keeps a pinned task message verbatim across two consecutive compaction cycles", async () => {
+      const mockRunner = createMockRecursiveRunner("Summary of prior tool calls.");
+      const agent = createMockAgent();
+      const filler = "x ".repeat(200);
+      const taskContent =
+        "Emit exactly two fenced blocks, four backticks, nothing before or after them. " + filler;
+
+      const messages: ConversationMessages = [
+        { role: "system", content: "You are an assistant" },
+        { role: "user", content: taskContent, kind: "task" },
+        ...Array.from({ length: 20 }, (_, index) => ({
+          role: "assistant" as const,
+          content: `Findings for file ${index}. ${filler}`,
+        })),
+      ];
+
+      const runEffect = (input: ConversationMessages) =>
+        Effect.runPromise(
+          Summarizer.compactIfNeeded(input, agent, "conv-1", mockRunner, 500).pipe(
+            Effect.provide(createTestLayer()),
+          ) as Effect.Effect<ConversationMessages, Error, never>,
+        );
+
+      const firstPass = await runEffect(messages);
+      const pinnedAfterFirst = firstPass.find(
+        (message) => message.kind === "task" && message.content === taskContent,
+      );
+      expect(pinnedAfterFirst).toBeDefined();
+      expect(firstPass.length).toBeLessThan(messages.length);
+
+      // A second round of work, appended onto the already-compacted transcript — this is
+      // where a fix that only protects the task message's original position would fail:
+      // the task message no longer sits at index 1 after the first compaction rebuilt
+      // the array as [system, task, summary, continuation, ...recent].
+      const secondRoundMessages: ConversationMessages = [
+        ...firstPass,
+        ...Array.from({ length: 20 }, (_, index) => ({
+          role: "assistant" as const,
+          content: `More findings ${index}. ${filler}`,
+        })),
+      ];
+
+      const secondPass = await runEffect(secondRoundMessages);
+      const pinnedAfterSecond = secondPass.find(
+        (message) => message.kind === "task" && message.content === taskContent,
+      );
+      expect(pinnedAfterSecond).toBeDefined();
+      expect(secondPass.length).toBeLessThan(secondRoundMessages.length);
+    });
   });
 });
 

--- a/packages/core/src/agent/context/summarizer.test.ts
+++ b/packages/core/src/agent/context/summarizer.test.ts
@@ -640,6 +640,11 @@ describe("Summarizer", () => {
       );
       expect(pinnedAfterSecond).toBeDefined();
       expect(secondPass.length).toBeLessThan(secondRoundMessages.length);
+
+      // The rebuild always appends a fresh continuation nudge; an old instance carried
+      // over from the first cycle must not survive alongside it as a duplicate.
+      const continuationMessages = secondPass.filter((message) => message.kind === "continuation");
+      expect(continuationMessages.length).toBe(1);
     });
   });
 });

--- a/packages/core/src/agent/context/summarizer.ts
+++ b/packages/core/src/agent/context/summarizer.ts
@@ -35,6 +35,13 @@ export const COMPACTION_CONTINUATION_MESSAGE: ChatMessage = {
 };
 
 /**
+ * Message `kind`s that must survive every compaction cycle verbatim — never summarized,
+ * never dropped. `"task"` is the only one today (a workflow's prompt); a future kind
+ * that needs the same guarantee joins this set rather than a new one-off field.
+ */
+const PINNED_KINDS = new Set<NonNullable<ChatMessage["kind"]>>(["task"]);
+
+/**
  * Keep arguments readable without letting one pasted payload dominate the transcript
  * the summarizer has to read.
  */
@@ -220,6 +227,7 @@ export const Summarizer = {
   ): {
     systemMessage: ChatMessage;
     priorSummary: ChatMessage | undefined;
+    pinnedMessages: ChatMessage[];
     messagesToSummarize: ChatMessage[];
     sanitizedRecentMessages: ChatMessage[];
   } {
@@ -229,8 +237,30 @@ export const Summarizer = {
     // A summary from an earlier compaction is prior *state*, not raw history. Feeding
     // it back through the summarizer re-summarizes a summary, and the drift compounds
     // with every cycle. Pull it out here and hand it to the summarizer to merge into.
-    const priorSummary = currentMessages[1]?.kind === "summary" ? currentMessages[1] : undefined;
+    // Found by kind rather than a fixed index: a pinned message (below) can occupy that
+    // position instead, on a conversation that has one.
+    const priorSummary = currentMessages.slice(1).find((msg) => msg.kind === "summary");
+
+    // Kinds that must survive every compaction cycle verbatim rather than ever being
+    // folded into a summary — currently just a workflow's task message, which carries a
+    // literal contract (exact output format, step ordering) that an LLM-generated
+    // summary is not obliged to preserve. A list, not a single slot: more kinds can join
+    // PINNED_KINDS later without reshaping this function again. Found by kind, not
+    // position, so each one survives being rebuilt at a stable spot after every
+    // compaction cycle rather than needing to still be wherever it started out.
+    const pinnedMessages = currentMessages
+      .slice(1)
+      .filter((msg) => msg.kind !== undefined && PINNED_KINDS.has(msg.kind));
+
     const hint: ModelHint = modelHint ?? { provider: "", modelId: "" };
+
+    // Everything eligible to be either summarized or kept verbatim as "recent" — i.e.
+    // everything except the system message, the prior summary, and the pinned messages
+    // above, none of which are ever candidates for either bucket.
+    const pinnedSet = new Set<ChatMessage>(pinnedMessages);
+    const middleMessages = currentMessages
+      .slice(1)
+      .filter((msg) => msg !== priorSummary && !pinnedSet.has(msg));
 
     // Reserve 20% of max tokens for recent context
     // This ensures we keep recent context while preventing it from eating the entire window
@@ -239,8 +269,8 @@ export const Summarizer = {
     let recentCount = 0;
 
     // Scan backwards to fill budget
-    for (let i = currentMessages.length - 1; i > 0; i--) {
-      const msg = currentMessages[i];
+    for (let i = middleMessages.length - 1; i >= 0; i--) {
+      const msg = middleMessages[i];
       if (!msg) continue;
       // Calculate tokens for this single message via the calibrated counter.
       const tokens = DEFAULT_TOKEN_COUNTER.countMessage(msg, hint);
@@ -255,14 +285,14 @@ export const Summarizer = {
       recentCount++;
     }
 
-    // Always keep at least the last message
-    recentCount = Math.max(1, recentCount);
+    // Always keep at least the last message, when there is one to keep.
+    recentCount = middleMessages.length > 0 ? Math.max(1, recentCount) : 0;
     // But don't exceed total messages available to separate
-    recentCount = Math.min(recentCount, currentMessages.length - 1);
+    recentCount = Math.min(recentCount, middleMessages.length);
 
-    const recentMessages = currentMessages.slice(-recentCount);
-    const summarizeFrom = priorSummary ? 2 : 1;
-    const messagesToSummarize = currentMessages.slice(summarizeFrom, -recentCount);
+    const recentMessages = recentCount > 0 ? middleMessages.slice(-recentCount) : [];
+    const messagesToSummarize =
+      recentCount > 0 ? middleMessages.slice(0, -recentCount) : middleMessages;
 
     // Sanitize recent messages to avoid orphaned tool call/result references.
     // The split may land in the middle of a tool call group, leaving:
@@ -305,7 +335,13 @@ export const Summarizer = {
       return acc;
     }, []);
 
-    return { systemMessage, priorSummary, messagesToSummarize, sanitizedRecentMessages };
+    return {
+      systemMessage,
+      priorSummary,
+      pinnedMessages,
+      messagesToSummarize,
+      sanitizedRecentMessages,
+    };
   },
 
   /**
@@ -399,8 +435,13 @@ export const Summarizer = {
         maxTokens,
       });
 
-      const { systemMessage, priorSummary, messagesToSummarize, sanitizedRecentMessages } =
-        Summarizer.splitMessages(currentMessages, maxTokens, hint);
+      const {
+        systemMessage,
+        priorSummary,
+        pinnedMessages,
+        messagesToSummarize,
+        sanitizedRecentMessages,
+      } = Summarizer.splitMessages(currentMessages, maxTokens, hint);
 
       if (messagesToSummarize.length === 0) {
         // Not enough to summarize, just return as-is
@@ -422,9 +463,13 @@ export const Summarizer = {
         priorSummary,
       );
 
-      // Rebuild: [system, summary, continuation, ...recent]
+      // Rebuild: [system, ...pinned, summary, continuation, ...recent]. Pinned messages
+      // are put back here at a stable spot so the next compaction cycle finds them again
+      // by kind and keeps pinning them — kept, never summarized, for the life of the
+      // conversation.
       const compactedMessages: ConversationMessages = [
         systemMessage,
+        ...pinnedMessages,
         summaryMessage,
         COMPACTION_CONTINUATION_MESSAGE,
         ...sanitizedRecentMessages,

--- a/packages/core/src/agent/context/summarizer.ts
+++ b/packages/core/src/agent/context/summarizer.ts
@@ -32,6 +32,7 @@ const MAX_RENDERED_ARGUMENT_CHARS = 200;
 export const COMPACTION_CONTINUATION_MESSAGE: ChatMessage = {
   role: "user",
   content: "Continue the task using the summary above as context.",
+  kind: "continuation",
 };
 
 /**
@@ -256,11 +257,14 @@ export const Summarizer = {
 
     // Everything eligible to be either summarized or kept verbatim as "recent" — i.e.
     // everything except the system message, the prior summary, and the pinned messages
-    // above, none of which are ever candidates for either bucket.
+    // above, none of which are ever candidates for either bucket. A leftover
+    // "continuation" nudge from an earlier cycle is dropped outright here rather than
+    // summarized or kept: the rebuild below always appends a fresh one, so carrying an
+    // old instance through either bucket would duplicate it.
     const pinnedSet = new Set<ChatMessage>(pinnedMessages);
     const middleMessages = currentMessages
       .slice(1)
-      .filter((msg) => msg !== priorSummary && !pinnedSet.has(msg));
+      .filter((msg) => msg !== priorSummary && !pinnedSet.has(msg) && msg.kind !== "continuation");
 
     // Reserve 20% of max tokens for recent context
     // This ensures we keep recent context while preventing it from eating the entire window

--- a/packages/core/src/agent/tools/subagent-tools.ts
+++ b/packages/core/src/agent/tools/subagent-tools.ts
@@ -353,7 +353,7 @@ ${args.task}`;
             }),
           }).tokens;
 
-          const { systemMessage, messagesToSummarize, sanitizedRecentMessages } =
+          const { systemMessage, pinnedMessages, messagesToSummarize, sanitizedRecentMessages } =
             Summarizer.splitMessages(
               [...conversationMessages] as unknown as ConversationMessages,
               contextWindowMaxTokens,
@@ -379,6 +379,7 @@ ${args.task}`;
 
           const compacted = [
             systemMessage,
+            ...pinnedMessages,
             summaryMessage,
             COMPACTION_CONTINUATION_MESSAGE,
             ...sanitizedRecentMessages,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -176,6 +176,14 @@ export interface AgentRunnerOptions {
    * flag behind `jazz run --ephemeral`.
    */
   readonly disablePersistence?: boolean;
+  /**
+   * True when `userInput` carries a literal task contract (exact output format, step
+   * ordering) rather than an ordinary conversational turn — e.g. a workflow's prompt.
+   * The initial user message it becomes is tagged `kind: "task"` so compaction pins
+   * it instead of summarizing it away, which an LLM-generated summary is not obliged
+   * to preserve verbatim.
+   */
+  readonly pinInitialMessage?: boolean;
 }
 
 /**

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -53,8 +53,11 @@ export interface ChatMessage {
    * "task" is a user message holding a task specification (e.g. a workflow's prompt)
    * rather than conversational history — pinned so compaction never summarizes it away,
    * the same way the system message at index 0 is pinned.
+   * "continuation" is the synthetic turn-taking nudge compaction re-inserts after every
+   * cycle — discarded (not pinned) on the next split, since the rebuild always appends a
+   * fresh one; keeping an old instance around too would duplicate it.
    */
-  kind?: "summary" | "task";
+  kind?: "summary" | "task" | "continuation";
   /**
    * For role === "assistant": include tool calls emitted by the model so that
    * subsequent tool messages are valid according to the OpenAI API.

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -46,11 +46,15 @@ export interface ChatMessage {
    */
   cleared?: true;
   /**
-   * Marks an assistant message as a compaction summary rather than model output.
-   * Identified by flag rather than position so summarization can carry it forward
-   * as prior state instead of re-summarizing its own previous summary.
+   * Marks a message's role in compaction rather than its literal content.
+   * "summary" is an assistant message holding a compaction summary rather than model
+   * output — identified by flag rather than position so summarization can carry it
+   * forward as prior state instead of re-summarizing its own previous summary.
+   * "task" is a user message holding a task specification (e.g. a workflow's prompt)
+   * rather than conversational history — pinned so compaction never summarizes it away,
+   * the same way the system message at index 0 is pinned.
    */
-  kind?: "summary";
+  kind?: "summary" | "task";
   /**
    * For role === "assistant": include tool calls emitted by the model so that
    * subsequent tool messages are valid according to the OpenAI API.

--- a/packages/core/src/workflows/catch-up.ts
+++ b/packages/core/src/workflows/catch-up.ts
@@ -270,6 +270,7 @@ export function runCatchUpForWorkflows(
         agent: agentResult.right,
         userInput: workflowContent.prompt,
         conversationId: runId,
+        pinInitialMessage: true,
         ...(workflow.maxIterations != null ? { maxIterations: workflow.maxIterations } : {}),
         ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       }).pipe(


### PR DESCRIPTION
## What changes

`Summarizer.splitMessages` only ever protected the system message (index 0) from being summarized away. A workflow's prompt — the entire `WORKFLOW.md`, including any literal output contract it specifies — lands as an ordinary first `user` message, fully exposed to compaction once the conversation grows past the threshold.

- `ChatMessage` gains `kind: "task"` alongside the existing `kind: "summary"`.
- `AgentRunnerOptions`/`AgentPromptOptions` gain `pinInitialMessage?: boolean`; `jazz workflow run` sets it, tagging the workflow prompt's message `kind: "task"` when constructed.
- `Summarizer.splitMessages` finds pinned messages by `kind` rather than position, and returns a `pinnedMessages: ChatMessage[]` list (not a single slot — a future kind that needs the same guarantee joins `PINNED_KINDS` rather than reshaping the function).
- `compactIfNeeded` and the manual `summarize_context` tool both rebuild pinned messages back into the compacted array at a stable spot, so they're found — and re-pinned — again on every subsequent compaction cycle, not just the first.

## Why

On `lysk-deploy` PR #275, mid-run compaction replaced `ksyl-reviewer`'s `WORKFLOW.md` prompt with an LLM-generated summary. The summarizer's own instructions are to preserve "goals, decisions, outcomes, key entities, current status" — nothing about preserving an exact syntax verbatim — and the run's final answer never came back wrapped in the required four-backtick fence format as a result. 27 minutes of real review work (including a correct, useful finding) got discarded as "not reviewed" because the output-format contract simply wasn't in context anymore by the time the model composed its answer.

This affects every workflow (`pr-review`, `pr-assistant`, `daily-news`), not just PR review — any workflow with a literal formatting or sequencing requirement in its prompt is exposed to the same failure mode once a run runs long enough to compact.

## How to verify

- New test in `summarizer.test.ts`: a pinned task message survives **two consecutive** compaction cycles (the case a fix that only protects the original position would miss, since the rebuilt array's shape changes after the first cycle).
- New tests in `agent-runner.test.ts`: `pinInitialMessage: true` tags the constructed initial message `kind: "task"`; omitted, it doesn't.
- `bun test` (full monorepo): 3244 pass, 0 fail.
- `bun run typecheck` (`tsc -b`, full workspace): clean.
- `eslint`/`prettier` on changed files: clean.