### PR TITLE
feat(agent): background job queue and Ctrl+B tool detach

### DIFF
--- a/docs/internals/reminders.md
+++ b/docs/internals/reminders.md
@@ -10,7 +10,9 @@ Source:
 [`services/reminder-service.ts`](../../packages/adapters/src/reminder-service.ts) ·
 [`interfaces/reminder-service.ts`](../../packages/core/src/interfaces/reminder-service.ts) ·
 [`tools/reminder-tools.ts`](../../packages/core/src/agent/tools/reminder-tools.ts) ·
-[`utils/time.ts`](../../packages/core/src/utils/time.ts)
+[`utils/time.ts`](../../packages/core/src/utils/time.ts) ·
+[`wake-triggers/reminder-os-scheduler.ts`](../../packages/core/src/wake-triggers/reminder-os-scheduler.ts) ·
+[`utils/desktop-notify.ts`](../../packages/core/src/utils/desktop-notify.ts)
 
 ---
 
@@ -34,7 +36,20 @@ execution context timezone when the surface supplies one, otherwise UTC.
 ~/.jazz/reminders/<agentId>.lock/    directory-mutex around read-modify-write
 ```
 
-A periodic sweep delivers due reminders to the surface that is currently running the agent.
+Delivery depends on which surface owns the agent:
+
+- **Telegram and Discord**: each bot bridge runs its own 20-second `setInterval` sweep
+  (`packages/telegram-bot/src/reminders.ts`, `packages/discord-bot/src/reminders.ts`) and
+  delivers due reminders as a chat message, unchanged by anything below.
+- **CLI-hosted agents** (`agentId` not prefixed `tg_`/`dc_`): `add_reminder` also installs a
+  real one-shot host-scheduler job — the same mechanism `register_trigger` uses for wake
+  triggers — so the reminder fires even without `jazz daemon` running. Firing invokes
+  `jazz reminder fire --agent <agentId> --id <id>`, which sends a native OS desktop
+  notification (`utils/desktop-notify.ts`) rather than resuming a conversation. `jazz daemon`'s
+  in-process ticker (`adapters/daemon/trigger-runner.ts`) remains a fallback sweep for hosts
+  with neither `launchd` nor `at`, and always skips `tg_`/`dc_` agent ids to avoid delivering
+  the same reminder twice.
+
 Late delivery is preferred to dropping a reminder if the process was down at fire time.
 
 ## Guardrails

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -178,6 +178,10 @@ config that must be written before the daemon has ever started.
 See [Setting up peers](../guide/peers-setup.md) for a full walkthrough, and
 [Peers](../concepts/peers.md) for the tier model this exists to serve.
 
+`jazz wake-trigger fire --agent <agentId> --id <id>` is internal plumbing, not something you run
+by hand: it's what `register_trigger` schedules with `launchd`/`at` to fire a wake trigger without
+`jazz daemon` running. See [Wake Triggers](./tools.md#wake-triggers).
+
 ---
 
 ## `jazz peers`

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -175,6 +175,14 @@ dumps, and intermediate artifacts live, referenced from memory rather than dupli
 
 Opt-in per agent. Reminders persist on disk and fire later on the same surface that scheduled them — see [Reminders](../internals/reminders.md).
 
+For CLI-hosted agents, `add_reminder` installs the same real one-shot host-scheduler job
+(`launchd` on macOS, an `at` job on Linux) used for wake triggers, so a reminder fires even if
+`jazz daemon` isn't running; firing sends a native OS desktop notification instead of resuming a
+conversation — a reminder is "notify a person," never "resume the agent." `jazz daemon`'s
+in-process ticker remains a fallback for hosts with neither `launchd` nor `at`. Telegram and
+Discord reminders are unaffected by any of this: their bots already sweep and deliver reminders
+as chat messages from their own in-process interval, unchanged.
+
 | Tool              | Risk        | Approval pair | What it does                                                                                                                                     |
 | ----------------- | ----------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `add_reminder`    | `low-risk`  | —             | Schedule a reminder from a duration (`30m`), clock time (`18:00`), `tomorrow HH:MM`, a weekday (`tue 20:00`), or an absolute `2026-08-25 20:00`. |
@@ -186,6 +194,14 @@ Opt-in per agent. Reminders persist on disk and fire later on the same surface t
 Opt-in per agent. A trigger causes the agent to actually run again with a given prompt, resuming
 the exact conversation it was scheduled from — unlike a reminder, which just delivers a note to a
 person. See [Reminders](../internals/reminders.md) for how the two compare.
+
+`register_trigger` does not depend on `jazz daemon` running to actually fire. Registering a
+trigger installs a real one-shot job with the host's own scheduler — a `launchd` job on macOS, an
+`at` job on Linux — that fires the trigger by invoking `jazz` directly at the scheduled time, even
+if nothing else is running. `jazz daemon`'s in-process ticker remains a fallback for platforms or
+environments with neither `launchd` nor the `at` binary available (most containers, some CI), and
+scheduling with the host is always best-effort: if it fails for any reason, registration still
+succeeds and the ticker is the safety net.
 
 | Tool                | Risk        | Approval pair | What it does                                                                                       |
 | -------------------- | ----------- | ------------- | ----------------------------------------------------------------------------------------------------- |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -19,13 +19,13 @@ and [Security](../../SECURITY.md) for the threat model.
 
 |                                                                         | Count  |
 | ----------------------------------------------------------------------- | ------ |
-| **Agent-facing tools**                                                  | **41** |
-| Hidden `execute_*` counterparts (the second half of each approval pair) | 8      |
-| Total registered                                                        | 50     |
-| `read-only`                                                             | 22     |
-| `low-risk`                                                              | 11     |
+| **Agent-facing tools**                                                  | **44** |
+| Hidden `execute_*` counterparts (the second half of each approval pair) | 9      |
+| Total registered                                                        | 54     |
+| `read-only`                                                             | 23     |
+| `low-risk`                                                              | 12     |
 | `high-risk`                                                             | 7      |
-| `unknown`                                                               | 1      |
+| `unknown`                                                               | 2      |
 
 Plus, registered per agent rather than globally:
 
@@ -39,7 +39,7 @@ Plus, registered per agent rather than globally:
 
 ## How approval pairs work
 
-Seven tools are **gated**: calling them does not act. They return a description of the
+Eight tools are **gated**: calling them does not act. They return a description of the
 intended action (including a preview diff for edits), and only after approval — from a human
 or from `--approval-policy` — does Jazz invoke the hidden `execute_*` counterpart.
 
@@ -73,8 +73,8 @@ cannot be added without someone deciding.
 | Level      | Safe to tell                                                    | Tools                                                                                                                                                                                                                                                                                  |
 | ---------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `public`   | safe to tell anyone                                             | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file`                                                                                                                                                                                                                                     |
-| `internal` | the shape of this machine — paths, names, what is installed     | `analyze_media`, `cancel_trigger`, `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `list_triggers`, `ls`, `pdf_page_count`, `pwd`, `register_trigger`, `stat`                                                                                                                               |
-| `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `manage_workspace`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory`, `view_workspace` |
+| `internal` | the shape of this machine — paths, names, what is installed     | `analyze_media`, `cancel_batch`, `cancel_trigger`, `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `list_jobs`, `list_triggers`, `ls`, `pdf_page_count`, `pwd`, `register_trigger`, `stat`                                                                                                                               |
+| `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `enqueue_batch`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `manage_workspace`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory`, `view_workspace` |
 
 A tool spanning two levels takes the more sensitive one — `edit_file` writes, but its approval
 message carries a diff of your file, so it is `private`. `http_request` reaches private
@@ -192,6 +192,19 @@ person. See [Reminders](../internals/reminders.md) for how the two compare.
 | `register_trigger` | `low-risk`  | —             | Schedule yourself to wake up later and resume this exact conversation — use this when you need to… |
 | `list_triggers`     | `read-only` | —             | List this agent's pending self-scheduled wake triggers.                                            |
 | `cancel_trigger`    | `low-risk`  | —             | Cancel a pending wake trigger by id (get the id from list_triggers first).                          |
+
+### Background Jobs
+
+Opt-in per agent. Runs several independent shell commands in the background with a concurrency
+cap and per-job retry/backoff, without blocking the agent's turn. Completion (fan-in) resumes the
+conversation the same way a wake trigger fires, once every job in the batch reaches a final
+state.
+
+| Tool            | Risk        | Approval pair            | What it does                                                                                                   |
+| --------------- | ----------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `enqueue_batch` | `unknown`   | `execute_enqueue_batch`  | Run several independent shell commands in the background with a concurrency cap and per-job retry/backoff. |
+| `list_jobs`     | `read-only` | —                        | List this agent's background job batches and every job's status.                                              |
+| `cancel_batch`  | `low-risk`  | —                        | Cancel a job batch's pending jobs by id (jobs already running finish naturally).                               |
 
 ### Context
 

--- a/packages/adapters/src/daemon/job-worker.ts
+++ b/packages/adapters/src/daemon/job-worker.ts
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Executing background job batches on a plain interval, from inside `jazz daemon`
+ * — the worker half of the job queue described in
+ * docs/superpowers/plans/job-queue-design.md. Ticked from `trigger-runner.ts` alongside wake
+ * triggers and workflow catch-up.
+ *
+ * A batch's completion (fan-in) reuses the exact resume mechanism wake triggers already use —
+ * `AgentRunner.run` with `parkWhenUnattended: true` against the batch's `conversationId` — the
+ * only difference is what causes the resume: a job finishing rather than a clock firing.
+ */
+
+import * as os from "node:os";
+import { AgentRunner } from "@jazz/core/agent/agent-runner";
+import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
+import { runShellCommand } from "@jazz/core/agent/tools/shell-tools";
+import { DEFAULT_JOB_TIMEOUT_MS, WORKER_POOL_SIZE } from "@jazz/core/constants/job-queue";
+import type { JobBatchRecord, JobRecord } from "@jazz/core/interfaces/job-queue-service";
+import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { createSanitizedEnv } from "@jazz/core/utils/env";
+import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
+import { Effect } from "effect";
+import {
+  claimDueJobs,
+  completeJob,
+  listAgentIdsWithActiveBatches,
+  reclaimExpiredLeases,
+  type ClaimedJob,
+} from "@/adapters/job-queue-service";
+import {
+  loadConversation,
+  saveConversation,
+} from "@jazz/adapters/history/conversation-history-service";
+
+function jobBatchDirectory(): string {
+  return `${getJazzHomeDirectory()}/job-batches`;
+}
+
+function formatJobLine(job: JobRecord): string {
+  if (job.status === "succeeded") {
+    return `- \`${job.command}\`: succeeded${job.attempt > 1 ? ` (attempt ${job.attempt})` : ""}.`;
+  }
+  if (job.status === "cancelled") {
+    return `- \`${job.command}\`: cancelled before it ran.`;
+  }
+  const stderrTail = job.result?.stderr
+    ? job.result.stderr.slice(-500)
+    : (job.lastError ?? "no output captured");
+  return `- \`${job.command}\`: failed after ${job.attempt} attempt(s) — ${stderrTail}`;
+}
+
+function summarizeBatch(batch: JobBatchRecord): string {
+  const succeeded = batch.jobs.filter((job) => job.status === "succeeded").length;
+  const lines = batch.jobs.map(formatJobLine);
+  return (
+    `Background job batch "${batch.reason}" finished: ${succeeded}/${batch.jobs.length} succeeded.\n\n` +
+    `${lines.join("\n")}\n\n` +
+    "Continue with whatever this batch was for."
+  );
+}
+
+/**
+ * Resume the batch's owning conversation with a synthesized summary of every job's outcome.
+ * Mirrors `fireWakeTrigger` in `trigger-runner.ts` exactly — same load/run/save shape — because a
+ * finished batch is just a different reason to fire the same kind of unattended resume.
+ */
+function fireBatchResume(agentId: string, batch: JobBatchRecord) {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+    const agentResult = yield* getAgentByIdentifier(agentId).pipe(Effect.either);
+    if (agentResult._tag === "Left") {
+      yield* logger.warn("Job batch resume skipped: agent not found", {
+        agentId,
+        batchId: batch.id,
+      });
+      return;
+    }
+    const agent = agentResult.right;
+
+    const priorRecord = yield* loadConversation(agentId, batch.conversationId).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
+
+    const response = yield* AgentRunner.run({
+      agent,
+      userInput: summarizeBatch(batch),
+      conversationId: batch.conversationId,
+      parkWhenUnattended: true,
+      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.gen(function* () {
+          yield* logger.warn("Job batch resume run failed", {
+            agentId,
+            batchId: batch.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return undefined;
+        }),
+      ),
+    );
+    if (response === undefined) return;
+
+    const now = new Date().toISOString();
+    yield* saveConversation({
+      agentId,
+      conversationId: batch.conversationId,
+      title: priorRecord?.title ?? batch.reason.slice(0, 80),
+      startedAt: priorRecord?.startedAt ?? now,
+      endedAt: now,
+      messages: response.messages ?? priorRecord?.messages ?? [],
+    }).pipe(
+      Effect.catchAll((error) =>
+        logger.warn("Job batch resume conversation save failed", {
+          agentId,
+          batchId: batch.id,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      ),
+    );
+  });
+}
+
+function runClaimedJob(claimed: ClaimedJob) {
+  return Effect.gen(function* () {
+    const outcome = yield* runShellCommand({
+      command: claimed.command,
+      workingDir: claimed.workingDir,
+      timeoutMs: DEFAULT_JOB_TIMEOUT_MS,
+      env: createSanitizedEnv({}, []),
+    }).pipe(
+      Effect.match({
+        onSuccess: (result) => ({
+          success: result.exitCode === 0,
+          result: { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode },
+          error: result.exitCode === 0 ? null : `exit code ${result.exitCode}`,
+        }),
+        onFailure: (error) => ({
+          success: false,
+          result: null,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      }),
+    );
+
+    const { batchNowComplete, batch } = yield* completeJob(
+      jobBatchDirectory(),
+      claimed.agentId,
+      claimed.batchId,
+      claimed.jobId,
+      outcome,
+    );
+    if (batchNowComplete && batch !== null) {
+      yield* fireBatchResume(claimed.agentId, batch);
+    }
+  });
+}
+
+/** One tick: reclaim abandoned jobs, then claim and run whatever is due for every agent. */
+export function runDueJobs() {
+  return Effect.gen(function* () {
+    const baseDirectory = jobBatchDirectory();
+    const leaseOwner = `${os.hostname()}-${process.pid}`;
+
+    const reclaimed = yield* reclaimExpiredLeases(baseDirectory, Date.now()).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+    for (const { agentId, batch } of reclaimed) {
+      yield* fireBatchResume(agentId, batch);
+    }
+
+    const agentIds = yield* listAgentIdsWithActiveBatches(baseDirectory).pipe(
+      Effect.catchAll(() => Effect.succeed<readonly string[]>([])),
+    );
+    for (const agentId of agentIds) {
+      const claimed = yield* claimDueJobs(
+        baseDirectory,
+        agentId,
+        Date.now(),
+        WORKER_POOL_SIZE,
+        leaseOwner,
+      ).pipe(Effect.catchAll(() => Effect.succeed<readonly ClaimedJob[]>([])));
+      yield* Effect.forEach(claimed, runClaimedJob, { concurrency: WORKER_POOL_SIZE }).pipe(
+        Effect.catchAll(() => Effect.void),
+      );
+    }
+  });
+}

--- a/packages/adapters/src/daemon/trigger-runner.ts
+++ b/packages/adapters/src/daemon/trigger-runner.ts
@@ -13,10 +13,12 @@
 import { AgentRunner } from "@jazz/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { sendDesktopNotification } from "@jazz/core/utils/desktop-notify";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { runInProcessScheduledWorkflows } from "@jazz/core/workflows/catch-up";
 import { Effect } from "effect";
 import { runDueJobs } from "@/adapters/daemon/job-worker";
+import { sweepDueReminders } from "@/adapters/reminder-service";
 import { sweepDueWakeTriggers } from "@/adapters/wake-trigger-service";
 import {
   loadConversation,
@@ -27,6 +29,21 @@ function wakeTriggerDirectory(): string {
   return `${getJazzHomeDirectory()}/wake-triggers`;
 }
 
+function reminderDirectory(): string {
+  return `${getJazzHomeDirectory()}/reminders`;
+}
+
+/**
+ * Telegram (`tg_...`) and Discord (`dc_...`) agents already sweep and deliver their own
+ * reminders in-process from inside the bot bridge — see `reminder-service.ts`'s
+ * `isBotHostedAgentId` for the full reasoning. This ticker-fallback sweep must skip them too,
+ * or a reminder set from a chat would fire twice: once as the bot's own message, once as a
+ * spurious desktop notification on whatever headless host happens to run `jazz daemon`.
+ */
+function isBotHostedAgentId(agentId: string): boolean {
+  return agentId.startsWith("tg_") || agentId.startsWith("dc_");
+}
+
 /**
  * Resume the conversation a wake trigger belongs to and run its prompt as the next turn.
  *
@@ -35,7 +52,7 @@ function wakeTriggerDirectory(): string {
  * its own), then persist the updated transcript. A trigger whose agent no longer exists is
  * logged and dropped rather than retried — there's nothing to resume it into.
  */
-function fireWakeTrigger(
+export function fireWakeTrigger(
   agentId: string,
   trigger: { id: string; conversationId: string; prompt: string },
 ) {
@@ -113,6 +130,17 @@ export function runDueTriggers(options: { readonly runWorkflows?: boolean } = {}
     );
     for (const { agentId, trigger } of due) {
       yield* fireWakeTrigger(agentId, trigger);
+    }
+
+    // Fallback for hosts with neither launchd nor `at`: the reliability upgrade in
+    // `reminder-os-scheduler.ts` is best-effort, so this ticker still needs to catch anything
+    // it missed. Bot-hosted reminders are excluded — their own bridge already delivers them.
+    const dueReminders = yield* sweepDueReminders(reminderDirectory(), Date.now()).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+    for (const { agentId, reminder } of dueReminders) {
+      if (isBotHostedAgentId(agentId)) continue;
+      yield* sendDesktopNotification("Jazz reminder", reminder.text);
     }
 
     yield* runDueJobs().pipe(Effect.catchAll(() => Effect.void));

--- a/packages/adapters/src/daemon/trigger-runner.ts
+++ b/packages/adapters/src/daemon/trigger-runner.ts
@@ -16,6 +16,7 @@ import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { runInProcessScheduledWorkflows } from "@jazz/core/workflows/catch-up";
 import { Effect } from "effect";
+import { runDueJobs } from "@/adapters/daemon/job-worker";
 import { sweepDueWakeTriggers } from "@/adapters/wake-trigger-service";
 import {
   loadConversation,
@@ -95,9 +96,10 @@ function fireWakeTrigger(
 }
 
 /**
- * One tick: run any due workflow catch-up, then fire any due wake triggers.
+ * One tick: run any due workflow catch-up, fire any due wake triggers, then claim and run any
+ * due background job batches.
  *
- * Failures in either half are logged and swallowed — a single bad trigger or a transient
+ * Failures in any part are logged and swallowed — a single bad trigger, job, or transient
  * catch-up error must never stop the ticker from running on the next interval.
  */
 export function runDueTriggers(options: { readonly runWorkflows?: boolean } = {}) {
@@ -112,5 +114,7 @@ export function runDueTriggers(options: { readonly runWorkflows?: boolean } = {}
     for (const { agentId, trigger } of due) {
       yield* fireWakeTrigger(agentId, trigger);
     }
+
+    yield* runDueJobs().pipe(Effect.catchAll(() => Effect.void));
   });
 }

--- a/packages/adapters/src/job-queue-service.test.ts
+++ b/packages/adapters/src/job-queue-service.test.ts
@@ -1,0 +1,299 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FileSystem } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { MAX_ACTIVE_BATCHES_PER_AGENT, MAX_JOBS_PER_BATCH } from "@jazz/core/constants/job-queue";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Effect } from "effect";
+import {
+  claimDueJobs,
+  completeJob,
+  JobQueueServiceImpl,
+  reclaimExpiredLeases,
+} from "./job-queue-service";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-job-queue-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function runEffect<A>(eff: Effect.Effect<A, unknown, FileSystem.FileSystem>) {
+  return Effect.runPromise(eff.pipe(Effect.provide(NodeFileSystem.layer)));
+}
+
+function makeService(): JobQueueServiceImpl {
+  return new JobQueueServiceImpl({ baseJobBatchDirectory: tmpDir });
+}
+
+function jobInputs(count: number) {
+  return Array.from({ length: count }, (_, i) => ({ command: `echo job-${i}` }));
+}
+
+describe("enqueueBatch", () => {
+  test("creates a batch with one pending job per input, immediately claimable", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(3), {
+        workingDir: "/tmp",
+        reason: "test batch",
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+    expect(outcome.batch.jobs).toHaveLength(3);
+    expect(outcome.batch.jobs.every((job) => job.status === "pending")).toBe(true);
+    expect(outcome.batch.completedAt).toBeNull();
+  });
+
+  test("rejects an empty batch", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", [], { workingDir: "/tmp", reason: "empty" }),
+    );
+    expect(outcome.success).toBe(false);
+  });
+
+  test("rejects a batch exceeding the per-batch job cap", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(MAX_JOBS_PER_BATCH + 1), {
+        workingDir: "/tmp",
+        reason: "too many",
+      }),
+    );
+    expect(outcome.success).toBe(false);
+    if (outcome.success) return;
+    expect(outcome.message).toContain("exceeding the maximum");
+  });
+
+  test("rejects once the active-batch-per-agent cap is reached", async () => {
+    const service = makeService();
+    for (let i = 0; i < MAX_ACTIVE_BATCHES_PER_AGENT; i++) {
+      const outcome = await runEffect(
+        service.enqueueBatch("agent-1", "conv-1", jobInputs(1), {
+          workingDir: "/tmp",
+          reason: `batch ${i}`,
+        }),
+      );
+      expect(outcome.success).toBe(true);
+    }
+    const rejected = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(1), {
+        workingDir: "/tmp",
+        reason: "one too many",
+      }),
+    );
+    expect(rejected.success).toBe(false);
+  });
+
+  test("keeps different agents' batches separate", async () => {
+    const service = makeService();
+    await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(1), { workingDir: "/tmp", reason: "a" }),
+    );
+    await runEffect(
+      service.enqueueBatch("agent-2", "conv-2", jobInputs(1), { workingDir: "/tmp", reason: "b" }),
+    );
+    const listOne = await runEffect(service.listActiveBatches("agent-1"));
+    const listTwo = await runEffect(service.listActiveBatches("agent-2"));
+    expect(listOne).toHaveLength(1);
+    expect(listTwo).toHaveLength(1);
+    expect(listOne[0]?.reason).toBe("a");
+    expect(listTwo[0]?.reason).toBe("b");
+  });
+});
+
+describe("claimDueJobs", () => {
+  test("never claims the same job twice across concurrent claim attempts", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(6), {
+        workingDir: "/tmp",
+        reason: "claim race",
+        concurrencyCap: 10,
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    const now = Date.now();
+    const [first, second] = await Promise.all([
+      runEffect(claimDueJobs(tmpDir, "agent-1", now, 4, "worker-a")),
+      runEffect(claimDueJobs(tmpDir, "agent-1", now, 4, "worker-b")),
+    ]);
+
+    const claimedIds = [...first, ...second].map((job) => job.jobId);
+    expect(new Set(claimedIds).size).toBe(claimedIds.length);
+    expect(claimedIds.length).toBe(6);
+  });
+
+  test("respects the batch's concurrencyCap even when more jobs are due", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(5), {
+        workingDir: "/tmp",
+        reason: "capped",
+        concurrencyCap: 2,
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    const claimed = await runEffect(claimDueJobs(tmpDir, "agent-1", Date.now(), 10, "worker-a"));
+    expect(claimed).toHaveLength(2);
+
+    const claimedAgain = await runEffect(
+      claimDueJobs(tmpDir, "agent-1", Date.now(), 10, "worker-b"),
+    );
+    expect(claimedAgain).toHaveLength(0);
+  });
+});
+
+describe("completeJob", () => {
+  test("retries a failed job with backoff instead of failing it outright, when attempts remain", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(1), {
+        workingDir: "/tmp",
+        reason: "retry",
+        maxAttempts: 3,
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+    const batchId = outcome.batch.id;
+
+    const [claimed] = await runEffect(claimDueJobs(tmpDir, "agent-1", Date.now(), 1, "worker-a"));
+    expect(claimed).toBeDefined();
+    if (!claimed) return;
+
+    const result = await runEffect(
+      completeJob(tmpDir, "agent-1", batchId, claimed.jobId, {
+        success: false,
+        result: { stdout: "", stderr: "boom", exitCode: 1 },
+        error: "exit code 1",
+      }),
+    );
+    expect(result.batchNowComplete).toBe(false);
+    const job = result.batch?.jobs.find((j) => j.id === claimed.jobId);
+    expect(job?.status).toBe("pending");
+    expect(job?.attempt).toBe(1);
+    expect(job?.nextAttemptAt).toBeGreaterThan(Date.now());
+  });
+
+  test("marks fan-in complete once every job in the batch is terminal", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(2), {
+        workingDir: "/tmp",
+        reason: "fan-in",
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+    const batchId = outcome.batch.id;
+
+    const claimed = await runEffect(claimDueJobs(tmpDir, "agent-1", Date.now(), 2, "worker-a"));
+    expect(claimed).toHaveLength(2);
+
+    const firstResult = await runEffect(
+      completeJob(tmpDir, "agent-1", batchId, claimed[0]!.jobId, {
+        success: true,
+        result: { stdout: "ok", stderr: "", exitCode: 0 },
+        error: null,
+      }),
+    );
+    expect(firstResult.batchNowComplete).toBe(false);
+
+    const secondResult = await runEffect(
+      completeJob(tmpDir, "agent-1", batchId, claimed[1]!.jobId, {
+        success: true,
+        result: { stdout: "ok", stderr: "", exitCode: 0 },
+        error: null,
+      }),
+    );
+    expect(secondResult.batchNowComplete).toBe(true);
+    expect(secondResult.batch?.completedAt).not.toBeNull();
+  });
+
+  test("a fresh service instance against the same directory sees jobs already scheduled for retry", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(1), {
+        workingDir: "/tmp",
+        reason: "restart",
+        maxAttempts: 2,
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+    const batchId = outcome.batch.id;
+
+    const [claimed] = await runEffect(claimDueJobs(tmpDir, "agent-1", Date.now(), 1, "worker-a"));
+    if (!claimed) return;
+    await runEffect(
+      completeJob(tmpDir, "agent-1", batchId, claimed.jobId, {
+        success: false,
+        result: null,
+        error: "transient failure",
+      }),
+    );
+
+    // Simulate a daemon restart: a brand new service instance, same on-disk directory.
+    const restarted = makeService();
+    const batch = await runEffect(restarted.getBatch("agent-1", batchId));
+    expect(batch?.jobs[0]?.status).toBe("pending");
+    expect(batch?.jobs[0]?.attempt).toBe(1);
+  });
+});
+
+describe("reclaimExpiredLeases", () => {
+  test("frees a job whose lease expired without completing, and fails it once attempts are exhausted", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(1), {
+        workingDir: "/tmp",
+        reason: "crash",
+        maxAttempts: 1,
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    const claimed = await runEffect(claimDueJobs(tmpDir, "agent-1", Date.now(), 1, "worker-a"));
+    expect(claimed).toHaveLength(1);
+
+    // Simulate a worker that died mid-job by checking for expired leases well past the lease timeout.
+    const reclaimed = await runEffect(reclaimExpiredLeases(tmpDir, Date.now() + 60 * 60 * 1000));
+    expect(reclaimed).toHaveLength(1);
+    expect(reclaimed[0]?.batch.jobs[0]?.status).toBe("failed");
+    expect(reclaimed[0]?.batch.jobs[0]?.lastError).toContain("lease expired");
+  });
+});
+
+describe("cancelBatch", () => {
+  test("cancels pending jobs and completes the batch when nothing is left running", async () => {
+    const service = makeService();
+    const outcome = await runEffect(
+      service.enqueueBatch("agent-1", "conv-1", jobInputs(3), {
+        workingDir: "/tmp",
+        reason: "cancel",
+      }),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    const cancelOutcome = await runEffect(service.cancelBatch("agent-1", outcome.batch.id));
+    expect(cancelOutcome.success).toBe(true);
+
+    const batch = await runEffect(service.getBatch("agent-1", outcome.batch.id));
+    expect(batch?.jobs.every((job) => job.status === "cancelled")).toBe(true);
+    expect(batch?.completedAt).not.toBeNull();
+  });
+});

--- a/packages/adapters/src/job-queue-service.ts
+++ b/packages/adapters/src/job-queue-service.ts
@@ -1,0 +1,662 @@
+/**
+ * Implements `JobQueueService`: fan-out/fan-in background job batches persisted as one
+ * lock-guarded JSON file per batch, under `<agentId>/<batchId>.json`, using the same
+ * directory-mutex (`withLock`) and atomic-write (`writeFileStringAtomic`) primitives as
+ * `WakeTriggerServiceImpl`. A batch's completion is fanned in and resumed the same way a wake
+ * trigger fires — see `packages/adapters/src/daemon/job-worker.ts` and `trigger-runner.ts`.
+ *
+ * Two families of exports live here:
+ * - the `JobQueueService` methods (`enqueueBatch`, `getBatch`, `listActiveBatches`,
+ *   `cancelBatch`), called from tools inside a live agent run
+ * - free functions used only by the daemon's worker loop (`claimDueJobs`, `completeJob`,
+ *   `reclaimExpiredLeases`, `listAgentIdsWithActiveBatches`) — these never run inside a tool
+ *   call, so they aren't part of the service interface
+ */
+
+import * as path from "node:path";
+import { FileSystem } from "@effect/platform";
+import {
+  DEFAULT_BACKOFF_INITIAL_MS,
+  DEFAULT_BACKOFF_MAX_MS,
+  DEFAULT_CONCURRENCY_CAP,
+  DEFAULT_MAX_ATTEMPTS,
+  JOB_COMMAND_MAX_LENGTH,
+  JOB_LEASE_TIMEOUT_MS,
+  JOB_REASON_MAX_LENGTH,
+  MAX_ACTIVE_BATCHES_PER_AGENT,
+  MAX_CONCURRENCY_CAP,
+  MAX_JOBS_PER_BATCH,
+  MAX_MAX_ATTEMPTS,
+} from "@jazz/core/constants/job-queue";
+import type {
+  CancelBatchOutcome,
+  EnqueueBatchJobInput,
+  EnqueueBatchOptions,
+  EnqueueBatchOutcome,
+  JobBatchRecord,
+  JobQueueService,
+  JobRecord,
+} from "@jazz/core/interfaces/job-queue-service";
+import { JobQueueServiceTag } from "@jazz/core/interfaces/job-queue-service";
+import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
+import {
+  requireValidAgentId,
+  requireValidStorageKey,
+  withLock,
+  writeFileStringAtomic,
+} from "@jazz/core/utils/storage";
+import { Effect, Layer } from "effect";
+
+/** Raised for guardrail violations — genuinely unexpected conditions, not tool-result-shaped errors. */
+export class JobQueueGuardrailViolation extends Error {}
+
+function newId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Exponential backoff with jitter, computed synchronously from persisted state rather than
+ * driven by Effect's `Schedule` — a `Schedule` is built to drive a *live* retry loop, and there
+ * is no in-process loop here: the delay just needs to become the `nextAttemptAt` a future daemon
+ * tick (possibly after a restart) compares against `Date.now()`.
+ */
+export function computeBackoffDelayMs(
+  backoff: { readonly initialMs: number; readonly maxMs: number },
+  attempt: number,
+): number {
+  const exponential = backoff.initialMs * 2 ** Math.max(0, attempt - 1);
+  const capped = Math.min(exponential, backoff.maxMs);
+  const jitterFactor = 0.5 + Math.random(); // spread retries across [0.5x, 1.5x) of the target delay
+  return Math.round(capped * jitterFactor);
+}
+
+function agentDirectory(baseDirectory: string, agentId: string): string {
+  return path.join(baseDirectory, agentId);
+}
+
+function batchFilePath(baseDirectory: string, agentId: string, batchId: string): string {
+  return path.join(agentDirectory(baseDirectory, agentId), `${batchId}.json`);
+}
+
+function batchLockPath(baseDirectory: string, agentId: string, batchId: string): string {
+  return path.join(agentDirectory(baseDirectory, agentId), `${batchId}.lock`);
+}
+
+/** Guards the "count active batches, then create a new one" sequence against concurrent enqueues. */
+function agentEnqueueLockPath(baseDirectory: string, agentId: string): string {
+  return path.join(baseDirectory, `${agentId}.enqueue.lock`);
+}
+
+function readBatchFile(
+  fs: FileSystem.FileSystem,
+  filePath: string,
+): Effect.Effect<JobBatchRecord | null, Error> {
+  return Effect.gen(function* () {
+    const exists = yield* fs.exists(filePath).pipe(Effect.catchAll(() => Effect.succeed(false)));
+    if (!exists) return null;
+
+    const content = yield* fs
+      .readFileString(filePath)
+      .pipe(Effect.catchAll((e) => Effect.fail(toError(e))));
+    try {
+      return JSON.parse(content) as JobBatchRecord;
+    } catch {
+      return null;
+    }
+  });
+}
+
+function writeBatchFile(
+  fs: FileSystem.FileSystem,
+  filePath: string,
+  batch: JobBatchRecord,
+): Effect.Effect<void, Error> {
+  return writeFileStringAtomic(fs, filePath, `${JSON.stringify(batch, null, 2)}\n`, {
+    tempPrefix: "job-batch",
+  });
+}
+
+function isTerminalStatus(status: JobRecord["status"]): boolean {
+  return status === "succeeded" || status === "failed" || status === "cancelled";
+}
+
+export interface JobQueueServiceImplOptions {
+  /** Override for tests; defaults to ~/.jazz/job-batches (or $JAZZ_HOME/job-batches). */
+  readonly baseJobBatchDirectory?: string;
+}
+
+export class JobQueueServiceImpl implements JobQueueService {
+  readonly baseJobBatchDirectory: string;
+
+  constructor(options?: JobQueueServiceImplOptions) {
+    this.baseJobBatchDirectory =
+      options?.baseJobBatchDirectory ?? path.join(getJazzHomeDirectory(), "job-batches");
+  }
+
+  readonly enqueueBatch: JobQueueService["enqueueBatch"] = (
+    agentId: string,
+    conversationId: string,
+    jobs: readonly EnqueueBatchJobInput[],
+    options: EnqueueBatchOptions,
+  ) => {
+    const baseJobBatchDirectory = this.baseJobBatchDirectory;
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId, JobQueueGuardrailViolation);
+
+      if (jobs.length === 0) {
+        return {
+          success: false,
+          message: "A batch needs at least one job.",
+        } satisfies EnqueueBatchOutcome;
+      }
+      if (jobs.length > MAX_JOBS_PER_BATCH) {
+        return {
+          success: false,
+          message: `Batch has ${jobs.length} jobs, exceeding the maximum of ${MAX_JOBS_PER_BATCH}.`,
+        } satisfies EnqueueBatchOutcome;
+      }
+      for (const job of jobs) {
+        const command = job.command.trim();
+        if (command.length === 0) {
+          return {
+            success: false,
+            message: "Every job needs a non-empty command.",
+          } satisfies EnqueueBatchOutcome;
+        }
+        if (command.length > JOB_COMMAND_MAX_LENGTH) {
+          return {
+            success: false,
+            message: `A job command is ${command.length} characters, exceeding the maximum of ${JOB_COMMAND_MAX_LENGTH}.`,
+          } satisfies EnqueueBatchOutcome;
+        }
+      }
+      if (options.reason.length > JOB_REASON_MAX_LENGTH) {
+        return {
+          success: false,
+          message: `Batch reason is ${options.reason.length} characters, exceeding the maximum of ${JOB_REASON_MAX_LENGTH}.`,
+        } satisfies EnqueueBatchOutcome;
+      }
+
+      const fs = yield* FileSystem.FileSystem;
+      yield* fs
+        .makeDirectory(agentDirectory(baseJobBatchDirectory, agentId), { recursive: true })
+        .pipe(Effect.mapError(toError));
+
+      const outcome = yield* withLock(
+        agentEnqueueLockPath(baseJobBatchDirectory, agentId),
+        Effect.gen(function* () {
+          const agentDir = agentDirectory(baseJobBatchDirectory, agentId);
+          const names = yield* fs
+            .readDirectory(agentDir)
+            .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+          const existingBatchIds = names
+            .filter((name) => name.endsWith(".json"))
+            .map((name) => name.slice(0, -".json".length));
+
+          let activeCount = 0;
+          for (const existingBatchId of existingBatchIds) {
+            const existing = yield* readBatchFile(
+              fs,
+              batchFilePath(baseJobBatchDirectory, agentId, existingBatchId),
+            );
+            if (existing !== null && existing.completedAt === null) activeCount++;
+          }
+          if (activeCount >= MAX_ACTIVE_BATCHES_PER_AGENT) {
+            return {
+              success: false,
+              message:
+                `You already have ${activeCount} active job batches, the maximum of ` +
+                `${MAX_ACTIVE_BATCHES_PER_AGENT}. Wait for one to finish or cancel_batch one before enqueueing another.`,
+            } satisfies EnqueueBatchOutcome;
+          }
+
+          const now = Date.now();
+          const concurrencyCap = clamp(
+            options.concurrencyCap ?? DEFAULT_CONCURRENCY_CAP,
+            1,
+            MAX_CONCURRENCY_CAP,
+          );
+          const maxAttempts = clamp(
+            options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+            1,
+            MAX_MAX_ATTEMPTS,
+          );
+          const batchId = newId();
+
+          const batch: JobBatchRecord = {
+            id: batchId,
+            agentId,
+            conversationId,
+            workingDir: options.workingDir,
+            concurrencyCap,
+            backoff: { initialMs: DEFAULT_BACKOFF_INITIAL_MS, maxMs: DEFAULT_BACKOFF_MAX_MS },
+            reason: options.reason,
+            createdAt: now,
+            completedAt: null,
+            jobs: jobs.map((job) => ({
+              id: newId(),
+              command: job.command.trim(),
+              status: "pending",
+              attempt: 0,
+              maxAttempts,
+              nextAttemptAt: now,
+              leaseOwner: null,
+              leaseExpiresAt: null,
+              result: null,
+              lastError: null,
+              createdAt: now,
+              updatedAt: now,
+            })),
+          };
+
+          yield* writeBatchFile(fs, batchFilePath(baseJobBatchDirectory, agentId, batchId), batch);
+          return { success: true, batch } satisfies EnqueueBatchOutcome;
+        }),
+      );
+
+      return outcome;
+    });
+  };
+
+  readonly getBatch: JobQueueService["getBatch"] = (agentId: string, batchId: string) => {
+    const baseJobBatchDirectory = this.baseJobBatchDirectory;
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId, JobQueueGuardrailViolation);
+      yield* requireValidStorageKey(batchId, "batch id", JobQueueGuardrailViolation);
+      const fs = yield* FileSystem.FileSystem;
+      return yield* readBatchFile(fs, batchFilePath(baseJobBatchDirectory, agentId, batchId));
+    });
+  };
+
+  readonly listActiveBatches: JobQueueService["listActiveBatches"] = (agentId: string) => {
+    const baseJobBatchDirectory = this.baseJobBatchDirectory;
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId, JobQueueGuardrailViolation);
+      const fs = yield* FileSystem.FileSystem;
+      const agentDir = agentDirectory(baseJobBatchDirectory, agentId);
+      const exists = yield* fs.exists(agentDir).pipe(Effect.catchAll(() => Effect.succeed(false)));
+      if (!exists) return [];
+
+      const names = yield* fs
+        .readDirectory(agentDir)
+        .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+      const batchIds = names
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => name.slice(0, -".json".length));
+
+      const batches: JobBatchRecord[] = [];
+      for (const batchId of batchIds) {
+        const batch = yield* readBatchFile(
+          fs,
+          batchFilePath(baseJobBatchDirectory, agentId, batchId),
+        );
+        if (batch !== null) batches.push(batch);
+      }
+      return batches.sort((left, right) => right.createdAt - left.createdAt);
+    });
+  };
+
+  readonly cancelBatch: JobQueueService["cancelBatch"] = (agentId: string, batchId: string) => {
+    const baseJobBatchDirectory = this.baseJobBatchDirectory;
+    return Effect.gen(function* () {
+      yield* requireValidAgentId(agentId, JobQueueGuardrailViolation);
+      yield* requireValidStorageKey(batchId, "batch id", JobQueueGuardrailViolation);
+      const fs = yield* FileSystem.FileSystem;
+
+      return yield* withLock(
+        batchLockPath(baseJobBatchDirectory, agentId, batchId),
+        Effect.gen(function* () {
+          const filePath = batchFilePath(baseJobBatchDirectory, agentId, batchId);
+          const batch = yield* readBatchFile(fs, filePath);
+          if (batch === null) {
+            return {
+              success: false,
+              message: `No job batch found with id "${batchId}".`,
+            } satisfies CancelBatchOutcome;
+          }
+          if (batch.completedAt !== null) {
+            return {
+              success: false,
+              message: "That batch has already finished.",
+            } satisfies CancelBatchOutcome;
+          }
+
+          const now = Date.now();
+          const jobs = batch.jobs.map((job) =>
+            job.status === "pending"
+              ? { ...job, status: "cancelled" as const, updatedAt: now }
+              : job,
+          );
+          const allTerminal = jobs.every((job) => isTerminalStatus(job.status));
+          const updated: JobBatchRecord = {
+            ...batch,
+            jobs,
+            completedAt: allTerminal ? now : batch.completedAt,
+          };
+          yield* writeBatchFile(fs, filePath, updated);
+
+          return {
+            success: true,
+            message: jobs.some((job) => job.status === "running")
+              ? "Pending jobs cancelled. Jobs already running will finish naturally."
+              : "Batch cancelled.",
+          } satisfies CancelBatchOutcome;
+        }),
+      );
+    });
+  };
+}
+
+export function createJobQueueServiceLayer(
+  options?: JobQueueServiceImplOptions,
+): Layer.Layer<JobQueueService> {
+  return Layer.succeed(JobQueueServiceTag, new JobQueueServiceImpl(options));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Daemon-only worker functions — never called from a tool handler.
+// ---------------------------------------------------------------------------------------------
+
+/** Every agentId with a job-batches directory — the daemon checks each for claimable work. */
+export function listAgentIdsWithActiveBatches(
+  baseJobBatchDirectory: string,
+): Effect.Effect<readonly string[], Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const exists = yield* fs
+      .exists(baseJobBatchDirectory)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+    if (!exists) return [];
+
+    const names = yield* fs
+      .readDirectory(baseJobBatchDirectory)
+      .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+    // Per-agent enqueue locks (`<agentId>.enqueue.lock`) live alongside the per-agent
+    // subdirectories in this same directory — filter those out.
+    return names.filter((name) => !name.endsWith(".lock"));
+  });
+}
+
+export interface ClaimedJob {
+  readonly agentId: string;
+  readonly batchId: string;
+  readonly jobId: string;
+  readonly command: string;
+  readonly workingDir: string;
+  readonly attempt: number;
+}
+
+/**
+ * Claim up to `count` pending, due, unleased jobs across one agent's active batches. Each batch
+ * file's read-modify-write happens inside that batch's own lock, so two daemon ticks (or two
+ * workers within one tick) can never claim the same job twice.
+ */
+export function claimDueJobs(
+  baseJobBatchDirectory: string,
+  agentId: string,
+  now: number,
+  count: number,
+  leaseOwner: string,
+): Effect.Effect<readonly ClaimedJob[], Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const agentDir = agentDirectory(baseJobBatchDirectory, agentId);
+    const exists = yield* fs.exists(agentDir).pipe(Effect.catchAll(() => Effect.succeed(false)));
+    if (!exists) return [];
+
+    const names = yield* fs
+      .readDirectory(agentDir)
+      .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+    const batchIds = names
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => name.slice(0, -".json".length));
+
+    const claimed: ClaimedJob[] = [];
+    for (const batchId of batchIds) {
+      if (claimed.length >= count) break;
+      const remaining = count - claimed.length;
+
+      const claimedInBatch = yield* withLock(
+        batchLockPath(baseJobBatchDirectory, agentId, batchId),
+        Effect.gen(function* () {
+          const filePath = batchFilePath(baseJobBatchDirectory, agentId, batchId);
+          const batch = yield* readBatchFile(fs, filePath);
+          if (batch === null || batch.completedAt !== null) return [] as ClaimedJob[];
+
+          const currentlyRunning = batch.jobs.filter((job) => job.status === "running").length;
+          const batchBudget = Math.max(0, batch.concurrencyCap - currentlyRunning);
+          const claimBudget = Math.min(remaining, batchBudget);
+
+          const claimedHere: ClaimedJob[] = [];
+          const jobs = batch.jobs.map((job) => {
+            if (
+              claimedHere.length < claimBudget &&
+              job.status === "pending" &&
+              job.nextAttemptAt <= now
+            ) {
+              claimedHere.push({
+                agentId,
+                batchId,
+                jobId: job.id,
+                command: job.command,
+                workingDir: batch.workingDir,
+                attempt: job.attempt,
+              });
+              return {
+                ...job,
+                status: "running" as const,
+                leaseOwner,
+                leaseExpiresAt: now + JOB_LEASE_TIMEOUT_MS,
+                updatedAt: now,
+              };
+            }
+            return job;
+          });
+
+          if (claimedHere.length > 0) {
+            yield* writeBatchFile(fs, filePath, { ...batch, jobs });
+          }
+          return claimedHere;
+        }),
+      ).pipe(Effect.catchAll(() => Effect.succeed([] as ClaimedJob[])));
+
+      claimed.push(...claimedInBatch);
+    }
+
+    return claimed;
+  });
+}
+
+export interface JobRunOutcome {
+  readonly success: boolean;
+  readonly result: {
+    readonly stdout: string;
+    readonly stderr: string;
+    readonly exitCode: number;
+  } | null;
+  readonly error: string | null;
+}
+
+export interface CompleteJobResult {
+  readonly batchNowComplete: boolean;
+  readonly batch: JobBatchRecord | null;
+}
+
+function applyOutcomeToJob(
+  job: JobRecord,
+  batch: JobBatchRecord,
+  outcome: JobRunOutcome,
+  now: number,
+): JobRecord {
+  const attempt = job.attempt + 1;
+  if (outcome.success) {
+    return {
+      ...job,
+      status: "succeeded",
+      attempt,
+      result: outcome.result,
+      lastError: null,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      updatedAt: now,
+    };
+  }
+
+  if (attempt < job.maxAttempts) {
+    return {
+      ...job,
+      status: "pending",
+      attempt,
+      nextAttemptAt: now + computeBackoffDelayMs(batch.backoff, attempt),
+      result: outcome.result,
+      lastError: outcome.error,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      updatedAt: now,
+    };
+  }
+
+  return {
+    ...job,
+    status: "failed",
+    attempt,
+    result: outcome.result,
+    lastError: outcome.error,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Record the outcome of a claimed job's execution, retrying with backoff if attempts remain, and
+ * report whether this was the batch's last non-terminal job (i.e. fan-in should fire).
+ */
+export function completeJob(
+  baseJobBatchDirectory: string,
+  agentId: string,
+  batchId: string,
+  jobId: string,
+  outcome: JobRunOutcome,
+): Effect.Effect<CompleteJobResult, Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* withLock(
+      batchLockPath(baseJobBatchDirectory, agentId, batchId),
+      Effect.gen(function* () {
+        const filePath = batchFilePath(baseJobBatchDirectory, agentId, batchId);
+        const batch = yield* readBatchFile(fs, filePath);
+        if (batch === null)
+          return { batchNowComplete: false, batch: null } satisfies CompleteJobResult;
+
+        const now = Date.now();
+        const wasAlreadyComplete = batch.completedAt !== null;
+        const jobs = batch.jobs.map((job) =>
+          job.id === jobId && !isTerminalStatus(job.status)
+            ? applyOutcomeToJob(job, batch, outcome, now)
+            : job,
+        );
+        const allTerminal = jobs.every((job) => isTerminalStatus(job.status));
+        const updated: JobBatchRecord = {
+          ...batch,
+          jobs,
+          completedAt: allTerminal ? (batch.completedAt ?? now) : batch.completedAt,
+        };
+        yield* writeBatchFile(fs, filePath, updated);
+
+        return {
+          batchNowComplete: allTerminal && !wasAlreadyComplete,
+          batch: updated,
+        } satisfies CompleteJobResult;
+      }),
+    );
+  });
+}
+
+export interface ReclaimedBatchCompletion {
+  readonly agentId: string;
+  readonly batch: JobBatchRecord;
+}
+
+/**
+ * Reclaim jobs whose lease expired without completing (the worker holding them crashed or was
+ * killed). Reclaiming consumes an attempt, same as any other failure, so a job that reliably
+ * kills its worker still terminates instead of looping forever. Returns every batch that became
+ * complete as a result, so the caller can fire fan-in for it exactly as `completeJob` does.
+ */
+export function reclaimExpiredLeases(
+  baseJobBatchDirectory: string,
+  now: number,
+): Effect.Effect<readonly ReclaimedBatchCompletion[], Error, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const agentIds = yield* listAgentIdsWithActiveBatches(baseJobBatchDirectory);
+    const fs = yield* FileSystem.FileSystem;
+    const newlyCompleted: ReclaimedBatchCompletion[] = [];
+
+    for (const agentId of agentIds) {
+      const agentDir = agentDirectory(baseJobBatchDirectory, agentId);
+      const names = yield* fs
+        .readDirectory(agentDir)
+        .pipe(Effect.catchAll(() => Effect.succeed<string[]>([])));
+      const batchIds = names
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => name.slice(0, -".json".length));
+
+      for (const batchId of batchIds) {
+        const completion = yield* withLock(
+          batchLockPath(baseJobBatchDirectory, agentId, batchId),
+          Effect.gen(function* () {
+            const filePath = batchFilePath(baseJobBatchDirectory, agentId, batchId);
+            const batch = yield* readBatchFile(fs, filePath);
+            if (batch === null || batch.completedAt !== null) return null;
+
+            const expired = batch.jobs.filter(
+              (job) =>
+                job.status === "running" &&
+                job.leaseExpiresAt !== null &&
+                job.leaseExpiresAt <= now,
+            );
+            if (expired.length === 0) return null;
+
+            const jobs = batch.jobs.map((job) =>
+              job.status === "running" && job.leaseExpiresAt !== null && job.leaseExpiresAt <= now
+                ? applyOutcomeToJob(
+                    job,
+                    batch,
+                    {
+                      success: false,
+                      result: null,
+                      error: "Job's worker lease expired before it completed.",
+                    },
+                    now,
+                  )
+                : job,
+            );
+            const allTerminal = jobs.every((job) => isTerminalStatus(job.status));
+            const updated: JobBatchRecord = {
+              ...batch,
+              jobs,
+              completedAt: allTerminal ? now : batch.completedAt,
+            };
+            yield* writeBatchFile(fs, filePath, updated);
+            return allTerminal
+              ? ({ agentId, batch: updated } satisfies ReclaimedBatchCompletion)
+              : null;
+          }),
+        ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+        if (completion !== null) newlyCompleted.push(completion);
+      }
+    }
+
+    return newlyCompleted;
+  });
+}

--- a/packages/adapters/src/reminder-service.test.ts
+++ b/packages/adapters/src/reminder-service.test.ts
@@ -4,18 +4,30 @@ import * as path from "node:path";
 import type { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { MAX_REMINDERS_PER_AGENT, REMINDER_TEXT_MAX_LENGTH } from "@jazz/core/constants/reminders";
+import type { ReminderOsScheduler } from "@jazz/core/wake-triggers/reminder-os-scheduler";
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Effect } from "effect";
 import { ReminderServiceImpl, sweepDueReminders } from "./reminder-service";
 
 let tmpDir: string;
+const originalSchedulerEnv = process.env["JAZZ_SCHEDULER"];
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-reminder-test-"));
+  // Tests that don't inject a fake `osScheduler` fall back to `createReminderOsScheduler()`,
+  // which would otherwise install real launchd plists / `at` jobs on the machine running the
+  // test suite. Forcing in-process mode keeps these tests hermetic; the `osScheduler
+  // integration` tests below inject an explicit fake and are unaffected by this env var.
+  process.env["JAZZ_SCHEDULER"] = "in-process";
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (originalSchedulerEnv === undefined) {
+    delete process.env["JAZZ_SCHEDULER"];
+  } else {
+    process.env["JAZZ_SCHEDULER"] = originalSchedulerEnv;
+  }
 });
 
 function runEffect<A>(eff: Effect.Effect<A, unknown, FileSystem.FileSystem>) {
@@ -26,8 +38,45 @@ function runEither<A>(eff: Effect.Effect<A, unknown, FileSystem.FileSystem>) {
   return runEffect(eff.pipe(Effect.either));
 }
 
-function makeService(): ReminderServiceImpl {
-  return new ReminderServiceImpl({ baseReminderDirectory: tmpDir });
+function makeService(osScheduler?: ReminderOsScheduler): ReminderServiceImpl {
+  return new ReminderServiceImpl({
+    baseReminderDirectory: tmpDir,
+    ...(osScheduler !== undefined ? { osScheduler } : {}),
+  });
+}
+
+interface FakeOsSchedulerCall {
+  readonly method: "scheduleFire" | "cancelFire";
+  readonly agentId: string;
+  readonly reminderId: string;
+}
+
+function makeFakeOsScheduler(options?: {
+  failScheduleFire?: boolean;
+  failCancelFire?: boolean;
+  jobId?: string;
+}): { scheduler: ReminderOsScheduler; calls: FakeOsSchedulerCall[] } {
+  const calls: FakeOsSchedulerCall[] = [];
+  const scheduler: ReminderOsScheduler = {
+    getType: () => "in-process",
+    scheduleFire: (agentId, reminderId) => {
+      calls.push({ method: "scheduleFire", agentId, reminderId });
+      if (options?.failScheduleFire) {
+        return Effect.fail(new Error("scheduleFire boom"));
+      }
+      return Effect.succeed(
+        options?.jobId !== undefined ? { osSchedulerJobId: options.jobId } : {},
+      );
+    },
+    cancelFire: (agentId, reminderId) => {
+      calls.push({ method: "cancelFire", agentId, reminderId });
+      if (options?.failCancelFire) {
+        return Effect.fail(new Error("cancelFire boom"));
+      }
+      return Effect.void;
+    },
+  };
+  return { scheduler, calls };
 }
 
 describe("add", () => {
@@ -214,5 +263,94 @@ describe("add guards against fire times in the past", () => {
     if (!outcome.success) {
       expect(outcome.message).toContain("in the past");
     }
+  });
+});
+
+describe("osScheduler integration", () => {
+  test("add calls osScheduler.scheduleFire and persists the returned job id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "42" });
+    const service = makeService(scheduler);
+
+    const outcome = await runEffect(service.add("agent-1", "30m", "scheduled reminder", "UTC"));
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    expect(outcome.reminder.osSchedulerJobId).toBe("42");
+    expect(calls).toEqual([
+      { method: "scheduleFire", agentId: "agent-1", reminderId: outcome.reminder.id },
+    ]);
+  });
+
+  test("add succeeds even when osScheduler.scheduleFire fails", async () => {
+    const { scheduler } = makeFakeOsScheduler({ failScheduleFire: true });
+    const service = makeService(scheduler);
+
+    const outcome = await runEffect(service.add("agent-1", "30m", "reminder", "UTC"));
+    expect(outcome.success).toBe(true);
+    if (outcome.success) {
+      expect(outcome.reminder.osSchedulerJobId).toBeUndefined();
+    }
+  });
+
+  test("cancel calls osScheduler.cancelFire with the persisted job id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "7" });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(service.add("agent-1", "30m", "reminder", "UTC"));
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+
+    const outcome = await runEffect(service.cancel("agent-1", added.reminder.id));
+    expect(outcome.success).toBe(true);
+
+    const cancelCall = calls.find((call) => call.method === "cancelFire");
+    expect(cancelCall).toEqual({
+      method: "cancelFire",
+      agentId: "agent-1",
+      reminderId: added.reminder.id,
+    });
+  });
+
+  test("cancel still removes the record even when osScheduler.cancelFire fails", async () => {
+    const { scheduler } = makeFakeOsScheduler({ failCancelFire: true });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(service.add("agent-1", "30m", "reminder", "UTC"));
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+
+    const outcome = await runEffect(service.cancel("agent-1", added.reminder.id));
+    expect(outcome.success).toBe(true);
+
+    const list = await runEffect(service.list("agent-1"));
+    expect(list).toEqual([]);
+  });
+
+  test("never calls the os scheduler for a Telegram-hosted agent id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "99" });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(service.add("tg_12345", "30m", "chat reminder", "UTC"));
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+    expect(added.reminder.osSchedulerJobId).toBeUndefined();
+
+    await runEffect(service.cancel("tg_12345", added.reminder.id));
+
+    expect(calls).toEqual([]);
+  });
+
+  test("never calls the os scheduler for a Discord-hosted agent id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "99" });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(service.add("dc_67890", "30m", "chat reminder", "UTC"));
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+    expect(added.reminder.osSchedulerJobId).toBeUndefined();
+
+    await runEffect(service.cancel("dc_67890", added.reminder.id));
+
+    expect(calls).toEqual([]);
   });
 });

--- a/packages/adapters/src/reminder-service.ts
+++ b/packages/adapters/src/reminder-service.ts
@@ -16,7 +16,24 @@ import { ReminderServiceTag } from "@jazz/core/interfaces/reminder-service";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { requireValidAgentId, withLock, writeFileStringAtomic } from "@jazz/core/utils/storage";
 import { parseWhen } from "@jazz/core/utils/time";
+import {
+  createReminderOsScheduler,
+  type ReminderOsScheduler,
+} from "@jazz/core/wake-triggers/reminder-os-scheduler";
 import { Effect, Layer } from "effect";
+
+/**
+ * Telegram (`tg_...`) and Discord (`dc_...`) agents already sweep and deliver their own
+ * reminders in-process (see `packages/telegram-bot/src/reminders.ts`,
+ * `packages/discord-bot/src/reminders.ts`), running a private interval inside their own
+ * long-lived bot process. Installing an OS job for those too would double-deliver: once as the
+ * bot's own chat message, once as a spurious desktop notification on whatever host happens to
+ * run the bot container — usually headless, with no GUI session, and often a shared service
+ * account under which writing LaunchAgents would be unwanted or fail outright.
+ */
+function isBotHostedAgentId(agentId: string): boolean {
+  return agentId.startsWith("tg_") || agentId.startsWith("dc_");
+}
 
 /** Raised for guardrail violations — genuinely unexpected conditions, not tool-result-shaped errors. */
 export class ReminderGuardrailViolation extends Error {}
@@ -57,14 +74,24 @@ function readReminderFile(
 export interface ReminderServiceImplOptions {
   /** Override for tests; defaults to ~/.jazz/reminders (or $JAZZ_HOME/reminders). */
   readonly baseReminderDirectory?: string;
+  /** Override for tests; defaults to `createReminderOsScheduler()`. */
+  readonly osScheduler?: ReminderOsScheduler;
 }
 
 export class ReminderServiceImpl implements ReminderService {
   private readonly baseReminderDirectory: string;
+  private readonly osScheduler: ReminderOsScheduler | undefined;
 
   constructor(options?: ReminderServiceImplOptions) {
     this.baseReminderDirectory =
       options?.baseReminderDirectory ?? path.join(getJazzHomeDirectory(), "reminders");
+    this.osScheduler = options?.osScheduler;
+  }
+
+  private resolveOsScheduler(): Effect.Effect<ReminderOsScheduler> {
+    return this.osScheduler !== undefined
+      ? Effect.succeed(this.osScheduler)
+      : createReminderOsScheduler();
   }
 
   private withValidatedAgentLock<A, E, R>(
@@ -122,11 +149,26 @@ export class ReminderServiceImpl implements ReminderService {
             } satisfies AddReminderOutcome;
           }
 
+          const reminderId = newReminderId();
+
+          // OS scheduling is a best-effort reliability upgrade on top of the JSON record
+          // below, which stays the source of truth — a scheduling failure must never block
+          // registering the reminder, so any error here is swallowed. Skipped entirely for
+          // bot-hosted agents; see `isBotHostedAgentId`.
+          const scheduleResult: { readonly osSchedulerJobId?: string } = isBotHostedAgentId(agentId)
+            ? {}
+            : yield* (yield* this.resolveOsScheduler())
+                .scheduleFire(agentId, reminderId, fireAt)
+                .pipe(Effect.catchAll(() => Effect.succeed({})));
+
           const reminder: ReminderRecord = {
-            id: newReminderId(),
+            id: reminderId,
             fireAt,
             text,
             createdAt: now,
+            ...(scheduleResult.osSchedulerJobId !== undefined
+              ? { osSchedulerJobId: scheduleResult.osSchedulerJobId }
+              : {}),
           };
           yield* writeFileStringAtomic(
             fs,
@@ -158,18 +200,31 @@ export class ReminderServiceImpl implements ReminderService {
           const fs = yield* FileSystem.FileSystem;
           const filePath = reminderFilePath(this.baseReminderDirectory, agentId);
           const existing = yield* readReminderFile(fs, filePath);
-          const remaining = existing.filter((reminder) => reminder.id !== id);
+          const removedReminder = existing.find((reminder) => reminder.id === id);
 
-          if (remaining.length === existing.length) {
+          if (removedReminder === undefined) {
             return {
               success: false,
               message: `No reminder found with id "${id}".`,
             } satisfies CancelReminderOutcome;
           }
 
+          const remaining = existing.filter((reminder) => reminder.id !== id);
           yield* writeFileStringAtomic(fs, filePath, `${JSON.stringify(remaining, null, 2)}\n`, {
             tempPrefix: "reminders",
           });
+
+          // Never let a failed OS unschedule block removing the JSON record — the record is
+          // the source of truth, and a stray leftover `at`/launchd job is harmless (the CLI
+          // it invokes checks whether the reminder still exists before firing). Skipped
+          // entirely for bot-hosted agents, which never had a job installed to begin with.
+          if (!isBotHostedAgentId(agentId)) {
+            const osScheduler = yield* this.resolveOsScheduler();
+            yield* osScheduler
+              .cancelFire(agentId, id, removedReminder.osSchedulerJobId)
+              .pipe(Effect.catchAll(() => Effect.void));
+          }
+
           return { success: true, message: "Reminder cancelled." } satisfies CancelReminderOutcome;
         }.bind(this),
       ),

--- a/packages/adapters/src/wake-trigger-service.test.ts
+++ b/packages/adapters/src/wake-trigger-service.test.ts
@@ -7,18 +7,30 @@ import {
   MAX_WAKE_TRIGGERS_PER_AGENT,
   WAKE_TRIGGER_PROMPT_MAX_LENGTH,
 } from "@jazz/core/constants/wake-triggers";
+import type { WakeTriggerOsScheduler } from "@jazz/core/wake-triggers/wake-trigger-os-scheduler";
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Effect } from "effect";
 import { WakeTriggerServiceImpl, sweepDueWakeTriggers } from "./wake-trigger-service";
 
 let tmpDir: string;
+const originalSchedulerEnv = process.env["JAZZ_SCHEDULER"];
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-wake-trigger-test-"));
+  // Tests that don't inject a fake `osScheduler` fall back to `createWakeTriggerOsScheduler()`,
+  // which would otherwise install real launchd plists / `at` jobs on the machine running the
+  // test suite. Forcing in-process mode keeps these tests hermetic; the `osScheduler
+  // integration` tests below inject an explicit fake and are unaffected by this env var.
+  process.env["JAZZ_SCHEDULER"] = "in-process";
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (originalSchedulerEnv === undefined) {
+    delete process.env["JAZZ_SCHEDULER"];
+  } else {
+    process.env["JAZZ_SCHEDULER"] = originalSchedulerEnv;
+  }
 });
 
 function runEffect<A>(eff: Effect.Effect<A, unknown, FileSystem.FileSystem>) {
@@ -29,8 +41,45 @@ function runEither<A>(eff: Effect.Effect<A, unknown, FileSystem.FileSystem>) {
   return runEffect(eff.pipe(Effect.either));
 }
 
-function makeService(): WakeTriggerServiceImpl {
-  return new WakeTriggerServiceImpl({ baseWakeTriggerDirectory: tmpDir });
+function makeService(osScheduler?: WakeTriggerOsScheduler): WakeTriggerServiceImpl {
+  return new WakeTriggerServiceImpl({
+    baseWakeTriggerDirectory: tmpDir,
+    ...(osScheduler !== undefined ? { osScheduler } : {}),
+  });
+}
+
+interface FakeOsSchedulerCall {
+  readonly method: "scheduleFire" | "cancelFire";
+  readonly agentId: string;
+  readonly triggerId: string;
+}
+
+function makeFakeOsScheduler(options?: {
+  failScheduleFire?: boolean;
+  failCancelFire?: boolean;
+  jobId?: string;
+}): { scheduler: WakeTriggerOsScheduler; calls: FakeOsSchedulerCall[] } {
+  const calls: FakeOsSchedulerCall[] = [];
+  const scheduler: WakeTriggerOsScheduler = {
+    getType: () => "in-process",
+    scheduleFire: (agentId, triggerId) => {
+      calls.push({ method: "scheduleFire", agentId, triggerId });
+      if (options?.failScheduleFire) {
+        return Effect.fail(new Error("scheduleFire boom"));
+      }
+      return Effect.succeed(
+        options?.jobId !== undefined ? { osSchedulerJobId: options.jobId } : {},
+      );
+    },
+    cancelFire: (agentId, triggerId) => {
+      calls.push({ method: "cancelFire", agentId, triggerId });
+      if (options?.failCancelFire) {
+        return Effect.fail(new Error("cancelFire boom"));
+      }
+      return Effect.void;
+    },
+  };
+  return { scheduler, calls };
 }
 
 describe("add", () => {
@@ -185,5 +234,74 @@ describe("sweepDueWakeTriggers", () => {
 
     const list = await runEffect(service.list("agent-1"));
     expect(list.length).toBe(1);
+  });
+});
+
+describe("osScheduler integration", () => {
+  test("add calls osScheduler.scheduleFire and persists the returned job id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "42" });
+    const service = makeService(scheduler);
+
+    const outcome = await runEffect(
+      service.add("agent-1", "conv-1", "30m", "scheduled prompt", "reason", "UTC"),
+    );
+    expect(outcome.success).toBe(true);
+    if (!outcome.success) return;
+
+    expect(outcome.trigger.osSchedulerJobId).toBe("42");
+    expect(calls).toEqual([
+      { method: "scheduleFire", agentId: "agent-1", triggerId: outcome.trigger.id },
+    ]);
+  });
+
+  test("add succeeds even when osScheduler.scheduleFire fails", async () => {
+    const { scheduler } = makeFakeOsScheduler({ failScheduleFire: true });
+    const service = makeService(scheduler);
+
+    const outcome = await runEffect(
+      service.add("agent-1", "conv-1", "30m", "prompt", "reason", "UTC"),
+    );
+    expect(outcome.success).toBe(true);
+    if (outcome.success) {
+      expect(outcome.trigger.osSchedulerJobId).toBeUndefined();
+    }
+  });
+
+  test("cancel calls osScheduler.cancelFire with the persisted job id", async () => {
+    const { scheduler, calls } = makeFakeOsScheduler({ jobId: "7" });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(
+      service.add("agent-1", "conv-1", "30m", "prompt", "reason", "UTC"),
+    );
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+
+    const outcome = await runEffect(service.cancel("agent-1", added.trigger.id));
+    expect(outcome.success).toBe(true);
+
+    const cancelCall = calls.find((call) => call.method === "cancelFire");
+    expect(cancelCall).toEqual({
+      method: "cancelFire",
+      agentId: "agent-1",
+      triggerId: added.trigger.id,
+    });
+  });
+
+  test("cancel still removes the record even when osScheduler.cancelFire fails", async () => {
+    const { scheduler } = makeFakeOsScheduler({ failCancelFire: true });
+    const service = makeService(scheduler);
+
+    const added = await runEffect(
+      service.add("agent-1", "conv-1", "30m", "prompt", "reason", "UTC"),
+    );
+    expect(added.success).toBe(true);
+    if (!added.success) return;
+
+    const outcome = await runEffect(service.cancel("agent-1", added.trigger.id));
+    expect(outcome.success).toBe(true);
+
+    const list = await runEffect(service.list("agent-1"));
+    expect(list).toEqual([]);
   });
 });

--- a/packages/adapters/src/wake-trigger-service.ts
+++ b/packages/adapters/src/wake-trigger-service.ts
@@ -23,6 +23,10 @@ import { WakeTriggerServiceTag } from "@jazz/core/interfaces/wake-trigger-servic
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { requireValidAgentId, withLock, writeFileStringAtomic } from "@jazz/core/utils/storage";
 import { parseWhen } from "@jazz/core/utils/time";
+import {
+  createWakeTriggerOsScheduler,
+  type WakeTriggerOsScheduler,
+} from "@jazz/core/wake-triggers/wake-trigger-os-scheduler";
 import { Effect, Layer } from "effect";
 
 /** Raised for guardrail violations — genuinely unexpected conditions, not tool-result-shaped errors. */
@@ -64,14 +68,24 @@ function readWakeTriggerFile(
 export interface WakeTriggerServiceImplOptions {
   /** Override for tests; defaults to ~/.jazz/wake-triggers (or $JAZZ_HOME/wake-triggers). */
   readonly baseWakeTriggerDirectory?: string;
+  /** Override for tests; defaults to `createWakeTriggerOsScheduler()`. */
+  readonly osScheduler?: WakeTriggerOsScheduler;
 }
 
 export class WakeTriggerServiceImpl implements WakeTriggerService {
   private readonly baseWakeTriggerDirectory: string;
+  private readonly osScheduler: WakeTriggerOsScheduler | undefined;
 
   constructor(options?: WakeTriggerServiceImplOptions) {
     this.baseWakeTriggerDirectory =
       options?.baseWakeTriggerDirectory ?? path.join(getJazzHomeDirectory(), "wake-triggers");
+    this.osScheduler = options?.osScheduler;
+  }
+
+  private resolveOsScheduler(): Effect.Effect<WakeTriggerOsScheduler> {
+    return this.osScheduler !== undefined
+      ? Effect.succeed(this.osScheduler)
+      : createWakeTriggerOsScheduler();
   }
 
   private withValidatedAgentLock<A, E, R>(
@@ -143,13 +157,26 @@ export class WakeTriggerServiceImpl implements WakeTriggerService {
             } satisfies AddWakeTriggerOutcome;
           }
 
+          const triggerId = newWakeTriggerId();
+
+          // OS scheduling is a best-effort reliability upgrade on top of the JSON record
+          // below, which stays the source of truth — a scheduling failure must never block
+          // registering the trigger, so any error here is swallowed.
+          const osScheduler = yield* this.resolveOsScheduler();
+          const scheduleResult = yield* osScheduler
+            .scheduleFire(agentId, triggerId, fireAt)
+            .pipe(Effect.catchAll(() => Effect.succeed({ osSchedulerJobId: undefined })));
+
           const trigger: WakeTriggerRecord = {
-            id: newWakeTriggerId(),
+            id: triggerId,
             fireAt,
             conversationId,
             prompt,
             reason,
             createdAt: now,
+            ...(scheduleResult.osSchedulerJobId !== undefined
+              ? { osSchedulerJobId: scheduleResult.osSchedulerJobId }
+              : {}),
           };
           yield* writeFileStringAtomic(
             fs,
@@ -181,18 +208,28 @@ export class WakeTriggerServiceImpl implements WakeTriggerService {
           const fs = yield* FileSystem.FileSystem;
           const filePath = wakeTriggerFilePath(this.baseWakeTriggerDirectory, agentId);
           const existing = yield* readWakeTriggerFile(fs, filePath);
-          const remaining = existing.filter((trigger) => trigger.id !== id);
+          const removedTrigger = existing.find((trigger) => trigger.id === id);
 
-          if (remaining.length === existing.length) {
+          if (removedTrigger === undefined) {
             return {
               success: false,
               message: `No wake trigger found with id "${id}".`,
             } satisfies CancelWakeTriggerOutcome;
           }
 
+          const remaining = existing.filter((trigger) => trigger.id !== id);
           yield* writeFileStringAtomic(fs, filePath, `${JSON.stringify(remaining, null, 2)}\n`, {
             tempPrefix: "wake-triggers",
           });
+
+          // Never let a failed OS unschedule block removing the JSON record — the record is
+          // the source of truth, and a stray leftover `at`/launchd job is harmless (the CLI
+          // it invokes checks whether the trigger still exists before firing).
+          const osScheduler = yield* this.resolveOsScheduler();
+          yield* osScheduler
+            .cancelFire(agentId, id, removedTrigger.osSchedulerJobId)
+            .pipe(Effect.catchAll(() => Effect.void));
+
           return {
             success: true,
             message: "Wake trigger cancelled.",

--- a/packages/cli/src/chat-service.ts
+++ b/packages/cli/src/chat-service.ts
@@ -495,6 +495,13 @@ export class ChatServiceImpl implements ChatService {
               Effect.runSync(terminal.user(queued));
               return queued;
             },
+            // A Ctrl+B-detached tool call reports back here, possibly long after this
+            // run has ended. Queuing it through the same path as text typed mid-run
+            // means it surfaces automatically — at the next tool-phase boundary if this
+            // run is still going, or as the opening line of the next turn otherwise.
+            onDetachedToolComplete: (summary: string) => {
+              store.appendToQueue(`[Background task finished]\n${summary}`);
+            },
           };
 
           // Run the agent with proper error handling

--- a/packages/cli/src/commands/reminder.ts
+++ b/packages/cli/src/commands/reminder.ts
@@ -1,0 +1,50 @@
+import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { ReminderServiceTag } from "@jazz/core/interfaces/reminder-service";
+import { sendDesktopNotification } from "@jazz/core/utils/desktop-notify";
+import { Effect } from "effect";
+
+/**
+ * Internal command invoked by the host scheduler (launchd/`at`), not meant for interactive use:
+ * fire one specific reminder, one-shot, by sending a native OS desktop notification. A reminder
+ * is "notify a person," never "resume the agent" — see `wake-trigger-tools.ts`'s file comment
+ * for that distinction, and `wake-trigger.ts`'s `fireWakeTriggerCommand` for the sibling that
+ * does resume a conversation.
+ *
+ * Cancels the reminder's JSON record before firing it, so the in-process ticker (or, for
+ * Telegram/Discord, the bot's own sweep — though those never reach this command; see
+ * `reminder-service.ts`) can never pick up the same reminder and deliver it a second time if
+ * both race. A reminder that is no longer found (already fired or cancelled) is an expected
+ * race, not an error — this exits cleanly rather than failing the scheduler job.
+ */
+export function fireReminderCommand(options: { agent: string; id: string }) {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+    const reminderService = yield* ReminderServiceTag;
+
+    const reminders = yield* reminderService.list(options.agent);
+    const reminder = reminders.find((candidate) => candidate.id === options.id);
+
+    if (reminder === undefined) {
+      yield* logger.info("Reminder not found — likely already fired or cancelled", {
+        agentId: options.agent,
+        reminderId: options.id,
+      });
+      return;
+    }
+
+    yield* reminderService.cancel(options.agent, options.id);
+
+    const delivered = yield* sendDesktopNotification("Jazz reminder", reminder.text);
+    if (delivered) {
+      yield* logger.info("Reminder delivered via desktop notification", {
+        agentId: options.agent,
+        reminderId: options.id,
+      });
+    } else {
+      yield* logger.warn("Reminder desktop notification could not be delivered", {
+        agentId: options.agent,
+        reminderId: options.id,
+      });
+    }
+  });
+}

--- a/packages/cli/src/commands/wake-trigger.ts
+++ b/packages/cli/src/commands/wake-trigger.ts
@@ -1,0 +1,34 @@
+import { fireWakeTrigger } from "@jazz/adapters/daemon/trigger-runner";
+import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { WakeTriggerServiceTag } from "@jazz/core/interfaces/wake-trigger-service";
+import { Effect } from "effect";
+
+/**
+ * Internal command invoked by the host scheduler (launchd/`at`), not meant for interactive use:
+ * fire one specific wake trigger, one-shot.
+ *
+ * Cancels the trigger's JSON record before firing it, so the in-process ticker can never pick
+ * up the same trigger and fire it a second time if both race. A trigger that is no longer
+ * found (already fired by the ticker, or cancelled by the user) is an expected race, not an
+ * error — this exits cleanly rather than failing the scheduler job.
+ */
+export function fireWakeTriggerCommand(options: { agent: string; id: string }) {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+    const wakeTriggerService = yield* WakeTriggerServiceTag;
+
+    const triggers = yield* wakeTriggerService.list(options.agent);
+    const trigger = triggers.find((candidate) => candidate.id === options.id);
+
+    if (trigger === undefined) {
+      yield* logger.info("Wake trigger not found — likely already fired or cancelled", {
+        agentId: options.agent,
+        triggerId: options.id,
+      });
+      return;
+    }
+
+    yield* wakeTriggerService.cancel(options.agent, options.id);
+    yield* fireWakeTrigger(options.agent, trigger);
+  });
+}

--- a/packages/cli/src/presentation/ink-presentation-service.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.ts
@@ -408,6 +408,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
       store.finalizeStream();
       store.setActivity({ phase: "idle" });
       store.setInterruptHandler(null);
+      store.setBackgroundHandler(null);
     });
   }
 
@@ -427,12 +428,19 @@ export class InkStreamingRenderer implements StreamingRenderer {
       store.finalizeStream();
       store.setActivity({ phase: "idle" });
       store.setInterruptHandler(null);
+      store.setBackgroundHandler(null);
     });
   }
 
   setInterruptHandler(handler: (() => void) | null): Effect.Effect<void, never> {
     return Effect.sync(() => {
       store.setInterruptHandler(handler);
+    });
+  }
+
+  setBackgroundHandler(handler: (() => void) | null): Effect.Effect<void, never> {
+    return Effect.sync(() => {
+      store.setBackgroundHandler(handler);
     });
   }
 

--- a/packages/cli/src/ui/fullscreen/bridge.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.tsx
@@ -63,6 +63,7 @@ import {
 } from "./composer-edit";
 import { wrapCommandIndex } from "./Input";
 import {
+  isBackgroundChord,
   isComposerNewline,
   isCtrlLetter,
   isInterruptChord,
@@ -1112,6 +1113,8 @@ export function FullscreenBridge(): React.ReactNode {
 
   const interrupt = useRef(session.interruptHandler);
   interrupt.current = session.interruptHandler;
+  const background = useRef(session.backgroundHandler);
+  background.current = session.backgroundHandler;
   const quitArmed = useRef(false);
 
   useEffect(() => {
@@ -1423,6 +1426,16 @@ export function FullscreenBridge(): React.ReactNode {
         }
         process.kill(process.pid, "SIGINT");
         return true;
+      }
+
+      // Ctrl+B: detach whatever tool call is currently running into the background
+      // instead of killing it — a no-op (falls through) when nothing is running to
+      // detach, unlike Ctrl+C which always does something.
+      if (isBackgroundChord({ name, ctrl, shift, super: superKey, sequence })) {
+        if (background.current !== null) {
+          background.current();
+          return true;
+        }
       }
 
       // Ctrl+V reads the host clipboard. Cmd+V / Shift+Insert arrive as a

--- a/packages/cli/src/ui/fullscreen/keymap.test.ts
+++ b/packages/cli/src/ui/fullscreen/keymap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   hintsFor,
   INTERRUPT_WINDOW_MS,
+  isBackgroundChord,
   isComposerNewline,
   isCopyChord,
   isCtrlLetter,
@@ -240,6 +241,15 @@ describe("normalizeKey", () => {
     expect(isInterruptChord(normalizeKey("\x1b[27;6;99~"))).toBe(false);
     expect(isInterruptChord(normalizeKey("\x1b[99;5u"))).toBe(true);
     expect(isCopyChord(normalizeKey("\x1b[99;5u"))).toBe(false);
+  });
+
+  it("recognizes Ctrl+B as the background chord, and only plain Ctrl+B", () => {
+    expect(isBackgroundChord({ name: "b", ctrl: true, shift: false, super: false })).toBe(true);
+    expect(isBackgroundChord({ name: "b", ctrl: true, shift: true, super: false })).toBe(false);
+    expect(isBackgroundChord({ name: "b", ctrl: false, shift: false, super: true })).toBe(false);
+    expect(isBackgroundChord({ name: "b", ctrl: true, shift: false, super: true })).toBe(false);
+    expect(isBackgroundChord(normalizeKey("\x02"))).toBe(true);
+    expect(isBackgroundChord({ name: "c", ctrl: true, shift: false, super: false })).toBe(false);
   });
 
   it("treats Ctrl/Cmd+Z as undo and the shifted form as redo", () => {

--- a/packages/cli/src/ui/fullscreen/keymap.ts
+++ b/packages/cli/src/ui/fullscreen/keymap.ts
@@ -267,6 +267,18 @@ export function isInterruptChord(
   return isCtrlLetter(key, "c");
 }
 
+/**
+ * Ctrl+B: detach the in-flight tool call into the background instead of killing it.
+ * Unambiguous and immediate like Ctrl+C — unlike Esc, it carries no other meaning at
+ * any point in the app, so it needs no double-tap ladder.
+ */
+export function isBackgroundChord(
+  key: Pick<NormalizedKey, "name" | "ctrl" | "shift" | "super"> & { readonly sequence?: string },
+): boolean {
+  if (key.super || key.shift) return false;
+  return isCtrlLetter(key, "b");
+}
+
 export function isUndoChord(
   key: Pick<NormalizedKey, "name" | "ctrl" | "shift" | "super">,
 ): boolean {

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -164,6 +164,8 @@ export interface SessionSnapshot {
   readonly isYolo: boolean;
   readonly connectors: ReadonlyMap<string, ConnectorStatus>;
   readonly interruptHandler: (() => void) | null;
+  /** Ctrl+B: detach the in-flight tool call into the background instead of killing it. */
+  readonly backgroundHandler: (() => void) | null;
   readonly approvalRequest: PendingApproval | null;
   readonly activeMenu: ActiveMenu | null;
   readonly modeToast: string | null;
@@ -195,6 +197,7 @@ const INITIAL_SESSION: SessionSnapshot = {
   isYolo: false,
   connectors: EMPTY_CONNECTORS,
   interruptHandler: null,
+  backgroundHandler: null,
   approvalRequest: null,
   activeMenu: null,
   modeToast: null,
@@ -280,6 +283,7 @@ export class UIStore {
   private ephemeralRegions: Map<EphemeralRegionId, EphemeralRegion> = new Map();
   private ephemeralIdCounter = 0;
   private interruptHandlerStack: Array<() => void> = [];
+  private backgroundHandlerStack: Array<() => void> = [];
   private promptContinuation: ((result: PromptResult) => void) | null = null;
   private rendererFallbackHandler: (() => void) | null = null;
 
@@ -420,6 +424,16 @@ export class UIStore {
     }
     const top = this.interruptHandlerStack[this.interruptHandlerStack.length - 1] ?? null;
     patchSlice(this.session, { interruptHandler: top });
+  };
+
+  setBackgroundHandler = (handler: (() => void) | null): void => {
+    if (handler === null) {
+      this.backgroundHandlerStack.pop();
+    } else {
+      this.backgroundHandlerStack.push(handler);
+    }
+    const top = this.backgroundHandlerStack[this.backgroundHandlerStack.length - 1] ?? null;
+    patchSlice(this.session, { backgroundHandler: top });
   };
 
   appendToQueue = (text: string): void => {

--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -22,6 +22,7 @@ import { makeDefaultObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
+import { JobQueueServiceTag } from "../../interfaces/job-queue-service";
 import type { LLMService } from "../../interfaces/llm";
 import { LLMServiceTag } from "../../interfaces/llm";
 import { LoggerServiceTag } from "../../interfaces/logger";
@@ -117,6 +118,7 @@ const TestLayer = Layer.mergeAll(
   Layer.succeed(MemoryServiceTag, {} as any),
   Layer.succeed(WorkspaceServiceTag, {} as any),
   Layer.succeed(WakeTriggerServiceTag, {} as any),
+  Layer.succeed(JobQueueServiceTag, {} as any),
   Layer.succeed(ReminderServiceTag, {} as any),
   Layer.succeed(PeerLedgerServiceTag, {} as any),
   Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -648,6 +650,7 @@ describe("executeAgentLoop", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -796,6 +799,7 @@ describe("executeAgentLoop", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -861,6 +865,7 @@ describe("executeAgentLoop", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -257,6 +257,17 @@ export interface CompletionStrategy {
   getInterruptSignal?(): Effect.Effect<void, never> | undefined;
 
   /**
+   * Optional background signal (Ctrl+B) used to detach the in-flight tool batch instead
+   * of interrupting it: the batch's fibers keep running (forked as daemon fibers so they
+   * outlive this tool phase), and each returns a "running in the background" placeholder
+   * result immediately so the loop continues. Unlike `getInterruptSignal`, firing this
+   * does not abort the run, and it must be re-triggerable across many tool batches within
+   * one run — implementations should not reuse a single one-shot `Deferred` the way
+   * `getInterruptSignal` does.
+   */
+  getBackgroundSignal?(): Effect.Effect<void, never> | undefined;
+
+  /**
    * Whether to show reasoning indicators for this strategy.
    */
   shouldShowReasoning: boolean;
@@ -503,6 +514,8 @@ function handleToolPhase(
       actualConversationId,
       agent.name,
       strategy.getInterruptSignal?.(),
+      strategy.getBackgroundSignal?.(),
+      options.onDetachedToolComplete,
     ).pipe(
       // The executor knows what the run is waiting for; only here are the messages that
       // let it start again. Everything else about the failure is left alone.

--- a/packages/core/src/agent/execution/batch-executor.test.ts
+++ b/packages/core/src/agent/execution/batch-executor.test.ts
@@ -7,6 +7,7 @@ import { executeWithoutStreaming } from "./batch-executor";
 import { DEFAULT_MAX_ITERATIONS } from "../../constants/agent";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
+import { JobQueueServiceTag } from "../../interfaces/job-queue-service";
 import type { LLMService } from "../../interfaces/llm";
 import { LLMServiceTag } from "../../interfaces/llm";
 import { LoggerServiceTag } from "../../interfaces/logger";
@@ -158,6 +159,7 @@ function buildLayer(presentationService: OneShotPresentationService) {
     Layer.succeed(MemoryServiceTag, {} as any),
     Layer.succeed(WorkspaceServiceTag, {} as any),
     Layer.succeed(WakeTriggerServiceTag, {} as any),
+    Layer.succeed(JobQueueServiceTag, {} as any),
     Layer.succeed(ReminderServiceTag, {} as any),
     Layer.succeed(PeerLedgerServiceTag, {} as any),
     Layer.succeed(PeerTokenServiceTag, {} as any),

--- a/packages/core/src/agent/execution/streaming-executor.test.ts
+++ b/packages/core/src/agent/execution/streaming-executor.test.ts
@@ -7,6 +7,7 @@ import { ToolExecutor } from "./tool-executor";
 import { DEFAULT_MAX_ITERATIONS } from "../../constants/agent";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
+import { JobQueueServiceTag } from "../../interfaces/job-queue-service";
 import type { LLMService } from "../../interfaces/llm";
 import { LLMServiceTag } from "../../interfaces/llm";
 import { LoggerServiceTag } from "../../interfaces/logger";
@@ -202,6 +203,7 @@ describe("executeWithStreaming", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -376,6 +378,7 @@ describe("executeWithStreaming", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -510,6 +513,7 @@ describe("executeWithStreaming", () => {
       Layer.succeed(MemoryServiceTag, {} as any),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, {} as any),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),

--- a/packages/core/src/agent/execution/streaming-executor.ts
+++ b/packages/core/src/agent/execution/streaming-executor.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Option, Ref, Stream } from "effect";
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Option, Queue, Ref, Stream } from "effect";
 import {
   makeUserVisibleLlmRetrySchedule,
   withLongRunningLlmNotice,
@@ -90,6 +90,18 @@ export function executeWithStreaming(
       Effect.runSync(Deferred.succeed(interruptDeferred, void 0));
     };
     yield* renderer.setInterruptHandler(onInterrupt);
+
+    // Ctrl+B ("background") signal: unlike interruptDeferred, a Deferred can only ever
+    // resolve once, but this run may go through many tool batches and each one needs its
+    // own chance to be backgrounded — so this is a queue of "detach whatever's running
+    // right now" requests, one per keypress, rather than a one-shot signal. Stale entries
+    // from a batch that already finished by the time the next one starts are drained away
+    // before each race so a leftover press never backgrounds the wrong batch.
+    const backgroundQueue = yield* Queue.unbounded<void>();
+    const onBackground = () => {
+      Effect.runSync(Queue.offer(backgroundQueue, void 0));
+    };
+    yield* renderer.setBackgroundHandler?.(onBackground) ?? Effect.void;
 
     // Ref to capture partial completion from stream events — hoisted to avoid per-iteration allocation
     const completionRef = yield* Ref.make<ChatCompletionResponse | undefined>(undefined);
@@ -375,6 +387,16 @@ export function executeWithStreaming(
       getInterruptSignal() {
         return Deferred.await(interruptDeferred);
       },
+
+      getBackgroundSignal() {
+        return Effect.gen(function* () {
+          // Discard any press that arrived while nothing was racing this queue (between
+          // batches, or held over from a batch that resolved on its own first) — only a
+          // press that lands while this specific race is live should count.
+          yield* Queue.takeAll(backgroundQueue);
+          yield* Queue.take(backgroundQueue);
+        });
+      },
     };
 
     const observer = makeDefaultObserver(presentationService);
@@ -388,6 +410,7 @@ export function executeWithStreaming(
     ).pipe(
       Effect.tapError(() => renderer.reset()),
       Effect.ensuring(renderer.setInterruptHandler(null)),
+      Effect.ensuring(renderer.setBackgroundHandler?.(null) ?? Effect.void),
     );
 
     return response;

--- a/packages/core/src/agent/execution/tool-executor.test.ts
+++ b/packages/core/src/agent/execution/tool-executor.test.ts
@@ -6,6 +6,7 @@ import type { AgentConfigService } from "../../interfaces/agent-config";
 import { AgentConfigServiceTag } from "../../interfaces/agent-config";
 import type { FileSystemContextService } from "../../interfaces/fs";
 import { FileSystemContextServiceTag } from "../../interfaces/fs";
+import { JobQueueServiceTag } from "../../interfaces/job-queue-service";
 import type { LLMService } from "../../interfaces/llm";
 import { LLMServiceTag } from "../../interfaces/llm";
 import type { LoggerService } from "../../interfaces/logger";
@@ -151,6 +152,7 @@ describe("ToolExecutor.executeTool", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -191,6 +193,7 @@ describe("ToolExecutor.executeTool", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -239,6 +242,7 @@ describe("ToolExecutor.executeToolCall", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -283,6 +287,7 @@ describe("ToolExecutor.executeToolCall", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -339,6 +344,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -416,6 +422,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -518,6 +525,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -661,6 +669,7 @@ describe("ToolExecutor.executeToolCall approval events", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -767,6 +776,7 @@ describe("ToolExecutor.executeToolCall approval events", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),
@@ -879,6 +889,7 @@ describe("ToolExecutor picker-style approvals", () => {
       Layer.succeed(MemoryServiceTag, emptyMemory),
       Layer.succeed(WorkspaceServiceTag, {} as any),
       Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(JobQueueServiceTag, {} as any),
       Layer.succeed(ReminderServiceTag, emptyReminders),
       Layer.succeed(PeerLedgerServiceTag, {} as any),
       Layer.succeed(PeerTokenServiceTag, {} as any),

--- a/packages/core/src/agent/execution/tool-executor.test.ts
+++ b/packages/core/src/agent/execution/tool-executor.test.ts
@@ -477,6 +477,128 @@ describe("ToolExecutor.executeToolCalls", () => {
       ),
     ).toBe(true);
   });
+
+  it("detaches an in-flight tool call when the background signal fires, instead of killing it", async () => {
+    const mockToolRegistry = {
+      getTool: () =>
+        Effect.succeed({
+          name: "background_tool",
+          timeoutMs: 60_000,
+          longRunning: false,
+          approvalExecuteToolName: undefined,
+        }),
+      executeTool: () =>
+        Effect.sleep("80 millis").pipe(
+          Effect.as({ success: true, result: { data: "real result" } }),
+        ),
+    } as unknown as ToolRegistry;
+
+    const emittedEvents: StreamEvent[] = [];
+    const recordingRenderer: StreamingRenderer = {
+      handleEvent: (event) =>
+        Effect.sync(() => {
+          emittedEvents.push(event);
+        }),
+      setInterruptHandler: () => Effect.void,
+      reset: () => Effect.void,
+      flush: () => Effect.void,
+    };
+
+    const testLayer = Layer.mergeAll(
+      Layer.succeed(LoggerServiceTag, mockLogger),
+      Layer.succeed(PresentationServiceTag, mockPresentationService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+      Layer.succeed(FileSystem.FileSystem, emptyFs),
+      Layer.succeed(TerminalServiceTag, emptyTerminal),
+      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
+      Layer.succeed(SkillServiceTag, mockSkillService),
+      Layer.succeed(LLMServiceTag, emptyLlm),
+      Layer.succeed(MCPServerManagerTag, emptyMcp),
+      Layer.succeed(MemoryServiceTag, emptyMemory),
+      Layer.succeed(WorkspaceServiceTag, {} as any),
+      Layer.succeed(WakeTriggerServiceTag, {} as any),
+      Layer.succeed(ReminderServiceTag, emptyReminders),
+      Layer.succeed(PeerLedgerServiceTag, {} as any),
+      Layer.succeed(PeerTokenServiceTag, {} as any),
+    );
+
+    const toolCalls: ToolCall[] = [
+      {
+        id: "call_bg",
+        type: "function",
+        function: { name: "background_tool", arguments: "{}" },
+      },
+    ];
+
+    const program = Effect.gen(function* () {
+      const backgroundDeferred = yield* Deferred.make<void>();
+      const completions: string[] = [];
+
+      const fiber = yield* Effect.fork(
+        ToolExecutor.executeToolCalls(
+          toolCalls,
+          { agentId: "agent-1", conversationId: "sess-1" },
+          { showReasoning: false, showToolExecution: true, mode: "hybrid" as const },
+          recordingRenderer,
+          makeRunMetrics(),
+          "agent-1",
+          "conv-123",
+          "test-agent",
+          undefined,
+          Deferred.await(backgroundDeferred),
+          (summary: string) => {
+            completions.push(summary);
+          },
+        ),
+      );
+
+      // Fire the background signal while `background_tool` is still mid-sleep.
+      yield* Effect.sleep("10 millis");
+      yield* Deferred.succeed(backgroundDeferred, undefined);
+
+      const immediateResults = yield* Fiber.join(fiber);
+
+      // Give the detached fiber time to actually finish and report back.
+      yield* Effect.sleep("150 millis");
+
+      return { immediateResults, completions };
+    });
+
+    const { immediateResults, completions } = await Effect.runPromise(
+      program.pipe(Effect.provide(testLayer)) as Effect.Effect<
+        {
+          immediateResults: readonly {
+            toolCallId: string;
+            result: unknown;
+            success: boolean;
+            name: string;
+          }[];
+          completions: readonly string[];
+        },
+        unknown,
+        never
+      >,
+    );
+
+    // The turn continues immediately with a placeholder, not the real (not-yet-ready) result.
+    expect(immediateResults).toHaveLength(1);
+    expect(immediateResults[0]?.success).toBe(true);
+    expect(immediateResults[0]?.result).toMatchObject({ backgrounded: true });
+
+    // The tool itself was never interrupted — the detached fiber ran to completion and
+    // reported its real result back through onDetachedToolComplete.
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toContain("real result");
+    expect(
+      emittedEvents.some(
+        (event) =>
+          event.type === "tool_execution_complete" &&
+          event.toolCallId === "call_bg" &&
+          event.success === true,
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("ToolExecutor.executeToolCall approval events", () => {

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -3,7 +3,7 @@
  * classification, approval gating, concurrency limits, timeouts, and interruption.
  */
 
-import { Effect, Either, Exit, Fiber, Option } from "effect";
+import { Cause, Effect, Either, Exit, Fiber, Option } from "effect";
 import { RunParkRequested } from "@/core/agent/run/park-signal";
 import { classifyCommandRisk, shouldClassifyExecuteCommand } from "@/core/agent/tools/command-risk";
 import { MAX_CONCURRENT_TOOLS, TOOL_TIMEOUT_MS } from "@/core/constants/agent";
@@ -617,6 +617,8 @@ export class ToolExecutor {
     conversationId: string,
     agentName: string,
     interruptSignal?: Effect.Effect<void, never>,
+    backgroundSignal?: Effect.Effect<void, never>,
+    onDetachedToolComplete?: (summary: string) => void,
   ): Effect.Effect<
     Array<{ toolCallId: string; result: unknown; name: string; success: boolean }>,
     Error,
@@ -702,10 +704,16 @@ export class ToolExecutor {
       // resuming replays the batch — which would repeat that sibling's effects.
       const parkable = context.parkWhenUnattended === true && toolCalls.length === 1;
 
-      // Limit concurrency to prevent resource exhaustion when many tools are requested
+      // Limit concurrency to prevent resource exhaustion when many tools are requested.
+      // Forked as daemon fibers (not structured children of this generator) so a
+      // detached-into-the-background call survives past this function returning — a
+      // plain `Effect.fork` child gets auto-interrupted the moment its parent scope
+      // closes, which is exactly what "detach" must not do. `Fiber.interrupt`,
+      // `Fiber.join`, and `Fiber.poll` all work the same on a daemon fiber, so this
+      // changes nothing about the existing interrupt/normal-completion paths.
       const toolFibers = yield* Effect.all(
         toolCalls.map((toolCall) =>
-          Effect.fork(
+          Effect.forkDaemon(
             ToolExecutor.executeToolCall(
               toolCall,
               context,
@@ -727,16 +735,31 @@ export class ToolExecutor {
         { concurrency: "unbounded" },
       );
 
-      if (!interruptSignal) {
+      // Both signals are optional and mutually exclusive per race: whichever fires first
+      // (if either does) decides how this batch resolves. Racing them against each other
+      // first, rather than nesting two `Effect.race` calls against `awaitResults`, keeps
+      // the outcome type to one flat union instead of an awkward `let`-reassigned one.
+      const interruptOrBackground = interruptSignal?.pipe(
+        Effect.as({ type: "interrupt" as const }),
+      );
+      const backgroundOrInterrupt = backgroundSignal?.pipe(
+        Effect.as({ type: "background" as const }),
+      );
+      const signalEffect =
+        interruptOrBackground && backgroundOrInterrupt
+          ? Effect.race(interruptOrBackground, backgroundOrInterrupt)
+          : (interruptOrBackground ?? backgroundOrInterrupt);
+
+      if (!signalEffect) {
         return yield* awaitResults;
       }
 
-      const resultsOrInterrupt = yield* Effect.race(
+      const resultsOrSignal = yield* Effect.race(
         awaitResults.pipe(Effect.map((results) => ({ type: "results" as const, results }))),
-        interruptSignal.pipe(Effect.as({ type: "interrupt" as const })),
+        signalEffect,
       );
 
-      if (resultsOrInterrupt.type === "interrupt") {
+      if (resultsOrSignal.type === "interrupt") {
         // Settle the UI before waiting on fiber interrupt: execute_command used
         // to wrap spawn in Effect.promise, which is uninterruptible, so this
         // wait could block until the child exited — leaving the 30s "still
@@ -770,9 +793,103 @@ export class ToolExecutor {
         );
       }
 
-      return resultsOrInterrupt.results;
+      if (resultsOrSignal.type === "background") {
+        return yield* detachInFlightToolCalls(
+          toolFibers,
+          toolCalls,
+          renderer,
+          displayConfig,
+          onDetachedToolComplete,
+        );
+      }
+
+      return resultsOrSignal.results;
     });
   }
+}
+
+type ToolCallOutcome = { toolCallId: string; result: unknown; success: boolean; name: string };
+
+/**
+ * Detach every tool call still in flight so it keeps running to completion as a daemon
+ * fiber (outliving this tool phase, and this turn) instead of being interrupted, and
+ * return a "running in the background" placeholder for each right away so the loop can
+ * continue. A call that already finished naturally in the small window before this fired
+ * is reported with its real result instead of a placeholder.
+ *
+ * `onDetachedToolComplete` fires later, once, per detached call, with a plain-text
+ * summary — there is no live turn to splice a proper tool-result message into by then,
+ * so the caller's job is just to get that summary in front of the model somehow (the CLI
+ * wiring queues it the same way a message typed mid-run is queued).
+ */
+function detachInFlightToolCalls(
+  toolFibers: ReadonlyArray<Fiber.RuntimeFiber<ToolCallOutcome, Error>>,
+  toolCalls: readonly ToolCall[],
+  renderer: StreamingRenderer | null,
+  displayConfig: DisplayConfig,
+  onDetachedToolComplete: ((summary: string) => void) | undefined,
+): Effect.Effect<ToolCallOutcome[], never> {
+  return Effect.gen(function* () {
+    const outcomes: ToolCallOutcome[] = [];
+
+    for (let index = 0; index < toolFibers.length; index++) {
+      const fiber = toolFibers[index];
+      const toolCall = toolCalls[index];
+      if (fiber === undefined || toolCall === undefined) continue;
+      const name = toolCall.type === "function" ? toolCall.function.name : "unknown";
+
+      const poll = yield* Fiber.poll(fiber);
+      if (Option.isSome(poll) && Exit.isSuccess(poll.value)) {
+        // Already finished naturally in the gap between the signal firing and this
+        // running — its real result, not a placeholder.
+        outcomes.push(poll.value.value);
+        continue;
+      }
+
+      outcomes.push({
+        toolCallId: toolCall.id,
+        result: {
+          backgrounded: true,
+          message: "Running in the background — you'll be told when it finishes.",
+        },
+        success: true,
+        name,
+      });
+
+      if (renderer && displayConfig.showToolExecution) {
+        yield* renderer.handleEvent({
+          type: "tool_execution_complete",
+          toolCallId: toolCall.id,
+          result: "Running in the background",
+          durationMs: 0,
+          success: true,
+          summary: "→ backgrounded",
+        });
+      }
+
+      yield* Effect.forkDaemon(
+        Fiber.await(fiber).pipe(
+          Effect.flatMap((exit) =>
+            Effect.sync(() => {
+              const summary = Exit.isSuccess(exit)
+                ? summarizeDetachedOutcome(exit.value)
+                : `Background task \`${name}\` failed to finish: ${Cause.pretty(exit.cause)}`;
+              onDetachedToolComplete?.(summary);
+            }),
+          ),
+        ),
+      );
+    }
+
+    return outcomes;
+  });
+}
+
+/** Plain-text summary of a detached tool call's real outcome, for `onDetachedToolComplete`. */
+function summarizeDetachedOutcome(outcome: ToolCallOutcome): string {
+  const body = typeof outcome.result === "string" ? outcome.result : JSON.stringify(outcome.result);
+  const truncated = body.length > 800 ? `${body.slice(0, 800)}…` : body;
+  return `Background task \`${outcome.name}\` ${outcome.success ? "finished" : "failed"}: ${truncated}`;
 }
 
 /**

--- a/packages/core/src/agent/tools/job-queue-tools.ts
+++ b/packages/core/src/agent/tools/job-queue-tools.ts
@@ -1,0 +1,297 @@
+import { FileSystem } from "@effect/platform";
+import { Effect } from "effect";
+import { z } from "zod";
+import {
+  JOB_COMMAND_MAX_LENGTH,
+  JOB_REASON_MAX_LENGTH,
+  MAX_CONCURRENCY_CAP,
+  MAX_JOBS_PER_BATCH,
+  MAX_MAX_ATTEMPTS,
+} from "@/core/constants/job-queue";
+import { FileSystemContextServiceTag, type FileSystemContextService } from "@/core/interfaces/fs";
+import type { JobBatchRecord, JobQueueService } from "@/core/interfaces/job-queue-service";
+import { JobQueueServiceTag } from "@/core/interfaces/job-queue-service";
+import type { Tool } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionResult } from "@/core/types/tools";
+import { defineApprovalTool, defineTool, makeZodValidator } from "./base-tool";
+import { buildKeyFromContext } from "./context-utils";
+import { denylistBlockedError } from "./shell-tools";
+
+type JobQueueToolDeps = JobQueueService | FileSystemContextService | FileSystem.FileSystem;
+
+function summarizeJobStatuses(batch: JobBatchRecord): {
+  succeeded: number;
+  failed: number;
+  pending: number;
+  running: number;
+  cancelled: number;
+} {
+  const counts = { succeeded: 0, failed: 0, pending: 0, running: 0, cancelled: 0 };
+  for (const job of batch.jobs) counts[job.status]++;
+  return counts;
+}
+
+function formatBatchSummary(batch: JobBatchRecord) {
+  const counts = summarizeJobStatuses(batch);
+  return {
+    batchId: batch.id,
+    reason: batch.reason,
+    concurrencyCap: batch.concurrencyCap,
+    createdAt: new Date(batch.createdAt).toISOString(),
+    completedAt: batch.completedAt !== null ? new Date(batch.completedAt).toISOString() : null,
+    jobCount: batch.jobs.length,
+    counts,
+    jobs: batch.jobs.map((job) => ({
+      id: job.id,
+      command: job.command,
+      status: job.status,
+      attempt: job.attempt,
+      maxAttempts: job.maxAttempts,
+      exitCode: job.result?.exitCode ?? null,
+      lastError: job.lastError,
+    })),
+  };
+}
+
+const enqueueBatchParameters = z
+  .object({
+    jobs: z
+      .array(
+        z.object({
+          command: z
+            .string()
+            .min(1)
+            .max(JOB_COMMAND_MAX_LENGTH)
+            .describe("The shell command to run."),
+        }),
+      )
+      .min(1)
+      .max(MAX_JOBS_PER_BATCH)
+      .describe("Independent shell commands to run — each becomes its own retried job."),
+    concurrencyCap: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_CONCURRENCY_CAP)
+      .optional()
+      .describe(
+        `How many jobs run at once, across the whole batch (default 3, max ${MAX_CONCURRENCY_CAP}).`,
+      ),
+    maxAttempts: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_MAX_ATTEMPTS)
+      .optional()
+      .describe(
+        `Attempts per job before giving up, with exponential backoff between retries (default 1, max ${MAX_MAX_ATTEMPTS}).`,
+      ),
+    reason: z
+      .string()
+      .min(1)
+      .max(JOB_REASON_MAX_LENGTH)
+      .describe(
+        "Brief note on what this batch is for, shown via list_jobs to a human — not sent back to you.",
+      ),
+  })
+  .strict();
+
+type EnqueueBatchArgs = z.infer<typeof enqueueBatchParameters>;
+
+export function createJobQueueTools(): {
+  readonly enqueueBatch: ReturnType<typeof defineApprovalTool<JobQueueToolDeps, EnqueueBatchArgs>>;
+  readonly listJobs: Tool<JobQueueToolDeps>;
+  readonly cancelBatch: Tool<JobQueueToolDeps>;
+} {
+  const enqueueBatch = defineApprovalTool<JobQueueToolDeps, EnqueueBatchArgs>({
+    name: "enqueue_batch",
+    disclosure: "private",
+    description:
+      "Run several independent shell commands in the background, with a concurrency cap and " +
+      "per-job retry/backoff, without blocking your turn. Returns immediately with a batchId — " +
+      "you will be woken up with a summary once every job in the batch reaches a final state " +
+      "(succeeded or exhausted its retries). Do not poll in a loop; call list_jobs only if the " +
+      "user explicitly asks for a progress check. Use this instead of chaining execute_command " +
+      "calls with sleeps when the work is independent (e.g. running the same check across " +
+      "several repos, retrying a flaky command) — not for commands that depend on each other's " +
+      "output.",
+    parameters: enqueueBatchParameters,
+    riskLevel: "unknown",
+    validate: makeZodValidator(enqueueBatchParameters),
+    approvalMessage: (args) => {
+      for (const job of args.jobs) {
+        const blocked = denylistBlockedError(job.command);
+        if (blocked) {
+          return Effect.succeed({
+            skipApproval: true as const,
+            toolResult: { success: false, result: null, error: blocked } as const,
+          });
+        }
+      }
+
+      const commandList = args.jobs.map((job, index) => `${index + 1}. ${job.command}`).join("\n");
+      return Effect.succeed(`Background job batch: ${args.reason}
+
+${commandList}
+
+Concurrency cap: ${args.concurrencyCap ?? 3}
+Max attempts per job: ${args.maxAttempts ?? 1}
+
+These commands will run unattended, without further approval, until every job finishes. Only approve commands you trust.`);
+    },
+    approvalErrorMessage:
+      "Running a background job batch requires explicit user approval for security reasons.",
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        if (context.conversationId === undefined) {
+          return {
+            success: false,
+            result: null,
+            error: "No conversation to resume — enqueue_batch is unavailable in this context.",
+          } satisfies ToolExecutionResult;
+        }
+
+        const jobQueueService = yield* JobQueueServiceTag;
+        const shell = yield* FileSystemContextServiceTag;
+        const workingDir = yield* shell.getCwd(buildKeyFromContext(context));
+
+        const outcome = yield* jobQueueService.enqueueBatch(
+          context.agentId,
+          context.conversationId,
+          args.jobs,
+          {
+            workingDir,
+            reason: args.reason,
+            ...(args.concurrencyCap !== undefined ? { concurrencyCap: args.concurrencyCap } : {}),
+            ...(args.maxAttempts !== undefined ? { maxAttempts: args.maxAttempts } : {}),
+          },
+        );
+
+        if (!outcome.success) {
+          return {
+            success: false,
+            result: null,
+            error: outcome.message,
+          } satisfies ToolExecutionResult;
+        }
+
+        return {
+          success: true,
+          result: { batchId: outcome.batch.id, jobCount: outcome.batch.jobs.length },
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { batchId: string; jobCount: number };
+      return `Enqueued batch ${data.batchId} (${data.jobCount} jobs)`;
+    },
+  });
+
+  const listJobsParameters = z
+    .object({
+      batchId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("A specific batch id, from enqueue_batch. Omit to list all active batches."),
+    })
+    .strict();
+
+  const listJobs = defineTool<JobQueueToolDeps, z.infer<typeof listJobsParameters>>({
+    name: "list_jobs",
+    disclosure: "internal",
+    description:
+      "List this agent's background job batches (active, or a specific one by id) and every job's status.",
+    parameters: listJobsParameters,
+    riskLevel: "read-only",
+    validate: makeZodValidator(listJobsParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const jobQueueService = yield* JobQueueServiceTag;
+
+        if (args.batchId !== undefined) {
+          const batch = yield* jobQueueService.getBatch(context.agentId, args.batchId);
+          if (batch === null) {
+            return {
+              success: false,
+              result: null,
+              error: `No job batch found with id "${args.batchId}".`,
+            } satisfies ToolExecutionResult;
+          }
+          return {
+            success: true,
+            result: { batches: [formatBatchSummary(batch)] },
+          } satisfies ToolExecutionResult;
+        }
+
+        const batches = yield* jobQueueService.listActiveBatches(context.agentId);
+        return {
+          success: true,
+          result: { batches: batches.map(formatBatchSummary) },
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { batches: readonly unknown[] };
+      return `Listed job batches (${data.batches.length})`;
+    },
+  });
+
+  const cancelBatchParameters = z
+    .object({
+      batchId: z.string().min(1).describe("The id of the job batch to cancel, from list_jobs."),
+    })
+    .strict();
+
+  const cancelBatch = defineTool<JobQueueToolDeps, z.infer<typeof cancelBatchParameters>>({
+    name: "cancel_batch",
+    disclosure: "internal",
+    description:
+      "Cancel a job batch's pending jobs by id (get the id from list_jobs first). Jobs already " +
+      "running finish naturally — this only stops jobs that haven't started yet.",
+    parameters: cancelBatchParameters,
+    riskLevel: "low-risk",
+    validate: makeZodValidator(cancelBatchParameters),
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const jobQueueService = yield* JobQueueServiceTag;
+        const outcome = yield* jobQueueService.cancelBatch(context.agentId, args.batchId);
+        return {
+          success: outcome.success,
+          result: outcome.success ? { message: outcome.message } : null,
+          ...(outcome.success ? {} : { error: outcome.message }),
+        } satisfies ToolExecutionResult;
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            success: false,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          } satisfies ToolExecutionResult),
+        ),
+      ),
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const data = result.result as { message: string };
+      return data.message;
+    },
+  });
+
+  return { enqueueBatch, listJobs, cancelBatch };
+}

--- a/packages/core/src/agent/tools/register-tools.ts
+++ b/packages/core/src/agent/tools/register-tools.ts
@@ -11,6 +11,7 @@ import { ToolRegistryTag } from "@/core/interfaces/tool-registry";
 import { createContextInfoTool, createGetTimeTool } from "./context-tools";
 import { fs } from "./fs";
 import { createHttpRequestTool } from "./http-tools";
+import { createJobQueueTools } from "./job-queue-tools";
 import { createManageMemoryTool, createViewMemoryTool } from "./memory-tools";
 import { createPdfTool } from "./pdf-tools";
 import { createAskPeerTool } from "./peer-tools";
@@ -28,6 +29,7 @@ import {
   CONTEXT_CATEGORY,
   FILE_MANAGEMENT_CATEGORY,
   HTTP_CATEGORY,
+  JOB_QUEUE_CATEGORY,
   MEMORY_CATEGORY,
   PEERS_CATEGORY,
   PERCEPTION_CATEGORY,
@@ -73,6 +75,7 @@ export function registerAllTools(): Effect.Effect<void, Error, ToolRegistry> {
     yield* registerWorkspaceTools();
     yield* registerReminderTools();
     yield* registerWakeTriggerTools();
+    yield* registerJobQueueTools();
     yield* registerContextTools();
     yield* registerSubagentTools();
     yield* registerPerceptionTools();
@@ -252,6 +255,19 @@ export function registerWakeTriggerTools(): Effect.Effect<void, Error, ToolRegis
     yield* registerTool(createRegisterTriggerTool());
     yield* registerTool(createListTriggersTool());
     yield* registerTool(createCancelTriggerTool());
+  });
+}
+
+export function registerJobQueueTools(): Effect.Effect<void, Error, ToolRegistry> {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const registerTool = registry.registerForCategory(JOB_QUEUE_CATEGORY);
+
+    const { enqueueBatch, listJobs, cancelBatch } = createJobQueueTools();
+    yield* registerTool(enqueueBatch.approval);
+    yield* registerTool(enqueueBatch.execute);
+    yield* registerTool(listJobs);
+    yield* registerTool(cancelBatch);
   });
 }
 

--- a/packages/core/src/agent/tools/tool-categories.ts
+++ b/packages/core/src/agent/tools/tool-categories.ts
@@ -28,6 +28,10 @@ export const WAKE_TRIGGER_CATEGORY: ToolCategory = {
   id: "wake_triggers",
   displayName: "Wake Triggers",
 };
+export const JOB_QUEUE_CATEGORY: ToolCategory = {
+  id: "job_queue",
+  displayName: "Background Jobs",
+};
 export const USER_INTERACTION_CATEGORY: ToolCategory = {
   id: "user_interaction",
   displayName: "User Interaction",
@@ -49,6 +53,7 @@ export const ALL_CATEGORIES: readonly ToolCategory[] = [
   WORKSPACE_CATEGORY,
   REMINDER_CATEGORY,
   WAKE_TRIGGER_CATEGORY,
+  JOB_QUEUE_CATEGORY,
   CONTEXT_CATEGORY,
   SUBAGENT_CATEGORY,
   PERCEPTION_CATEGORY,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -163,6 +163,15 @@ export interface AgentRunnerOptions {
    */
   readonly checkQueuedMessage?: () => string | undefined;
   /**
+   * Callback invoked when a tool call the user detached with Ctrl+B (see
+   * `getBackgroundSignal` on `CompletionStrategy`) finishes running. Receives a
+   * human-readable summary of the outcome. The default CLI wiring appends it to the
+   * same queue `checkQueuedMessage` drains, so it surfaces at the next tool-phase
+   * boundary if this run is still going, or at the start of the next turn otherwise —
+   * whichever comes first. Not called for internal (sub-agent) runs.
+   */
+  readonly onDetachedToolComplete?: (summary: string) => void;
+  /**
    * IANA timezone (e.g. "Europe/Paris") for this run, copied into the tool
    * execution context so tools like add_reminder can resolve "now" in the
    * caller's local time without asking the model to supply a timezone string.

--- a/packages/core/src/constants/job-queue.ts
+++ b/packages/core/src/constants/job-queue.ts
@@ -1,0 +1,37 @@
+/**
+ * Ceilings mirror wake-triggers.ts's reasoning: a model that talks itself into enqueueing
+ * without bound should hit a wall long before it burns meaningful spend or overwhelms the
+ * daemon's worker pool.
+ */
+export const MAX_JOBS_PER_BATCH = 20;
+
+/** Maximum number of batches with at least one non-terminal job, per agent. */
+export const MAX_ACTIVE_BATCHES_PER_AGENT = 5;
+
+/** Maximum length, in characters, of a single job's shell command. */
+export const JOB_COMMAND_MAX_LENGTH = 4000;
+
+/** Maximum length, in characters, of a batch's reason (shown via list_jobs, not sent to the model). */
+export const JOB_REASON_MAX_LENGTH = 300;
+
+export const DEFAULT_CONCURRENCY_CAP = 3;
+export const MAX_CONCURRENCY_CAP = 10;
+
+export const DEFAULT_MAX_ATTEMPTS = 1;
+export const MAX_MAX_ATTEMPTS = 5;
+
+export const DEFAULT_BACKOFF_INITIAL_MS = 2_000;
+export const DEFAULT_BACKOFF_MAX_MS = 5 * 60 * 1000;
+
+/** Default per-job shell execution timeout. */
+export const DEFAULT_JOB_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * A job claimed by a worker that never reaches a terminal state within this window (worker
+ * crashed, process killed) becomes claimable again. Must exceed DEFAULT_JOB_TIMEOUT_MS so a
+ * merely slow job is never reclaimed out from under its own worker.
+ */
+export const JOB_LEASE_TIMEOUT_MS = DEFAULT_JOB_TIMEOUT_MS + 2 * 60 * 1000;
+
+/** How many jobs one daemon tick claims per agent, across that agent's active batches. */
+export const WORKER_POOL_SIZE = 4;

--- a/packages/core/src/interfaces/job-queue-service.ts
+++ b/packages/core/src/interfaces/job-queue-service.ts
@@ -1,0 +1,97 @@
+import { FileSystem } from "@effect/platform";
+import { Context, Effect } from "effect";
+
+export type JobStatus = "pending" | "running" | "succeeded" | "failed" | "cancelled";
+
+export interface JobRecord {
+  readonly id: string;
+  readonly command: string;
+  readonly status: JobStatus;
+  /** 1-based; incremented each time a failed job is retried. */
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  /** Epoch ms; a job is claimable once this has passed. */
+  readonly nextAttemptAt: number;
+  /** Opaque id of the worker currently holding this job's claim, or null when unclaimed. */
+  readonly leaseOwner: string | null;
+  /** Epoch ms after which an unfinished claim is considered abandoned and reclaimable. */
+  readonly leaseExpiresAt: number | null;
+  readonly result: {
+    readonly stdout: string;
+    readonly stderr: string;
+    readonly exitCode: number;
+  } | null;
+  readonly lastError: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+export interface JobBackoffPolicy {
+  readonly initialMs: number;
+  readonly maxMs: number;
+}
+
+export interface JobBatchRecord {
+  readonly id: string;
+  readonly agentId: string;
+  readonly conversationId: string;
+  /** Working directory every job in the batch runs in — the agent's cwd at enqueue time. */
+  readonly workingDir: string;
+  readonly concurrencyCap: number;
+  readonly backoff: JobBackoffPolicy;
+  /** Why the agent enqueued this batch, shown via list_jobs — not sent to the model. */
+  readonly reason: string;
+  readonly createdAt: number;
+  /** Epoch ms once every job is terminal (succeeded, failed, or cancelled); null while active. */
+  readonly completedAt: number | null;
+  readonly jobs: readonly JobRecord[];
+}
+
+export interface EnqueueBatchJobInput {
+  readonly command: string;
+}
+
+export interface EnqueueBatchOptions {
+  readonly workingDir: string;
+  readonly concurrencyCap?: number;
+  readonly maxAttempts?: number;
+  readonly reason: string;
+}
+
+export type EnqueueBatchOutcome =
+  | { readonly success: true; readonly batch: JobBatchRecord }
+  | { readonly success: false; readonly message: string };
+
+export type CancelBatchOutcome = { readonly success: boolean; readonly message: string };
+
+/**
+ * Fan-out/fan-in background job batches: the agent enqueues N independent shell commands with a
+ * concurrency cap and per-job retry/backoff, the daemon's worker executes them unattended, and
+ * fan-in (every job reaching a terminal state) fires a wake-style resume of the owning
+ * conversation — the same "come back later" mechanism {@link WakeTriggerService} uses, just
+ * triggered by job completion instead of a clock. See docs/superpowers/plans/job-queue-design.md.
+ */
+export interface JobQueueService {
+  readonly enqueueBatch: (
+    agentId: string,
+    conversationId: string,
+    jobs: readonly EnqueueBatchJobInput[],
+    options: EnqueueBatchOptions,
+  ) => Effect.Effect<EnqueueBatchOutcome, Error, FileSystem.FileSystem>;
+
+  readonly getBatch: (
+    agentId: string,
+    batchId: string,
+  ) => Effect.Effect<JobBatchRecord | null, Error, FileSystem.FileSystem>;
+
+  readonly listActiveBatches: (
+    agentId: string,
+  ) => Effect.Effect<readonly JobBatchRecord[], Error, FileSystem.FileSystem>;
+
+  readonly cancelBatch: (
+    agentId: string,
+    batchId: string,
+  ) => Effect.Effect<CancelBatchOutcome, Error, FileSystem.FileSystem>;
+}
+
+export const JobQueueServiceTag = Context.GenericTag<JobQueueService>("JobQueueService");

--- a/packages/core/src/interfaces/presentation.ts
+++ b/packages/core/src/interfaces/presentation.ts
@@ -356,6 +356,14 @@ export interface StreamingRenderer {
   readonly setInterruptHandler: (handler: (() => void) | null) => Effect.Effect<void, never>;
 
   /**
+   * Register or clear a "detach the in-flight tool call into the background" handler
+   * (Ctrl+B) for the active stream. Optional — only a UI that can offer that chord
+   * (the Ink renderer) implements it; other presentation modes simply have no way to
+   * trigger it, which is the correct behavior for them, not a missing feature.
+   */
+  readonly setBackgroundHandler?: (handler: (() => void) | null) => Effect.Effect<void, never>;
+
+  /**
    * Reset renderer state (call between conversations)
    */
   readonly reset: () => Effect.Effect<void, never>;

--- a/packages/core/src/interfaces/reminder-service.ts
+++ b/packages/core/src/interfaces/reminder-service.ts
@@ -7,6 +7,13 @@ export interface ReminderRecord {
   readonly fireAt: number;
   readonly text: string;
   readonly createdAt: number;
+  /**
+   * The host scheduler's own job id for this reminder, when one was created (`at` on Linux).
+   * Needed to `atrm` the job on cancel; not needed for launchd, whose plist path is derivable
+   * from agentId+id alone. Left undefined for tg_/dc_-prefixed agents, which never get an OS
+   * job — see `reminder-service.ts`.
+   */
+  readonly osSchedulerJobId?: string;
 }
 
 export type AddReminderOutcome =

--- a/packages/core/src/interfaces/tool-registry.ts
+++ b/packages/core/src/interfaces/tool-registry.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types";
 import type { AgentConfigService } from "./agent-config";
 import type { FileSystemContextService } from "./fs";
+import type { JobQueueService } from "./job-queue-service";
 import type { LLMService } from "./llm";
 import type { LoggerService } from "./logger";
 import type { MCPServerManager } from "./mcp-server";
@@ -87,6 +88,7 @@ export type ToolRequirements =
   | WorkspaceService
   | ReminderService
   | WakeTriggerService
+  | JobQueueService
   | PeerLedgerService
   | PeerTokenService;
 

--- a/packages/core/src/interfaces/wake-trigger-service.ts
+++ b/packages/core/src/interfaces/wake-trigger-service.ts
@@ -12,6 +12,12 @@ export interface WakeTriggerRecord {
   /** Why the agent registered this, for a human reading `list_triggers` — not sent to the model. */
   readonly reason: string;
   readonly createdAt: number;
+  /**
+   * The host scheduler's own job id for this trigger, when one was created (`at` on Linux).
+   * Needed to `atrm` the job on cancel; not needed for launchd, whose plist path is derivable
+   * from agentId+id alone.
+   */
+  readonly osSchedulerJobId?: string;
 }
 
 export type AddWakeTriggerOutcome =

--- a/packages/core/src/utils/desktop-notify.ts
+++ b/packages/core/src/utils/desktop-notify.ts
@@ -1,0 +1,60 @@
+/**
+ * Best-effort native OS desktop notification, used to deliver a CLI-hosted agent's reminder
+ * without resuming a conversation. A headless server, an SSH session, or an unsupported OS must
+ * never make this fail its caller — the error channel is intentionally `never`.
+ */
+import { Effect } from "effect";
+import { execCommand } from "./shell";
+
+/**
+ * Escape a string for interpolation into an AppleScript string literal.
+ *
+ * This is distinct from shell escaping: `script` below is still passed as a single argv element
+ * to `execCommand("osascript", ["-e", script])` with `shell: false`, so there is no shell to
+ * inject into. The escaping here only protects AppleScript's own string-literal syntax from the
+ * quotes and backslashes that might appear in a reminder's text.
+ */
+function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function sendMacOsNotification(title: string, body: string): Effect.Effect<boolean, never> {
+  const script = `display notification "${escapeAppleScriptString(body)}" with title "${escapeAppleScriptString(title)}"`;
+  return execCommand("osascript", ["-e", script]).pipe(
+    Effect.map(() => true),
+    Effect.catchAll(() => Effect.succeed(false)),
+  );
+}
+
+function sendLinuxNotification(title: string, body: string): Effect.Effect<boolean, never> {
+  return execCommand("which", ["notify-send"]).pipe(
+    Effect.map(() => true),
+    Effect.catchAll(() => Effect.succeed(false)),
+    Effect.flatMap((hasNotifySend) =>
+      hasNotifySend
+        ? execCommand("notify-send", [title, body]).pipe(
+            Effect.map(() => true),
+            Effect.catchAll(() => Effect.succeed(false)),
+          )
+        : Effect.succeed(false),
+    ),
+  );
+}
+
+/**
+ * Send a native OS desktop notification. Returns `true` on apparent success, `false` when the
+ * platform is unsupported, the platform tool is missing, or anything else goes wrong — a failed
+ * notification is never a failure of the caller (typically a reminder firing).
+ */
+export function sendDesktopNotification(
+  title: string,
+  body: string,
+): Effect.Effect<boolean, never> {
+  if (process.platform === "darwin") {
+    return sendMacOsNotification(title, body);
+  }
+  if (process.platform === "linux") {
+    return sendLinuxNotification(title, body);
+  }
+  return Effect.succeed(false);
+}

--- a/packages/core/src/utils/shell.ts
+++ b/packages/core/src/utils/shell.ts
@@ -215,3 +215,63 @@ export function execCommandWithStdin(
     }
   });
 }
+
+/** Both output streams of a completed command, regardless of exit code. */
+export interface CommandOutput {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * Execute a shell command, writing to its stdin, and return both stdout and stderr
+ * regardless of exit code.
+ *
+ * `execCommandWithStdin` only ever surfaces stderr on failure — but `at` prints the job id
+ * ("job 3 at ...") to stderr on a *successful* run, so callers that need that output on the
+ * success path need this instead.
+ */
+export function execCommandWithStdinCapturingOutput(
+  command: string,
+  args: readonly string[],
+  stdin: string,
+  options?: ExecCommandOptions,
+): Effect.Effect<CommandOutput, Error> {
+  return Effect.async<CommandOutput, Error>((resume) => {
+    const child = spawn(command, args as string[], {
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: false,
+      ...(options?.cwd && { cwd: options.cwd }),
+      ...(options?.env && { env: options.env }),
+      ...(options?.timeout && { timeout: options.timeout }),
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    if (child.stdout) {
+      child.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+    }
+
+    if (child.stderr) {
+      child.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+    }
+
+    child.on("close", (code) => {
+      resume(Effect.succeed({ exitCode: code ?? -1, stdout, stderr }));
+    });
+
+    child.on("error", (err) => {
+      resume(Effect.fail(err));
+    });
+
+    if (child.stdin) {
+      child.stdin.write(stdin);
+      child.stdin.end();
+    }
+  });
+}

--- a/packages/core/src/wake-triggers/one-shot-os-job.ts
+++ b/packages/core/src/wake-triggers/one-shot-os-job.ts
@@ -1,0 +1,304 @@
+/**
+ * Shared mechanics behind installing and removing a one-shot OS job — a launchd plist on macOS,
+ * a one-shot `at` job on Linux — for a single `fireAt` instant. Both `wake-trigger-os-scheduler.ts`
+ * (resume a conversation) and `reminder-os-scheduler.ts` (notify a person) are "install a real OS
+ * job that runs one jazz command at a future timestamp"; they differ only in the label prefix,
+ * log file name, and program args passed to that command, which is why this module is
+ * parameterized rather than duplicated per record type.
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Effect, Option } from "effect";
+import * as plist from "plist";
+import { AgentConfigServiceTag } from "../interfaces/agent-config";
+import type { SchedulerMode } from "../types/config";
+import { escapeShellArg, getLaunchdPath } from "../workflows/scheduler-service";
+import { getGlobalUserDataDirectory } from "./../utils/paths";
+import { getJazzSchedulerInvocation } from "./../utils/runtime";
+import { execCommand, execCommandWithStdinCapturingOutput } from "./../utils/shell";
+
+export interface OneShotOsJobResult {
+  readonly osSchedulerJobId?: string;
+}
+
+export interface OneShotOsScheduler {
+  readonly getType: () => "launchd" | "at" | "in-process" | "unsupported";
+  readonly scheduleFire: (
+    agentId: string,
+    itemId: string,
+    fireAt: number,
+  ) => Effect.Effect<OneShotOsJobResult, Error>;
+  readonly cancelFire: (
+    agentId: string,
+    itemId: string,
+    osSchedulerJobId: string | undefined,
+  ) => Effect.Effect<void, Error>;
+}
+
+export interface OneShotOsSchedulerConfig {
+  /** launchd `Label` prefix, e.g. `com.jazz.trigger` or `com.jazz.reminder`. */
+  readonly labelPrefix: string;
+  /** Prefix for the launchd stdout/stderr log file names. */
+  readonly logNamePrefix: string;
+  /** Builds the jazz CLI args to run when the job fires, given the agent and item id. */
+  readonly buildProgramArgs: (agentId: string, itemId: string) => readonly string[];
+}
+
+const launchAgentsDir = path.join(os.homedir(), "Library", "LaunchAgents");
+
+function jobLabel(config: OneShotOsSchedulerConfig, agentId: string, itemId: string): string {
+  return `${config.labelPrefix}.${agentId}.${itemId}`;
+}
+
+function jobPlistPath(config: OneShotOsSchedulerConfig, agentId: string, itemId: string): string {
+  return path.join(launchAgentsDir, `${jobLabel(config, agentId, itemId)}.plist`);
+}
+
+/**
+ * macOS implementation: one launchd plist per item, loaded with a `StartCalendarInterval`
+ * computed from `fireAt`'s local time components.
+ */
+class LaunchdOneShotScheduler implements OneShotOsScheduler {
+  constructor(private readonly config: OneShotOsSchedulerConfig) {}
+
+  getType(): "launchd" | "at" | "in-process" | "unsupported" {
+    return "launchd";
+  }
+
+  scheduleFire(
+    agentId: string,
+    itemId: string,
+    fireAt: number,
+  ): Effect.Effect<OneShotOsJobResult, Error> {
+    return Effect.gen(
+      function* (this: LaunchdOneShotScheduler) {
+        const jazzInvocation = yield* getJazzSchedulerInvocation();
+        const programArgs = [...jazzInvocation, ...this.config.buildProgramArgs(agentId, itemId)];
+
+        // Wrap in bash -c to print a timestamped header before exec'ing the real command,
+        // the same approach `generateLaunchdPlist` uses for workflows, so logs carry a
+        // timestamp even if the jazz process crashes before writing anything itself.
+        const commandString = programArgs.map(escapeShellArg).join(" ");
+        const header = `[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] launchd firing ${this.config.logNamePrefix}: ${itemId}`;
+        const wrappedArgs = [
+          "/bin/bash",
+          "-c",
+          `echo "${header}"; echo "${header}" >&2; exec ${commandString}`,
+        ];
+
+        const fireDate = new Date(fireAt);
+        const logDir = path.join(getGlobalUserDataDirectory(), "logs");
+
+        // StartCalendarInterval has no Year key — a plist left behind would in theory refire
+        // a year later. In practice this never happens: the fired command unloads and deletes
+        // its own plist immediately after running, whether the run succeeded or not.
+        const plistObject = {
+          Label: jobLabel(this.config, agentId, itemId),
+          ProgramArguments: wrappedArgs,
+          StartCalendarInterval: {
+            Minute: fireDate.getMinutes(),
+            Hour: fireDate.getHours(),
+            Day: fireDate.getDate(),
+            Month: fireDate.getMonth() + 1,
+          },
+          StandardOutPath: `${logDir}/${this.config.logNamePrefix}-${itemId}.log`,
+          StandardErrorPath: `${logDir}/${this.config.logNamePrefix}-${itemId}.error.log`,
+          RunAtLoad: false,
+          EnvironmentVariables: {
+            PATH: getLaunchdPath(),
+          },
+        };
+        const plistContent = plist.build(plistObject);
+        const plistFilePath = jobPlistPath(this.config, agentId, itemId);
+
+        yield* Effect.tryPromise({
+          try: () => fs.mkdir(launchAgentsDir, { recursive: true }),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        });
+        yield* Effect.tryPromise({
+          try: () => fs.mkdir(logDir, { recursive: true }),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        });
+
+        // Unload a stale job with the same label first, ignoring errors (there usually isn't
+        // one — item ids are fresh per registration).
+        yield* execCommand("launchctl", ["unload", plistFilePath]).pipe(
+          Effect.catchAll(() => Effect.void),
+        );
+
+        yield* Effect.tryPromise({
+          try: () => fs.writeFile(plistFilePath, plistContent, "utf-8"),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        });
+
+        yield* execCommand("launchctl", ["load", plistFilePath]);
+
+        return {};
+      }.bind(this),
+    );
+  }
+
+  cancelFire(agentId: string, itemId: string): Effect.Effect<void, Error> {
+    return Effect.gen(
+      function* (this: LaunchdOneShotScheduler) {
+        const plistFilePath = jobPlistPath(this.config, agentId, itemId);
+        yield* execCommand("launchctl", ["unload", plistFilePath]).pipe(
+          Effect.catchAll(() => Effect.void),
+        );
+        yield* Effect.tryPromise({
+          try: () => fs.unlink(plistFilePath),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        }).pipe(Effect.catchAll(() => Effect.void));
+      }.bind(this),
+    );
+  }
+}
+
+/** Parse the job id out of `at`'s "job 3 at Thu Aug 29 06:00:00 2026" line. */
+function parseAtJobId(output: string): string | undefined {
+  const match = /job\s+(\d+)/i.exec(output);
+  return match?.[1];
+}
+
+/** Format `fireAt` as `at -t`'s local-time `YYYYMMDDHHmm.ss` timestamp. */
+function formatAtTimestamp(fireAt: number): string {
+  const date = new Date(fireAt);
+  const pad = (value: number, length = 2) => String(value).padStart(length, "0");
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hour = pad(date.getHours());
+  const minute = pad(date.getMinutes());
+  const second = pad(date.getSeconds());
+  return `${year}${month}${day}${hour}${minute}.${second}`;
+}
+
+/**
+ * Linux implementation: one one-shot `at` job per item. `createOneShotOsScheduler` only selects
+ * this when the `at` binary is actually present.
+ */
+class AtOneShotScheduler implements OneShotOsScheduler {
+  constructor(private readonly config: OneShotOsSchedulerConfig) {}
+
+  getType(): "launchd" | "at" | "in-process" | "unsupported" {
+    return "at";
+  }
+
+  scheduleFire(
+    agentId: string,
+    itemId: string,
+    fireAt: number,
+  ): Effect.Effect<OneShotOsJobResult, Error> {
+    return Effect.gen(
+      function* (this: AtOneShotScheduler) {
+        const jazzInvocation = yield* getJazzSchedulerInvocation();
+        const programArgs = [...jazzInvocation, ...this.config.buildProgramArgs(agentId, itemId)];
+        const commandLine = programArgs.map(escapeShellArg).join(" ");
+        const timestamp = formatAtTimestamp(fireAt);
+
+        const result = yield* execCommandWithStdinCapturingOutput(
+          "at",
+          ["-t", timestamp],
+          commandLine,
+        );
+
+        if (result.exitCode !== 0) {
+          return yield* Effect.fail(
+            new Error(`at failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`),
+          );
+        }
+
+        // `at` prints the job id to stderr, not stdout, even on success. When it can't be
+        // parsed, cancelFire below just becomes a no-op — the in-process ticker or the stale
+        // `at` job remain the safety net, so this never blocks registration.
+        const jobId = parseAtJobId(result.stderr) ?? parseAtJobId(result.stdout);
+        return jobId !== undefined ? { osSchedulerJobId: jobId } : {};
+      }.bind(this),
+    );
+  }
+
+  cancelFire(
+    _agentId: string,
+    _itemId: string,
+    osSchedulerJobId: string | undefined,
+  ): Effect.Effect<void, Error> {
+    if (osSchedulerJobId === undefined) {
+      return Effect.void;
+    }
+    return execCommand("atrm", [osSchedulerJobId]).pipe(Effect.catchAll(() => Effect.void));
+  }
+}
+
+/**
+ * No-op scheduler: preserves ticker-only behavior. Used when no host scheduler is available, or
+ * when `JAZZ_SCHEDULER=in-process` opts out of installing OS-level jobs. Also used, unchanged,
+ * for genuinely unsupported platforms — both cases never block scheduling.
+ */
+class NoopOneShotScheduler implements OneShotOsScheduler {
+  constructor(private readonly type: "in-process" | "unsupported") {}
+
+  getType(): "launchd" | "at" | "in-process" | "unsupported" {
+    return this.type;
+  }
+
+  scheduleFire(): Effect.Effect<OneShotOsJobResult, Error> {
+    return Effect.succeed({});
+  }
+
+  cancelFire(): Effect.Effect<void, Error> {
+    return Effect.void;
+  }
+}
+
+/**
+ * Resolve the scheduler mode from `JAZZ_SCHEDULER` and, when the config service is available,
+ * `appConfig.scheduler.mode` — the same precedence `SchedulerServiceLayer` uses for workflow
+ * scheduling.
+ */
+function resolveSchedulerMode(): Effect.Effect<SchedulerMode> {
+  return Effect.gen(function* () {
+    const configServiceOption = yield* Effect.serviceOption(AgentConfigServiceTag);
+    const appConfig = Option.isSome(configServiceOption)
+      ? yield* configServiceOption.value.appConfig
+      : undefined;
+    return process.env["JAZZ_SCHEDULER"] === "in-process" ||
+      appConfig?.scheduler?.mode === "in-process"
+      ? "in-process"
+      : "auto";
+  });
+}
+
+/**
+ * Create the appropriate `OneShotOsScheduler` for the current platform and configuration.
+ *
+ * Never throws and never blocks: an unavailable `at` binary, or any other detection failure,
+ * falls back to the in-process scheduler rather than failing registration of whatever this
+ * backs (a wake trigger or a reminder).
+ */
+export function createOneShotOsScheduler(
+  config: OneShotOsSchedulerConfig,
+): Effect.Effect<OneShotOsScheduler> {
+  return Effect.gen(function* () {
+    const mode = yield* resolveSchedulerMode();
+    if (mode === "in-process") {
+      return new NoopOneShotScheduler("in-process");
+    }
+
+    const platform = process.platform;
+
+    if (platform === "darwin") {
+      return new LaunchdOneShotScheduler(config);
+    }
+
+    if (platform === "linux") {
+      const hasAt = yield* execCommand("which", ["at"]).pipe(
+        Effect.map(() => true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+      return hasAt ? new AtOneShotScheduler(config) : new NoopOneShotScheduler("in-process");
+    }
+
+    return new NoopOneShotScheduler("unsupported");
+  });
+}

--- a/packages/core/src/wake-triggers/reminder-os-scheduler.test.ts
+++ b/packages/core/src/wake-triggers/reminder-os-scheduler.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { Effect } from "effect";
+import { createReminderOsScheduler } from "./reminder-os-scheduler";
+
+const originalSchedulerEnv = process.env["JAZZ_SCHEDULER"];
+
+afterEach(() => {
+  if (originalSchedulerEnv === undefined) {
+    delete process.env["JAZZ_SCHEDULER"];
+  } else {
+    process.env["JAZZ_SCHEDULER"] = originalSchedulerEnv;
+  }
+});
+
+describe("createReminderOsScheduler", () => {
+  test("respects JAZZ_SCHEDULER=in-process regardless of platform", async () => {
+    process.env["JAZZ_SCHEDULER"] = "in-process";
+    const scheduler = await Effect.runPromise(createReminderOsScheduler());
+    expect(scheduler.getType()).toBe("in-process");
+  });
+
+  test("in-process scheduler never fails scheduleFire/cancelFire", async () => {
+    process.env["JAZZ_SCHEDULER"] = "in-process";
+    const scheduler = await Effect.runPromise(createReminderOsScheduler());
+    const result = await Effect.runPromise(
+      scheduler.scheduleFire("agent-1", "reminder-1", Date.now()),
+    );
+    expect(result).toEqual({});
+    await Effect.runPromise(scheduler.cancelFire("agent-1", "reminder-1", undefined));
+  });
+
+  test("selects a scheduler type matching a supported platform when not forced in-process", async () => {
+    delete process.env["JAZZ_SCHEDULER"];
+    const scheduler = await Effect.runPromise(createReminderOsScheduler());
+    expect(["launchd", "at", "in-process", "unsupported"]).toContain(scheduler.getType());
+  });
+});

--- a/packages/core/src/wake-triggers/reminder-os-scheduler.ts
+++ b/packages/core/src/wake-triggers/reminder-os-scheduler.ts
@@ -1,0 +1,60 @@
+/**
+ * `ReminderOsScheduler`: installs one real OS-level job per reminder (launchd on macOS, a
+ * one-shot `at` job on Linux) so a reminder fires even when nothing else is watching for it —
+ * the CLI-hosted-agent equivalent of `WakeTriggerOsScheduler`. Firing means something different
+ * here, though: a reminder is "notify a person," never "resume the agent" (see
+ * `wake-trigger-tools.ts`'s file comment for that distinction), so `jazz reminder fire` sends a
+ * native OS desktop notification instead of re-entering the agent loop.
+ *
+ * This is only ever wired up for reminders whose `agentId` does not start with `tg_`/`dc_` —
+ * see `reminder-service.ts` for why: Telegram and Discord already sweep and deliver their own
+ * reminders in-process, and installing an OS job here too would double-deliver.
+ *
+ * Shares its OS-job mechanics with `wake-trigger-os-scheduler.ts` via `./one-shot-os-job`.
+ */
+import { Context, Effect, Layer } from "effect";
+import { createOneShotOsScheduler } from "./one-shot-os-job";
+
+export interface ReminderScheduleFireResult {
+  readonly osSchedulerJobId?: string;
+}
+
+export interface ReminderOsScheduler {
+  readonly getType: () => "launchd" | "at" | "in-process" | "unsupported";
+  readonly scheduleFire: (
+    agentId: string,
+    reminderId: string,
+    fireAt: number,
+  ) => Effect.Effect<ReminderScheduleFireResult, Error>;
+  readonly cancelFire: (
+    agentId: string,
+    reminderId: string,
+    osSchedulerJobId: string | undefined,
+  ) => Effect.Effect<void, Error>;
+}
+
+export const ReminderOsSchedulerTag =
+  Context.GenericTag<ReminderOsScheduler>("ReminderOsScheduler");
+
+function buildFireArgs(agentId: string, reminderId: string): readonly string[] {
+  return ["--output", "quiet", "reminder", "fire", "--agent", agentId, "--id", reminderId];
+}
+
+/**
+ * Create the appropriate `ReminderOsScheduler` for the current platform and configuration.
+ *
+ * Never throws and never blocks: an unavailable `at` binary, or any other detection failure,
+ * falls back to the in-process scheduler rather than failing reminder registration.
+ */
+export function createReminderOsScheduler(): Effect.Effect<ReminderOsScheduler> {
+  return createOneShotOsScheduler({
+    labelPrefix: "com.jazz.reminder",
+    logNamePrefix: "reminder",
+    buildProgramArgs: buildFireArgs,
+  });
+}
+
+export const ReminderOsSchedulerLayer = Layer.effect(
+  ReminderOsSchedulerTag,
+  createReminderOsScheduler(),
+);

--- a/packages/core/src/wake-triggers/wake-trigger-os-scheduler.test.ts
+++ b/packages/core/src/wake-triggers/wake-trigger-os-scheduler.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { Effect } from "effect";
+import { createWakeTriggerOsScheduler } from "./wake-trigger-os-scheduler";
+
+const originalSchedulerEnv = process.env["JAZZ_SCHEDULER"];
+
+afterEach(() => {
+  if (originalSchedulerEnv === undefined) {
+    delete process.env["JAZZ_SCHEDULER"];
+  } else {
+    process.env["JAZZ_SCHEDULER"] = originalSchedulerEnv;
+  }
+});
+
+describe("createWakeTriggerOsScheduler", () => {
+  test("respects JAZZ_SCHEDULER=in-process regardless of platform", async () => {
+    process.env["JAZZ_SCHEDULER"] = "in-process";
+    const scheduler = await Effect.runPromise(createWakeTriggerOsScheduler());
+    expect(scheduler.getType()).toBe("in-process");
+  });
+
+  test("in-process scheduler never fails scheduleFire/cancelFire", async () => {
+    process.env["JAZZ_SCHEDULER"] = "in-process";
+    const scheduler = await Effect.runPromise(createWakeTriggerOsScheduler());
+    const result = await Effect.runPromise(
+      scheduler.scheduleFire("agent-1", "trigger-1", Date.now()),
+    );
+    expect(result).toEqual({});
+    await Effect.runPromise(scheduler.cancelFire("agent-1", "trigger-1", undefined));
+  });
+
+  test("selects a scheduler type matching a supported platform when not forced in-process", async () => {
+    delete process.env["JAZZ_SCHEDULER"];
+    const scheduler = await Effect.runPromise(createWakeTriggerOsScheduler());
+    expect(["launchd", "at", "in-process", "unsupported"]).toContain(scheduler.getType());
+  });
+});

--- a/packages/core/src/wake-triggers/wake-trigger-os-scheduler.ts
+++ b/packages/core/src/wake-triggers/wake-trigger-os-scheduler.ts
@@ -1,0 +1,65 @@
+/**
+ * `WakeTriggerOsScheduler`: installs one real OS-level job per wake trigger (launchd on macOS,
+ * a one-shot `at` job on Linux) so a trigger fires even when `jazz daemon`'s in-process ticker
+ * isn't running. Mirrors `SchedulerService` (`../workflows/scheduler-service`), which does the
+ * same thing for scheduled workflows — the difference is shape: a workflow schedule is
+ * recurring (cron), a wake trigger is a single `fireAt` instant, which is why this uses `at`
+ * rather than cron on Linux. Cron has no year field and cannot express a genuine one-shot
+ * without a follow-up job to remove itself; `at` already is a one-shot primitive.
+ *
+ * The actual OS-job mechanics (plist building, launchd load/unload, `at` scheduling, platform
+ * detection) live in `./one-shot-os-job`, shared with `reminder-os-scheduler.ts` — a wake
+ * trigger and a reminder are both "run one jazz command at a future instant," differing only in
+ * what that command does once invoked.
+ *
+ * Scheduling here is a best-effort reliability upgrade layered on top of the JSON record that
+ * `WakeTriggerServiceImpl` writes, not a replacement for it: a scheduling failure must never
+ * block registering a trigger, and the in-process ticker (`runDueTriggers`) remains the
+ * fallback for hosts with neither launchd nor `at`.
+ */
+import { Context, Effect, Layer } from "effect";
+import { createOneShotOsScheduler } from "./one-shot-os-job";
+
+export interface ScheduleFireResult {
+  readonly osSchedulerJobId?: string;
+}
+
+export interface WakeTriggerOsScheduler {
+  readonly getType: () => "launchd" | "at" | "in-process" | "unsupported";
+  readonly scheduleFire: (
+    agentId: string,
+    triggerId: string,
+    fireAt: number,
+  ) => Effect.Effect<ScheduleFireResult, Error>;
+  readonly cancelFire: (
+    agentId: string,
+    triggerId: string,
+    osSchedulerJobId: string | undefined,
+  ) => Effect.Effect<void, Error>;
+}
+
+export const WakeTriggerOsSchedulerTag =
+  Context.GenericTag<WakeTriggerOsScheduler>("WakeTriggerOsScheduler");
+
+function buildFireArgs(agentId: string, triggerId: string): readonly string[] {
+  return ["--output", "quiet", "wake-trigger", "fire", "--agent", agentId, "--id", triggerId];
+}
+
+/**
+ * Create the appropriate `WakeTriggerOsScheduler` for the current platform and configuration.
+ *
+ * Never throws and never blocks: an unavailable `at` binary, or any other detection failure,
+ * falls back to the in-process scheduler rather than failing trigger registration.
+ */
+export function createWakeTriggerOsScheduler(): Effect.Effect<WakeTriggerOsScheduler> {
+  return createOneShotOsScheduler({
+    labelPrefix: "com.jazz.trigger",
+    logNamePrefix: "wake-trigger",
+    buildProgramArgs: buildFireArgs,
+  });
+}
+
+export const WakeTriggerOsSchedulerLayer = Layer.effect(
+  WakeTriggerOsSchedulerTag,
+  createWakeTriggerOsScheduler(),
+);

--- a/packages/core/src/workflows/scheduler-service.ts
+++ b/packages/core/src/workflows/scheduler-service.ts
@@ -89,7 +89,7 @@ function getSchedulesDirectory(): string {
  * Escape a string for safe use in shell commands.
  * Wraps in single quotes and escapes any embedded single quotes.
  */
-function escapeShellArg(arg: string): string {
+export function escapeShellArg(arg: string): string {
   // Replace single quotes with '\'' (end quote, escaped quote, start quote)
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/runtime/src/app-layer.ts
+++ b/packages/runtime/src/app-layer.ts
@@ -10,6 +10,7 @@ import { createAgentServiceLayer } from "@jazz/adapters/agent-service";
 import { createConfigLayer } from "@jazz/adapters/config";
 import { createFileSystemContextServiceLayer } from "@jazz/adapters/fs";
 import { createJazzStateServiceLayer } from "@jazz/adapters/jazz-state";
+import { createJobQueueServiceLayer } from "@jazz/adapters/job-queue-service";
 import { createAISDKServiceLayer } from "@jazz/adapters/llm/ai-sdk-service";
 import { createLoggerLayer, setLogFormat, setLogLevel } from "@jazz/adapters/logger";
 import { createMCPServerManagerLayer } from "@jazz/adapters/mcp/mcp-server-manager";
@@ -210,6 +211,7 @@ export function createAppLayer(
   const workspaceServiceLayer = createWorkspaceServiceLayer().pipe(Layer.provide(configLayer));
   const reminderServiceLayer = createReminderServiceLayer();
   const wakeTriggerServiceLayer = createWakeTriggerServiceLayer();
+  const jobQueueServiceLayer = createJobQueueServiceLayer();
   const peerLedgerServiceLayer = createPeerLedgerServiceLayer();
   const peerTokenServiceLayer = createPeerTokenServiceLayer();
 
@@ -252,6 +254,7 @@ export function createAppLayer(
     workspaceServiceLayer,
     reminderServiceLayer,
     wakeTriggerServiceLayer,
+    jobQueueServiceLayer,
     peerLedgerServiceLayer,
     peerTokenServiceLayer,
     chatLayer,

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -765,6 +765,61 @@ function registerDaemonCommand(program: Command): void {
     );
 }
 
+/**
+ * Register `jazz wake-trigger fire` — internal, invoked by the host scheduler (launchd/`at`)
+ * when a wake trigger's `fireAt` arrives, not meant for interactive use. Named `wake-trigger`
+ * rather than `trigger`/`triggers`, which already names the unrelated `/triggers/` HTTP
+ * webhook feature (`daemon.ts`, `appConfig.triggers`).
+ */
+function registerWakeTriggerCommand(program: Command): void {
+  const wakeTriggerCommand = program
+    .command("wake-trigger")
+    .description("Internal: commands invoked by the host scheduler for self-registered wake-ups");
+
+  wakeTriggerCommand
+    .command("fire")
+    .description(
+      "Internal: fire a specific wake trigger (invoked by the OS scheduler, not meant for interactive use)",
+    )
+    .requiredOption("--agent <agentId>", "Agent id the trigger belongs to")
+    .requiredOption("--id <id>", "Wake trigger id")
+    .action((options: { agent: string; id: string }) =>
+      runCliAction(
+        () =>
+          import("@jazz/cli/commands/wake-trigger").then((mod) =>
+            mod.fireWakeTriggerCommand(options),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+}
+
+/**
+ * Register `jazz reminder fire` — internal, invoked by the host scheduler (launchd/`at`) when a
+ * reminder's `fireAt` arrives, not meant for interactive use. Sibling of `wake-trigger fire`:
+ * both are one-shot OS-job firings, but this one sends a desktop notification instead of
+ * resuming a conversation.
+ */
+function registerReminderCommand(program: Command): void {
+  const reminderCommand = program
+    .command("reminder")
+    .description("Internal: commands invoked by the host scheduler for self-registered reminders");
+
+  reminderCommand
+    .command("fire")
+    .description(
+      "Internal: fire a specific reminder (invoked by the OS scheduler, not meant for interactive use)",
+    )
+    .requiredOption("--agent <agentId>", "Agent id the reminder belongs to")
+    .requiredOption("--id <id>", "Reminder id")
+    .action((options: { agent: string; id: string }) =>
+      runCliAction(
+        () => import("@jazz/cli/commands/reminder").then((mod) => mod.fireReminderCommand(options)),
+        cliRuntimeOptions(program),
+      ),
+    );
+}
+
 function registerPeersCommands(program: Command): void {
   const peersCommand = program
     .command("peers")
@@ -1154,6 +1209,8 @@ export function createCLIApp(): Command {
   registerMCPCommands(program);
   registerUpdateCommand(program);
   registerDaemonCommand(program);
+  registerWakeTriggerCommand(program);
+  registerReminderCommand(program);
   registerPeersCommands(program);
   registerRunsCommands(program);
   registerWorkflowCommands(program);


### PR DESCRIPTION
## What & why
The agent can now kick off several independent shell commands in the background — with a concurrency cap and per-job retry — instead of blocking the conversation on each one in turn. It comes back and reports the results once the whole batch finishes, rather than making you wait or poll.

Separately, any single long-running command can be detached mid-flight with Ctrl+B: instead of killing it (like Ctrl+C does), it keeps running while the agent continues with other work, and reports back automatically once it's done.

Both land through the same idea — the agent doesn't have to sit idle waiting on slow shell commands anymore, whether that's one command you choose to background, or several the agent fans out itself.

## How to verify
- Ask the agent to run several independent slow commands at once (e.g. "check these 5 URLs are up") and confirm it reports one batchId immediately, keeps working, and later reports a summary of which succeeded/failed.
- Ask it to list active job batches, and to cancel one — pending jobs should cancel, already-running ones finish naturally.
- Kick off a slow command (`execute_command` with something like `sleep 20`) and press Ctrl+B while it's running: the turn should continue immediately, and the real result should show up once the command finishes, without the process being killed.
- Confirm Ctrl+C still interrupts and kills a running command as before (unaffected by this change).
