### PR TITLE
feat(cli): persisted scheduler mode and keyring-backed daemon tokens

### DIFF
--- a/docs/concepts/scheduling.md
+++ b/docs/concepts/scheduling.md
@@ -13,10 +13,12 @@ Jazz uses your operating system's built-in scheduler:
 
 ## ⚠️ Important: Computer Must Be Awake at Schedule Time
 
-On an always-on host, use `JAZZ_SCHEDULER=in-process jazz daemon` to let Jazz own the ticker
-instead of installing an OS scheduler. Normal in-process scheduling is independent of
-`catchUpOnRestart`; that setting only controls replay of a recent slot missed while the daemon
-was stopped.
+On an always-on host, set `scheduler.mode: "in-process"` (`jazz config set scheduler.mode
+in-process`, or **Scheduler** in `jazz config`) and run `jazz daemon` to let Jazz own the ticker
+instead of installing an OS scheduler. The `JAZZ_SCHEDULER=in-process` environment variable does
+the same thing for a single run without changing saved config. Normal in-process scheduling is
+independent of `catchUpOnRestart`; that setting only controls replay of a recent slot missed
+while the daemon was stopped. See [Configuration → `scheduler`](../reference/configuration.md#scheduler).
 
 If your computer is **closed, asleep, or powered off** when a workflow is scheduled to run:
 

--- a/docs/guide/peers-setup.md
+++ b/docs/guide/peers-setup.md
@@ -12,11 +12,11 @@ You need three things, in order: something worth asking, someone willing to answ
 shared secret only the two of you know. Everything else is which network sits between you,
 and that's the actual difference between the three setups below:
 
-| | Where the daemon binds | Encryption | Needs a domain? |
-| --- | --- | --- | --- |
-| [One machine](#one-machine-two-agents) | loopback | none needed | no |
-| [A tailnet](#over-a-tailnet) | the tailnet interface | Tailscale's WireGuard | no |
-| [The internet](#over-the-internet) | loopback, behind a proxy | TLS at the proxy | yes |
+|                                        | Where the daemon binds   | Encryption            | Needs a domain? |
+| -------------------------------------- | ------------------------ | --------------------- | --------------- |
+| [One machine](#one-machine-two-agents) | loopback                 | none needed           | no              |
+| [A tailnet](#over-a-tailnet)           | the tailnet interface    | Tailscale's WireGuard | no              |
+| [The internet](#over-the-internet)     | loopback, behind a proxy | TLS at the proxy      | yes             |
 
 Pick the one that matches your actual situation — they don't build on each other.
 
@@ -41,7 +41,7 @@ Edit `$BOB/config.json` and add Alice as a peer:
 
 ```jsonc
 {
-  "peers": [{ "name": "alice", "url": "http://127.0.0.1:4748/peer/ask", "may": "about-me" }]
+  "peers": [{ "name": "alice", "url": "http://127.0.0.1:4748/peer/ask", "may": "about-me" }],
 }
 ```
 
@@ -61,7 +61,7 @@ JAZZ_HOME=$BOB   JAZZ_PEER_TOKEN=$TOKEN jazz peers set-token alice
 JAZZ_HOME=$ALICE JAZZ_PEER_TOKEN=$TOKEN jazz peers set-token bob
 ```
 
-Yes, both sides store it under the *other's* name — Bob's copy answers "is this really
+Yes, both sides store it under the _other's_ name — Bob's copy answers "is this really
 Alice?", Alice's copy answers "here's what I present as Alice." This is the same on all three
 setups; the walkthroughs below won't repeat it.
 
@@ -158,7 +158,9 @@ In Bob's `~/.jazz/config.json`:
 
 ```jsonc
 {
-  "peers": [{ "name": "alice", "url": "http://<alice's-tailnet-ip>:4747/peer/ask", "may": "about-me" }]
+  "peers": [
+    { "name": "alice", "url": "http://<alice's-tailnet-ip>:4747/peer/ask", "may": "about-me" },
+  ],
 }
 ```
 
@@ -173,14 +175,17 @@ JAZZ_PEER_TOKEN=<shared-secret> jazz peers set-token bob     # on Alice's machin
 ### 4. Bob serves on the tailnet interface — not `0.0.0.0`
 
 ```bash
-JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24) jazz daemon --serve-peers bob --host 100.101.102.103
+jazz daemon --serve-peers bob --host 100.101.102.103
 ```
 
 Bind the specific tailnet address, not `0.0.0.0`. If this machine also has a public interface
 (a cloud VM with a tailnet sidecar, say), `0.0.0.0` would listen on that too — binding the
 `100.x` address keeps the daemon reachable only from the tailnet, which is the whole reason to
-use one. `$JAZZ_DAEMON_TOKEN` is still required, because the bind-safety check has no way to
-know *which* non-loopback interface is safe — it treats all of them the same, on purpose.
+use one. A bearer token is still required to reach the operator routes, because the
+bind-safety check has no way to know _which_ non-loopback interface is safe — it treats all of
+them the same, on purpose. The first run generates one and stores it in the OS keyring,
+printing it once; set `JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24)` yourself instead if this is a
+container with no persistent keyring, or you need the value before the daemon's first run.
 
 ### 5. Ask, from Alice's machine
 
@@ -241,7 +246,11 @@ TLS is what Caddy just set up in step 2.
 ### 4. Bob configures Alice's tier, and the token, exactly as before
 
 ```jsonc
-{ "peers": [{ "name": "alice", "url": "https://alice-agent.example.com/peer/ask", "may": "about-me" }] }
+{
+  "peers": [
+    { "name": "alice", "url": "https://alice-agent.example.com/peer/ask", "may": "about-me" },
+  ],
+}
 ```
 
 ```bash
@@ -270,7 +279,7 @@ jazz peers log
   answering side. Re-run `peers set-token` on both ends with the exact same value.
 - **403, `"not accepting questions"`** — the peer exists in config but has no `may`, which
   defaults to `none`. Add a tier.
-- **403, some other reason, with a ledger entry** — the question was refused *by the agent*,
+- **403, some other reason, with a ledger entry** — the question was refused _by the agent_,
   not the connection. Read the reason in `jazz peers log`; it's usually the tier working as
   designed.
 - **`ask_peer` doesn't show up in the toolset** — no peer is configured on that side yet, or

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -153,16 +153,27 @@ Serves runs over HTTP: start one, poll it, approve or reject what a parked one i
 began it. Runs in the foreground; supervision (restart on crash, start on boot) is the host's
 job, not the daemon's.
 
-| Flag                      | Purpose                                                                             |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| `--port <n>`              | Port to listen on. Default `4747`                                                   |
-| `--host <address>`        | Interface to bind. Default `127.0.0.1`. Anything else requires `$JAZZ_DAEMON_TOKEN` |
-| `--serve-peers <agentId>` | Also answer questions from configured peers, using this agent. Off unless given     |
+| Flag                      | Purpose                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `--port <n>`              | Port to listen on. Default `4747`                                               |
+| `--host <address>`        | Interface to bind. Default `127.0.0.1`. Anything else requires a daemon token   |
+| `--serve-peers <agentId>` | Also answer questions from configured peers, using this agent. Off unless given |
 
-`$JAZZ_DAEMON_TOKEN` authenticates the operator routes (`/runs`, `/health`); it is read from
-the environment, never a flag, so it never lands in `ps` output or shell history. `/peer/ask`
-(when `--serve-peers` is given) uses a separate, per-peer credential instead — see
-[`jazz peers`](#jazz-peers).
+A bearer token authenticates the operator routes (`/runs`, `/health`) whenever `--host` is
+anything but loopback; loopback needs none. The first time this daemon binds a non-loopback
+host with no token already set, Jazz generates one and stores it in the OS keyring, printing
+it once so it can be copied to a client — the daemon works from the first run, with no setup
+command required. `/peer/ask` (when `--serve-peers` is given) uses a separate, per-peer
+credential instead — see [`jazz peers`](#jazz-peers).
+
+| Command                    | Purpose                                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `jazz daemon set-token`    | Generate (or store `$JAZZ_DAEMON_TOKEN` if set) a token before the daemon's first run — useful when a client needs the value in advance |
+| `jazz daemon forget-token` | Remove the stored token                                                                                                                 |
+
+Set `$JAZZ_DAEMON_TOKEN` yourself instead of letting Jazz generate one when the value needs to
+be known ahead of time — a container with no persistent keyring across restarts, or a client
+config that must be written before the daemon has ever started.
 
 See [Setting up peers](../guide/peers-setup.md) for a full walkthrough, and
 [Peers](../concepts/peers.md) for the tier model this exists to serve.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -131,6 +131,35 @@ Terminal display of reasoning, tools, and formatting. The interactive TUI reads 
 
 Set `collapseReasoning` to `false` to leave the full reasoning visible after it finishes. Ctrl+R is then unused — there is nothing collapsed to expand. Change it with `jazz config set output.collapseReasoning false`, or from **Output & Display** in `jazz config`.
 
+### `scheduler`
+
+Which scheduler runs workflows: your OS scheduler (launchd on macOS, cron on Linux), or Jazz's
+own in-process ticker inside `jazz daemon`. Defaults to `"auto"`, which uses the OS scheduler.
+
+```json
+{
+  "scheduler": {
+    "mode": "in-process"
+  }
+}
+```
+
+| Value          | Effect                                                                 |
+| -------------- | ----------------------------------------------------------------------- |
+| `"auto"`       | Default. `jazz workflow schedule` installs a launchd/cron entry         |
+| `"in-process"` | `jazz daemon` polls due schedules itself once per minute; no OS entries |
+
+Set it from **Scheduler** in `jazz config`, or directly:
+
+```bash
+jazz config set scheduler.mode in-process
+```
+
+`in-process` only matters for a host you leave running — `jazz daemon` must itself be running for
+its ticker to fire. The `JAZZ_SCHEDULER=in-process` environment variable still works and overrides
+this setting, which is useful for a one-off run without touching the saved config. See
+[Scheduled runs](../surfaces/scheduled.md) for how each mode installs and fires.
+
 ## Project Overrides: `./.jazz/config.json`
 
 Use for project-specific settings such as MCP enable/disable flags or logging level. Do not put agent storage paths here — agents always load from `~/.jazz`.

--- a/docs/surfaces/scheduled.md
+++ b/docs/surfaces/scheduled.md
@@ -6,9 +6,18 @@ description: "Schedule unattended Jazz runs with launchd or cron: workflow promp
 
 How to have Jazz do something every morning without you being there.
 
-For an always-on host without launchd or cron, set `JAZZ_SCHEDULER=in-process` and run
-`jazz daemon`. The daemon checks due schedules once per minute and runs each latest due slot
-once. This mode is opt-in; launchd and cron remain the defaults on supported platforms.
+For an always-on host without launchd or cron, switch to in-process mode and run `jazz daemon`.
+The daemon then checks due schedules once per minute and runs each latest due slot once. This
+mode is opt-in; launchd and cron remain the defaults on supported platforms.
+
+```bash
+jazz config set scheduler.mode in-process   # persists across restarts
+# or, for a single run without touching config:
+JAZZ_SCHEDULER=in-process jazz daemon
+```
+
+You can also flip this from **Scheduler** in `jazz config`. See
+[Configuration → `scheduler`](../reference/configuration.md#scheduler) for both settings.
 
 A scheduled run is a [workflow](../concepts/workflows.md) handed to your OS scheduler.
 Jazz writes the launchd plist or crontab entry for you; from then on the run happens with

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -67,7 +67,7 @@ export interface DaemonOptions {
   readonly peerAgent?: string | undefined;
 }
 
-function isLoopback(host: string): boolean {
+export function isLoopback(host: string): boolean {
   return host === "127.0.0.1" || host === "::1" || host === "localhost";
 }
 

--- a/packages/adapters/src/daemon/token.ts
+++ b/packages/adapters/src/daemon/token.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Finding the daemon's own bearer token.
+ *
+ * Same order as peer and trigger tokens, for the same reason: the environment is the
+ * deliberate override (a container has no keyring at all, and someone exporting
+ * `JAZZ_DAEMON_TOKEN` on a workstation is doing it on purpose), and the keyring is where the
+ * token lives otherwise.
+ */
+
+import { randomBytes } from "node:crypto";
+import { Effect } from "effect";
+import { detectKeyringBackend, keyringGet, keyringSet } from "@/adapters/secrets/keyring";
+import { DAEMON_TOKEN_ENV_VAR, DAEMON_TOKEN_PATH } from "@/adapters/secrets/registry";
+
+export function resolveDaemonToken(): Effect.Effect<string | undefined, never> {
+  return Effect.gen(function* () {
+    const fromEnv = process.env[DAEMON_TOKEN_ENV_VAR];
+    if (fromEnv !== undefined && fromEnv.trim().length > 0) return fromEnv.trim();
+
+    const backend = yield* detectKeyringBackend();
+    return yield* keyringGet(backend, DAEMON_TOKEN_PATH);
+  });
+}
+
+export interface ProvisionedDaemonToken {
+  readonly token: string;
+  /** True when this call generated the token rather than finding one already set. */
+  readonly generated: boolean;
+}
+
+/**
+ * `resolveDaemonToken`, but generates and persists a token the first time none exists —
+ * rather than making a fresh daemon unusable on a non-loopback host until someone runs
+ * `jazz daemon set-token` by hand first. Nobody else needs to independently know this token
+ * (unlike a peer's), so Jazz inventing it costs nothing.
+ *
+ * Returns `undefined` only when there is nowhere safe to keep a generated token: no keyring,
+ * and no `$JAZZ_DAEMON_TOKEN` already set. The caller decides what to do in that case; this
+ * never writes a token to disk in plaintext.
+ */
+export function resolveOrProvisionDaemonToken(): Effect.Effect<
+  ProvisionedDaemonToken | undefined,
+  never
+> {
+  return Effect.gen(function* () {
+    const existing = yield* resolveDaemonToken();
+    if (existing !== undefined) return { token: existing, generated: false };
+
+    const backend = yield* detectKeyringBackend();
+    if (backend === "none") return undefined;
+
+    const generatedToken = randomBytes(24).toString("hex");
+    const stored = yield* keyringSet(backend, DAEMON_TOKEN_PATH, generatedToken);
+    if (!stored) return undefined;
+
+    return { token: generatedToken, generated: true };
+  });
+}

--- a/packages/adapters/src/secrets/registry.ts
+++ b/packages/adapters/src/secrets/registry.ts
@@ -72,6 +72,12 @@ const OTLP_HEADER_PATH = /^telemetry\.otlp\.headers\.[^.]+$/;
 /** The header operators actually set; listed so the keyring is checked for it on load. */
 export const OTLP_AUTHORIZATION_PATH = "telemetry.otlp.headers.authorization";
 
+/** The config path holding the daemon's own bearer token. */
+export const DAEMON_TOKEN_PATH = "daemon.token";
+
+/** Environment variable that overrides the daemon token stored in the keyring. */
+export const DAEMON_TOKEN_ENV_VAR = "JAZZ_DAEMON_TOKEN";
+
 /** A peer's bearer token, e.g. `peers.sam.token`. */
 const PEER_TOKEN_PATH = /^peers\.[^.]+\.token$/;
 
@@ -114,6 +120,7 @@ export function peerTokenEnvVar(peerName: string): string {
 export const SECRET_PATHS: readonly string[] = [
   ...Object.keys(SECRET_ENV_VARS),
   OTLP_AUTHORIZATION_PATH,
+  DAEMON_TOKEN_PATH,
 ];
 
 /**
@@ -124,6 +131,9 @@ export const SECRET_PATHS: readonly string[] = [
  */
 export function isSecretPath(path: string): boolean {
   if (path in SECRET_ENV_VARS) return true;
+  // The daemon's own bearer token authenticates operator HTTP calls the same way a peer or
+  // trigger token authenticates theirs — it belongs in the keyring, not in plaintext config.
+  if (path === DAEMON_TOKEN_PATH) return true;
   // A peer's bearer token authenticates this machine to somebody else's agent. It belongs
   // in the keyring for the same reason an API key does, and the config file names the peer
   // without ever holding its credential.
@@ -140,6 +150,7 @@ export function isSecretPath(path: string): boolean {
 
 /** Environment variable that supplies a secret path, if one is defined. */
 export function envVarForSecretPath(path: string): string | undefined {
+  if (path === DAEMON_TOKEN_PATH) return DAEMON_TOKEN_ENV_VAR;
   // Peer names are user-defined, so their variables are derived rather than enumerated.
   const peer = /^peers\.([^.]+)\.token$/.exec(path);
   if (peer?.[1] !== undefined) return peerTokenEnvVar(peer[1]);

--- a/packages/cli/src/commands/config-wizard.ts
+++ b/packages/cli/src/commands/config-wizard.ts
@@ -1,6 +1,6 @@
 /**
  * Interactive `jazz config` wizard — menu-driven editing of LLM providers, web
- * search providers, output display, logging, and notifications.
+ * search providers, output display, logging, scheduler mode, and notifications.
  */
 
 import { WEB_SEARCH_PROVIDERS } from "@jazz/core/agent/tools/web-search-tools";
@@ -8,7 +8,7 @@ import { AVAILABLE_PROVIDERS, type ProviderName } from "@jazz/core/constants/mod
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
 import { TerminalServiceTag } from "@jazz/core/interfaces/terminal";
 import { resolveDisplayConfig } from "@jazz/core/presentation/display-config";
-import type { LoggingConfig, WebSearchProviderName } from "@jazz/core/types/config";
+import type { LoggingConfig, SchedulerMode, WebSearchProviderName } from "@jazz/core/types/config";
 import type { ColorProfile, OutputMode } from "@jazz/core/types/output";
 import { formatProviderDisplayName } from "@jazz/core/utils/provider-model";
 import { sortProvidersForPicker } from "@jazz/core/utils/provider-picker";
@@ -20,7 +20,13 @@ import type { WizardMenuOption } from "../ui/WizardHome";
  * Menu actions for the config wizard
  */
 type ConfigMenuAction =
-  "llm-providers" | "web-search" | "output-display" | "logging" | "notifications" | "back";
+  | "llm-providers"
+  | "web-search"
+  | "output-display"
+  | "scheduler"
+  | "logging"
+  | "notifications"
+  | "back";
 
 /**
  * Main entry point for the configuration wizard
@@ -34,6 +40,7 @@ export function configWizardCommand() {
         { label: "LLM Providers (API Keys)", value: "llm-providers" },
         { label: "Web Search Providers", value: "web-search" },
         { label: "Output & Display", value: "output-display" },
+        { label: "Scheduler", value: "scheduler" },
         { label: "Logging", value: "logging" },
         { label: "Notifications", value: "notifications" },
         { label: "Back to Main Menu", value: "back" },
@@ -52,6 +59,10 @@ export function configWizardCommand() {
         }
         case "output-display": {
           yield* configureOutputDisplay();
+          break;
+        }
+        case "scheduler": {
+          yield* configureScheduler();
           break;
         }
         case "logging": {
@@ -354,6 +365,39 @@ function configureOutputDisplay() {
       }
 
       yield* terminal.log("");
+    }
+  });
+}
+
+function configureScheduler() {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const configService = yield* AgentConfigServiceTag;
+
+    while (true) {
+      const appConfig = yield* configService.appConfig;
+      const currentMode = appConfig.scheduler?.mode ?? "auto";
+
+      const selection = yield* terminal.select<string>("Scheduler settings:", {
+        choices: [
+          { name: `Auto${currentMode === "auto" ? " (current)" : ""}`, value: "auto" },
+          {
+            name: `In-process${currentMode === "in-process" ? " (current)" : ""}`,
+            value: "in-process",
+          },
+          { name: "Back", value: "back" },
+        ],
+      });
+
+      if (!selection || selection === "back") {
+        break;
+      }
+
+      const mode = selection as SchedulerMode;
+      yield* configService.set("scheduler.mode", mode);
+      yield* terminal.success(`Scheduler mode set to ${mode}.`);
+      yield* terminal.log("");
+      break;
     }
   });
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -7,16 +7,21 @@
  * with both, and the first thing anyone deploying it would have to work around.
  */
 
+import { randomBytes } from "node:crypto";
 import {
   DEFAULT_DAEMON_PORT,
+  isLoopback,
   makeHandler,
   makePeerHandler,
   makeTriggerHandler,
   refuseReason,
   type DaemonRequirements,
 } from "@jazz/adapters/daemon/server";
+import { resolveDaemonToken, resolveOrProvisionDaemonToken } from "@jazz/adapters/daemon/token";
 import { runDueTriggers } from "@jazz/adapters/daemon/trigger-runner";
 import { resolvePeerToken } from "@jazz/adapters/peers/token";
+import { detectKeyringBackend, keyringDelete, keyringSet } from "@jazz/adapters/secrets/keyring";
+import { DAEMON_TOKEN_ENV_VAR, DAEMON_TOKEN_PATH } from "@jazz/adapters/secrets/registry";
 import { makeFileRunStoreLayer } from "@jazz/adapters/storage/run-store";
 import { resolveTriggerToken } from "@jazz/adapters/triggers/token";
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
@@ -42,12 +47,20 @@ export interface DaemonCommandOptions {
 /**
  * Serve until interrupted.
  *
- * The token comes from the environment rather than a flag: a token in argv is a token in
- * `ps` output and in shell history, and this one authorises driving an agent.
+ * The token comes from the environment or the OS keyring rather than a flag: a token in argv
+ * is a token in `ps` output and in shell history, and this one authorises driving an agent.
+ *
+ * Loopback needs no token at all. A non-loopback host does, and rather than making a fresh
+ * daemon unusable there until someone runs `jazz daemon set-token` by hand first, one is
+ * generated and stored in the keyring automatically the first time — the daemon works from
+ * the first run, at the cost of printing the token once so it can be copied to a client.
  */
 export function daemonCommand(options: DaemonCommandOptions) {
   return Effect.gen(function* () {
-    const token = process.env["JAZZ_DAEMON_TOKEN"]; // kept for network auth only
+    const provisioned = isLoopback(options.host)
+      ? { token: yield* resolveDaemonToken(), generated: false }
+      : yield* resolveOrProvisionDaemonToken();
+    const token = provisioned?.token;
     const daemonOptions = {
       port: options.port,
       host: options.host,
@@ -60,6 +73,13 @@ export function daemonCommand(options: DaemonCommandOptions) {
       process.stderr.write(`${refusal}\n`);
       process.exitCode = 1;
       return;
+    }
+
+    if (provisioned?.generated === true) {
+      process.stderr.write(
+        `Generated a daemon token and stored it in the OS keyring: ${provisioned.token}\n` +
+          `Use it as a bearer token from any client reaching this daemon over the network.\n`,
+      );
     }
 
     const logger = yield* LoggerServiceTag;
@@ -160,6 +180,52 @@ export function daemonCommand(options: DaemonCommandOptions) {
 
     yield* logger.info("Daemon stopped");
   }).pipe(Effect.provide(makeFileRunStoreLayer()));
+}
+
+/**
+ * Store the daemon's bearer token in the OS keyring, generating one if `$JAZZ_DAEMON_TOKEN`
+ * isn't set.
+ *
+ * Unlike a peer's token, nobody else needs to independently know this one — it only
+ * authenticates *this* operator to *their own* daemon — so there is nothing wrong with Jazz
+ * inventing it. `$JAZZ_DAEMON_TOKEN` is still honored when set, e.g. to reuse a token already
+ * deployed to a container as a secret.
+ */
+export function setDaemonTokenCommand() {
+  return Effect.gen(function* () {
+    const fromEnv = process.env[DAEMON_TOKEN_ENV_VAR];
+    const generated = fromEnv === undefined || fromEnv.trim().length === 0;
+    const token = generated ? randomBytes(24).toString("hex") : fromEnv.trim();
+
+    const backend = yield* detectKeyringBackend();
+    if (backend === "none") {
+      process.stderr.write(
+        "No OS keyring is available, and the daemon token is not written to disk in plaintext.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const stored = yield* keyringSet(backend, DAEMON_TOKEN_PATH, token);
+    if (!stored) {
+      process.stderr.write("Could not store the daemon token.\n");
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(
+      generated
+        ? `Generated and stored a daemon token in the ${backend} keyring.\n`
+        : `Stored the daemon token in the ${backend} keyring.\n`,
+    );
+  });
+}
+
+export function forgetDaemonTokenCommand() {
+  return Effect.gen(function* () {
+    const backend = yield* detectKeyringBackend();
+    yield* keyringDelete(backend, DAEMON_TOKEN_PATH);
+    process.stdout.write("Removed the stored daemon token.\n");
+  });
 }
 
 export { DEFAULT_DAEMON_PORT };

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -21,6 +21,7 @@ import { makeFileRunStoreLayer } from "@jazz/adapters/storage/run-store";
 import { resolveTriggerToken } from "@jazz/adapters/triggers/token";
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { SchedulerServiceTag } from "@jazz/core/workflows/scheduler-service";
 import { Effect, Runtime } from "effect";
 
 /** How often the daemon checks for due workflow schedules and wake triggers. */
@@ -46,7 +47,7 @@ export interface DaemonCommandOptions {
  */
 export function daemonCommand(options: DaemonCommandOptions) {
   return Effect.gen(function* () {
-    const token = process.env["JAZZ_DAEMON_TOKEN"];
+    const token = process.env["JAZZ_DAEMON_TOKEN"]; // kept for network auth only
     const daemonOptions = {
       port: options.port,
       host: options.host,
@@ -62,6 +63,8 @@ export function daemonCommand(options: DaemonCommandOptions) {
     }
 
     const logger = yield* LoggerServiceTag;
+    const scheduler = yield* SchedulerServiceTag;
+    const runInProcessWorkflows = scheduler.getSchedulerType() === "in-process";
 
     // The whole agent stack, captured once. Each request runs on this rather than on a
     // fresh runtime: `Effect.runPromise` inside the handler would start with an empty
@@ -121,7 +124,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
         const parsed = raw !== undefined ? Number(raw) : Number.NaN;
         return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TICK_INTERVAL_MS;
       })();
-      const runInProcessWorkflows = process.env["JAZZ_SCHEDULER"] === "in-process";
+
       let tickRunning = false;
       const ticker = setInterval(() => {
         if (tickRunning) return;

--- a/packages/cli/src/ui/fullscreen/bridge.test.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.test.tsx
@@ -672,8 +672,8 @@ describe("fullscreen bridge", () => {
         title: "delete an agent",
         action: "delete",
         agents: [
-          { id: "a1", name: "Basil", model: "claude-sonnet-4", lastUsed: true },
-          { id: "a2", name: "Cass", model: "gpt-5" },
+          { id: "a1", name: "Basil", model: "claude-sonnet-4", persona: "default", lastUsed: true },
+          { id: "a2", name: "Cass", model: "gpt-5", persona: "default" },
         ],
       });
     });
@@ -693,7 +693,7 @@ describe("fullscreen bridge", () => {
         kind: "agents",
         title: "pick an agent",
         action: "start",
-        agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4" }],
+        agents: [{ id: "a1", name: "Basil", model: "claude-sonnet-4", persona: "default" }],
       },
       (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
     );
@@ -715,8 +715,8 @@ describe("fullscreen bridge", () => {
         title: "pick an agent",
         action: "start",
         agents: [
-          { id: "a1", name: "Basil", model: "claude-sonnet-4" },
-          { id: "a2", name: "Cass", model: "gpt-5" },
+          { id: "a1", name: "Basil", model: "claude-sonnet-4", persona: "default" },
+          { id: "a2", name: "Cass", model: "gpt-5", persona: "default" },
         ],
       },
       (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
@@ -739,8 +739,8 @@ describe("fullscreen bridge", () => {
         action: "back",
         browse: true,
         agents: [
-          { id: "a1", name: "doitall", model: "claude-sonnet-4" },
-          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
+          { id: "a1", name: "doitall", model: "claude-sonnet-4", persona: "default" },
+          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder", persona: "default" },
         ],
       });
     });
@@ -764,8 +764,8 @@ describe("fullscreen bridge", () => {
         action: "back",
         browse: true,
         agents: [
-          { id: "a1", name: "doitall", model: "claude-sonnet-4" },
-          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder" },
+          { id: "a1", name: "doitall", model: "claude-sonnet-4", persona: "default" },
+          { id: "a2", name: "qwen-coder", model: "qwen2.5-coder", persona: "default" },
         ],
       },
       (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
@@ -784,7 +784,7 @@ describe("fullscreen bridge", () => {
         title: "agents",
         action: "back",
         browse: true,
-        agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4" }],
+        agents: [{ id: "a1", name: "doitall", model: "claude-sonnet-4", persona: "default" }],
       },
       (result) => selected.push(result.kind === "exit" ? "EXIT" : result.value),
     );

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -7,6 +7,12 @@ import type { OutputConfig } from "./output";
 import type { PeerConfig } from "./peer";
 import type { TriggerConfig } from "./trigger";
 
+export type SchedulerMode = "auto" | "in-process";
+
+export interface SchedulerConfig {
+  readonly mode?: SchedulerMode;
+}
+
 export interface AppConfig {
   readonly storage: StorageConfig;
   readonly logging: LoggingConfig;
@@ -32,6 +38,15 @@ export interface AppConfig {
    * Defaults to 1GB (`DEFAULT_MAX_WORKSPACE_TOTAL_BYTES_PER_AGENT`).
    */
   readonly workspaceMaxTotalBytesPerAgent?: number;
+  /**
+   * Scheduler selection for unattended workflow execution.
+   *
+   * Leave unset (or "auto") to use the platform scheduler: launchd on macOS,
+   * cron on Linux. Set to "in-process" to let `jazz daemon` own the ticker on
+   * an always-on host.
+   */
+  readonly scheduler?: SchedulerConfig;
+
   /**
    * Other people's agents this machine will talk to.
    *

--- a/packages/core/src/workflows/scheduler-service.ts
+++ b/packages/core/src/workflows/scheduler-service.ts
@@ -1,14 +1,16 @@
 /**
- * `SchedulerService`: schedules workflows with the host OS scheduler (launchd
- * on macOS, cron on Linux), converting cron expressions to each backend's
- * native format.
+ * `SchedulerService`: schedules workflows either with the host OS scheduler
+ * (launchd on macOS, cron on Linux) or, when configured, with Jazz's
+ * in-process daemon ticker.
  */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Option } from "effect";
 import * as plist from "plist";
 import type { WorkflowMetadata } from "./workflow-service";
+import { AgentConfigServiceTag } from "../interfaces/agent-config";
+import type { SchedulerMode } from "../types/config";
 import { isValidCronExpression } from "../utils/cron";
 import { getGlobalUserDataDirectory } from "../utils/paths";
 import { getJazzSchedulerInvocation } from "../utils/runtime";
@@ -799,9 +801,12 @@ class UnsupportedScheduler implements SchedulerService {
 
 /**
  * Create the appropriate scheduler implementation for the current platform.
+ *
+ * `mode === "in-process"` is an always-on-host mode selected by config or the
+ * `JAZZ_SCHEDULER` override; otherwise the platform scheduler stays the default.
  */
-function createScheduler(): SchedulerService {
-  if (process.env["JAZZ_SCHEDULER"] === "in-process") {
+function createScheduler(mode: SchedulerMode): SchedulerService {
+  if (mode === "in-process") {
     return new InProcessScheduler();
   }
 
@@ -819,4 +824,17 @@ function createScheduler(): SchedulerService {
 /**
  * Layer providing the SchedulerService.
  */
-export const SchedulerServiceLayer = Layer.succeed(SchedulerServiceTag, createScheduler());
+export const SchedulerServiceLayer = Layer.effect(
+  SchedulerServiceTag,
+  Effect.gen(function* () {
+    const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
+    const appConfig = Option.isSome(configServiceOption)
+      ? yield* configServiceOption.value.appConfig
+      : undefined;
+    const mode =
+      process.env["JAZZ_SCHEDULER"] === "in-process" || appConfig?.scheduler?.mode === "in-process"
+        ? "in-process"
+        : "auto";
+    return createScheduler(mode);
+  }),
+);

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -712,7 +712,7 @@ function registerUpdateCommand(program: Command): void {
  * forked and wrote a pidfile would be a third mechanism competing with both.
  */
 function registerDaemonCommand(program: Command): void {
-  program
+  const daemonCommand = program
     .command("daemon")
     .description(
       "Serve runs over HTTP so a parked run can be answered later, and from somewhere else",
@@ -720,7 +720,7 @@ function registerDaemonCommand(program: Command): void {
     .option("--port <n>", "Port to listen on", parsePositiveInt("--port"), 4747)
     .option(
       "--host <address>",
-      "Interface to bind. Anything other than loopback requires $JAZZ_DAEMON_TOKEN.",
+      "Interface to bind. Anything other than loopback requires a daemon token (env or keyring).",
       "127.0.0.1",
     )
     .option(
@@ -739,6 +739,28 @@ function registerDaemonCommand(program: Command): void {
           ),
         cliRuntimeOptions(program),
         { session: true },
+      ),
+    );
+
+  daemonCommand
+    .command("set-token")
+    .description(
+      "Generate and store a daemon bearer token in the OS keyring, or store $JAZZ_DAEMON_TOKEN if set",
+    )
+    .action(() =>
+      runCliAction(
+        () => import("@jazz/cli/commands/daemon").then((mod) => mod.setDaemonTokenCommand()),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  daemonCommand
+    .command("forget-token")
+    .description("Remove the daemon's stored token")
+    .action(() =>
+      runCliAction(
+        () => import("@jazz/cli/commands/daemon").then((mod) => mod.forgetDaemonTokenCommand()),
+        cliRuntimeOptions(program),
       ),
     );
 }


### PR DESCRIPTION
## What & why
Makes scheduler mode a persisted config setting instead of an env-var-only toggle. Operators can now pick between the platform scheduler (launchd/cron) and Jazz's in-process daemon ticker from `jazz config`, rather than having to set `JAZZ_SCHEDULER=in-process` by hand. `JAZZ_SCHEDULER` still works as an override.

Also moves the daemon's own bearer token (`JAZZ_DAEMON_TOKEN`) off of env-var-only: it now resolves from the OS keyring too, the same way peer and trigger tokens already do. `jazz daemon` auto-generates and stores one the first time it binds a non-loopback host with no token set, so it works out of the box instead of failing until someone runs a setup command first. `JAZZ_DAEMON_TOKEN` still works, for containers or cases where the value needs to be known before the daemon's first run.

## How to verify
- Run `jazz config` → Scheduler, switch to "In-process", confirm it's saved and shown as current on re-entry; confirm `jazz daemon` then runs the workflow ticker itself.
- Leave scheduler mode unset and confirm `jazz daemon` defers to the platform scheduler as before; confirm `JAZZ_SCHEDULER=in-process` still overrides it.
- Run `jazz daemon --host 0.0.0.0` with no `JAZZ_DAEMON_TOKEN` set and no stored token: it should start, print a generated token, and store it in the OS keyring.
- Run it again: the daemon should reuse the stored token silently (no new one printed).
- Set `JAZZ_DAEMON_TOKEN` explicitly and confirm it's used instead of anything stored.
- `jazz daemon set-token` / `jazz daemon forget-token` manage the stored token directly.
