### PR TITLE
fix(tests): flaky custom-tools subprocess timeout + jazz-ai CI trust docs

### DIFF
--- a/packages/core/src/agent/tools/custom-tools.test.ts
+++ b/packages/core/src/agent/tools/custom-tools.test.ts
@@ -1017,7 +1017,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
 
     expect(result.success).toBe(true);
     expect(result.result).toBe(JSON.stringify({ value: "hello" }));
-  });
+  }, 15_000);
 
   it("returns an error result carrying stderr when the command exits non-zero", async () => {
     const definition: CustomToolDefinition = {
@@ -1037,7 +1037,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     expect(result.result).toBeNull();
     expect(String(result.error ?? "")).toContain("boom");
     expect(String(result.error ?? "")).toContain("1");
-  });
+  }, 15_000);
 
   it("kills the command and returns a timeout error when it runs past timeoutMs", async () => {
     const definition: CustomToolDefinition = {
@@ -1080,7 +1080,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     expect(result.success).toBe(true);
     expect(typeof result.result).toBe("string");
     expect((result.result as string).length).toBe(16 * 1024);
-  });
+  }, 15_000);
 
   it("scrubs a sensitive-name env var when the declaring agent has no envAllowlist, but passes it through when the declaring agent allowlists it", async () => {
     const originalValue = process.env["FAKE_TOKEN"];
@@ -1115,7 +1115,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
         process.env["FAKE_TOKEN"] = originalValue;
       }
     }
-  });
+  }, 15_000);
 
   it("uses the DECLARING agent's envAllowlist, not context.parentAgent's, at call time", async () => {
     const originalValue = process.env["FAKE_TOKEN"];
@@ -1164,7 +1164,7 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
         process.env["FAKE_TOKEN"] = originalValue;
       }
     }
-  });
+  }, 15_000);
 
   it("carries Tool.timeoutMs = handler.timeoutMs + 5000ms margin so the executor's default 3-minute timeout can't undercut it", async () => {
     const definition: CustomToolDefinition = {
@@ -1216,5 +1216,5 @@ describe("registerCustomToolsForAgent: command-handler execution", () => {
     expect(typeof result.result).toBe("string");
     expect(Buffer.byteLength(result.result as string, "utf8")).toBeLessThanOrEqual(16 * 1024);
     expect(Buffer.byteLength(result.result as string, "utf8")).toBeGreaterThan(16 * 1024 - 4);
-  });
+  }, 15_000);
 });

--- a/skills/install-jazz-github-action/SKILL.md
+++ b/skills/install-jazz-github-action/SKILL.md
@@ -68,10 +68,12 @@ Record the chosen `llmProvider` + `llmModel` and the secret name — every later
 
 The key design:
 - **`resolve` job** uses `actions/github-script@v7` to extract PR context from `pull_request`, `issue_comment`, `push`, or `workflow_dispatch` events, and reacts with 👀 on triggering comments
-- **`code-review` job** checks out PR head, installs `jazz-ai`, copies agent config + workflow file into `$HOME/.jazz/agents/` and `workflows/code-review/` with placeholder substitution, snapshots PR context, runs `jazz --output raw workflow run code-review --auto-approve --agent ci-reviewer`, then posts results
+- **`code-review` job** checks out PR head, installs `jazz-ai` (`bun install -g jazz-ai --trust`), copies agent config + workflow file into `$HOME/.jazz/agents/` and `workflows/code-review/` with placeholder substitution, snapshots PR context, runs `jazz --output raw workflow run code-review --auto-approve --agent ci-reviewer`, then posts results
 - **`assistant` job** same structure, runs `jazz --output raw workflow run pr-assistant --auto-approve --agent pr-assistant`, posts a PR comment
 
 `--output raw` is required: it disables the interactive TUI so the agent's fenced output reaches the log parser intact.
+
+`--trust` is required on the install step: `bun install -g` runs with lifecycle scripts (postinstall) blocked by default, and `jazz-ai`'s postinstall is what actually installs the `jazz` binary. Without `--trust`, the install "succeeds" but no binary lands, and every later `jazz` invocation in the workflow fails with `jazz: command not found`. CI runners are ephemeral, so there's no persistent trust state to set up (unlike `bun pm trust` on a dev machine) — pass `--trust` on every run.
 
 ### 2. Create agent configs
 


### PR DESCRIPTION
## Summary
- CI run https://github.com/lvndry/jazz/actions/runs/33210206658 failed `custom-tools.test.ts`'s stdin-echo test at exactly 5000.14ms — a cold `node` subprocess spawn on a loaded runner exceeding bun's default 5s per-test timeout, not a real regression (14/14 local runs pass, including under parallel load). Gave the 5 tests in that file that spawn a real subprocess and wait on it an explicit 15s timeout; the rest of the suite stays at the default so a genuine hang still fails fast.
- Documented the `--trust` flag needed for `bun install -g jazz-ai` in CI in the `install-jazz-github-action` skill: `bun install -g` blocks lifecycle scripts (postinstall) by default, and jazz-ai's postinstall is what installs the `jazz` binary — without `--trust` the install "succeeds" but `jazz: command not found` later. Previously this was only mentioned in the troubleshooting table; now it's called out up front where the install step is described.

## Test plan
- [x] `bun test packages/core/src/agent/tools/custom-tools.test.ts` — 24 pass
- [x] Ran the affected test 8x sequentially and 6x in parallel locally with no failures