### PR TITLE
docs(email): update skill for Himalaya v2 config and CLI

### DIFF
--- a/skills/email/SKILL.md
+++ b/skills/email/SKILL.md
@@ -7,30 +7,53 @@ description: Manage emails via Himalaya CLI. Use when the user wants to read, se
 
 Manage emails using [Himalaya CLI](https://github.com/pimalaya/himalaya) - a powerful command-line email client supporting IMAP, SMTP, Maildir, and Notmuch backends.
 
+> **Config format note (Himalaya v2.x).** Himalaya v2 reorganized the config from the old
+> `backend.*` / `message.send.backend.*` schema into per-protocol tables (`[accounts.x.imap]`,
+> `[accounts.x.smtp]`, `[accounts.x.jmap]`). A v1 config silently loads with **zero backends**, so
+> every command fails with `No backend matching \`auto\` is configured`. If you see that error, the
+> config is in the wrong format — see [references/providers.md](references/providers.md) for the v2
+> shape. `account list` shows the resolved backends per account; use it to confirm.
+
 ## Agent Usage (Power User Patterns)
 
 **When using this skill as an agent**, run commands via `execute_command`. Prefer these patterns:
 
 0. **Install and set up if needed.** Run [Prerequisites Check](#prerequisites-check) before the first Himalaya command. If `himalaya` is missing, fetch the live README and install it. If no account is configured, walk the user through [Account Setup](#account-setup), then continue the original request (check mail, etc.). Do not stop at "go install Himalaya".
 
-1. **Always use `--output json`** when you need to parse results (subject, from, id). Example:
+1. **Always use `--json`** (the global flag) when you need to parse results (subject, from, id):
    ```bash
-   himalaya envelope list --folder INBOX --page-size 20 --output json | jq '.[] | {id, subject, from, date}'
+   himalaya envelope list -m INBOX -s 20 --json | jq '.envelopes[] | {id, subject, from, date}'
+   ```
+   Note: in v2 the flag is the **global `--json`**, not `--output json`. `envelope list` emits
+   `{"envelopes":[...]}`; `account list` emits `{"accounts":[...]}`.
+
+2. **Non-interactive send** uses `message write` with flags and `--send` (no editor):
+   ```bash
+   himalaya message write --to "recipient@example.com" --subject "Subject" --body "Body text" --send
+   ```
+   Or feed the body via stdin:
+   ```bash
+   printf 'Body text' | himalaya message write --to "recipient@example.com" --subject "Subject" --send
+   ```
+   `--save <MAILBOX>` appends a copy (e.g. Sent) alongside `--send`.
+
+3. **Extract message IDs** for follow-up actions:
+   ```bash
+   himalaya envelope list -m INBOX -s 20 --json | jq -r '.envelopes[].id'
    ```
 
-2. **Non-interactive send**: `message write` opens `$EDITOR`. For automation, pipe a full RFC-style message to `himalaya template send` (if available), or use a temp file:
+4. **Batch operations** — pass multiple IDs; move/copy use `--to` (and optional `--from`):
    ```bash
-   echo -e "To: recipient@example.com\nSubject: Subject\n\nBody text" | himalaya template send
+   himalaya message move --to "Archives" <id1> <id2> <id3>
+   himalaya message copy --to "Important" <id1> <id2>
    ```
-   If `template send` is not available, use `himalaya message write --to "recipient" --subject "Subject"` and note that it may open an editor—check `himalaya --help` for your version.
 
-3. **Extract message IDs** for follow-up actions: `himalaya envelope list --output json | jq -r '.[].id'`
+5. **Check before acting**: Run `himalaya account list` first if the user has multiple accounts or folders. Folders/mailboxes are listed with `himalaya mailbox list` (v2 renamed `folder` to `mailbox`).
 
-4. **Batch operations**: Pass multiple IDs to move/delete: `himalaya message move <id1> <id2> <id3> --folder "Archives"`
-
-5. **Check before acting**: Run `himalaya account list` and `himalaya folder list` first if the user has multiple accounts or folders.
-
-6. **Use `--account <name>`** when the user has multiple accounts (e.g., `himalaya --account work envelope list`).
+6. **Use `-a <name>`** (not `--account`) when the user has multiple accounts:
+   ```bash
+   himalaya -a gmail envelope list -m INBOX
+   ```
 
 ## Prerequisites Check
 
@@ -50,7 +73,12 @@ Before any email operation:
    himalaya account list
    ```
 
-   If no accounts → walk them through [Account Setup](#account-setup), then continue what they asked. Do not invent credentials. The wizard needs a real TTY; do not run it via `execute_command`. In a headless run, write a one-line failure note and stop.
+   If it errors with `No backend matching \`auto\` is configured`, the config is in the old
+   (v1) format — don't treat it as "no account". Open the config and migrate it to the v2
+   per-protocol schema (see [references/providers.md](references/providers.md)). If `account list`
+   is truly empty → walk them through [Account Setup](#account-setup). Do not invent credentials.
+   The wizard needs a real TTY; do not run it via `execute_command`. In a headless run, write a
+   one-line failure note and stop.
 
 ---
 
@@ -86,7 +114,7 @@ Himalaya is a third-party CLI ([pimalaya/himalaya](https://github.com/pimalaya/h
 
    Tell the user to add `~/.local/bin` to PATH permanently if it is not already.
 
-6. Verify with `himalaya --version` (or `himalaya -V`). If a later command fails with unknown flags, re-read the README Usage section and `himalaya --help` — prefer those over this skill's examples.
+6. Verify with `himalaya --version` (or `himalaya -V`). If a later command fails with unknown flags, re-read `himalaya <command> --help` — prefer that over this skill's examples, since flags changed in v2.
 
 If fetch and every install method fail, tell the user what you tried and point them at https://github.com/pimalaya/himalaya#installation.
 
@@ -94,49 +122,30 @@ If fetch and every install method fail, tell the user what you tried and point t
 
 ## Account Setup
 
-Himalaya with no config starts an interactive TTY wizard. **Do not run bare `himalaya` via `execute_command`** — it will hang waiting for a terminal. Guide the user instead, then continue the original request.
+Himalaya v2 has **no `account configure` subcommand** (it was removed). To add an account you
+write the TOML directly — see [references/providers.md](references/providers.md) for the v2 schema,
+or run bare `himalaya` to start the (interactive, TTY-only) setup wizard. **Do not run bare
+`himalaya` via `execute_command`** — it will hang waiting for a terminal. Guide the user instead,
+then continue the original request.
 
-Fetch the live README Configuration section if the wizard flags have changed: `https://raw.githubusercontent.com/pimalaya/himalaya/master/README.md`. Prefer that over this page.
-
-### First-run (interactive chat)
-
-When `himalaya account list` is empty or errors because nothing is configured — e.g. the user just asked "check my latest emails":
+When `himalaya account list` shows no accounts — e.g. the user just asked "check my latest emails":
 
 1. Say in one or two lines that mail isn't set up yet, and you will walk them through it so you can then do what they asked. Setup is part of the request, not a detour.
 2. Ask the provider with `ask_user_question`: Gmail, Outlook / Microsoft 365, iCloud, Proton Mail, Fastmail, other IMAP.
-3. Load [references/providers.md](references/providers.md) for that provider. Tell them the one thing they need *before* the wizard:
+3. Load [references/providers.md](references/providers.md) for that provider. Tell them the one thing they need *before* writing config:
    - **Gmail** — App Password at https://myaccount.google.com/apppasswords (2-Step Verification must be on).
    - **Outlook** — OAuth 2.0; basic auth is retired.
    - **iCloud** — app-specific password; IMAP login is the local-part only (`johnappleseed`, not the full address).
    - **Proton Mail** — Proton Bridge running locally; the password is the Bridge password.
    - **Fastmail** — app password for IMAP/SMTP, or an API token for JMAP.
-4. Ask them to run the wizard in **their** terminal (a new tab is fine):
-
-   ```bash
-   himalaya
-   ```
-
-   If their version has `himalaya account configure <name>`, that works too. Prefer whatever `himalaya --help` and the live README show. The wizard asks for an email address and discovers IMAP/SMTP. **Never ask them to paste a password into this chat.** Secrets belong in the wizard, `pass`, or `secret-tool`.
-5. When they say the wizard finished, re-run `himalaya account list` (and `himalaya account check` if it exists). If it works, immediately continue the original request. Do not wait to be asked again.
+4. Write the account block into `~/.config/himalaya/config.toml` (v2 schema). For passwords prefer
+   `pass`/`security`/keyring over a raw value; **never paste a password into chat** — secrets
+   belong in the wizard, `pass`, `secret-tool`, or the macOS Keychain. If OAuth is needed, the user
+   must run the auth flow in their own terminal.
+5. When config is written, re-run `himalaya account list` (and `himalaya account check <name>` if it exists). If it shows `imap, smtp` backends, immediately continue the original request. Do not wait to be asked again.
 
 ### Headless / unattended
-
 Do not start a wizard. Write a one-line failure that Himalaya has no account configured, and stop.
-
-### Writing config yourself
-
-If they already use `pass` (or similar) and want you to write `~/.config/himalaya/config.toml`, fetch the live README Configuration section — the TOML shape changes across versions — and `load_skill_section` for [references/providers.md](references/providers.md). Never put a raw password in the file or in chat.
-
-### Provider-Specific Notes
-
-| Provider        | Special Requirements                         |
-| --------------- | -------------------------------------------- |
-| **Gmail**       | Requires App Password or OAuth 2.0 setup     |
-| **Outlook**     | Works with password or OAuth 2.0             |
-| **iCloud**      | IMAP login is username only (not full email) |
-| **Proton Mail** | Requires Proton Bridge running locally       |
-
-Many providers use the same app-specific password for both email and calendar. Store credentials in `pass` with consistent naming (e.g., `google/app-password`, `icloud/app-password`) to reuse them across both skills. For multiple accounts, use a hierarchical structure (e.g., `google/personal/app-password`) — the `/` creates folders.
 
 For detailed provider configs, see [references/providers.md](references/providers.md)
 
@@ -144,168 +153,152 @@ For detailed provider configs, see [references/providers.md](references/provider
 
 ## Common Operations
 
+All commands below are for **Himalaya v2.x**. The mailbox flag is `-m/--mailbox` and is required for
+message commands unless `mailbox.alias.inbox` is set; account selection is `-a/--account`; JSON is
+the global `--json`.
+
 ### List Emails
 
 ```bash
-# List recent emails in INBOX
-himalaya envelope list
+# List recent emails in INBOX (most recent first, page 1)
+himalaya envelope list -m INBOX -s 20
 
-# List from specific folder
-himalaya envelope list --folder "Archives"
+# List from a specific mailbox
+himalaya envelope list -m "[Gmail]/All Mail" -s 20
 
-# List with specific account
-himalaya envelope list --account gmail
+# List with a specific account
+himalaya -a gmail envelope list -m INBOX -s 20
 
-# Paginate results
-himalaya envelope list --page 2 --page-size 20
+# Paginate
+himalaya envelope list -m INBOX -p 2 -s 20
+
+# JSON for parsing
+himalaya envelope list -m INBOX -s 20 --json
 ```
+
+Note: `envelope list` does **not** accept a positional search query in v2 — use `envelope search`
+(see [Searching emails](#searching-emails)) or filter client-side.
 
 ### Read Email
 
 ```bash
-# Read by ID
-himalaya message read <id>
+# Read by ID (prints a header block + walks MIME parts)
+himalaya message read <id> -m INBOX
 
-# Read in plain text (no HTML)
-himalaya message read <id> --plain
+# Mark seen while reading
+himalaya message read <id> -m INBOX --seen
 
-# Read headers only
-himalaya message read <id> --headers
+# Raw RFC 5322 bytes (pipe into a renderer / grep for headers)
+himalaya message read <id> -m INBOX --raw
+
+# Structured parse as JSON
+himalaya message read <id> -m INBOX --json
 ```
+
+There is no `--plain` or `--headers` flag in v2; use `--raw` (then `grep`) or `--json` to inspect
+headers selectively.
 
 ### Send Email
 
 ```bash
-# Compose new email (opens $EDITOR)
-himalaya message write
+# Compose + send non-interactively (writes RFC5322 then sends via SMTP/JMAP)
+himalaya message write --to "recipient@example.com" --subject "Hello" --body "Body" --send
+himalaya message write --to "a@x.com,b@y.com" --subject "Hello" --body "Body" --send --save "Sent"
 
-# Send with pre-filled fields
-himalaya message write --to "recipient@example.com" --subject "Hello"
+# Body from a file
+himalaya message write --to "recipient@example.com" --subject "S" --body-file /tmp/body.txt --send
 
-# Reply to a message
-himalaya message reply <id>
-
-# Reply all
-himalaya message reply <id> --all
+# Reply to a message (opens $EDITOR unless you also pass --body)
+himalaya message reply <id> -m INBOX
+himalaya message reply <id> -m INBOX --all --send
 ```
+
+`message write` with flags does not open an editor; only `message reply`/`forward` without a body do.
 
 ### Search Emails
 
 ```bash
-# NOTE: `envelope list` does NOT support a `--query` flag.
-# Any trailing arguments are interpreted as the search query.
-# Put options FIRST (e.g., --folder/--output/--page-size), then query tokens.
-# NOTE: There is no `--max-size` flag. To limit results, use `--page-size` (and optionally `--page`).
-
-
-# Basic filters (direct Himalaya query syntax)
-
-# Search by subject
-himalaya envelope list --folder INBOX subject "meeting"
-
-# Search by sender
-himalaya envelope list --folder INBOX from "boss@company.com"
-
-# Unread (not seen)
-himalaya envelope list --folder INBOX not flag seen
-
-# Search by exact date (YYYY-MM-DD or YYYY/MM/DD)
-himalaya envelope list --folder INBOX date 2026-02-09
-
-# Combine filters with and/or (quote the expression to keep it as one arg)
-himalaya envelope list --folder INBOX "from client@example.com and subject invoice and not flag seen"
-
-# ---------------------------------------------------------------------------
-# Shell-level helpers (useful patterns for LLMs)
-# ---------------------------------------------------------------------------
-
-# Count emails received TODAY in INBOX
-# 1) List all envelopes
-# 2) Skip the header lines
-# 3) Grep for today's ISO date string
-# 4) Count lines
-TODAY=$(date +%Y-%m-%d)
-himalaya envelope list --folder INBOX \
-  | tail -n +3 \
-  | grep "${TODAY}" \
-  | wc -l
-
-# Count unread emails in INBOX
-himalaya envelope list --folder INBOX not flag seen \
-  | tail -n +3 \
-  | wc -l
-
-# Show latest N emails in INBOX (for quick inspection)
-# Use pagination flags (not `tail`) to reliably fetch only N messages.
-himalaya envelope list --folder INBOX --page 1 --page-size 10
-
-# Show latest N *unread* emails
-himalaya envelope list --folder INBOX --page 1 --page-size 10 not flag seen
+# Search uses the `envelope search` subcommand + a positional query DSL
+himalaya envelope search -m INBOX "from google"
+himalaya envelope search -m INBOX "subject report"
+himalaya envelope search -m INBOX "from boss@company.com and subject invoice"
+himalaya envelope search -m INBOX "not flag seen"        # unread only
+himalaya envelope search -m INBOX "after 2026-08-01"
+himalaya envelope search -m INBOX "date 2026-08-09"
 ```
 
-### Manage Folders
+Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `before <yyyy-mm-dd>`, `from <pattern>`,
+`to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`.
+Combine with `and` / `or`; quote the whole expression.
+
+### Manage Mailboxes (was `folder` in v1)
 
 ```bash
-# List folders
-himalaya folder list
+# List mailboxes
+himalaya mailbox list
 
-# Create folder
-himalaya folder create "Projects/ClientA"
+# Move message(s) to a mailbox
+himalaya message move --to "Archives" <id1> <id2>
+himalaya message move --from INBOX --to "Archives" <id>
 
-# Move message to folder
-himalaya message move <id> --folder "Archives"
-
-# Copy message
-himalaya message copy <id> --folder "Important"
+# Copy message(s)
+himalaya message copy --to "Important" <id>
 ```
+
+There is **no `mailbox create`** in this build; create folders from a client (or use the provider's
+web UI) and they appear via `mailbox list`.
 
 ### Manage Flags
 
 ```bash
-# Mark as read
-himalaya flag add <id> seen
+# Mark as read (seen)
+himalaya flag add -f seen <id>
 
 # Mark as unread
-himalaya flag remove <id> seen
+himalaya flag remove -f seen <id>
 
 # Star/flag message
-himalaya flag add <id> flagged
+himalaya flag add -f flagged <id>
 
-# Delete (move to trash)
-himalaya message delete <id>
+# Delete (trash-first: moves to trash, expunges if already in trash)
+himalaya message delete <id> -m INBOX
 ```
+
+`flag add` / `flag remove` require `-f/--flag` (repeatable). Delete requires a mailbox (`-m`).
 
 ### Switch Between Accounts
 
 ```bash
 # Use specific account for any command
-himalaya --account work envelope list
-himalaya --account personal message write
+himalaya -a work envelope list -m INBOX
+himalaya -a personal message write --to ... --send
 ```
 
 ### Check All Accounts
 
 ```bash
-# List configured accounts
+# List configured accounts (with resolved backends)
 himalaya account list
 
 # Check unread across accounts
-for account in $(himalaya account list --output json | jq -r '.[].name'); do
+for account in $(himalaya account list --json | jq -r '.accounts[].name'); do
   echo "=== $account ==="
-  himalaya --account "$account" envelope list --page-size 5 not flag seen
+  himalaya -a "$account" envelope search -m INBOX "not flag seen" -s 5
 done
 ```
 
 ## Output Formats
 
-Himalaya supports JSON output for scripting:
+Himalaya v2 emits JSON with the global `--json` flag (not `--output json`):
 
 ```bash
 # JSON output
-himalaya envelope list --output json
+himalaya envelope list -m INBOX -s 20 --json
+himalaya account list --json
 
 # Parse with jq
-himalaya envelope list --output json | jq '.[].subject'
+himalaya envelope list -m INBOX -s 20 --json | jq '.envelopes[].subject'
+himalaya account list --json | jq -r '.accounts[].name'
 ```
 
 ---
@@ -316,20 +309,18 @@ himalaya envelope list --output json | jq '.[].subject'
 
 ```bash
 # Enable debug logging
-RUST_LOG=debug himalaya envelope list
-
-# Full trace
-himalaya --debug envelope list
+RUST_LOG=debug himalaya envelope list -m INBOX
 ```
 
 ### Common Errors
 
-| Error                   | Solution                                          |
-| ----------------------- | ------------------------------------------------- |
-| "Account not found"     | Run `himalaya account configure <name>`           |
-| "Authentication failed" | Check password/app password, regenerate if needed |
-| "Connection refused"    | Check IMAP/SMTP host and port settings            |
-| "Certificate error"     | Check TLS settings in config                      |
+| Error                                          | Solution                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `No backend matching \`auto\` is configured`   | Config is in the old v1 format. Migrate to the v2 per-protocol schema — see `references/providers.md`. |
+| `Mailbox is required` / `mailbox.alias.inbox` | Pass `-m INBOX` (or set `mailbox.alias.inbox` in config).                |
+| `Invalid credentials` (IMAP AUTHENTICATE)     | App password wrong/expired or 2-Step off. Regenerate at the provider; for Gmail, https://myaccount.google.com/apppasswords. |
+| `Account not found`                            | Use the exact account name from `himalaya account list`.                 |
+| `Connection refused` / `Certificate error`     | Check IMAP/SMTP host/port/TLS in config.                                 |
 
 ### Reset Configuration
 
@@ -342,25 +333,28 @@ cat ~/.config/himalaya/config.toml
 # Edit config manually
 $EDITOR ~/.config/himalaya/config.toml
 
-# Reconfigure account interactively
-himalaya account configure <name>
+# Validate an account's connection (v2; replaces the removed `account configure`)
+himalaya account check <name>
 
 # Use alternative config file
-himalaya --config /path/to/custom/config.toml envelope list
+himalaya -c /path/to/custom/config.toml envelope list -m INBOX
 ```
 
 **Environment variable override:**
 
 ```bash
 export HIMALAYA_CONFIG=~/.config/himalaya/custom-config.toml
-himalaya envelope list
+himalaya envelope list -m INBOX
 ```
 
 ---
 
 ## Composing Emails
 
-Himalaya uses your `$EDITOR` for composing. The format is:
+Himalaya uses `message write` for composition. Without body flags it opens `$EDITOR` with an
+RFC-style draft (`To:`, `Cc:`, `Subject:`, blank line, body). With `--to/--subject/--body` it
+composes and prints the RFC 5322 bytes; add `--send` to deliver and/or `--save <MAILBOX>` to keep a
+copy.
 
 ```
 To: recipient@example.com
@@ -371,56 +365,59 @@ Your message body here.
 ```
 
 ### Adding Attachments (MML Syntax)
+Pipe MML through `mml` then into `himalaya message write` (see `himalaya message write --help`).
 
 ---
 
 ## Searching emails
 
-Himalaya’s search uses a **positional query expression**, not a `--query` flag.
+Himalaya's search lives in the **`envelope search`** subcommand and a positional query DSL (v2
+removed the inline query from `envelope list`).
 
 ### Date filters
 
 ```bash
 # Envelopes strictly after a given date
-himalaya envelope list "after 2026-02-10"
+himalaya envelope search -m INBOX "after 2026-02-10"
 
 # Envelopes strictly before a given date
-himalaya envelope list "before 2026-02-10"
+himalaya envelope search -m INBOX "before 2026-02-10"
 
 # All emails received today (from local date)
-himalaya envelope list "after $(date +%Y-%m-%d)"
+himalaya envelope search -m INBOX "after $(date +%Y-%m-%d)"
 ```
 
 ### Other common filters
 
 ```bash
 # From a specific sender
-himalaya envelope list "from me@example.com"
+himalaya envelope search -m INBOX "from me@example.com"
 
 # To a specific recipient
-himalaya envelope list "to someone@example.com"
+himalaya envelope search -m INBOX "to someone@example.com"
 
 # Subject contains words
-himalaya envelope list "subject report"
+himalaya envelope search -m INBOX "subject report"
 
 # Combine filters (AND semantics)
-himalaya envelope list "from me@example.com and subject report"
+himalaya envelope search -m INBOX "from me@example.com and subject report"
 ```
 
 ---
 
 ## Quick Reference
 
-| Task        | Command                                                |
-| ----------- | ------------------------------------------------------ |
-| Check inbox | `himalaya envelope list`                               |
-| Read email  | `himalaya message read <id>`                           |
-| Compose new | `himalaya message write`                               |
-| Reply       | `himalaya message reply <id>`                          |
-| Search      | `himalaya envelope list "from me@example.com"`         |
-| Mark read   | `himalaya flag add <id> seen`                          |
-| Delete      | `himalaya message delete <id>`                         |
-| Move        | `himalaya message move --folder SOURCE TARGET <id...>` |
+| Task        | Command                                                              |
+| ----------- | ------------------------------------------------------------------- |
+| Check inbox | `himalaya envelope list -m INBOX -s 20`                             |
+| Read email  | `himalaya message read <id> -m INBOX`                               |
+| Compose new | `himalaya message write --to ... --subject ... --body ... --send`   |
+| Reply       | `himalaya message reply <id> -m INBOX`                              |
+| Search      | `himalaya envelope search -m INBOX "from me@example.com"`           |
+| Mark read   | `himalaya flag add -f seen <id>`                                    |
+| Delete      | `himalaya message delete <id> -m INBOX`                             |
+| Move        | `himalaya message move --to <MBOX> <id...>`                         |
+| List boxes  | `himalaya mailbox list`                                             |
 
 - For provider-specific setup, see [references/providers.md](references/providers.md)
 - Official docs: https://github.com/pimalaya/himalaya

--- a/skills/email/references/providers.md
+++ b/skills/email/references/providers.md
@@ -1,104 +1,116 @@
-# Email Provider Configuration
+# Email Provider Configuration (Himalaya v2.x)
 
 Detailed setup instructions for common email providers with Himalaya.
 
-Config file location: `~/.config/himalaya/config.toml`
+> **v2 config schema.** Himalaya v2 uses per-protocol tables, not the old `backend.*` /
+> `message.send.backend.*` keys. A v1 config loads with **zero backends** and every command fails
+> with `No backend matching \`auto\` is configured`. Use this shape:
+>
+> ```toml
+> [accounts.example]
+> email = "you@example.com"
+>
+> [accounts.example.imap]
+> server = "imap.example.com:993"
+> sasl.plain.username = "you@example.com"
+> sasl.plain.password.raw = "app-password"   # or .command / .keyring
+>
+> [accounts.example.smtp]
+> server = "smtp.example.com:465"
+> sasl.plain.username = "you@example.com"
+> sasl.plain.password.raw = "app-password"
+> ```
+>
+> Password sources for `sasl.plain.password`:
+> - `raw = "..."` — inline (testing only, never commit)
+> - `command = "pass show google/app-password"` — runs a command, uses stdout
+> - `keyring = "entry-name"` — OS keyring
+>
+> Config file location: `~/.config/himalaya/config.toml` (or `$XDG_CONFIG_HOME/himalaya/config.toml`).
+> Validate with `himalaya account check <name>`. There is **no `account configure`** in v2 — write
+> the TOML directly.
 
 ---
 
 ## Gmail
 
-### Option 1: App Password with pass (Recommended)
+### Option 1: App Password (Recommended)
 
 **Prerequisites:**
 
 1. Enable IMAP in Gmail settings
 2. Enable 2-Step Verification
 3. Create App Password: https://myaccount.google.com/apppasswords
-4. Store in pass: `pass insert google/app-password`
+4. Store in `pass`: `pass insert google/app-password`
 
 ```toml
 [accounts.gmail]
 email = "yourname@gmail.com"
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+[accounts.gmail.imap]
+server = "imap.gmail.com:993"
+sasl.plain.username = "yourname@gmail.com"
+sasl.plain.password.command = "pass show google/app-password"
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.login = "yourname@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
-
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 465
-message.send.backend.login = "yourname@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+[accounts.gmail.smtp]
+server = "smtp.gmail.com:465"
+sasl.plain.username = "yourname@gmail.com"
+sasl.plain.password.command = "pass show google/app-password"
 ```
 
 **Note**: This same app-specific password works for Google Calendar. Store once, use for both email and calendar skills.
 
-### Option 1b: App Password with keyring
+### Option 1b: App Password with macOS Keychain
 
 ```toml
-backend.auth.keyring = "gmail-password"
-message.send.backend.auth.keyring = "gmail-password"
+[accounts.gmail.imap]
+server = "imap.gmail.com:993"
+sasl.plain.username = "yourname@gmail.com"
+sasl.plain.password.command = "security find-generic-password -a 'gmail' -s 'himalaya-gmail-imap' -w"
+
+[accounts.gmail.smtp]
+server = "smtp.gmail.com:465"
+sasl.plain.username = "yourname@gmail.com"
+sasl.plain.password.command = "security find-generic-password -a 'gmail' -s 'himalaya-gmail-smtp' -w"
 ```
 
-Then run:
-
+Store the password once with:
 ```bash
-himalaya account configure gmail
-# Paste your App Password when prompted
+security add-generic-password -a 'gmail' -s 'himalaya-gmail-imap' -w 'APP_PASSWORD' -U
+security add-generic-password -a 'gmail' -s 'himalaya-gmail-smtp' -w 'APP_PASSWORD' -U
 ```
 
 ### Option 2: OAuth 2.0 (More Secure)
 
-Requires creating OAuth credentials in Google Cloud Console.
+Requires creating OAuth credentials in Google Cloud Console. v2 uses `sasl.oauth2.*` blocks.
 
 ```toml
 [accounts.gmail]
 email = "yourname@gmail.com"
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+[accounts.gmail.imap]
+server = "imap.gmail.com:993"
+sasl.plain.username = "yourname@gmail.com"
+sasl.oauth2.client-id = "YOUR_CLIENT_ID"
+sasl.oauth2.client-secret.command = "pass show google/oauth2-client-secret"
+sasl.oauth2.access-token.command = "pass show google/oauth2-access-token"
+sasl.oauth2.refresh-token.command = "pass show google/oauth2-refresh-token"
+sasl.oauth2.auth-url = "https://accounts.google.com/o/oauth2/v2/auth"
+sasl.oauth2.token-url = "https://www.googleapis.com/oauth2/v3/token"
+sasl.oauth2.pkce = true
+sasl.oauth2.scope = "https://mail.google.com/"
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.login = "yourname@gmail.com"
-backend.auth.type = "oauth2"
-backend.auth.method = "xoauth2"
-backend.auth.client-id = "YOUR_CLIENT_ID"
-backend.auth.client-secret.keyring = "gmail-oauth2-client-secret"
-backend.auth.access-token.keyring = "gmail-oauth2-access-token"
-backend.auth.refresh-token.keyring = "gmail-oauth2-refresh-token"
-backend.auth.auth-url = "https://accounts.google.com/o/oauth2/v2/auth"
-backend.auth.token-url = "https://www.googleapis.com/oauth2/v3/token"
-backend.auth.pkce = true
-backend.auth.scope = "https://mail.google.com/"
-
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 465
-message.send.backend.login = "yourname@gmail.com"
-message.send.backend.auth.type = "oauth2"
-message.send.backend.auth.method = "xoauth2"
-message.send.backend.auth.client-id = "YOUR_CLIENT_ID"
-message.send.backend.auth.client-secret.keyring = "gmail-oauth2-client-secret"
-message.send.backend.auth.access-token.keyring = "gmail-oauth2-access-token"
-message.send.backend.auth.refresh-token.keyring = "gmail-oauth2-refresh-token"
-message.send.backend.auth.auth-url = "https://accounts.google.com/o/oauth2/v2/auth"
-message.send.backend.auth.token-url = "https://www.googleapis.com/oauth2/v3/token"
-message.send.backend.auth.pkce = true
-message.send.backend.auth.scope = "https://mail.google.com/"
+[accounts.gmail.smtp]
+server = "smtp.gmail.com:465"
+sasl.plain.username = "yourname@gmail.com"
+sasl.oauth2.client-id = "YOUR_CLIENT_ID"
+sasl.oauth2.client-secret.command = "pass show google/oauth2-client-secret"
+sasl.oauth2.access-token.command = "pass show google/oauth2-access-token"
+sasl.oauth2.refresh-token.command = "pass show google/oauth2-refresh-token"
+sasl.oauth2.auth-url = "https://accounts.google.com/o/oauth2/v2/auth"
+sasl.oauth2.token-url = "https://www.googleapis.com/oauth2/v3/token"
+sasl.oauth2.pkce = true
+sasl.oauth2.scope = "https://mail.google.com/"
 ```
 
 ---
@@ -113,20 +125,16 @@ Store in pass: `pass insert outlook/app-password`
 [accounts.outlook]
 email = "yourname@outlook.com"
 
-backend.type = "imap"
-backend.host = "outlook.office365.com"
-backend.port = 993
-backend.login = "yourname@outlook.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show outlook/app-password"
+[accounts.outlook.imap]
+server = "outlook.office365.com:993"
+sasl.plain.username = "yourname@outlook.com"
+sasl.plain.password.command = "pass show outlook/app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp-mail.outlook.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "yourname@outlook.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show outlook/app-password"
+[accounts.outlook.smtp]
+server = "smtp-mail.outlook.com:587"
+starttls = true
+sasl.plain.username = "yourname@outlook.com"
+sasl.plain.password.command = "pass show outlook/app-password"
 ```
 
 ### Option 2: OAuth 2.0
@@ -135,34 +143,30 @@ message.send.backend.auth.cmd = "pass show outlook/app-password"
 [accounts.outlook]
 email = "yourname@outlook.com"
 
-backend.type = "imap"
-backend.host = "outlook.office365.com"
-backend.port = 993
-backend.login = "yourname@outlook.com"
-backend.auth.type = "oauth2"
-backend.auth.client-id = "YOUR_CLIENT_ID"
-backend.auth.client-secret.keyring = "outlook-oauth2-client-secret"
-backend.auth.access-token.keyring = "outlook-oauth2-access-token"
-backend.auth.refresh-token.keyring = "outlook-oauth2-refresh-token"
-backend.auth.auth-url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-backend.auth.token-url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-backend.auth.pkce = true
-backend.auth.scopes = ["https://outlook.office.com/IMAP.AccessAsUser.All", "https://outlook.office.com/SMTP.Send"]
+[accounts.outlook.imap]
+server = "outlook.office365.com:993"
+sasl.plain.username = "yourname@outlook.com"
+sasl.oauth2.client-id = "YOUR_CLIENT_ID"
+sasl.oauth2.client-secret.command = "pass show outlook/oauth2-client-secret"
+sasl.oauth2.access-token.command = "pass show outlook/oauth2-access-token"
+sasl.oauth2.refresh-token.command = "pass show outlook/oauth2-refresh-token"
+sasl.oauth2.auth-url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+sasl.oauth2.token-url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+sasl.oauth2.pkce = true
+sasl.oauth2.scopes = ["https://outlook.office.com/IMAP.AccessAsUser.All", "https://outlook.office.com/SMTP.Send"]
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.outlook.com"
-message.send.backend.port = 587
-message.send.backend.starttls = true
-message.send.backend.login = "yourname@outlook.com"
-message.send.backend.auth.type = "oauth2"
-message.send.backend.auth.client-id = "YOUR_CLIENT_ID"
-message.send.backend.auth.client-secret.keyring = "outlook-oauth2-client-secret"
-message.send.backend.auth.access-token.keyring = "outlook-oauth2-access-token"
-message.send.backend.auth.refresh-token.keyring = "outlook-oauth2-refresh-token"
-message.send.backend.auth.auth-url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-message.send.backend.auth.token-url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-message.send.backend.auth.pkce = true
-message.send.backend.auth.scopes = ["https://outlook.office.com/IMAP.AccessAsUser.All", "https://outlook.office.com/SMTP.Send"]
+[accounts.outlook.smtp]
+server = "smtp-mail.outlook.com:587"
+starttls = true
+sasl.plain.username = "yourname@outlook.com"
+sasl.oauth2.client-id = "YOUR_CLIENT_ID"
+sasl.oauth2.client-secret.command = "pass show outlook/oauth2-client-secret"
+sasl.oauth2.access-token.command = "pass show outlook/oauth2-access-token"
+sasl.oauth2.refresh-token.command = "pass show outlook/oauth2-refresh-token"
+sasl.oauth2.auth-url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+sasl.oauth2.token-url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+sasl.oauth2.pkce = true
+sasl.oauth2.scopes = ["https://outlook.office.com/IMAP.AccessAsUser.All", "https://outlook.office.com/SMTP.Send"]
 ```
 
 ---
@@ -180,20 +184,16 @@ message.send.backend.auth.scopes = ["https://outlook.office.com/IMAP.AccessAsUse
 [accounts.icloud]
 email = "yourname@icloud.com"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.login = "yourname"  # Username only, no @icloud.com!
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+[accounts.icloud.imap]
+server = "imap.mail.me.com:993"
+sasl.plain.username = "yourname"  # Username only, no @icloud.com!
+sasl.plain.password.command = "pass show icloud/app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "yourname@icloud.com"  # Full email for SMTP
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+[accounts.icloud.smtp]
+server = "smtp.mail.me.com:587"
+starttls = true
+sasl.plain.username = "yourname@icloud.com"  # Full email for SMTP
+sasl.plain.password.command = "pass show icloud/app-password"
 ```
 
 **Note**: This same app-specific password works for iCloud Calendar. Store once, use for both email and calendar skills.
@@ -211,34 +211,20 @@ message.send.backend.auth.cmd = "pass show icloud/app-password"
 [accounts.proton]
 email = "yourname@proton.me"
 
-backend.type = "imap"
-backend.host = "127.0.0.1"
-backend.port = 1143
-backend.encryption.type = "none"  # Bridge handles encryption
-backend.login = "yourname@proton.me"
-backend.auth.type = "password"
-backend.auth.keyring = "proton-bridge-password"
+[accounts.proton.imap]
+server = "127.0.0.1:1143"
+sasl.plain.username = "yourname@proton.me"
+sasl.plain.password.keyring = "proton-bridge-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "127.0.0.1"
-message.send.backend.port = 1025
-message.send.backend.encryption.type = "none"
-message.send.backend.login = "yourname@proton.me"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.keyring = "proton-bridge-password"
+[accounts.proton.smtp]
+server = "127.0.0.1:1025"
+sasl.plain.username = "yourname@proton.me"
+sasl.plain.password.keyring = "proton-bridge-password"
 ```
 
-### With TLS (Alternative)
-
-Export certificate from Proton Bridge, then:
-
-```toml
-backend.encryption.type = "start-tls"
-backend.encryption.cert = "/path/to/proton-bridge-cert.pem"
-
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.encryption.cert = "/path/to/proton-bridge-cert.pem"
-```
+Proton Bridge terminates TLS locally, so no `tls`/`starttls` block is needed. If you export the
+Bridge certificate and want to enforce it, add `tls.type = "start-tls"` plus a `tls.cert` pointing
+at the PEM under the `imap`/`smtp` tables.
 
 ---
 
@@ -253,19 +239,15 @@ message.send.backend.encryption.cert = "/path/to/proton-bridge-cert.pem"
 [accounts.fastmail]
 email = "yourname@fastmail.com"
 
-backend.type = "imap"
-backend.host = "imap.fastmail.com"
-backend.port = 993
-backend.login = "yourname@fastmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show fastmail/app-password"
+[accounts.fastmail.imap]
+server = "imap.fastmail.com:993"
+sasl.plain.username = "yourname@fastmail.com"
+sasl.plain.password.command = "pass show fastmail/app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.fastmail.com"
-message.send.backend.port = 465
-message.send.backend.login = "yourname@fastmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show fastmail/app-password"
+[accounts.fastmail.smtp]
+server = "smtp.fastmail.com:465"
+sasl.plain.username = "yourname@fastmail.com"
+sasl.plain.password.command = "pass show fastmail/app-password"
 ```
 
 **Note**: Use "All" access when creating the app password to enable both email and calendar sync with the same credential.
@@ -282,19 +264,15 @@ message.send.backend.auth.cmd = "pass show fastmail/app-password"
 [accounts.yahoo]
 email = "yourname@yahoo.com"
 
-backend.type = "imap"
-backend.host = "imap.mail.yahoo.com"
-backend.port = 993
-backend.login = "yourname@yahoo.com"
-backend.auth.type = "password"
-backend.auth.keyring = "yahoo-password"
+[accounts.yahoo.imap]
+server = "imap.mail.yahoo.com:993"
+sasl.plain.username = "yourname@yahoo.com"
+sasl.plain.password.keyring = "yahoo-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.yahoo.com"
-message.send.backend.port = 465
-message.send.backend.login = "yourname@yahoo.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.keyring = "yahoo-password"
+[accounts.yahoo.smtp]
+server = "smtp.mail.yahoo.com:465"
+sasl.plain.username = "yourname@yahoo.com"
+sasl.plain.password.keyring = "yahoo-password"
 ```
 
 ---
@@ -307,19 +285,15 @@ For other providers, use this template:
 [accounts.custom]
 email = "yourname@example.com"
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.login = "yourname@example.com"
-backend.auth.type = "password"
-backend.auth.keyring = "custom-password"
+[accounts.custom.imap]
+server = "imap.example.com:993"
+sasl.plain.username = "yourname@example.com"
+sasl.plain.password.keyring = "custom-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 465  # or 587 with start-tls
-message.send.backend.login = "yourname@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.keyring = "custom-password"
+[accounts.custom.smtp]
+server = "smtp.example.com:465"  # or :587 with starttls = true
+sasl.plain.username = "yourname@example.com"
+sasl.plain.password.keyring = "custom-password"
 ```
 
 ---
@@ -331,8 +305,7 @@ message.send.backend.auth.keyring = "custom-password"
 Use `pass` (Password Store) with consistent naming for reusability across email and calendar skills. For multiple accounts of the same provider, use a hierarchical folder structure (e.g., `google/personal/app-password` and `google/work/app-password`). The `/` character explicitly creates a folder structure in `pass`.
 
 ```toml
-backend.auth.cmd = "pass show google/app-password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+sasl.plain.password.command = "pass show google/app-password"
 ```
 
 **Consistent naming convention**:
@@ -365,17 +338,16 @@ pass insert fastmail/account_b/app-password
 ### Option 2: System Keyring
 
 ```toml
-backend.auth.keyring = "account-name"
+sasl.plain.password.keyring = "account-name"
 ```
 
-Run `himalaya account configure <name>` to store password securely.
-
-**Note**: Keyring storage is Himalaya-specific and won't be automatically shared with calendar tools.
+The agent stores the secret via `security add-generic-password` (macOS) or the platform keyring.
+Keyring storage is Himalaya-specific and won't be automatically shared with calendar tools.
 
 ### Option 3: Raw Password (NOT Recommended)
 
 ```toml
-backend.auth.raw = "your-password-here"
+sasl.plain.password.raw = "your-password-here"
 ```
 
 ⚠️ Only use for testing. Never commit to version control.


### PR DESCRIPTION
## Summary
The `email` skill was written for Himalaya v1, but the installed binary is v2.1.0. Several documented commands and the entire config schema are silently wrong, which causes failures like `No backend matching \`auto\` is configured` and unknown-flag errors. This PR brings both `SKILL.md` and `references/providers.md` in line with v2 so the skill actually works against a current install.

## Changes
- Rewrote every command example to v2 syntax: `-m/--mailbox` (was `--folder`), global `--json` (was `--output json`), `message move --to X <id...>` (was `--folder`), `flag add -f seen <id>` (was positional), `mailbox list` (was `folder list`), and `message write --send` (was `template send`, removed).
- Documented that `envelope list` no longer takes a positional query — search now goes through `envelope search` with a query DSL.
- Replaced the removed `account configure` wizard flow with "write the TOML directly" + `account check`.
- Migrated all provider config blocks from the v1 `backend.*` / `message.send.backend.*` schema to the v2 per-protocol `[accounts.x.imap]` / `[accounts.x.smtp]` tables, covering Gmail (incl. macOS Keychain via `security`), Outlook, iCloud, Proton Bridge, Fastmail, Yahoo, and generic IMAP/SMTP.
- Added a prominent "Config format note" callout about the v1→v2 breakage (the root cause of the original failure) and expanded the troubleshooting table with the new error messages.

## Related
- This mismatch is what blocked the first "check my latest emails" run this session; the fix was verified by migrating the operator's own config to v2 (both accounts now resolve `imap, smtp`).

## How to Test
1. `himalaya -c <a v2 config> account list` should show `imap, smtp` backends (a sample v2 block is included in `providers.md`; validated during this change).
2. `himalaya envelope list -m INBOX -s 20 --json | jq '.envelopes[].subject'` should return subjects (note `{"envelopes":[...]}`, not a bare array).
3. Edge case: running any command with a v1-format config must now surface the "Config format note" guidance instead of a confusing `No backend matching \`auto\`` — confirm the skill text directs the agent to migrate rather than treat it as "no account".

## Checklist
- [x] Docs updated
- [x] No breaking changes (docs only; no runtime code touched)
