### PR TITLE
fix(cli): put New conversation first on the wizard home menu

### DIFF
--- a/packages/cli/src/commands/wizard.ts
+++ b/packages/cli/src/commands/wizard.ts
@@ -73,17 +73,17 @@ export function wizardCommand() {
       // Build menu options dynamically
       const menuOptions: WizardMenuOption[] = [];
 
-      if (hasConversationHistory) {
-        menuOptions.push({
-          label: "Resume conversation",
-          value: "resume-conversation",
-        });
-      }
-
       if (agents.length > 0) {
         menuOptions.push({
           label: "New conversation",
           value: "new-conversation",
+        });
+      }
+
+      if (hasConversationHistory) {
+        menuOptions.push({
+          label: "Resume conversation",
+          value: "resume-conversation",
         });
       }
 


### PR DESCRIPTION
## What & why
On the Jazz home menu, **New conversation** now sits above **Resume conversation** whenever both are shown. Starting a fresh chat is the usual next step; resume should not steal the first slot.

## How to verify
- Run `jazz` with at least one agent that has saved history. Confirm the menu lists New conversation first, then Resume conversation, then the rest.
- Run `jazz` with agents but no conversation history. Confirm New conversation still appears and Resume conversation does not.
- Run `jazz` with no agents. Confirm neither conversation option appears, and Create agent is still first.
