### PR TITLE
fix(ci): make npm publish idempotent for a re-run release

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -167,6 +167,11 @@ jobs:
           failed=()
           for dir in deploy/npm/jazz-ai-*/; do
             name="$(node -p "require('./${dir}package.json').name")"
+            version="$(node -p "require('./${dir}package.json').version")"
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "$name@$version already published, skipping"
+              continue
+            fi
             echo "Publishing $name..."
             (cd "$dir" && npm publish) || failed+=("$name")
           done
@@ -177,4 +182,11 @@ jobs:
 
       - name: Publish jazz-ai
         working-directory: deploy/npm/jazz-ai
-        run: npm publish
+        run: |
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "$name@$version already published, skipping"
+            exit 0
+          fi
+          npm publish


### PR DESCRIPTION
## What changes

Both npm publish steps in \`release-binaries.yml\` now check \`npm view <name>@<version>\` first and skip (with a notice) if that exact version is already published, instead of always attempting \`npm publish\`.

## Why

v0.15.9's platform packages had to be manually bootstrapped mid-release (Trusted Publishing needed configuring per-package on npmjs.com first, which can only happen once a package exists). Re-running \`Release Binaries\` afterward hit \`npm error: You cannot publish over the previously published versions\` for every already-published package — a correct rejection from npm, but the script's \`failed+=(...)\` treated it identically to a real failure, so the step kept exiting 1 and \`jazz-ai\` itself never got attempted, even though every platform package it depends on was actually fine.

Re-running a release for a tag that's already partly published is a normal recovery path (a flaky publish, an unrelated CI failure, a mid-release config fix like this one) — not an error condition that should block the rest of the release.

## How to verify

- Manually verified the skip-check against the live registry: \`npm view jazz-ai-linux-x64@0.15.9\` (exists) correctly resolves to "skip"; \`npm view jazz-ai-linux-x64@99.99.99\` (doesn't exist) correctly resolves to "attempt publish."
- \`bash -n\` on the extracted script: clean.
- \`python3 -c "import yaml; yaml.safe_load(...)"\`: valid.