### PR TITLE
fix(fullscreen): let the live band shrink to what it actually needs

### DIFF
--- a/packages/cli/src/ui/fullscreen/bridge.test.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.test.tsx
@@ -258,6 +258,75 @@ describe("fullscreen bridge", () => {
     expect(text).toContain("Draft replies");
   });
 
+  it("shrinks the live band once tools finish instead of leaving it stuck at its peak height", async () => {
+    // The band's reservation is a settling high-water mark: it must not only
+    // reset to zero once everything is done, it must also settle down to a
+    // smaller-but-still-positive height once the todo panel is the only thing
+    // left claiming rows. Getting stuck at the peak leaves a block of empty,
+    // near-black rows above the checklist that never goes away on its own.
+    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
+    await rendered.renderOnce();
+
+    // Dense, gapless transcript filler: whatever sits directly above the live
+    // band should be this filler, not a stray blank row, so a leftover
+    // reservation shows up as an unmistakable blank gap instead of hiding
+    // behind naturally blank transcript padding.
+    store.printOutput({
+      type: "streamContent",
+      message: "A".repeat(2_000),
+      timestamp: new Date(),
+    });
+
+    const todoSnapshot = [
+      { content: "Inspect inbox", status: "completed" as const },
+      { content: "Rank urgent threads", status: "in_progress" as const },
+    ];
+
+    store.setActivity({
+      phase: "tool-execution",
+      agentName: "jazz",
+      tools: [
+        { toolCallId: "1", toolName: "gmail", startedAt: Date.now() },
+        { toolCallId: "2", toolName: "web", startedAt: Date.now() },
+        { toolCallId: "3", toolName: "calendar", startedAt: Date.now() },
+      ],
+      todoSnapshot,
+    });
+    await rendered.flush();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await rendered.flush();
+
+    // The tools finish; only the todo panel still needs room.
+    store.setActivity({
+      phase: "tool-execution",
+      agentName: "jazz",
+      tools: [],
+      todoSnapshot,
+    });
+    await rendered.flush();
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    await rendered.flush();
+
+    const settledRows = rendered.captureCharFrame().split("\n");
+    const settledTodoIndex = settledRows.findIndex((row) => row.includes("todo"));
+    expect(settledTodoIndex).toBeGreaterThan(-1);
+
+    // The row directly above the checklist header belongs to the transcript
+    // filler once the band has settled down to just what the checklist needs.
+    // A stuck-too-tall reservation leaves that row as the band's own blank
+    // padding instead.
+    // Exactly one blank separator row sits between the transcript and the
+    // checklist by design. A stuck-too-tall reservation pads that gap with
+    // extra blank rows that never fill back in with transcript or content.
+    let blankRowsAboveTodo = 0;
+    for (let index = settledTodoIndex - 1; settledRows[index]?.trim() === ""; index -= 1) {
+      blankRowsAboveTodo += 1;
+    }
+    expect(blankRowsAboveTodo).toBe(1);
+
+    rendered.renderer.destroy();
+  });
+
   it("shows the arguments a running tool was called with", async () => {
     const text = await frame(() => {
       store.setActivity({

--- a/packages/cli/src/ui/fullscreen/bridge.test.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.test.tsx
@@ -327,6 +327,40 @@ describe("fullscreen bridge", () => {
     rendered.renderer.destroy();
   });
 
+  it("clears a lingering checklist the instant the next run starts, without a stale flash", async () => {
+    // The checklist deliberately survives the run that produced it — through
+    // streaming, completion, and idle — so it's readable once the response
+    // lands. Only a *new* run is allowed to clear it, and it must do so before
+    // that render paints, or the old checklist would flash for a frame ahead
+    // of the new run's own.
+    const rendered = await testRender(<FullscreenBridge />, { width: WIDTH, height: HEIGHT });
+    await rendered.renderOnce();
+
+    store.setActivity({
+      phase: "tool-execution",
+      agentName: "jazz",
+      tools: [],
+      todoSnapshot: [
+        { content: "Inspect inbox", status: "completed" },
+        { content: "Rank urgent threads", status: "in_progress" },
+      ],
+    });
+    await rendered.flush();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("todo 1/2");
+
+    store.setActivity({ phase: "idle" });
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).toContain("todo 1/2");
+
+    store.setChatBusy(true);
+    await rendered.flush();
+    expect(rendered.captureCharFrame()).not.toContain("todo 1/2");
+
+    rendered.renderer.destroy();
+  });
+
   it("shows the arguments a running tool was called with", async () => {
     const text = await frame(() => {
       store.setActivity({

--- a/packages/cli/src/ui/fullscreen/bridge.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.tsx
@@ -100,7 +100,7 @@ const WAITING = ["comping behind you", "turning it over", "two horns out", "digg
 const FOOTER_ELAPSED_MS = 1000;
 const WAITING_ROTATE_MS = 4_000;
 
-/** How long the band holds its height after the last tool finishes. */
+/** How long the band holds its height after it has room to shrink. */
 const SETTLE_MS = 800;
 export const APPROVAL_ARM_MS = 250;
 
@@ -1229,12 +1229,12 @@ export function FullscreenBridge(): React.ReactNode {
   );
 
   useEffect(() => {
-    if (neededRows > 0) {
-      setReservedRows((current) => Math.max(current, neededRows));
+    if (neededRows > reservedRows) {
+      setReservedRows(neededRows);
       return;
     }
-    if (reservedRows === 0) return;
-    const timer = setTimeout(() => setReservedRows(0), SETTLE_MS);
+    if (neededRows === reservedRows) return;
+    const timer = setTimeout(() => setReservedRows(neededRows), SETTLE_MS);
     return () => clearTimeout(timer);
   }, [neededRows, reservedRows]);
 


### PR DESCRIPTION
## Summary
- The fullscreen TUI's live band (tool rows + todo checklist, above the composer) reserved its height as a high-water mark that only ever grew or reset all the way to zero. Once mid-turn tool activity settled down to just a lingering todo checklist, the band stayed pinned at its historical peak height, leaving a block of empty near-black rows above the checklist — it only cleared once the next run reset the reservation from scratch.
- The debounced shrink now settles to whatever the band currently needs, not just to zero, so it correctly shrinks down instead of getting stuck oversized.

## Test plan
- [x] `bun test packages/cli/src/ui/fullscreen/bridge.test.tsx packages/cli/src/ui/fullscreen/app.test.tsx` — 118 pass
- [x] New regression test confirmed to fail against the pre-fix logic (4 stray blank rows instead of 1) and pass with the fix
- [x] `bun run typecheck` and `bun eslint` clean on changed files