### PR TITLE
feat(cli): load the operator's shell rc file for `!` commands

### DIFF
--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -197,7 +197,11 @@ export function handleSpecialCommand(
  * This is intentionally outside the model tool loop: the operator authored the
  * command and its output is then handed to the model as context. It still uses
  * the shell tool's denylist, sanitized environment, cwd resolution, timeout,
- * and output cap so the two shell entry points share the same host boundary.
+ * and output cap so the two shell entry points share the same host boundary —
+ * except it runs `interactive: true`, loading the operator's own shell rc file
+ * (aliases, functions), since the operator typed this command themselves and
+ * expects it to behave like their own terminal. The model-invoked
+ * `execute_command` tool must never set this.
  */
 function handleShellCommand(
   command: string,
@@ -233,6 +237,7 @@ function handleShellCommand(
       workingDir: workingDirectory,
       timeoutMs: 900_000,
       env: createSanitizedEnv({}, context.agent.config.envAllowlist ?? []),
+      interactive: true,
     }).pipe(
       Effect.catchAll((error) =>
         Effect.succeed({

--- a/packages/core/src/agent/tools/shell-tools.ts
+++ b/packages/core/src/agent/tools/shell-tools.ts
@@ -440,18 +440,67 @@ export type ShellCommandOutput = {
   readonly exitCode: number;
 };
 
+type InteractiveShellKind = "zsh" | "bash";
+
+function interactiveShellKind(shellPath: string): InteractiveShellKind | undefined {
+  const name = shellPath.split("/").pop();
+  if (name === "zsh") return "zsh";
+  if (name === "bash") return "bash";
+  return undefined;
+}
+
+/**
+ * `<shell> -l -c <script> jazz <cwd>` for a shell whose rc file (aliases,
+ * functions) the operator wants loaded — without ever setting the shell's own
+ * interactive flag. `-i` would make an rc framework's guarded, interactive-only
+ * setup (line editor, prompt theme) run too, and that assumes a real TTY;
+ * spawned without one it throws (e.g. oh-my-zsh's `can't change option: zle`)
+ * and the noise lands in the command's own stderr. Sourcing the rc file
+ * explicitly, with a plain login shell, gets the aliases without that.
+ * `bash` additionally needs `shopt -s expand_aliases`: bash disables alias
+ * expansion in non-interactive shells even once the rc file defining them has
+ * been sourced. Mirrors opencode's `packages/core/src/shell.ts`.
+ */
+function interactiveShellArgs(
+  kind: InteractiveShellKind,
+  command: string,
+  cwd: string,
+): readonly string[] {
+  const evalCommand = `eval ${JSON.stringify(command)}`;
+  const script =
+    kind === "zsh"
+      ? `[[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
+[[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
+cd -- "$1"
+${evalCommand}`
+      : `shopt -s expand_aliases
+[[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
+cd -- "$1"
+${evalCommand}`;
+  return ["-l", "-c", script, "jazz", cwd];
+}
+
 /**
  * Spawn `sh -c command` in a way that Effect can interrupt. `Effect.promise`
  * is uninterruptible, so a double-Esc during a long `sleep` (or any other
  * hanging command) used to leave the child running and the UI stuck on
  * "still running after 30s". Returning an interrupt finalizer from
  * `Effect.async` SIGKILLs the child when the tool fiber is interrupted.
+ *
+ * `interactive` loads the operator's own shell rc file (aliases, functions)
+ * for zsh/bash — see {@link interactiveShellArgs}. Any other `$SHELL` falls
+ * back to plain `sh -c`, since there's no equivalently tested rc-loading
+ * incantation for it here. Only the operator-typed `!` escape may set this —
+ * the model-invoked `execute_command` tool must keep running plain `sh`, or
+ * dotfile content would silently reshape what an autonomous tool call
+ * executes.
  */
 export function runShellCommand(input: {
   readonly command: string;
   readonly workingDir: string;
   readonly timeoutMs: number;
   readonly env: NodeJS.ProcessEnv;
+  readonly interactive?: boolean;
 }): Effect.Effect<ShellCommandOutput, Error> {
   return Effect.async((resume) => {
     let settled = false;
@@ -469,7 +518,13 @@ export function runShellCommand(input: {
     };
 
     try {
-      child = spawn("sh", ["-c", input.command], {
+      const shellPath = input.env["SHELL"] ?? "/bin/sh";
+      const kind = input.interactive ? interactiveShellKind(shellPath) : undefined;
+      const shellBinary = kind ? shellPath : "sh";
+      const shellArgs = kind
+        ? interactiveShellArgs(kind, input.command, input.workingDir)
+        : ["-c", input.command];
+      child = spawn(shellBinary, shellArgs, {
         cwd: input.workingDir,
         stdio: ["ignore", "pipe", "pipe"],
         timeout: input.timeoutMs,

--- a/packages/core/src/agent/tools/shell-tools.ts
+++ b/packages/core/src/agent/tools/shell-tools.ts
@@ -467,16 +467,18 @@ function interactiveShellArgs(
   cwd: string,
 ): readonly string[] {
   const evalCommand = `eval ${JSON.stringify(command)}`;
-  const script =
-    kind === "zsh"
-      ? `[[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
+  let script: string;
+  if (kind === "zsh") {
+    script = `[[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
 [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
 cd -- "$1"
-${evalCommand}`
-      : `shopt -s expand_aliases
+${evalCommand}`;
+  } else {
+    script = `shopt -s expand_aliases
 [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
 cd -- "$1"
 ${evalCommand}`;
+  }
   return ["-l", "-c", script, "jazz", cwd];
 }
 


### PR DESCRIPTION
## What & why
The `!` shell escape ran commands through a bare `sh -c`, so any alias or
function defined in the operator's `~/.zshrc`/`~/.bashrc` (a common one:
`alias code=cursor`) silently didn't exist there, even though it works fine
in the operator's own terminal — confusing, since `!` is meant to behave like
"run this in my shell."

zsh/bash now run as a login shell that explicitly sources the rc file, rather
than using `-i` (which would also trigger interactive-only setup like the
line editor and prompt themes — those assume a real TTY and error without
one). Any other `$SHELL` keeps the previous plain `sh -c` behavior. This only
applies to the operator-typed `!` escape; the model-invoked `execute_command`
tool is unchanged and still runs a bare `sh`, so aliases/functions can't
reshape what an autonomous tool call executes.

## How to verify
- Add `alias hello='echo hi'` to `~/.zshrc` (or `~/.bashrc`), start a jazz
  session, run `! hello`, confirm it prints `hi` instead of "command not
  found".
- Run `! echo $PWD` from a nested directory; confirm the command still runs
  in the conversation's working directory, not wherever the rc file happens
  to `cd`.
- Set `$SHELL` to something other than zsh/bash (e.g. `fish` or `dash`) and
  confirm `!` still runs normally via plain `sh -c`.
