### PR TITLE
feat(tools): defer MCP/situational tool schemas, add search_tools

### DIFF
--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -42,6 +42,12 @@ An agent's config lists which tools it may use. **Omitting a tool is the stronge
 there is** — an agent without `execute_command` cannot run shell commands no matter what
 policy is set.
 
+MCP tools, along with a few other situational categories (background jobs, reminders, wake
+triggers, workspace, peers), are also **deferred**: the model sees their names and a one-line
+summary every turn, but not their full schema until it calls `search_tools`. Built-in tools
+like `read_file` and `execute_command` are always sent in full. See
+[Design decisions](../internals/design-decisions.md#deferred-tool-schemas).
+
 Built-in and custom tools are validated against their own schema before the handler runs. MCP
 tools are the exception: their schemas are translated from the server's JSON Schema, and that
 translation is lossy enough that enforcing it locally would reject calls the server accepts.

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -13,6 +13,11 @@ Jazz speaks [Model Context Protocol](https://modelcontextprotocol.io/). Add a se
 > first time one of its tools is actually invoked, so a broken or slow server never blocks
 > `jazz` from starting. See
 > [Design decisions](../internals/design-decisions.md#lazy-mcp-connection).
+>
+> **Schemas load lazily too.** Once connected, a server's tools appear in the agent's prompt
+> by name and one-line summary only — the model fetches a tool's full schema via `search_tools`
+> the first time it needs one. See
+> [Design decisions](../internals/design-decisions.md#deferred-tool-schemas).
 
 ---
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -33,14 +33,11 @@ MCP (Model Context Protocol) provides a standardized way for AI agents to:
 
 ## Configuration
 
-Jazz loads MCP servers from multiple locations (later sources override earlier ones):
-
-1. **Main config** — `~/.jazz/config.json` with optional `./.jazz/config.json` overrides (see [Configuration Reference](../reference/configuration.md))
-2. **`.agents/mcp.json`** — Project-level and user-level, following the [.agents convention](https://agentskills.io)
-
-Add MCP servers to any of these files under the `mcpServers` key:
+**A server's full definition — `command`, `args`, `env` — only ever lives in `.agents/mcp.json`.**
+`jazz mcp add` writes there for you; if you're editing by hand, that's the file to edit:
 
 ```json
+// ~/.agents/mcp.json (user-level) or ./.agents/mcp.json (project-level, in your repo root)
 {
   "mcpServers": {
     "serverName": {
@@ -54,10 +51,24 @@ Add MCP servers to any of these files under the `mcpServers` key:
 }
 ```
 
-**.agents/mcp.json** locations (merged in order, project overrides user):
+Both locations merge, following the [.agents convention](https://agentskills.io) — project
+overrides user on a name collision.
 
-- `~/.agents/mcp.json` — User-level (shared across projects)
-- `./.agents/mcp.json` — Project-level (in your repo root)
+`~/.jazz/config.json` (and its project-local `./.jazz/config.json` override) can *also* declare
+`mcpServers`, but only to toggle `enabled`/`trusted` on a server already defined above — a
+`command`/`args`/`env` written here is silently ignored, not merged in:
+
+```json
+// ~/.jazz/config.json
+{
+  "mcpServers": {
+    "serverName": { "enabled": false }
+  }
+}
+```
+
+If a tool you expect isn't showing up, check that the server itself is actually declared in
+`.agents/mcp.json`, not just referenced from `~/.jazz/config.json`.
 
 ### Configuration Options
 

--- a/docs/internals/context-management.md
+++ b/docs/internals/context-management.md
@@ -273,10 +273,12 @@ referenced it and provoke a provider error.
 
 ### What the budget counts
 
-Tokens are messages **plus per-request overhead** — tool schemas and provider scaffolding,
-which reach 10–30k once MCP servers are attached. Overhead is measured, not estimated:
-after each call, `promptTokens − estimatedMessageTokens` is the gap, smoothed per model.
-Counting messages alone meant an agent believed it was at 79% when it was at 102%.
+Tokens are messages **plus per-request overhead** — tool schemas and provider scaffolding.
+MCP server schemas no longer count toward this by default: they're a `deferred`-tier category
+(see [Design decisions](./design-decisions.md#deferred-tool-schemas)), so only the always-on
+tool set's schemas are in the request until `search_tools` fetches one. Overhead is measured,
+not estimated: after each call, `promptTokens − estimatedMessageTokens` is the gap, smoothed
+per model. Counting messages alone meant an agent believed it was at 79% when it was at 102%.
 
 ### Warn first, compact second
 

--- a/docs/internals/design-decisions.md
+++ b/docs/internals/design-decisions.md
@@ -295,6 +295,25 @@ turns must follow a playbook that lives in transcript history, not in the system
 
 📄 [`skill-tools.ts`](../../packages/core/src/agent/tools/skill-tools.ts) · [Skills loading](./skills-loading.md)
 
+### Deferred tool schemas
+
+**Decision.** Tool categories declare a `loadTier`: `eager` (schema sent every turn — files,
+shell, todo, etc.) or `deferred` (name + one-line summary only — MCP servers, background jobs,
+reminders, wake triggers, workspace, peers). A `search_tools` tool fetches a deferred tool's
+full schema on demand; once fetched it stays callable for the rest of the run.
+
+**Alternatives rejected.** Sending every registered tool's full schema every turn, including
+every tool a connected MCP server advertises. Server tool counts are unbounded and
+user-configured, so this cost grows without bound as someone adds servers, most of whose tools
+never come up in a given conversation.
+
+**Cost accepted.** An extra `search_tools` round trip before a deferred tool's first use per
+run. Names/summaries must stay visible in the prompt regardless — hiding them entirely would
+push the model toward replicating a listed tool with `execute_command` instead of discovering
+it, which `execute_command`'s own description now warns against explicitly.
+
+📄 [`search-tools-tool.ts`](../../packages/core/src/agent/tools/search-tools-tool.ts) · [Tools reference](../reference/tools.md)
+
 ---
 
 ## Related

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -19,10 +19,10 @@ and [Security](../../SECURITY.md) for the threat model.
 
 |                                                                         | Count  |
 | ----------------------------------------------------------------------- | ------ |
-| **Agent-facing tools**                                                  | **41** |
+| **Agent-facing tools**                                                  | **42** |
 | Hidden `execute_*` counterparts (the second half of each approval pair) | 8      |
-| Total registered                                                        | 50     |
-| `read-only`                                                             | 22     |
+| Total registered                                                        | 51     |
+| `read-only`                                                             | 23     |
 | `low-risk`                                                              | 11     |
 | `high-risk`                                                             | 7      |
 | `unknown`                                                               | 1      |
@@ -73,7 +73,7 @@ cannot be added without someone deciding.
 | Level      | Safe to tell                                                    | Tools                                                                                                                                                                                                                                                                                  |
 | ---------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `public`   | safe to tell anyone                                             | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file`                                                                                                                                                                                                                                     |
-| `internal` | the shape of this machine — paths, names, what is installed     | `analyze_media`, `cancel_trigger`, `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `list_triggers`, `ls`, `pdf_page_count`, `pwd`, `register_trigger`, `stat`                                                                                                                               |
+| `internal` | the shape of this machine — paths, names, what is installed     | `analyze_media`, `cancel_trigger`, `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `list_triggers`, `ls`, `pdf_page_count`, `pwd`, `register_trigger`, `search_tools`, `stat`                                                                                                                               |
 | `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `manage_workspace`, `read_file`, `read_pdf`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory`, `view_workspace` |
 
 A tool spanning two levels takes the more sensitive one — `edit_file` writes, but its approval
@@ -199,6 +199,12 @@ person. See [Reminders](../internals/reminders.md) for how the two compare.
 | -------------- | ----------- | ------------- | ------------------------------------------------------------------------------------------------------- |
 | `context_info` | `read-only` | —             | Get current context window token usage statistics.                                                      |
 | `get_time`     | `read-only` | —             | Get current date and time. Use for scheduling, relative times (yesterday, next Monday), and timestamps. |
+
+### Tool Search
+
+| Tool           | Risk        | Approval pair | What it does                                                                                       |
+| -------------- | ----------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| `search_tools` | `read-only` | —             | Fetch full parameter schemas for deferred tools (MCP servers, background jobs, etc.) you can see by name in your tool list but haven't fetched yet. |
 
 ### Sub Agents
 

--- a/packages/cli/src/commands/create-agent.ts
+++ b/packages/cli/src/commands/create-agent.ts
@@ -257,10 +257,7 @@ export function createAgentCommand(): Effect.Effect<
           }
 
           // Determine category for tools
-          const category = {
-            id: `mcp_${serverConfig.name.toLowerCase()}`,
-            displayName: `${toPascalCase(serverConfig.name)} (MCP)`,
-          };
+          const category = mcpToolCategory(serverConfig.name);
 
           // Register tools
           const registerTool = toolRegistry.registerForCategory(category);

--- a/packages/cli/src/commands/edit-agent.ts
+++ b/packages/cli/src/commands/edit-agent.ts
@@ -26,7 +26,7 @@ import { MCPServerManagerTag } from "@jazz/core/interfaces/mcp-server";
 import { PersonaServiceTag, type PersonaService } from "@jazz/core/interfaces/persona-service";
 import { ink, TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
 import { ToolRegistryTag, type ToolRegistry } from "@jazz/core/interfaces/tool-registry";
-import type { Agent, AgentConfig, LLMProvider } from "@jazz/core/types";
+import type { Agent, AgentConfig, LLMProvider, ToolCategory } from "@jazz/core/types";
 import type { WebSearchProviderName } from "@jazz/core/types/config";
 import {
   AgentAlreadyExistsError,
@@ -345,9 +345,10 @@ export function editAgentCommand(
               );
 
               // Determine category for tools using the exact display name from the UI
-              const category = {
+              const category: ToolCategory = {
                 id: `mcp_${serverConfig.name.toLowerCase()}`,
                 displayName: categoryDisplayName,
+                loadTier: "deferred",
               };
 
               // Register tools

--- a/packages/core/src/agent/agent-prompt-instructions.test.ts
+++ b/packages/core/src/agent/agent-prompt-instructions.test.ts
@@ -94,6 +94,22 @@ describe("skills playbook instructions", () => {
   });
 });
 
+describe("deferred tools index", () => {
+  test("no deferred-tools block when there are none", () => {
+    const result = build("default");
+    expect(result).not.toContain("<deferred_tools>");
+  });
+
+  test("deferred tools render as a name/summary index, not a schema", () => {
+    const result = build("default", {
+      deferredTools: [{ name: "linear_create_issue", summary: "Create a Linear issue." }],
+    });
+    expect(result).toContain("<deferred_tools>");
+    expect(result).toContain("- linear_create_issue: Create a Linear issue.");
+    expect(result).toContain("Call search_tools before using one");
+  });
+});
+
 describe("system prompt cache keys off the toolset", () => {
   test("same persona with different tools yields different prompts", () => {
     const builder = new AgentPromptBuilder();

--- a/packages/core/src/agent/agent-prompt-instructions.test.ts
+++ b/packages/core/src/agent/agent-prompt-instructions.test.ts
@@ -106,7 +106,8 @@ describe("deferred tools index", () => {
     });
     expect(result).toContain("<deferred_tools>");
     expect(result).toContain("- linear_create_issue: Create a Linear issue.");
-    expect(result).toContain("Call search_tools before using one");
+    expect(result).toContain("Calling one of these names directly will fail");
+    expect(result).toContain("Call search_tools with a short phrase");
   });
 });
 

--- a/packages/core/src/agent/agent-prompt.ts
+++ b/packages/core/src/agent/agent-prompt.ts
@@ -18,6 +18,7 @@ import {
   MEMORY_INSTRUCTIONS,
   SKILLS_INSTRUCTIONS,
   TASK_STATE_INSTRUCTIONS,
+  TOOL_SEARCH_INSTRUCTIONS,
   TOOL_SELECTION_INSTRUCTIONS,
 } from "./prompts/shared";
 import { collectUserInputAttachments } from "./user-input-attachments";
@@ -91,6 +92,12 @@ export interface AgentPromptOptions {
     readonly description: string;
     readonly path: string;
   }[];
+  /**
+   * `deferred`-tier tools (see `ToolCategory.loadTier`) available to this run but not sent as
+   * full schemas — rendered as a compact index so the model knows they exist and can fetch one
+   * via `search_tools`, without paying every schema's token cost every turn.
+   */
+  readonly deferredTools?: readonly { readonly name: string; readonly summary: string }[];
   /**
    * AGENTS.md files discovered for the working directory, outermost first.
    * Rendered verbatim into the system prompt so project conventions reach the
@@ -216,6 +223,10 @@ export class AgentPromptBuilder {
     // (memory, task state, questions) and the per-tool notes both key off it.
     if (options.toolNames && options.toolNames.length > 0) {
       hash.update(`tools:${[...options.toolNames].sort().join(",")}`);
+    }
+    if (options.deferredTools && options.deferredTools.length > 0) {
+      const deferredFingerprints = options.deferredTools.map((t) => `${t.name}|${t.summary}`);
+      hash.update(`deferredTools:${JSON.stringify(deferredFingerprints.sort())}`);
     }
     // Content, not just paths: editing an AGENTS.md must take effect on the
     // next turn rather than waiting for a process restart.
@@ -376,6 +387,18 @@ ${SKILLS_INSTRUCTIONS}
 ${indexLines}
 </available_skills>`;
           systemPrompt = systemPrompt + skillsSection;
+        }
+
+        if (options.deferredTools && options.deferredTools.length > 0) {
+          const indexLines = options.deferredTools
+            .map((t) => `- ${t.name}: ${t.summary}`)
+            .join("\n");
+
+          systemPrompt = `${systemPrompt}
+${TOOL_SEARCH_INSTRUCTIONS}
+<deferred_tools>
+${indexLines}
+</deferred_tools>`;
         }
 
         if (options.toolNames?.includes("view_memory")) {

--- a/packages/core/src/agent/agent-runner.test.ts
+++ b/packages/core/src/agent/agent-runner.test.ts
@@ -79,6 +79,26 @@ const BUILTIN_TOOLS_BY_CATEGORY: Record<string, string[]> = {
   context: ["context_info", "get_time"],
 };
 
+const MOCK_TOOL_DEFINITIONS = [
+  { function: { name: "tool1", description: "Tool 1 description", parameters: {} } },
+  { function: { name: "tool2", description: "Tool 2 description", parameters: {} } },
+  { function: { name: "manage_memory", description: "Manage long-term memory", parameters: {} } },
+  {
+    function: {
+      name: "ask_user_question",
+      description: "Ask the human a blocking question",
+      parameters: {},
+    },
+  },
+  {
+    function: {
+      name: "ask_file_picker",
+      description: "Show an interactive file picker",
+      parameters: {},
+    },
+  },
+];
+
 const mockToolRegistry = {
   registerTool: mock(() => Effect.succeed(undefined)),
   registerForCategory: mock(() => mock(() => Effect.succeed(undefined))),
@@ -112,44 +132,15 @@ const mockToolRegistry = {
       function: { name, description: `Description for ${name}` },
     }),
   ),
-  getToolDefinitions: mock(() =>
-    Effect.succeed([
-      {
-        function: {
-          name: "tool1",
-          description: "Tool 1 description",
-          parameters: {},
-        },
-      },
-      {
-        function: {
-          name: "tool2",
-          description: "Tool 2 description",
-          parameters: {},
-        },
-      },
-      {
-        function: {
-          name: "manage_memory",
-          description: "Manage long-term memory",
-          parameters: {},
-        },
-      },
-      {
-        function: {
-          name: "ask_user_question",
-          description: "Ask the human a blocking question",
-          parameters: {},
-        },
-      },
-      {
-        function: {
-          name: "ask_file_picker",
-          description: "Show an interactive file picker",
-          parameters: {},
-        },
-      },
-    ]),
+  getToolDefinitions: mock(() => Effect.succeed(MOCK_TOOL_DEFINITIONS)),
+  getToolDefinitionsFor: mock((names: readonly string[]) =>
+    Effect.succeed(MOCK_TOOL_DEFINITIONS.filter((d) => names.includes(d.function.name))),
+  ),
+  getToolSummaries: mock(() => Effect.succeed([])),
+  // No categories are registered on this mock, so every name is treated as eager — matching
+  // the real registry's behavior for uncategorized names.
+  partitionByTier: mock((names: readonly string[]) =>
+    Effect.succeed({ eager: names, deferred: [] }),
   ),
 } as unknown as ToolRegistry;
 

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -342,10 +342,16 @@ function initializeAgentRun(
     }
 
     const expandedToolNames = Array.from(expandedToolNameSet);
-    const allTools = yield* toolRegistry.getToolDefinitions();
-    const tools = Array.from(
-      allTools.filter((tool) => expandedToolNames.includes(tool.function.name)),
-    );
+
+    // Only `eager`-tier tools get full schemas in the request; `deferred`-tier ones (MCP
+    // servers, background jobs, etc.) are rendered as a name/summary index in the prompt
+    // instead, and their schemas are fetched on demand by `search_tools`. See
+    // docs/superpowers/plans/tool-search-design.md.
+    const { eager: eagerToolNames, deferred: deferredToolNames } =
+      yield* toolRegistry.partitionByTier(expandedToolNames);
+    const tools = Array.from(yield* toolRegistry.getToolDefinitionsFor(eagerToolNames));
+    const deferredToolSummaries =
+      deferredToolNames.length > 0 ? yield* toolRegistry.getToolSummaries(deferredToolNames) : [];
 
     // Build tool descriptions map
     const availableTools: Record<string, string> = {};
@@ -397,6 +403,7 @@ function initializeAgentRun(
         toolNames: expandedToolNames,
         availableTools,
         knownSkills: relevantSkills,
+        ...(deferredToolSummaries.length > 0 && { deferredTools: deferredToolSummaries }),
         ...(attachmentWorkingDirectory !== undefined && {
           workingDirectory: attachmentWorkingDirectory,
         }),
@@ -443,6 +450,20 @@ function initializeAgentRun(
       autoApprovedCommands,
       autoApprovedTools,
       parentToolNames: expandedToolNames,
+      ...(deferredToolNames.length > 0 ? { deferredToolNames } : {}),
+      // `tools` is a real mutable array (see AgentRunContext) reused by reference across every
+      // iteration of this run's loop, so pushing here makes a fetched schema callable on the
+      // very next LLM request. Dedup by name: a repeat search_tools call for the same tool must
+      // not send its schema twice.
+      unlockDeferredTools: (definitions) => {
+        const alreadyPresent = new Set(tools.map((t) => t.function.name));
+        for (const definition of definitions) {
+          if (!alreadyPresent.has(definition.function.name)) {
+            tools.push(definition);
+            alreadyPresent.add(definition.function.name);
+          }
+        }
+      },
       // A sub-agent never parks: resuming one would mean replaying a child context that no
       // longer exists, so nested runs keep declining and the parent reasons about it.
       parkWhenUnattended: options.parkWhenUnattended === true && options.internal !== true,

--- a/packages/core/src/agent/prompts/shared.ts
+++ b/packages/core/src/agent/prompts/shared.ts
@@ -76,6 +76,10 @@ export const TOOL_SELECTION_INSTRUCTIONS = `
 # Tool usage
 
 1. If a skill matches the task, load it and execute its playbook.
-2. Prefer the most specific tool available; reach for a general shell command only when no dedicated tool covers the task.
+2. Prefer the most specific tool available; reach for a general shell command only when no dedicated tool covers the task — this includes tools listed under deferred_tools below, not just ones already in your schema.
 3. Call independent operations (searches, reads, status checks) in parallel in a single response. Sequence calls only when one result feeds the next.
+`;
+
+export const TOOL_SEARCH_INSTRUCTIONS = `
+Deferred tools: names and one-line summaries only, not full schemas. Call search_tools before using one — it becomes directly callable afterward. Do not replicate one with execute_command instead.
 `;

--- a/packages/core/src/agent/prompts/shared.ts
+++ b/packages/core/src/agent/prompts/shared.ts
@@ -76,10 +76,20 @@ export const TOOL_SELECTION_INSTRUCTIONS = `
 # Tool usage
 
 1. If a skill matches the task, load it and execute its playbook.
-2. Prefer the most specific tool available; reach for a general shell command only when no dedicated tool covers the task — this includes tools listed under deferred_tools below, not just ones already in your schema.
+2. Prefer the most specific tool available. Reach for a general shell command only when nothing else covers the task — check the deferred_tools list below too, not just the tools already in your schema; a real tool may exist there under a name you have not unlocked yet.
 3. Call independent operations (searches, reads, status checks) in parallel in a single response. Sequence calls only when one result feeds the next.
 `;
 
 export const TOOL_SEARCH_INSTRUCTIONS = `
-Deferred tools: names and one-line summaries only, not full schemas. Call search_tools before using one — it becomes directly callable afterward. Do not replicate one with execute_command instead.
+# Deferred tools
+
+Two kinds of tools exist in this conversation:
+- The tools in your schema above: you can call them directly, right now.
+- The tools listed in <deferred_tools> below: real, available tools you do NOT have full definitions for yet — only their name and a one-line summary, to save space. Calling one of these names directly will fail; it is not in your schema.
+
+To use a deferred tool:
+1. Call search_tools with a short phrase describing the task (e.g. "create a linear issue").
+2. It returns the matching tool's real schema and makes it callable for the rest of this conversation — from then on, call it exactly like any other tool.
+
+Never fall back to execute_command (or any other workaround) to hand-roll what a deferred tool already does — the tool exists, it is just one search_tools call away.
 `;

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -122,6 +122,17 @@ function makeLayers(store: InMemoryRunStore) {
         { function: { name: "danger", description: "Does something gated", parameters: {} } },
       ]),
     ),
+    getToolDefinitionsFor: mock((names: readonly string[]) =>
+      Effect.succeed(
+        names.includes("danger")
+          ? [{ function: { name: "danger", description: "Does something gated", parameters: {} } }]
+          : [],
+      ),
+    ),
+    getToolSummaries: mock(() => Effect.succeed([])),
+    partitionByTier: mock((names: readonly string[]) =>
+      Effect.succeed({ eager: names, deferred: [] }),
+    ),
     executeTool: mock((name: string, args: Record<string, unknown>) => {
       if (name === "danger") {
         return Effect.succeed({

--- a/packages/core/src/agent/tools/custom-tools.ts
+++ b/packages/core/src/agent/tools/custom-tools.ts
@@ -147,6 +147,7 @@ function runCustomToolCommand(
 export const CUSTOM_TOOLS_CATEGORY: ToolCategory = {
   id: "custom_tools",
   displayName: "Custom Tools",
+  loadTier: "eager",
 };
 
 /**

--- a/packages/core/src/agent/tools/register-mcp-tools.test.ts
+++ b/packages/core/src/agent/tools/register-mcp-tools.test.ts
@@ -13,9 +13,9 @@ import { registerMCPToolsForAgent } from "./register-mcp-tools";
  * `enabled !== false` and a matching name) so the function returns before reaching the actual
  * connect/registration loop — these tests are about the resolution warning, not connecting.
  */
-function harness(configuredServers: readonly { name: string }[]) {
-  const warn = mock(() => Effect.void);
-  const debug = mock(() => Effect.void);
+function harness(configuredServers: readonly { name: string; enabled?: boolean }[]) {
+  const warn = mock((_message: string, _meta?: Record<string, unknown>) => Effect.void);
+  const debug = mock((_message: string, _meta?: Record<string, unknown>) => Effect.void);
 
   const loggerLayer = Layer.succeed(LoggerServiceTag, {
     debug,
@@ -49,7 +49,7 @@ describe("registerMCPToolsForAgent — server resolution warning", () => {
     );
 
     expect(warn).toHaveBeenCalledTimes(1);
-    const [message] = warn.mock.calls[0] as [string];
+    const message = warn.mock.calls[0]![0];
     expect(message).toContain("mcp_linear_create_issue");
     expect(message).toContain(".agents/mcp.json");
   });
@@ -83,7 +83,7 @@ describe("registerMCPToolsForAgent — server resolution warning", () => {
     );
 
     expect(warn).toHaveBeenCalledTimes(1);
-    const [message] = warn.mock.calls[0] as [string];
+    const message = warn.mock.calls[0]![0];
     expect(message).toContain("mcp_linear_create_issue");
     expect(message).not.toContain("mcp_notion_search");
   });

--- a/packages/core/src/agent/tools/register-mcp-tools.test.ts
+++ b/packages/core/src/agent/tools/register-mcp-tools.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
+import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
+import { MCPServerManagerTag, type MCPServerManager } from "@/core/interfaces/mcp-server";
+import { PresentationServiceTag, type PresentationService } from "@/core/interfaces/presentation";
+import { TerminalServiceTag, type TerminalService } from "@/core/interfaces/terminal";
+import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import { registerMCPToolsForAgent } from "./register-mcp-tools";
+
+/**
+ * `serversToConnect` is intentionally kept empty in every case here (no configured server has
+ * `enabled !== false` and a matching name) so the function returns before reaching the actual
+ * connect/registration loop — these tests are about the resolution warning, not connecting.
+ */
+function harness(configuredServers: readonly { name: string }[]) {
+  const warn = mock(() => Effect.void);
+  const debug = mock(() => Effect.void);
+
+  const loggerLayer = Layer.succeed(LoggerServiceTag, {
+    debug,
+    info: mock(() => Effect.void),
+    warn,
+    error: mock(() => Effect.void),
+  } as unknown as LoggerService);
+
+  const mcpManagerLayer = Layer.succeed(MCPServerManagerTag, {
+    listServers: () => Effect.succeed(configuredServers),
+  } as unknown as MCPServerManager);
+
+  const layer = Layer.mergeAll(
+    loggerLayer,
+    mcpManagerLayer,
+    Layer.succeed(ToolRegistryTag, {} as unknown as ToolRegistry),
+    Layer.succeed(AgentConfigServiceTag, {} as unknown as AgentConfigService),
+    Layer.succeed(TerminalServiceTag, {} as unknown as TerminalService),
+    Layer.succeed(PresentationServiceTag, {} as unknown as PresentationService),
+  );
+
+  return { layer, warn, debug };
+}
+
+describe("registerMCPToolsForAgent — server resolution warning", () => {
+  it("warns when a tool references a server with no matching configuration", async () => {
+    const { layer, warn } = harness([{ name: "notion" }]);
+
+    await Effect.runPromise(
+      registerMCPToolsForAgent(["mcp_linear_create_issue"]).pipe(Effect.provide(layer)),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("mcp_linear_create_issue");
+    expect(message).toContain(".agents/mcp.json");
+  });
+
+  it("does not warn when every referenced tool matches a configured server", async () => {
+    const { layer, warn } = harness([{ name: "notion", enabled: false }]);
+
+    await Effect.runPromise(
+      registerMCPToolsForAgent(["mcp_notion_search"]).pipe(Effect.provide(layer)),
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn (and skips server lookup entirely) when the agent has no MCP tools", async () => {
+    const { layer, warn, debug } = harness([]);
+
+    await Effect.runPromise(registerMCPToolsForAgent(["read_file"]).pipe(Effect.provide(layer)));
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).toHaveBeenCalledWith("Agent has no MCP tools, skipping MCP server connections");
+  });
+
+  it("only names the unresolved tool when a mix of resolved and unresolved names are present", async () => {
+    const { layer, warn } = harness([{ name: "notion", enabled: false }]);
+
+    await Effect.runPromise(
+      registerMCPToolsForAgent(["mcp_notion_search", "mcp_linear_create_issue"]).pipe(
+        Effect.provide(layer),
+      ),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("mcp_linear_create_issue");
+    expect(message).not.toContain("mcp_notion_search");
+  });
+});

--- a/packages/core/src/agent/tools/register-mcp-tools.ts
+++ b/packages/core/src/agent/tools/register-mcp-tools.ts
@@ -171,11 +171,27 @@ export function registerMCPToolsForAgent(
     // Match tool names to servers by prefix rather than by splitting the name:
     // both the server name and the tool name may contain underscores.
     const requiredServerNames = new Set<string>();
-    for (const server of allServers) {
-      const prefix = `mcp_${server.name.toLowerCase()}_`;
-      if (mcpToolNames.some((name) => name.startsWith(prefix))) {
-        requiredServerNames.add(server.name);
+    const unresolvedToolNames: string[] = [];
+    for (const toolName of mcpToolNames) {
+      const matchedServer = allServers.find((server) =>
+        toolName.startsWith(`mcp_${server.name.toLowerCase()}_`),
+      );
+      if (matchedServer) {
+        requiredServerNames.add(matchedServer.name);
+      } else {
+        unresolvedToolNames.push(toolName);
       }
+    }
+
+    // A typo, or a server declared in ~/.jazz/config.json instead of .agents/mcp.json (the
+    // former only toggles enabled/trusted on a server already defined in the latter — it
+    // cannot define one), both look identical from here: the tool silently never appears.
+    if (unresolvedToolNames.length > 0) {
+      yield* logger.warn(
+        `Agent references MCP tool(s) with no matching configured server, so they will not be ` +
+          `available: ${unresolvedToolNames.join(", ")}. Check that the server is declared in ` +
+          `.agents/mcp.json.`,
+      );
     }
 
     const serversToConnect = allServers.filter(

--- a/packages/core/src/agent/tools/register-tools.ts
+++ b/packages/core/src/agent/tools/register-tools.ts
@@ -20,6 +20,7 @@ import {
   createCancelReminderTool,
   createListRemindersTool,
 } from "./reminder-tools";
+import { createSearchToolsTool } from "./search-tools-tool";
 import { createShellCommandTools } from "./shell-tools";
 import { createSkillTools } from "./skill-tools";
 import { createSubagentTools } from "./subagent-tools";
@@ -32,6 +33,7 @@ import {
   PEERS_CATEGORY,
   PERCEPTION_CATEGORY,
   REMINDER_CATEGORY,
+  SEARCH_TOOLS_CATEGORY,
   SHELL_COMMANDS_CATEGORY,
   SKILLS_CATEGORY,
   SUBAGENT_CATEGORY,
@@ -74,6 +76,7 @@ export function registerAllTools(): Effect.Effect<void, Error, ToolRegistry> {
     yield* registerReminderTools();
     yield* registerWakeTriggerTools();
     yield* registerContextTools();
+    yield* registerSearchToolsTool();
     yield* registerSubagentTools();
     yield* registerPerceptionTools();
     yield* registerUserInteractionTools();
@@ -262,6 +265,15 @@ export function registerContextTools(): Effect.Effect<void, Error, ToolRegistry>
 
     yield* registerTool(createContextInfoTool());
     yield* registerTool(createGetTimeTool());
+  });
+}
+
+export function registerSearchToolsTool(): Effect.Effect<void, Error, ToolRegistry> {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const registerTool = registry.registerForCategory(SEARCH_TOOLS_CATEGORY);
+
+    yield* registerTool(createSearchToolsTool());
   });
 }
 

--- a/packages/core/src/agent/tools/search-tools-tool.test.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { z } from "zod";
+import { ToolRegistryTag, type Tool, type ToolRequirements } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionContext } from "@/core/types/tools";
+import {
+  createSearchToolsTool,
+  MAX_SEARCH_TOOLS_RESULTS,
+  rankToolsByQuery,
+} from "./search-tools-tool";
+import { createToolRegistryLayer } from "./tool-registry";
+
+const deferredCategory = {
+  id: "deferred-cat",
+  displayName: "Deferred",
+  loadTier: "deferred" as const,
+};
+
+function makeTool(name: string, summary: string): Tool<ToolRequirements> {
+  return {
+    name,
+    description: `${summary} Full schema hidden until fetched.`,
+    summary,
+    parameters: z.object({ id: z.string() }),
+    hidden: false,
+    riskLevel: "read-only",
+    disclosure: "internal",
+    execute: () => Effect.succeed({ success: true, result: "" }),
+    createSummary: undefined,
+  };
+}
+
+function baseContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
+  return { agentId: "test-agent", ...overrides };
+}
+
+describe("rankToolsByQuery", () => {
+  it("ranks by token overlap and caps results", () => {
+    const candidates = Array.from({ length: MAX_SEARCH_TOOLS_RESULTS + 5 }, (_, i) => ({
+      name: `linear_tool_${i}`,
+      summary: "Create a Linear issue in a project.",
+    }));
+    const matches = rankToolsByQuery("create linear issue", candidates);
+    expect(matches.length).toBe(MAX_SEARCH_TOOLS_RESULTS);
+  });
+
+  it("returns nothing for a query with no overlap", () => {
+    const candidates = [{ name: "linear_create_issue", summary: "Create a Linear issue." }];
+    expect(rankToolsByQuery("completely unrelated xyz", candidates)).toEqual([]);
+  });
+
+  it("returns nothing for an empty query", () => {
+    const candidates = [{ name: "linear_create_issue", summary: "Create a Linear issue." }];
+    expect(rankToolsByQuery("   ", candidates)).toEqual([]);
+  });
+});
+
+describe("search_tools", () => {
+  const testLayer = createToolRegistryLayer();
+
+  it("fetches full schemas for matched deferred tools and calls unlockDeferredTools", async () => {
+    const tool = createSearchToolsTool();
+    let unlocked: readonly { function: { name: string } }[] = [];
+
+    const program = Effect.gen(function* () {
+      const registry = yield* ToolRegistryTag;
+      yield* registry.registerTool(
+        makeTool("linear_create_issue", "Create a Linear issue in a project."),
+        deferredCategory,
+      );
+      yield* registry.registerTool(
+        makeTool("linear_list_issues", "List Linear issues in a project."),
+        deferredCategory,
+      );
+
+      return yield* tool.execute(
+        { query: "create linear issue" },
+        baseContext({
+          deferredToolNames: ["linear_create_issue", "linear_list_issues"],
+          unlockDeferredTools: (defs) => {
+            unlocked = defs;
+          },
+        }),
+      );
+    });
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+    expect(result.success).toBe(true);
+    const matched = (result.result as { matchedToolNames: readonly string[] }).matchedToolNames;
+    expect(matched).toContain("linear_create_issue");
+    expect(unlocked.map((d) => d.function.name)).toEqual(matched);
+  });
+
+  it("returns no matches without calling unlockDeferredTools when nothing overlaps", async () => {
+    const tool = createSearchToolsTool();
+    let unlockCalled = false;
+
+    const program = Effect.gen(function* () {
+      const registry = yield* ToolRegistryTag;
+      yield* registry.registerTool(
+        makeTool("railway_deploy", "Deploy a Railway service."),
+        deferredCategory,
+      );
+
+      return yield* tool.execute(
+        { query: "send a slack message" },
+        baseContext({
+          deferredToolNames: ["railway_deploy"],
+          unlockDeferredTools: () => {
+            unlockCalled = true;
+          },
+        }),
+      );
+    });
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+    expect(result.success).toBe(true);
+    expect((result.result as { matchedToolNames: readonly string[] }).matchedToolNames).toEqual([]);
+    expect(unlockCalled).toBe(false);
+  });
+
+  it("returns empty immediately when the run has no deferred tools", async () => {
+    const tool = createSearchToolsTool();
+    const program = tool.execute({ query: "anything" }, baseContext());
+    const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+    expect(result.success).toBe(true);
+    expect((result.result as { matchedToolNames: readonly string[] }).matchedToolNames).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/tools/search-tools-tool.test.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.test.ts
@@ -88,7 +88,7 @@ describe("search_tools", () => {
     expect(result.success).toBe(true);
     const matched = (result.result as { matchedToolNames: readonly string[] }).matchedToolNames;
     expect(matched).toContain("linear_create_issue");
-    expect(unlocked.map((d) => d.function.name)).toEqual(matched);
+    expect(unlocked.map((d) => d.function.name)).toEqual([...matched]);
   });
 
   it("returns no matches without calling unlockDeferredTools when nothing overlaps", async () => {

--- a/packages/core/src/agent/tools/search-tools-tool.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.ts
@@ -1,0 +1,104 @@
+/** Fetches full schemas for `deferred`-tier tools on demand. See docs/superpowers/plans/tool-search-design.md. */
+import { Effect } from "effect";
+import { z } from "zod";
+import { ToolRegistryTag, type Tool, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import type { ToolExecutionResult } from "@/core/types/tools";
+
+/** Caps schemas per call so a broad query can't dump the entire deferred surface into context. */
+export const MAX_SEARCH_TOOLS_RESULTS = 8;
+
+/** Ranks by case-insensitive token overlap against name + summary. No embeddings; revisit only past a few hundred deferred tools. */
+export function rankToolsByQuery(
+  query: string,
+  candidates: readonly { readonly name: string; readonly summary: string }[],
+): readonly string[] {
+  // Tokens under 3 chars ("a", "to", "in") match as a substring almost everywhere and would
+  // turn any query containing one into a false-positive match against unrelated tools.
+  const queryTokens = query
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((token) => token.length >= 3);
+  if (queryTokens.length === 0) return [];
+
+  const scored = candidates
+    .map((candidate) => {
+      const haystack = `${candidate.name} ${candidate.summary}`.toLowerCase();
+      const score = queryTokens.reduce(
+        (total, token) => total + (haystack.includes(token) ? 1 : 0),
+        0,
+      );
+      return { name: candidate.name, score };
+    })
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  return scored.slice(0, MAX_SEARCH_TOOLS_RESULTS).map((candidate) => candidate.name);
+}
+
+const searchToolsParameters = z.object({
+  query: z
+    .string()
+    .min(1, "query cannot be empty")
+    .describe("Keywords describing the capability you need, e.g. 'create linear issue'."),
+});
+
+export function createSearchToolsTool(): Tool<ToolRegistry> {
+  return {
+    name: "search_tools",
+    disclosure: "internal",
+    description:
+      "Fetch full parameter schemas for tools you can currently see only by name and one-line summary in your tool list (MCP server tools, background jobs, reminders, wake triggers, workspace, peers). " +
+      "Call this before attempting to use one of them — once fetched, the tool becomes directly callable for the rest of this conversation. " +
+      "Do not use execute_command to replicate what a listed-but-unfetched tool already does; search for it here instead.",
+    parameters: searchToolsParameters,
+    riskLevel: "read-only",
+    hidden: false,
+    createSummary: (result) => {
+      if (!result.success) return undefined;
+      const matched = (result.result as { matchedToolNames?: readonly string[] } | null)
+        ?.matchedToolNames;
+      return matched && matched.length > 0
+        ? `Found ${matched.length} tool(s): ${matched.join(", ")}`
+        : "No matching tools found";
+    },
+    execute: (args, context) =>
+      Effect.gen(function* () {
+        const { query } = searchToolsParameters.parse(args);
+        const registry = yield* ToolRegistryTag;
+        const deferredToolNames = context.deferredToolNames ?? [];
+
+        if (deferredToolNames.length === 0) {
+          return {
+            success: true,
+            result: { matchedToolNames: [], definitions: [] },
+          } satisfies ToolExecutionResult;
+        }
+
+        const summaries = yield* registry.getToolSummaries(deferredToolNames);
+        const matchedNames = rankToolsByQuery(query, summaries);
+
+        if (matchedNames.length === 0) {
+          return {
+            success: true,
+            result: {
+              matchedToolNames: [],
+              definitions: [],
+              message:
+                "No deferred tool matched that query. Check the tool list's names/summaries for a closer match, or fall back to execute_command only if truly no tool covers this.",
+            },
+          } satisfies ToolExecutionResult;
+        }
+
+        const definitions = yield* registry.getToolDefinitionsFor(matchedNames);
+        context.unlockDeferredTools?.(definitions);
+
+        return {
+          success: true,
+          result: {
+            matchedToolNames: definitions.map((definition) => definition.function.name),
+            definitions: definitions.map((definition) => definition.function),
+          },
+        } satisfies ToolExecutionResult;
+      }),
+  };
+}

--- a/packages/core/src/agent/tools/shell-tools.ts
+++ b/packages/core/src/agent/tools/shell-tools.ts
@@ -590,6 +590,7 @@ export function createShellCommandTools(): ApprovalToolPair<ShellCommandDeps> {
     disclosure: "private",
     description:
       "Run a shell command. Do not use this when a dedicated tool exists: use ls to list files, find (also available as glob) to search names, grep to search contents, read_file to read a file (startLine: -N for the end), and mkdir to create directories. " +
+      "This also applies to tools you can only see by name in your tool list (MCP servers, background jobs, and similar) — call search_tools to fetch one's schema rather than replicating what it does with curl or a CLI. " +
       "Git has no dedicated tools — use this for status, diff, log, commit, push, rebase, stash, and the rest. " +
       "Risk is unknown until each command is classified: inspect-only and minor reversible commands may be auto-approved, mutating or ambiguous ones stay high-risk and need approval. " +
       "Commands are non-interactive: stdin is discarded, so do not run pagers, REPLs, or git rebase -i without a non-interactive editor. " +

--- a/packages/core/src/agent/tools/tool-categories.ts
+++ b/packages/core/src/agent/tools/tool-categories.ts
@@ -1,38 +1,92 @@
 import type { ToolCategory } from "@/core/types";
 import { toPascalCase } from "@/core/utils/string";
 
-export const HTTP_CATEGORY: ToolCategory = { id: "http", displayName: "HTTP" };
+export const HTTP_CATEGORY: ToolCategory = {
+  id: "http",
+  displayName: "HTTP",
+  loadTier: "eager",
+};
 export const FILE_MANAGEMENT_CATEGORY: ToolCategory = {
   id: "file_management",
   displayName: "File Management",
+  loadTier: "eager",
 };
 export const SHELL_COMMANDS_CATEGORY: ToolCategory = {
   id: "shell_commands",
   displayName: "Shell Commands",
+  loadTier: "eager",
 };
-export const WEB_SEARCH_CATEGORY: ToolCategory = { id: "search", displayName: "Web Search" };
-export const WEB_FETCH_CATEGORY: ToolCategory = { id: "web_fetch", displayName: "Web Fetch" };
-export const SKILLS_CATEGORY: ToolCategory = { id: "skills", displayName: "Skills" };
-export const CONTEXT_CATEGORY: ToolCategory = { id: "context", displayName: "Context" };
-export const SUBAGENT_CATEGORY: ToolCategory = { id: "subagent", displayName: "Sub Agents" };
+export const WEB_SEARCH_CATEGORY: ToolCategory = {
+  id: "search",
+  displayName: "Web Search",
+  loadTier: "eager",
+};
+export const WEB_FETCH_CATEGORY: ToolCategory = {
+  id: "web_fetch",
+  displayName: "Web Fetch",
+  loadTier: "eager",
+};
+export const SKILLS_CATEGORY: ToolCategory = {
+  id: "skills",
+  displayName: "Skills",
+  loadTier: "eager",
+};
+export const CONTEXT_CATEGORY: ToolCategory = {
+  id: "context",
+  displayName: "Context",
+  loadTier: "eager",
+};
+export const SEARCH_TOOLS_CATEGORY: ToolCategory = {
+  id: "search_tools",
+  displayName: "Tool Search",
+  loadTier: "eager",
+};
+export const SUBAGENT_CATEGORY: ToolCategory = {
+  id: "subagent",
+  displayName: "Sub Agents",
+  loadTier: "eager",
+};
 export const PERCEPTION_CATEGORY: ToolCategory = {
   id: "perception",
   displayName: "Perception Delegation",
+  loadTier: "eager",
 };
-export const TODO_CATEGORY: ToolCategory = { id: "todo", displayName: "Todo" };
-export const MEMORY_CATEGORY: ToolCategory = { id: "memory", displayName: "Memory" };
-export const WORKSPACE_CATEGORY: ToolCategory = { id: "workspace", displayName: "Workspace" };
-export const PEERS_CATEGORY: ToolCategory = { id: "peers", displayName: "Peers" };
-export const REMINDER_CATEGORY: ToolCategory = { id: "reminders", displayName: "Reminders" };
+export const TODO_CATEGORY: ToolCategory = { id: "todo", displayName: "Todo", loadTier: "eager" };
+export const MEMORY_CATEGORY: ToolCategory = {
+  id: "memory",
+  displayName: "Memory",
+  loadTier: "eager",
+};
+export const WORKSPACE_CATEGORY: ToolCategory = {
+  id: "workspace",
+  displayName: "Workspace",
+  loadTier: "deferred",
+};
+export const PEERS_CATEGORY: ToolCategory = {
+  id: "peers",
+  displayName: "Peers",
+  loadTier: "deferred",
+};
+export const REMINDER_CATEGORY: ToolCategory = {
+  id: "reminders",
+  displayName: "Reminders",
+  loadTier: "deferred",
+};
 export const WAKE_TRIGGER_CATEGORY: ToolCategory = {
   id: "wake_triggers",
   displayName: "Wake Triggers",
+  loadTier: "deferred",
 };
 export const USER_INTERACTION_CATEGORY: ToolCategory = {
   id: "user_interaction",
   displayName: "User Interaction",
+  loadTier: "eager",
 };
-export const WEB_APP_CATEGORY: ToolCategory = { id: "web_app", displayName: "Web App" };
+export const WEB_APP_CATEGORY: ToolCategory = {
+  id: "web_app",
+  displayName: "Web App",
+  loadTier: "deferred",
+};
 
 /**
  * All available builtin tool categories (excludes per-server MCP categories).
@@ -50,6 +104,7 @@ export const ALL_CATEGORIES: readonly ToolCategory[] = [
   REMINDER_CATEGORY,
   WAKE_TRIGGER_CATEGORY,
   CONTEXT_CATEGORY,
+  SEARCH_TOOLS_CATEGORY,
   SUBAGENT_CATEGORY,
   PERCEPTION_CATEGORY,
   USER_INTERACTION_CATEGORY,
@@ -66,17 +121,20 @@ export const BUILTIN_TOOL_CATEGORIES: readonly ToolCategory[] = [
   PERCEPTION_CATEGORY,
   USER_INTERACTION_CATEGORY,
   CONTEXT_CATEGORY,
+  SEARCH_TOOLS_CATEGORY,
   WEB_FETCH_CATEGORY,
 ] as const;
 
 /**
  * Category for tools discovered from one MCP server.
- * Id format: `mcp_<servername>` (lowercase).
+ * Id format: `mcp_<servername>` (lowercase). Always `deferred` — server tool counts are
+ * unbounded and user-configured.
  */
 export function mcpToolCategory(serverName: string): ToolCategory {
   return {
     id: `mcp_${serverName.toLowerCase()}`,
     displayName: `${toPascalCase(serverName)} (MCP)`,
+    loadTier: "deferred",
   };
 }
 

--- a/packages/core/src/agent/tools/tool-registry.test.ts
+++ b/packages/core/src/agent/tools/tool-registry.test.ts
@@ -133,7 +133,7 @@ describe("ToolRegistry", () => {
   });
 
   it("should manage tool categories", async () => {
-    const category = { id: "cat1", displayName: "Category 1" };
+    const category = { id: "cat1", displayName: "Category 1", loadTier: "eager" as const };
     const tool: Tool<ToolRequirements> = {
       name: "cat-tool",
       description: "desc",
@@ -156,5 +156,88 @@ describe("ToolRegistry", () => {
     const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
     expect(result.byCat["Category 1"]).toContain("cat-tool");
     expect(result.cats[0]?.id).toBe("cat1");
+  });
+
+  describe("load-tier splitting", () => {
+    const eagerCategory = { id: "eager-cat", displayName: "Eager", loadTier: "eager" as const };
+    const deferredCategory = {
+      id: "deferred-cat",
+      displayName: "Deferred",
+      loadTier: "deferred" as const,
+    };
+
+    function makeTool(name: string, summary?: string): Tool<ToolRequirements> {
+      return {
+        name,
+        description: `Full description for ${name}. Extra detail that a summary would drop.`,
+        ...(summary !== undefined ? { summary } : {}),
+        parameters: z.object({}),
+        hidden: false,
+        riskLevel: "read-only",
+        disclosure: "internal",
+        execute: () => Effect.succeed({ success: true, result: "" }),
+        createSummary: undefined,
+      };
+    }
+
+    it("partitionByTier splits by category loadTier, defaulting uncategorized names to eager", async () => {
+      const program = Effect.gen(function* () {
+        const registry = yield* ToolRegistryTag;
+        yield* registry.registerTool(makeTool("eager-tool"), eagerCategory);
+        yield* registry.registerTool(makeTool("deferred-tool"), deferredCategory);
+        yield* registry.registerTool(makeTool("uncategorized-tool"));
+        return yield* registry.partitionByTier([
+          "eager-tool",
+          "deferred-tool",
+          "uncategorized-tool",
+        ]);
+      });
+
+      const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+      expect(result.eager).toEqual(["eager-tool", "uncategorized-tool"]);
+      expect(result.deferred).toEqual(["deferred-tool"]);
+    });
+
+    it("getToolSummaries uses the explicit summary when set, else truncates the description", async () => {
+      const longDescription =
+        "A".repeat(90) + " and then some more words that push it past the fallback cutoff length";
+      const program = Effect.gen(function* () {
+        const registry = yield* ToolRegistryTag;
+        yield* registry.registerTool(
+          makeTool("with-summary", "Short explicit summary."),
+          deferredCategory,
+        );
+        yield* registry.registerTool(
+          { ...makeTool("no-summary"), description: longDescription },
+          deferredCategory,
+        );
+        return yield* registry.getToolSummaries(["with-summary", "no-summary"]);
+      });
+
+      const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+      const withSummary = result.find((s) => s.name === "with-summary");
+      const noSummary = result.find((s) => s.name === "no-summary");
+
+      expect(withSummary?.summary).toBe("Short explicit summary.");
+      expect(withSummary?.categoryDisplayName).toBe("Deferred");
+      expect(noSummary?.summary.length).toBeLessThanOrEqual(103); // 100 + "..."
+      expect(noSummary?.summary.endsWith("...")).toBe(true);
+    });
+
+    it("getToolDefinitionsFor returns full schemas only for the requested, non-hidden names", async () => {
+      const program = Effect.gen(function* () {
+        const registry = yield* ToolRegistryTag;
+        yield* registry.registerTool(makeTool("wanted"), deferredCategory);
+        yield* registry.registerTool(makeTool("unwanted"), deferredCategory);
+        yield* registry.registerTool(
+          { ...makeTool("hidden-wanted"), hidden: true },
+          deferredCategory,
+        );
+        return yield* registry.getToolDefinitionsFor(["wanted", "hidden-wanted"]);
+      });
+
+      const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+      expect(result.map((d) => d.function.name)).toEqual(["wanted"]);
+    });
   });
 });

--- a/packages/core/src/agent/tools/tool-registry.ts
+++ b/packages/core/src/agent/tools/tool-registry.ts
@@ -13,6 +13,7 @@ import {
   type Tool,
   type ToolRegistry,
   type ToolRequirements,
+  type ToolSummary,
 } from "@/core/interfaces/tool-registry";
 import { ToolNotFoundError } from "@/core/types/errors";
 import type {
@@ -21,6 +22,18 @@ import type {
   ToolExecutionContext,
   ToolExecutionResult,
 } from "@/core/types/tools";
+
+/** Max length of a summary derived from a tool's `description` when no explicit `summary` is set. */
+const SUMMARY_FALLBACK_MAX_LENGTH = 100;
+
+/** Fallback for `ToolSummary.summary`; cuts at a word boundary so it doesn't end mid-word. */
+function truncateForSummary(description: string): string {
+  const firstLine = description.split("\n")[0]?.trim() ?? "";
+  if (firstLine.length <= SUMMARY_FALLBACK_MAX_LENGTH) return firstLine;
+  const cut = firstLine.slice(0, SUMMARY_FALLBACK_MAX_LENGTH);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${lastSpace > 0 ? cut.slice(0, lastSpace) : cut}...`;
+}
 
 /**
  * Tool registry for managing agent tools
@@ -162,6 +175,74 @@ class DefaultToolRegistry implements ToolRegistry {
 
       this.cachedDefinitions = definitions;
       return definitions;
+    });
+  }
+
+  getToolDefinitionsFor(names: readonly string[]): Effect.Effect<readonly ToolDefinition[], never> {
+    return Effect.sync(() => {
+      const requested = new Set(names.map((name) => this.aliasMap.get(name) ?? name));
+      const definitions: ToolDefinition[] = [];
+
+      this.tools.forEach((tool) => {
+        if (tool.hidden || !requested.has(tool.name)) return;
+        definitions.push({
+          type: "function",
+          function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+            ...(tool.jsonSchema !== undefined ? { jsonSchema: tool.jsonSchema } : {}),
+          },
+        });
+      });
+
+      return definitions;
+    });
+  }
+
+  getToolSummaries(names: readonly string[]): Effect.Effect<readonly ToolSummary[], never> {
+    return Effect.sync(() => {
+      const requested = new Set(names.map((name) => this.aliasMap.get(name) ?? name));
+      const summaries: ToolSummary[] = [];
+
+      this.tools.forEach((tool) => {
+        if (tool.hidden || !requested.has(tool.name)) return;
+        const categoryId = this.toolCategories.get(tool.name);
+        const category = categoryId ? this.categories.get(categoryId) : undefined;
+        summaries.push({
+          name: tool.name,
+          categoryId: category?.id ?? "other",
+          categoryDisplayName: category?.displayName ?? "Other",
+          summary: tool.summary ?? truncateForSummary(tool.description),
+        });
+      });
+
+      return summaries;
+    });
+  }
+
+  partitionByTier(
+    names: readonly string[],
+  ): Effect.Effect<
+    { readonly eager: readonly string[]; readonly deferred: readonly string[] },
+    never
+  > {
+    return Effect.sync(() => {
+      const eager: string[] = [];
+      const deferred: string[] = [];
+
+      for (const name of names) {
+        const resolvedName = this.aliasMap.get(name) ?? name;
+        const categoryId = this.toolCategories.get(resolvedName);
+        const category = categoryId ? this.categories.get(categoryId) : undefined;
+        if (category?.loadTier === "deferred") {
+          deferred.push(name);
+        } else {
+          eager.push(name);
+        }
+      }
+
+      return { eager, deferred };
     });
   }
 

--- a/packages/core/src/interfaces/tool-registry.ts
+++ b/packages/core/src/interfaces/tool-registry.ts
@@ -88,13 +88,25 @@ export type ToolRequirements =
   | ReminderService
   | WakeTriggerService
   | PeerLedgerService
-  | PeerTokenService;
+  | PeerTokenService
+  // search_tools reads the registry itself to look up deferred-tool summaries/definitions.
+  | ToolRegistry;
+
+/** Name + one-liner for a `deferred`-tier tool, shown every turn so the model knows it exists before fetching its schema via `search_tools`. */
+export interface ToolSummary {
+  readonly name: string;
+  readonly categoryId: string;
+  readonly categoryDisplayName: string;
+  readonly summary: string;
+}
 
 export interface Tool<R = never> {
   /** Function name the model calls (`read_file`, `execute_command`). Must be unique in the registry. */
   readonly name: string;
   /** Model-facing summary of when to use the tool, what it returns, and when not to. */
   readonly description: string;
+  /** One-line summary for a `deferred`-tier tool; falls back to a truncated `description` if unset. Ignored for `eager` tools. */
+  readonly summary?: string;
   /** Optional labels for grouping (UI, docs). Not sent to the model. */
   readonly tags?: readonly string[];
   /** Alternative names the LLM may use to call this tool. Resolved transparently at execution time. */
@@ -258,6 +270,21 @@ export interface ToolRegistry {
    * @returns An Effect that resolves to an array of ToolDefinition objects.
    */
   readonly getToolDefinitions: () => Effect.Effect<readonly ToolDefinition[], never>;
+  /** Full tool definitions for exactly the given names (unknown names skipped) — used to fetch a `deferred`-tier schema on demand via `search_tools`. */
+  readonly getToolDefinitionsFor: (
+    names: readonly string[],
+  ) => Effect.Effect<readonly ToolDefinition[], never>;
+  /** Name/category/summary projections for the given tool names, regardless of `loadTier`. */
+  readonly getToolSummaries: (
+    names: readonly string[],
+  ) => Effect.Effect<readonly ToolSummary[], never>;
+  /** Splits names into `eager`/`deferred` by their category's `loadTier`; uncategorized or unknown names count as `eager`. */
+  readonly partitionByTier: (
+    names: readonly string[],
+  ) => Effect.Effect<
+    { readonly eager: readonly string[]; readonly deferred: readonly string[] },
+    never
+  >;
   /**
    * Lists tools organized by category.
    *

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -216,9 +216,13 @@ export function isApprovalRequiredResult(result: unknown): result is ApprovalReq
   );
 }
 
+/** `eager`: schema sent every turn. `deferred`: only name/summary sent; schema fetched on demand via `search_tools`. */
+export type ToolLoadTier = "eager" | "deferred";
+
 export interface ToolCategory {
   readonly id: string;
   readonly displayName: string;
+  readonly loadTier: ToolLoadTier;
 }
 
 export interface ToolExecutionContext {
@@ -286,6 +290,10 @@ export interface ToolExecutionContext {
    * Used by summarize_context to actually update the executor's message array.
    */
   readonly compactConversation?: (compacted: readonly ChatMessage[]) => void;
+  /** Names of this run's `deferred`-tier tools `search_tools` may look up. */
+  readonly deferredToolNames?: readonly string[];
+  /** Called by `search_tools` to make fetched schemas callable for the rest of this run — mirrors `compactConversation`. */
+  readonly unlockDeferredTools?: (definitions: readonly ToolDefinition[]) => void;
   /**
    * Attach a media file (image/pdf/audio/video) to the current turn so the model actually
    * receives its contents on the next request.


### PR DESCRIPTION
## What & why
Every LLM turn currently sends the full parameter schema for every tool an agent can call — including every tool a connected MCP server advertises, whether or not the current task touches it. This grows unbounded with the number of MCP servers/tools a user configures, wasting context on every single request.

Adds a `search_tools` tool and marks situational tool categories (MCP servers, background jobs, reminders, wake triggers, workspace, peers) as "deferred": the model still sees their names and a one-line summary every turn for free, but full schemas are only fetched — and become callable — once the model calls `search_tools`. Core always-on tools (files, shell, todo, etc.) are unaffected. `shell_commands`'s description now explicitly points at `search_tools` instead of letting the model replicate a listed-but-unfetched tool with a raw shell command.

Also fixes an MCP config gap found while live-testing this: `~/.jazz/config.json`'s `mcpServers` key only ever applies `enabled`/`trusted` overrides to a server already defined in `.agents/mcp.json` — a `command`/`args`/`env` written there was silently ignored. The docs previously showed exactly that as a valid example; they're corrected, and referencing an MCP tool whose server can't be resolved now logs a distinct warning instead of looking identical to "no MCP tools configured."

## How to verify
- Configure an agent with an MCP server (declared in `.agents/mcp.json`) that exposes several tools, start a conversation, and confirm the first LLM request's `tools` array excludes that server's schemas while the system prompt still lists their names/summaries.
- Ask the agent to do something only the MCP server covers; confirm it calls `search_tools` first, then the fetched tool, rather than shelling out via `execute_command`. Verified live end-to-end against `ollama/gpt-oss:120b-cloud` with a real MCP server.
- Ask for something with no matching deferred tool (e.g. "what is 15 times 23?"); confirm no tool calls happen at all rather than a spurious `search_tools` call.
- Reference an MCP tool from an agent's `tools` list whose server isn't declared anywhere; confirm a warning names it, instead of the silent "no MCP tools" debug log.
- `bun test packages/core/src/agent` covers the eager/deferred split, `search_tools` ranking, the new prompt section, and the MCP resolution warning.
