### PR TITLE
fix(prompt): key system-prompt cache on media capability and full skill content

### DIFF
--- a/packages/core/src/agent/agent-prompt-instructions.test.ts
+++ b/packages/core/src/agent/agent-prompt-instructions.test.ts
@@ -104,15 +104,15 @@ describe("system prompt cache keys off the toolset", () => {
       userInput: "hello",
     };
 
-    const withQuestions = Effect.runSync(
-      builder.buildSystemPrompt("default", { ...base, toolNames: ["ask_user_question"] }, service),
+    const withMemory = Effect.runSync(
+      builder.buildSystemPrompt("default", { ...base, toolNames: ["view_memory"] }, service),
     );
-    const withoutQuestions = Effect.runSync(
+    const withoutMemory = Effect.runSync(
       builder.buildSystemPrompt("default", { ...base, toolNames: ["http_request"] }, service),
     );
 
-    expect(withQuestions).toContain("# Asking the user questions");
-    expect(withoutQuestions).not.toContain("# Asking the user questions");
+    expect(withMemory).toContain("# Memory");
+    expect(withoutMemory).not.toContain("# Memory");
   });
 });
 

--- a/packages/core/src/agent/prompts/shared.ts
+++ b/packages/core/src/agent/prompts/shared.ts
@@ -41,10 +41,13 @@ Note: Prefer skill workflows over ad-hoc handling for matched tasks. Do not load
 export const MEMORY_INSTRUCTIONS = `
 # Memory
 
-You persist across separate conversations, it is an ongoing relationship. Call view_memory to check what you already know about this person (or, for a project-scoped agent, this project) every time, even if the conversation opens casually.
-Write to memory with manage_memory whenever you learn something durable about this person that would make a later answer better: a stated preference, where they are, their age, how they like to work, a recurring fact about their life or work, a decision they've made, a correction to something you had wrong, a goal they're working toward across multiple sessions. Write it when you learn it, not at the end — you may not get a clean "end of conversation" signal in a chat surface, so treat "I now know something worth keeping" as the trigger, not "the conversation is wrapping up."
-Do not write: small talk, one-off task details that only matter for this exchange, anything you could re-derive from context, or anything the person is clearly just thinking out loud about rather than telling you as settled fact. When in doubt, ask yourself: would this still be true and still matter in three weeks? If not, leave it out. If a new fact contradicts something already saved, update or delete the old entry — don't leave both versions sitting in memory for a future you to get confused by.
-Never save financial account numbers, passwords, API keys, government ID numbers health details, PII unless the person is explicitly asking you to store exactly that for their own later reference.
+You persist across separate conversations, it is an ongoing relationship.
+
+1. Call view_memory to check what you already know about this person (or, for a project-scoped agent, this project) every time, even if the conversation opens casually.
+2. Write to memory with manage_memory whenever you learn something durable about this person that would make a later answer better: a stated preference, where they are, their age, how they like to work, a recurring fact about their life or work, a decision they've made, a correction to something you had wrong, a goal they're working toward across multiple sessions. Write it when you learn it, not at the end — you may not get a clean "end of conversation" signal in a chat surface, so treat "I now know something worth keeping" as the trigger, not "the conversation is wrapping up."
+3. Do not write: small talk, one-off task details that only matter for this exchange, anything you could re-derive from context, or anything the person is clearly just thinking out loud about rather than telling you as settled fact. When in doubt, ask yourself: would this still be true and still matter in three weeks? If not, leave it out.
+4. If a new fact contradicts something already saved, update or delete the old entry — don't leave both versions sitting in memory for a future you to get confused by.
+5. Never save financial account numbers, passwords, API keys, government ID numbers, health details, or other PII unless the person is explicitly asking you to store exactly that for their own later reference.
 `;
 
 export const TASK_STATE_INSTRUCTIONS = `


### PR DESCRIPTION
## Summary
- The system-prompt cache key hashed skills by name only, so editing a skill's description/tagline/triggers without renaming it could serve a stale rendered prompt.
- `canGenerateMedia` wasn't part of the cache key at all, even though it toggles the media-unavailable notice appended to the prompt — a capability flip could reuse a prompt built for the other state.
- Added a completion-instructions rule: resolve the intended branch/PR/file before making a change, rather than building it against the wrong target and relocating it afterward.
- Reformatted `MEMORY_INSTRUCTIONS` as a numbered list to match its sibling instruction blocks (`ASK_VS_ASSUME_INSTRUCTIONS`, `COMPLETION_INSTRUCTIONS`, etc.) — no content change.

## Test plan
- [x] `bun test packages/core/src/agent` — 816 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun eslint packages/core/src/agent/agent-prompt.ts packages/core/src/agent/prompts/shared.ts` — clean