### PR TITLE
feat(agent): per-run cost, token, and duration caps

### DIFF
--- a/docs/internals/agent-loop.md
+++ b/docs/internals/agent-loop.md
@@ -121,6 +121,33 @@ If it were stored, iteration 98 would carry eight escalating "FINISH NOW" messag
 one costing tokens and confusing the transcript that later gets summarized. This way the
 nudge steers the run without polluting its history.
 
+### Sibling guards — cost, tokens, and wall-clock time
+
+Three more budgets check in the same place, right after each iteration's tool phase
+finishes, and are configured via `maxCostUSD`, `maxTokens`, and `maxDurationMs` (see
+[Configuration reference](../reference/configuration.md#maxcostusd-maxtokens-and-maxdurationms)):
+
+- **`maxCostUSD`** re-prices the run's accumulated tokens (plus any sub-agent spend rolled up
+  via `childCostUSD`) against the model's models.dev pricing. Skipped entirely when pricing is
+  unknown — it never guess-aborts a run it cannot verify the spend of.
+- **`maxTokens`** just sums `totalPromptTokens + totalCompletionTokens`. No pricing lookup, so
+  it still enforces on a local/unpriced model where `maxCostUSD` cannot.
+- **`maxDurationMs`** compares wall-clock elapsed time (`Date.now() - runMetrics.startedAt`)
+  against the budget. Unlike the other two, it also gets an ephemeral pressure message inside
+  `runIteration` itself — `buildTimeBudgetPressureMessage` — at 50%, 80%, and 90% elapsed,
+  mirroring the iteration-budget nudge above.
+
+All three share the same timing as the iteration budget: checked *between* iterations, not a
+preemptive interrupt. A single expensive iteration — a costly tool call, or a sub-agent
+delegation that itself runs for a while — can push the total past the cap before the next
+check trips. A run stopped this way reports which cap fired on the response:
+`costCapped` / `tokenCapped` / `durationCapped`.
+
+This is deliberately different from `--timeout`, which lives outside the loop entirely — the
+CLI races the whole run against a deadline (`packages/core/src/utils/run-deadline.ts`) and
+kills it with no warning to the agent. `--timeout` is the hard outer safety net;
+`maxDurationMs` is the warned, graceful budget.
+
 ---
 
 ## Guard 2 — meltdown detection

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,7 +61,7 @@ absent and stdin is not a TTY.
 | `--timeout <ms>`        | none         | Abort the run after this many milliseconds (hard external kill, no warning)                                                       |
 | `--max-iterations <n>`  | 80           | Cap reasoning iterations                                                                                                          |
 | `--max-cost-usd <$>`    | none         | Abort once cumulative spend (own + sub-agent) reaches this many dollars, checked between iterations                              |
-| `--max-tokens <n>`      | none         | Abort once cumulative own tokens reach this count, checked between iterations — needs no model pricing                          |
+| `--max-tokens <n>`      | none         | Abort once cumulative prompt + completion tokens (own run only, not sub-agents) reach this count, checked between iterations — needs no model pricing |
 | `--max-duration-ms <ms>`| none         | Abort once elapsed wall-clock time reaches this budget, with agent pressure nudges at 50/80/90%, checked between iterations       |
 | `--stream`              | auto         | Force streaming. Required for `--events` in non-TTY contexts, where streaming auto-disables                                       |
 | `--no-stream`           | —            | Disable streaming                                                                                                                 |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,10 +58,17 @@ absent and stdin is not a TTY.
 | `--approval-policy <p>` | none         | `read-only` \| `low-risk` \| `high-risk`. Tools above the tier are **declined**                                                   |
 | `--events <categories>` | none         | NDJSON progress on stderr: `tools`, `reasoning`, `text`, `usage`, `approval`, `subagent`, `all` (comma-separated)                 |
 | `--reasoning <effort>`  | agent config | `low` \| `medium` \| `high` \| `disable`                                                                                          |
-| `--timeout <ms>`        | none         | Abort the run after this many milliseconds                                                                                        |
+| `--timeout <ms>`        | none         | Abort the run after this many milliseconds (hard external kill, no warning)                                                       |
 | `--max-iterations <n>`  | 80           | Cap reasoning iterations                                                                                                          |
+| `--max-cost-usd <$>`    | none         | Abort once cumulative spend (own + sub-agent) reaches this many dollars, checked between iterations                              |
+| `--max-tokens <n>`      | none         | Abort once cumulative own tokens reach this count, checked between iterations — needs no model pricing                          |
+| `--max-duration-ms <ms>`| none         | Abort once elapsed wall-clock time reaches this budget, with agent pressure nudges at 50/80/90%, checked between iterations       |
 | `--stream`              | auto         | Force streaming. Required for `--events` in non-TTY contexts, where streaming auto-disables                                       |
 | `--no-stream`           | —            | Disable streaming                                                                                                                 |
+
+`--max-cost-usd`, `--max-tokens`, and `--max-duration-ms` are soft checkpoints, not preemptive
+interrupts — see [Configuration → `maxCostUSD`, `maxTokens`, and `maxDurationMs`](./configuration.md#maxcostusd-maxtokens-and-maxdurationms)
+for the enforcement model and how they differ from `--timeout`.
 
 **Exit codes:** `0` on success, `1` on failure. In plain mode stdout is empty on failure and
 the message goes to stderr; in `--json` mode stdout always carries exactly one object.
@@ -106,8 +113,11 @@ Full contract, examples, and a complete bridge implementation:
 | `--auto-approve`        | Apply the workflow's own `autoApprove:` policy instead of prompting      |
 | `--agent <agentId>`     | Override the agent for this run                                          |
 | `--max-iterations <n>`  | Override the workflow's iteration cap                                    |
+| `--max-cost-usd <$>`    | Override the workflow's spend cap                                        |
+| `--max-tokens <n>`      | Override the workflow's token cap                                        |
+| `--max-duration-ms <ms>`| Override the workflow's wall-clock budget (50/80/90% agent pressure nudges) |
 | `--json`                | One JSON envelope on stdout; all chatter suppressed                      |
-| `--timeout <ms>`        | Abort after this many milliseconds                                       |
+| `--timeout <ms>`        | Abort after this many milliseconds (hard external kill, no warning)      |
 | `--events <categories>` | NDJSON progress on stderr. **Requires `--json`** — otherwise it errors   |
 | `--scheduled`           | Marks the run as scheduler-triggered (set automatically by launchd/cron) |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -100,11 +100,12 @@ in one important way:
   model with no catalog entry, say), `costUSD` stays undefined and the cap is skipped entirely
   rather than assumed to be zero or exceeded. `maxTokens` has no such gap — it needs no pricing
   metadata, so it still enforces where `maxCostUSD` cannot.
-- **`maxDurationMs` also nudges the agent before it stops it.** Ephemeral pressure messages —
-  never persisted to the conversation, same reasoning as the iteration-budget nudge — are injected
-  at 50%, 80%, and 90% of the budget elapsed, mirroring the context-window and iteration-budget
-  warnings. The 90% message asks the agent to wrap up immediately; by 100% the run is stopped
-  between iterations regardless of what it answers back.
+- **All three nudge the agent before they stop it.** Ephemeral pressure messages — never
+  persisted to the conversation, same reasoning as the iteration-budget nudge — are injected at
+  50%, 80%, and 90% of whichever budget is closest to being spent, mirroring the context-window
+  and iteration-budget warnings. The 90% message asks the agent to wrap up immediately; at 100%
+  the run is stopped between iterations regardless of what it answers back. `maxCostUSD`'s nudge
+  is skipped under the same unknown-pricing condition as its hard stop.
 
 A run stopped by one of these reports it on the `AgentResponse`: `costCapped`, `tokenCapped`, or
 `durationCapped`, each `true` only when that specific cap tripped. `jazz run --json` and

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -68,6 +68,56 @@ misunderstood the brief rather than found more to do.
 An explicit `--max-iterations` on the command line, or a workflow's own `maxIterations`, still
 wins over `maxIterations` here. Both values are floored at 1.
 
+### `maxCostUSD`, `maxTokens`, and `maxDurationMs`
+
+Three more per-run budgets, alongside `maxIterations`: a dollar ceiling, a token ceiling, and a
+wall-clock ceiling. Unlike `maxIterations` none of them has a default — leave a key unset and that
+dimension is uncapped.
+
+```json
+{
+  "maxCostUSD": 0.2,
+  "maxTokens": 200000,
+  "maxDurationMs": 1800000
+}
+```
+
+| Key             | Unit         | Checks                                         |
+| --------------- | ------------ | ----------------------------------------------- |
+| `maxCostUSD`    | US dollars   | Own tokens priced via models.dev, plus any sub-agent spend rolled up through `childCostUSD`. |
+| `maxTokens`     | token count  | Own prompt + completion tokens. Sub-agent tokens are not rolled up (cost is; tokens are not). |
+| `maxDurationMs` | milliseconds | Wall-clock time since the run started.          |
+
+All three share the same enforcement model, distinct from `maxIterations`/`maxSubagentIterations`
+in one important way:
+
+- **Checked between iterations, not preemptively.** Each is evaluated once after an iteration's
+  LLM call and tool phase both finish, the same timing as the iteration-budget check. A single
+  expensive iteration — one that calls an expensive tool, or delegates to a sub-agent that itself
+  runs for a while — can push the total past the cap before the next check trips. None of them
+  interrupt an in-flight LLM call or tool execution.
+- **`maxCostUSD` never guess-aborts an unpriced run.** If the model's pricing is unknown (a local
+  model with no catalog entry, say), `costUSD` stays undefined and the cap is skipped entirely
+  rather than assumed to be zero or exceeded. `maxTokens` has no such gap — it needs no pricing
+  metadata, so it still enforces where `maxCostUSD` cannot.
+- **`maxDurationMs` also nudges the agent before it stops it.** Ephemeral pressure messages —
+  never persisted to the conversation, same reasoning as the iteration-budget nudge — are injected
+  at 50%, 80%, and 90% of the budget elapsed, mirroring the context-window and iteration-budget
+  warnings. The 90% message asks the agent to wrap up immediately; by 100% the run is stopped
+  between iterations regardless of what it answers back.
+
+A run stopped by one of these reports it on the `AgentResponse`: `costCapped`, `tokenCapped`, or
+`durationCapped`, each `true` only when that specific cap tripped. `jazz run --json` and
+`jazz workflow run --json` surface the same fields in their envelope.
+
+An explicit `--max-cost-usd`, `--max-tokens`, or `--max-duration-ms` on the command line, or a
+workflow's own frontmatter key, still wins over the config value here.
+
+Distinct from `--timeout` (`jazz run --timeout <ms>` / `jazz workflow run --timeout <ms>`), which
+is an *external* hard kill — a race against the whole run with no pressure warning — rather than a
+soft, in-loop checkpoint. Use `--timeout` as the outer safety net and `maxDurationMs` for the
+warned, graceful budget.
+
 ### `maxSubagentDepth`
 
 How many levels of sub-agent may nest below a top-level run. Defaults to **3**.

--- a/docs/reference/workflow-frontmatter.md
+++ b/docs/reference/workflow-frontmatter.md
@@ -27,6 +27,9 @@ skills:
 catchUpOnRestart: true
 maxCatchUpAge: 7200
 maxIterations: 40
+maxCostUSD: 0.20
+maxTokens: 200000
+maxDurationMs: 1800000
 ---
 ```
 
@@ -41,6 +44,14 @@ maxIterations: 40
 | `catchUpOnRestart` | boolean     | —        | Whether a recent missed run may be replayed after daemon restart                  |
 | `maxCatchUpAge`    | seconds     | —        | Past this age a missed run is skipped. Default 86400 (24 h)                       |
 | `maxIterations`    | number      | —        | Iteration cap for this workflow. Default 100. Overridable with `--max-iterations`  |
+| `maxCostUSD`       | number      | —        | Spend cap in USD, checked between iterations. Unset = uncapped. Overridable with `--max-cost-usd` |
+| `maxTokens`        | number      | —        | Own-token cap, checked between iterations. Unset = uncapped. Overridable with `--max-tokens` |
+| `maxDurationMs`    | ms          | —        | Wall-clock budget with 50/80/90% agent pressure nudges. Unset = uncapped. Overridable with `--max-duration-ms` |
+
+`maxCostUSD`, `maxTokens`, and `maxDurationMs` are soft checkpoints, evaluated between
+iterations — not preemptive interrupts. See
+[Configuration → `maxCostUSD`, `maxTokens`, and `maxDurationMs`](./configuration.md#maxcostusd-maxtokens-and-maxdurationms)
+for the full enforcement model and how `maxDurationMs` differs from `--timeout`.
 
 There is **no** `autoApprovedCommands` field in frontmatter — that is a global config setting.
 See [the note below](#the-low-risk-trap).

--- a/docs/reference/workflow-frontmatter.md
+++ b/docs/reference/workflow-frontmatter.md
@@ -45,7 +45,7 @@ maxDurationMs: 1800000
 | `maxCatchUpAge`    | seconds     | —        | Past this age a missed run is skipped. Default 86400 (24 h)                       |
 | `maxIterations`    | number      | —        | Iteration cap for this workflow. Default 100. Overridable with `--max-iterations`  |
 | `maxCostUSD`       | number      | —        | Spend cap in USD, checked between iterations. Unset = uncapped. Overridable with `--max-cost-usd` |
-| `maxTokens`        | number      | —        | Own-token cap, checked between iterations. Unset = uncapped. Overridable with `--max-tokens` |
+| `maxTokens`        | number      | —        | Cap on cumulative prompt + completion tokens for this run (not sub-agents), checked between iterations. Unset = uncapped. Overridable with `--max-tokens` |
 | `maxDurationMs`    | ms          | —        | Wall-clock budget with 50/80/90% agent pressure nudges. Unset = uncapped. Overridable with `--max-duration-ms` |
 
 `maxCostUSD`, `maxTokens`, and `maxDurationMs` are soft checkpoints, evaluated between

--- a/packages/cli/src/commands/run/envelope.ts
+++ b/packages/cli/src/commands/run/envelope.ts
@@ -47,6 +47,12 @@ export interface OneShotSuccess {
   readonly costUSD: number;
   /** Whether costUSD is based on pricing metadata rather than an unknown-price fallback. */
   readonly costKnown: boolean;
+  /** True when the run stopped early because it hit a configured --max-cost-usd cap. */
+  readonly costCapped?: boolean;
+  /** True when the run stopped early because it hit a configured --max-tokens cap. */
+  readonly tokenCapped?: boolean;
+  /** True when the run stopped early because it hit a configured --max-duration-ms budget. */
+  readonly durationCapped?: boolean;
   readonly tokenUsage: OneShotTokenUsage;
   readonly toolCalls: readonly OneShotToolCall[];
   readonly webApp?: OneShotWebApp;
@@ -116,6 +122,9 @@ export function formatOneShotResult(result: OneShotSuccess, options: OneShotOutp
     answer: result.answer,
     costUSD: result.costUSD,
     costKnown: result.costKnown,
+    ...(result.costCapped ? { costCapped: true } : {}),
+    ...(result.tokenCapped ? { tokenCapped: true } : {}),
+    ...(result.durationCapped ? { durationCapped: true } : {}),
     tokenUsage: result.tokenUsage,
     toolCalls: result.toolCalls,
     ...(result.webApp ? { webApp: result.webApp } : {}),

--- a/packages/cli/src/commands/run/execute.ts
+++ b/packages/cli/src/commands/run/execute.ts
@@ -123,6 +123,9 @@ export interface RunAgentOnceOptions {
   readonly companions?: Partial<Record<PerceptionCapability, `${string}/${string}`>> | undefined;
   readonly timeoutMs?: number | undefined;
   readonly maxIterations?: number | undefined;
+  readonly maxCostUSD?: number | undefined;
+  readonly maxTokens?: number | undefined;
+  readonly maxDurationMs?: number | undefined;
   readonly eventTypes?: ReadonlySet<StreamEvent["type"]> | undefined;
   /**
    * Force streaming on/off. Streaming auto-disables for non-TTY stdout, which
@@ -368,6 +371,9 @@ export function runAgentOnceCommand(
         : {}),
       ...(options.timezone !== undefined ? { timezone: options.timezone } : {}),
       ...(options.maxIterations != null ? { maxIterations: options.maxIterations } : {}),
+      ...(options.maxCostUSD != null ? { maxCostUSD: options.maxCostUSD } : {}),
+      ...(options.maxTokens != null ? { maxTokens: options.maxTokens } : {}),
+      ...(options.maxDurationMs != null ? { maxDurationMs: options.maxDurationMs } : {}),
       ...(options.stream !== undefined ? { stream: options.stream } : {}),
       ...(interactiveInput.interactive ? {} : { withholdInteractiveTools: true }),
       ...(ephemeral ? { disablePersistence: true } : {}),
@@ -420,6 +426,9 @@ export function runAgentOnceCommand(
             agentForRun.config.llmModel,
             runResult.costIncomplete === true,
           ),
+          ...(runResult.costCapped === true ? { costCapped: true } : {}),
+          ...(runResult.tokenCapped === true ? { tokenCapped: true } : {}),
+          ...(runResult.durationCapped === true ? { durationCapped: true } : {}),
           tokenUsage: {
             promptTokens,
             completionTokens,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -196,6 +196,12 @@ export function runWorkflowCommand(
     autoApprove?: boolean;
     agent?: string;
     maxIterations?: number;
+    /** Spend ceiling in USD, checked between iterations. Overrides the workflow's own setting. */
+    maxCostUSD?: number;
+    /** Token ceiling, checked between iterations. Overrides the workflow's own setting. */
+    maxTokens?: number;
+    /** Wall-clock budget in ms, checked between iterations. Overrides the workflow's own setting. */
+    maxDurationMs?: number;
     scheduled?: boolean;
     /** Emit a single JSON envelope on stdout (same shape as `jazz run --json`) and suppress terminal chatter. */
     json?: boolean;
@@ -384,15 +390,22 @@ export function runWorkflowCommand(
       autoApprove: autoApprovePolicy,
     });
 
-    // Run the agent with the workflow prompt. Iteration cap precedence:
-    // CLI --max-iterations flag > workflow metadata > default (omitted here).
+    // Run the agent with the workflow prompt. Cap precedence for maxIterations,
+    // maxCostUSD, maxTokens, and maxDurationMs alike: CLI flag > workflow metadata >
+    // default (omitted here).
     const resolvedMaxIterations = options?.maxIterations ?? workflow.metadata.maxIterations;
+    const resolvedMaxCostUSD = options?.maxCostUSD ?? workflow.metadata.maxCostUSD;
+    const resolvedMaxTokens = options?.maxTokens ?? workflow.metadata.maxTokens;
+    const resolvedMaxDurationMs = options?.maxDurationMs ?? workflow.metadata.maxDurationMs;
     const runEffect = AgentRunner.run({
       agent,
       userInput: workflow.prompt,
       conversationId: generateConversationId(`workflow-${workflowName}`),
       pinInitialMessage: true,
       ...(resolvedMaxIterations != null ? { maxIterations: resolvedMaxIterations } : {}),
+      ...(resolvedMaxCostUSD != null ? { maxCostUSD: resolvedMaxCostUSD } : {}),
+      ...(resolvedMaxTokens != null ? { maxTokens: resolvedMaxTokens } : {}),
+      ...(resolvedMaxDurationMs != null ? { maxDurationMs: resolvedMaxDurationMs } : {}),
       ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       ...(options?.stream !== undefined ? { stream: options.stream } : {}),
     });
@@ -452,6 +465,9 @@ export function runWorkflowCommand(
                 agent.config.llmModel,
                 runResult.costIncomplete === true,
               ),
+              ...(runResult.costCapped === true ? { costCapped: true } : {}),
+              ...(runResult.tokenCapped === true ? { tokenCapped: true } : {}),
+              ...(runResult.durationCapped === true ? { durationCapped: true } : {}),
               tokenUsage: {
                 promptTokens,
                 completionTokens,
@@ -838,10 +854,16 @@ export function workflowHistoryCommand(workflowName?: string) {
 function runCostFields(result: {
   costUSD?: number;
   usage?: { promptTokens: number; completionTokens: number };
+  costCapped?: boolean;
+  tokenCapped?: boolean;
+  durationCapped?: boolean;
 }) {
   return {
     ...(result.costUSD !== undefined ? { costUSD: result.costUSD } : {}),
     ...(result.usage !== undefined ? { tokenUsage: result.usage } : {}),
+    ...(result.costCapped === true ? { costCapped: true } : {}),
+    ...(result.tokenCapped === true ? { tokenCapped: true } : {}),
+    ...(result.durationCapped === true ? { durationCapped: true } : {}),
   };
 }
 

--- a/packages/cli/src/utils/option-parsers.test.ts
+++ b/packages/cli/src/utils/option-parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parsePositiveInt } from "./option-parsers";
+import { parsePositiveFloat, parsePositiveInt } from "./option-parsers";
 
 describe("parsePositiveInt", () => {
   const parse = parsePositiveInt("--timeout");
@@ -23,6 +23,32 @@ describe("parsePositiveInt", () => {
   it("uses the provided label in the error message", () => {
     expect(() => parsePositiveInt("--max-iterations")("x")).toThrow(
       "--max-iterations must be a positive integer",
+    );
+  });
+});
+
+describe("parsePositiveFloat", () => {
+  const parse = parsePositiveFloat("--max-cost-usd");
+
+  it("parses a positive integer or decimal string", () => {
+    expect(parse("20")).toBe(20);
+    expect(parse("0.2")).toBe(0.2);
+    expect(parse("0.001")).toBe(0.001);
+  });
+
+  it("throws on zero, negatives, and non-numeric input", () => {
+    expect(() => parse("0")).toThrow('--max-cost-usd must be a positive number (got "0").');
+    expect(() => parse("-1")).toThrow("--max-cost-usd must be a positive number");
+    expect(() => parse("abc")).toThrow("--max-cost-usd must be a positive number");
+  });
+
+  it("rejects trailing non-numeric characters instead of silently truncating", () => {
+    expect(() => parse("0.2s")).toThrow('--max-cost-usd must be a positive number (got "0.2s").');
+  });
+
+  it("uses the provided label in the error message", () => {
+    expect(() => parsePositiveFloat("--max-tokens")("x")).toThrow(
+      "--max-tokens must be a positive number",
     );
   });
 });

--- a/packages/cli/src/utils/option-parsers.ts
+++ b/packages/cli/src/utils/option-parsers.ts
@@ -25,3 +25,23 @@ export function parsePositiveInt(label: string) {
     return value;
   };
 }
+
+/**
+ * Build a Commander option parser that accepts only positive (fractional) numbers, for
+ * dollar-amount flags like --max-cost-usd where "20" or "0.20" both make sense but "20s"
+ * or a negative amount do not.
+ *
+ * @param label - The flag name used in the error message (e.g. "--max-cost-usd").
+ */
+export function parsePositiveFloat(label: string) {
+  return (raw: string): number => {
+    if (!/^\d+(\.\d+)?$/.test(raw)) {
+      throw new Error(`${label} must be a positive number (got "${raw}").`);
+    }
+    const value = Number.parseFloat(raw);
+    if (!(value > 0)) {
+      throw new Error(`${label} must be a positive number (got "${raw}").`);
+    }
+    return value;
+  };
+}

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -166,6 +166,15 @@ function resolveProjectInstructions(
 }
 
 /**
+ * Resolve a `maxCostUSD`/`maxTokens`-style cap: unlike `maxIterations`, neither has a
+ * default ceiling, so an unset or non-positive value means uncapped rather than falling
+ * back to a constant.
+ */
+function resolvePositiveCap(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
  * Initialize common agent run context (tools, messages, metrics)
  */
 function initializeAgentRun(
@@ -213,6 +222,13 @@ function initializeAgentRun(
       1,
       Math.floor(options.maxIterations ?? appConfig.maxIterations ?? DEFAULT_MAX_ITERATIONS),
     );
+    // No default ceiling for either — unset at both the call site and app config means
+    // uncapped, unlike maxIterations which always falls back to DEFAULT_MAX_ITERATIONS.
+    const resolvedMaxCostUSD = resolvePositiveCap(options.maxCostUSD ?? appConfig.maxCostUSD);
+    const resolvedMaxTokens = resolvePositiveCap(options.maxTokens ?? appConfig.maxTokens);
+    const resolvedMaxDurationMs = resolvePositiveCap(
+      options.maxDurationMs ?? appConfig.maxDurationMs,
+    );
 
     const runMetrics = createAgentRunMetrics({
       agent,
@@ -221,6 +237,7 @@ function initializeAgentRun(
       model,
       reasoningEffort: agent.config.reasoningEffort ?? "disable",
       maxIterations: resolvedMaxIterations,
+      maxCostUSD: resolvedMaxCostUSD,
     });
 
     yield* emitAgentRunStarted(runMetrics);
@@ -510,6 +527,9 @@ function initializeAgentRun(
       connectedMCPServers,
       maxRetries: Math.max(0, Math.floor(appConfig.maxRetries ?? DEFAULT_MAX_LLM_RETRIES)),
       maxIterations: resolvedMaxIterations,
+      maxCostUSD: resolvedMaxCostUSD,
+      maxTokens: resolvedMaxTokens,
+      maxDurationMs: resolvedMaxDurationMs,
       knownSkills: relevantSkills,
     };
   });

--- a/packages/core/src/agent/execution/agent-loop-observer.test.ts
+++ b/packages/core/src/agent/execution/agent-loop-observer.test.ts
@@ -40,6 +40,26 @@ describe("makeDefaultObserver", () => {
     expect(calls[2]).toBe("warning:Agent:model returned an empty response");
   });
 
+  it("maps onCostCapReached to presentWarning with spend and limit", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(makeDefaultObserver(service).onCostCapReached("Agent", 0.2, 0.2134));
+    expect(calls[0]).toContain("cost cap reached ($0.2134 spent, limit $0.2000)");
+  });
+
+  it("maps onTokenCapReached to presentWarning with token count and limit", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(makeDefaultObserver(service).onTokenCapReached("Agent", 50000, 51234));
+    expect(calls[0]).toContain("token cap reached (51,234 tokens, limit 50,000)");
+  });
+
+  it("maps onDurationCapReached to presentWarning with elapsed and budget minutes", async () => {
+    const { service, calls } = recordingPresentation();
+    await Effect.runPromise(
+      makeDefaultObserver(service).onDurationCapReached("Agent", 30 * 60_000, 31 * 60_000),
+    );
+    expect(calls[0]).toContain("time budget reached (31 min elapsed, limit 30 min)");
+  });
+
   it("warns with the percentage and budget on context pressure", async () => {
     const { service, calls } = recordingPresentation();
     await Effect.runPromise(makeDefaultObserver(service).onContextPressure("Agent", 72, 128000));

--- a/packages/core/src/agent/execution/agent-loop-observer.ts
+++ b/packages/core/src/agent/execution/agent-loop-observer.ts
@@ -10,6 +10,24 @@ export interface AgentLoopObserver {
   onThinking(agentName: string, isFirstIteration: boolean): Effect.Effect<void, never, never>;
   onInterrupted(agentName: string): Effect.Effect<void, never, never>;
   onIterationLimit(agentName: string, maxIterations: number): Effect.Effect<void, never, never>;
+  /** Cumulative run cost (own + sub-agent spend) reached the configured `maxCostUSD` cap. */
+  onCostCapReached(
+    agentName: string,
+    maxCostUSD: number,
+    costUSD: number,
+  ): Effect.Effect<void, never, never>;
+  /** Cumulative own tokens reached the configured `maxTokens` cap. */
+  onTokenCapReached(
+    agentName: string,
+    maxTokens: number,
+    totalTokens: number,
+  ): Effect.Effect<void, never, never>;
+  /** Wall-clock elapsed time reached the configured `maxDurationMs` budget. */
+  onDurationCapReached(
+    agentName: string,
+    maxDurationMs: number,
+    elapsedMs: number,
+  ): Effect.Effect<void, never, never>;
   onEmptyResponse(agentName: string): Effect.Effect<void, never, never>;
   /** The agent runs on a local server whose real context window Jazz could not determine. */
   onContextWindowUnknown(agentName: string, advice: string): Effect.Effect<void, never, never>;
@@ -38,6 +56,21 @@ export function makeDefaultObserver(presentation: PresentationService): AgentLoo
       presentation.presentWarning(
         agentName,
         `iteration limit reached (${maxIterations}) - type 'continue' to resume`,
+      ),
+    onCostCapReached: (agentName, maxCostUSD, costUSD) =>
+      presentation.presentWarning(
+        agentName,
+        `cost cap reached ($${costUSD.toFixed(4)} spent, limit $${maxCostUSD.toFixed(4)}) - run stopped`,
+      ),
+    onTokenCapReached: (agentName, maxTokens, totalTokens) =>
+      presentation.presentWarning(
+        agentName,
+        `token cap reached (${totalTokens.toLocaleString()} tokens, limit ${maxTokens.toLocaleString()}) - run stopped`,
+      ),
+    onDurationCapReached: (agentName, maxDurationMs, elapsedMs) =>
+      presentation.presentWarning(
+        agentName,
+        `time budget reached (${Math.round(elapsedMs / 60_000)} min elapsed, limit ${Math.round(maxDurationMs / 60_000)} min) - run stopped`,
       ),
     onEmptyResponse: (agentName) =>
       presentation.presentWarning(agentName, "model returned an empty response"),

--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -12,6 +12,7 @@ import { clearModelsDevCache } from "@/core/utils/models-dev";
 import {
   buildBudgetPressureMessage,
   buildPostCompactionMessage,
+  buildTimeBudgetPressureMessage,
   detectMeltdown,
   executeAgentLoop,
   type CompletionStrategy,
@@ -135,6 +136,12 @@ function recordingObserver() {
     onInterrupted: (name: string) => Effect.sync(() => void calls.push(`interrupted:${name}`)),
     onIterationLimit: (name: string, max: number) =>
       Effect.sync(() => void calls.push(`limit:${name}:${max}`)),
+    onCostCapReached: (name: string, maxCostUSD: number, costUSD: number) =>
+      Effect.sync(() => void calls.push(`cost-cap:${name}:${maxCostUSD}:${costUSD}`)),
+    onTokenCapReached: (name: string, maxTokens: number, totalTokens: number) =>
+      Effect.sync(() => void calls.push(`token-cap:${name}:${maxTokens}:${totalTokens}`)),
+    onDurationCapReached: (name: string, maxDurationMs: number, elapsedMs: number) =>
+      Effect.sync(() => void calls.push(`duration-cap:${name}:${maxDurationMs}:${elapsedMs}`)),
     onEmptyResponse: (name: string) => Effect.sync(() => void calls.push(`empty:${name}`)),
     onContextWindowUnknown: (name: string) =>
       Effect.sync(() => void calls.push(`context-window-unknown:${name}`)),
@@ -178,6 +185,9 @@ function makeRunContext(overrides?: Partial<AgentRunContext>): AgentRunContext {
       toolsUsed: new Set(),
       totalPromptTokens: 0,
       totalCompletionTokens: 0,
+      totalCacheReadTokens: 0,
+      childCostUSD: 0,
+      childCostUnknown: false,
       iterationSummaries: [],
       errors: [],
       metrics: {
@@ -205,6 +215,9 @@ function makeRunContext(overrides?: Partial<AgentRunContext>): AgentRunContext {
     connectedMCPServers: [],
     knownSkills: [],
     maxIterations: DEFAULT_MAX_ITERATIONS,
+    maxCostUSD: undefined,
+    maxTokens: undefined,
+    maxDurationMs: undefined,
     ...overrides,
   };
 }
@@ -1095,6 +1108,37 @@ describe("buildBudgetPressureMessage", () => {
   });
 });
 
+describe("buildTimeBudgetPressureMessage", () => {
+  const thirtyMinutes = 30 * 60_000;
+
+  it("returns null below 50% elapsed", () => {
+    expect(buildTimeBudgetPressureMessage(0, thirtyMinutes)).toBeNull();
+    expect(buildTimeBudgetPressureMessage(14 * 60_000, thirtyMinutes)).toBeNull();
+  });
+
+  it("returns a notice at 50% elapsed", () => {
+    const msg = buildTimeBudgetPressureMessage(15 * 60_000, thirtyMinutes);
+    expect(msg?.content).toContain("TIME NOTICE");
+    expect(msg?.content).toContain("halfway");
+  });
+
+  it("returns a warning at 80% elapsed", () => {
+    const msg = buildTimeBudgetPressureMessage(24 * 60_000, thirtyMinutes);
+    expect(msg?.content).toContain("TIME WARNING");
+    expect(msg?.content).toContain("consolidat");
+  });
+
+  it("returns critical at 90% elapsed", () => {
+    const msg = buildTimeBudgetPressureMessage(27 * 60_000, thirtyMinutes);
+    expect(msg?.content).toContain("TIME CRITICAL");
+    expect(msg?.content).toContain("NOW");
+  });
+
+  it("returns null for a non-positive budget", () => {
+    expect(buildTimeBudgetPressureMessage(1000, 0)).toBeNull();
+  });
+});
+
 function tc(name: string, args: Record<string, unknown> = {}): TrackedToolCall {
   return { name, arguments: JSON.stringify(args) };
 }
@@ -1376,5 +1420,272 @@ describe("executeAgentLoop context window accounting", () => {
     );
 
     expect(calls).toContain("context-window-unknown:local-agent");
+  });
+});
+
+describe("executeAgentLoop cost and token caps", () => {
+  // Each iteration calls one tool; the mocked executor drives cost through the same
+  // recordChildCost path a real sub-agent tool uses. This deliberately avoids the real
+  // models-dev pricing lookup (a process-wide in-memory cache — see models-dev.ts — that
+  // a concurrently-running test file could otherwise repopulate mid-test) so the cap
+  // arithmetic is exercised without any dependency on shared global state or network.
+  function toolLoopStrategy(usage: { promptTokens: number; completionTokens: number }): {
+    strategy: CompletionStrategy;
+    calls: () => number;
+  } {
+    let call = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: () => {
+        call++;
+        return Effect.succeed({
+          completion: {
+            id: `c${call}`,
+            model: "gpt-4",
+            content: "",
+            usage,
+            toolCalls: [
+              {
+                id: `call_${call}`,
+                type: "function" as const,
+                function: { name: "test_tool", arguments: "{}" },
+              },
+            ],
+          },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+    return { strategy, calls: () => call };
+  }
+
+  function mockToolExecutorRecordingChildCost(costPerCall: number) {
+    return mock(
+      (toolCalls: { id: string }[], context: { recordChildCost: (usd: number) => void }) => {
+        context.recordChildCost(costPerCall);
+        return Effect.succeed(
+          toolCalls.map((tc) => ({
+            toolCallId: tc.id,
+            name: "test_tool",
+            result: "output",
+            success: true,
+          })),
+        );
+      },
+    );
+  }
+
+  it("stops early and reports costCapped once cumulative spend crosses maxCostUSD", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.2) as any;
+
+    const { strategy, calls } = toolLoopStrategy({ promptTokens: 10, completionTokens: 10 });
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 10 }),
+        makeRunContext({ maxIterations: 10, maxCostUSD: 0.15 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(calls()).toBe(1);
+    expect(result.costCapped).toBe(true);
+    expect(result.costUSD).toBeGreaterThanOrEqual(0.15);
+  });
+
+  it("runs normally when cumulative spend stays under maxCostUSD", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.01) as any;
+
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: {
+            id: "c1",
+            model: "gpt-4",
+            content: "done",
+            usage: { promptTokens: 10, completionTokens: 10 },
+          },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext({ maxCostUSD: 1 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(result.content).toBe("done");
+    expect(result.costCapped).toBeUndefined();
+  });
+
+  it("never caps a run whose spend is unknown even with maxCostUSD set", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    // No usage tokens and no recorded child cost: computeRunCost never resolves a costUSD
+    // (own tokens are zero, childCostUSD stays zero) — the cap must never guess-abort a
+    // run it cannot verify the spend of.
+    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
+      Effect.succeed(
+        toolCalls.map((tc) => ({
+          toolCallId: tc.id,
+          name: "test_tool",
+          result: "output",
+          success: true,
+        })),
+      ),
+    );
+
+    const { strategy, calls } = toolLoopStrategy({ promptTokens: 0, completionTokens: 0 });
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 3 }),
+        makeRunContext({ maxIterations: 3, maxCostUSD: 0.0001 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(calls()).toBe(3);
+    expect(result.costCapped).toBeUndefined();
+  });
+
+  it("stops early and reports tokenCapped once cumulative tokens cross maxTokens", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
+      Effect.succeed(
+        toolCalls.map((tc) => ({
+          toolCallId: tc.id,
+          name: "test_tool",
+          result: "output",
+          success: true,
+        })),
+      ),
+    );
+
+    const { strategy, calls } = toolLoopStrategy({ promptTokens: 100, completionTokens: 100 });
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 10 }),
+        makeRunContext({ maxIterations: 10, maxTokens: 150 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(calls()).toBe(1);
+    expect(result.tokenCapped).toBe(true);
+  });
+
+  it("stops early and reports durationCapped once elapsed time crosses maxDurationMs", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
+      Effect.succeed(
+        toolCalls.map((tc) => ({
+          toolCallId: tc.id,
+          name: "test_tool",
+          result: "output",
+          success: true,
+        })),
+      ),
+    );
+
+    // maxDurationMs: 0 means the budget is already exhausted from the first check —
+    // elapsed time is never negative — so this trips deterministically on iteration 1
+    // without needing a sleep, fake timers, or relying on timer-resolution granularity.
+    const { strategy, calls } = toolLoopStrategy({ promptTokens: 10, completionTokens: 10 });
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 10 }),
+        makeRunContext({ maxIterations: 10, maxDurationMs: 0 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(calls()).toBe(1);
+    expect(result.durationCapped).toBe(true);
+  });
+
+  it("runs normally when elapsed time stays under maxDurationMs", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
+      Effect.succeed(
+        toolCalls.map((tc) => ({
+          toolCallId: tc.id,
+          name: "test_tool",
+          result: "output",
+          success: true,
+        })),
+      ),
+    );
+
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: () =>
+        Effect.succeed({
+          completion: {
+            id: "c1",
+            model: "gpt-4",
+            content: "done",
+            usage: { promptTokens: 10, completionTokens: 10 },
+          },
+          interrupted: false,
+        }),
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    const result = await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions(),
+        makeRunContext({ maxDurationMs: 30 * 60_000 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    expect(result.content).toBe("done");
+    expect(result.durationCapped).toBeUndefined();
   });
 });

--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -11,8 +11,10 @@ import type { DisplayConfig } from "@/core/types/output";
 import { clearModelsDevCache } from "@/core/utils/models-dev";
 import {
   buildBudgetPressureMessage,
+  buildCostBudgetPressureMessage,
   buildPostCompactionMessage,
   buildTimeBudgetPressureMessage,
+  buildTokenBudgetPressureMessage,
   detectMeltdown,
   executeAgentLoop,
   type CompletionStrategy,
@@ -1139,6 +1141,70 @@ describe("buildTimeBudgetPressureMessage", () => {
   });
 });
 
+describe("buildTokenBudgetPressureMessage", () => {
+  const maxTokens = 100_000;
+
+  it("returns null below 50% used", () => {
+    expect(buildTokenBudgetPressureMessage(0, maxTokens)).toBeNull();
+    expect(buildTokenBudgetPressureMessage(49_000, maxTokens)).toBeNull();
+  });
+
+  it("returns a notice at 50% used", () => {
+    const msg = buildTokenBudgetPressureMessage(50_000, maxTokens);
+    expect(msg?.content).toContain("TOKEN NOTICE");
+    expect(msg?.content).toContain("halfway");
+    expect(msg?.content).toContain("50,000/100,000 tokens used");
+  });
+
+  it("returns a warning at 80% used", () => {
+    const msg = buildTokenBudgetPressureMessage(80_000, maxTokens);
+    expect(msg?.content).toContain("TOKEN WARNING");
+    expect(msg?.content).toContain("consolidat");
+  });
+
+  it("returns critical at 90% used", () => {
+    const msg = buildTokenBudgetPressureMessage(90_000, maxTokens);
+    expect(msg?.content).toContain("TOKEN CRITICAL");
+    expect(msg?.content).toContain("NOW");
+  });
+
+  it("returns null for a non-positive budget", () => {
+    expect(buildTokenBudgetPressureMessage(1000, 0)).toBeNull();
+  });
+});
+
+describe("buildCostBudgetPressureMessage", () => {
+  const maxCostUSD = 1;
+
+  it("returns null below 50% spent", () => {
+    expect(buildCostBudgetPressureMessage(0, maxCostUSD)).toBeNull();
+    expect(buildCostBudgetPressureMessage(0.49, maxCostUSD)).toBeNull();
+  });
+
+  it("returns a notice at 50% spent", () => {
+    const msg = buildCostBudgetPressureMessage(0.5, maxCostUSD);
+    expect(msg?.content).toContain("COST NOTICE");
+    expect(msg?.content).toContain("halfway");
+    expect(msg?.content).toContain("$0.5000/$1.0000 spent");
+  });
+
+  it("returns a warning at 80% spent", () => {
+    const msg = buildCostBudgetPressureMessage(0.8, maxCostUSD);
+    expect(msg?.content).toContain("COST WARNING");
+    expect(msg?.content).toContain("consolidat");
+  });
+
+  it("returns critical at 90% spent", () => {
+    const msg = buildCostBudgetPressureMessage(0.9, maxCostUSD);
+    expect(msg?.content).toContain("COST CRITICAL");
+    expect(msg?.content).toContain("NOW");
+  });
+
+  it("returns null for a non-positive budget", () => {
+    expect(buildCostBudgetPressureMessage(0.01, 0)).toBeNull();
+  });
+});
+
 function tc(name: string, args: Record<string, unknown> = {}): TrackedToolCall {
   return { name, arguments: JSON.stringify(args) };
 }
@@ -1429,6 +1495,10 @@ describe("executeAgentLoop cost and token caps", () => {
   // models-dev pricing lookup (a process-wide in-memory cache — see models-dev.ts — that
   // a concurrently-running test file could otherwise repopulate mid-test) so the cap
   // arithmetic is exercised without any dependency on shared global state or network.
+  type ExecuteToolCallsArgs = Parameters<typeof ToolExecutor.executeToolCalls>;
+  type ExecuteToolCallsToolCalls = ExecuteToolCallsArgs[0];
+  type ExecuteToolCallsContext = ExecuteToolCallsArgs[1];
+
   function toolLoopStrategy(usage: { promptTokens: number; completionTokens: number }): {
     strategy: CompletionStrategy;
     calls: () => number;
@@ -1443,7 +1513,7 @@ describe("executeAgentLoop cost and token caps", () => {
             id: `c${call}`,
             model: "gpt-4",
             content: "",
-            usage,
+            usage: { ...usage, totalTokens: usage.promptTokens + usage.completionTokens },
             toolCalls: [
               {
                 id: `call_${call}`,
@@ -1462,25 +1532,36 @@ describe("executeAgentLoop cost and token caps", () => {
     return { strategy, calls: () => call };
   }
 
-  function mockToolExecutorRecordingChildCost(costPerCall: number) {
-    return mock(
-      (toolCalls: { id: string }[], context: { recordChildCost: (usd: number) => void }) => {
-        context.recordChildCost(costPerCall);
-        return Effect.succeed(
-          toolCalls.map((tc) => ({
-            toolCallId: tc.id,
-            name: "test_tool",
-            result: "output",
-            success: true,
-          })),
-        );
-      },
+  function mockToolExecutor(
+    handler: (
+      toolCalls: ExecuteToolCallsToolCalls,
+      context: ExecuteToolCallsContext,
+    ) => ReturnType<typeof ToolExecutor.executeToolCalls>,
+  ): typeof ToolExecutor.executeToolCalls {
+    return mock(handler) as unknown as typeof ToolExecutor.executeToolCalls;
+  }
+
+  function succeedWithToolResults(toolCalls: ExecuteToolCallsToolCalls) {
+    return Effect.succeed(
+      toolCalls.map((tc) => ({
+        toolCallId: tc.id,
+        name: "test_tool",
+        result: "output",
+        success: true,
+      })),
     );
+  }
+
+  function mockToolExecutorRecordingChildCost(costPerCall: number) {
+    return mockToolExecutor((toolCalls, context) => {
+      context.recordChildCost?.(costPerCall);
+      return succeedWithToolResults(toolCalls);
+    });
   }
 
   it("stops early and reports costCapped once cumulative spend crosses maxCostUSD", async () => {
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.2) as any;
+    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.2);
 
     const { strategy, calls } = toolLoopStrategy({ promptTokens: 10, completionTokens: 10 });
 
@@ -1504,7 +1585,7 @@ describe("executeAgentLoop cost and token caps", () => {
 
   it("runs normally when cumulative spend stays under maxCostUSD", async () => {
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.01) as any;
+    ToolExecutor.executeToolCalls = mockToolExecutorRecordingChildCost(0.01);
 
     const strategy: CompletionStrategy = {
       shouldShowReasoning: false,
@@ -1514,7 +1595,7 @@ describe("executeAgentLoop cost and token caps", () => {
             id: "c1",
             model: "gpt-4",
             content: "done",
-            usage: { promptTokens: 10, completionTokens: 10 },
+            usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
           },
           interrupted: false,
         }),
@@ -1545,15 +1626,8 @@ describe("executeAgentLoop cost and token caps", () => {
     // No usage tokens and no recorded child cost: computeRunCost never resolves a costUSD
     // (own tokens are zero, childCostUSD stays zero) — the cap must never guess-abort a
     // run it cannot verify the spend of.
-    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
-      Effect.succeed(
-        toolCalls.map((tc) => ({
-          toolCallId: tc.id,
-          name: "test_tool",
-          result: "output",
-          success: true,
-        })),
-      ),
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
     );
 
     const { strategy, calls } = toolLoopStrategy({ promptTokens: 0, completionTokens: 0 });
@@ -1577,15 +1651,8 @@ describe("executeAgentLoop cost and token caps", () => {
 
   it("stops early and reports tokenCapped once cumulative tokens cross maxTokens", async () => {
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
-      Effect.succeed(
-        toolCalls.map((tc) => ({
-          toolCallId: tc.id,
-          name: "test_tool",
-          result: "output",
-          success: true,
-        })),
-      ),
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
     );
 
     const { strategy, calls } = toolLoopStrategy({ promptTokens: 100, completionTokens: 100 });
@@ -1609,15 +1676,8 @@ describe("executeAgentLoop cost and token caps", () => {
 
   it("stops early and reports durationCapped once elapsed time crosses maxDurationMs", async () => {
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
-      Effect.succeed(
-        toolCalls.map((tc) => ({
-          toolCallId: tc.id,
-          name: "test_tool",
-          result: "output",
-          success: true,
-        })),
-      ),
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
     );
 
     // maxDurationMs: 0 means the budget is already exhausted from the first check —
@@ -1644,15 +1704,8 @@ describe("executeAgentLoop cost and token caps", () => {
 
   it("runs normally when elapsed time stays under maxDurationMs", async () => {
     const originalExecute = ToolExecutor.executeToolCalls;
-    ToolExecutor.executeToolCalls = mock((toolCalls: { id: string }[]) =>
-      Effect.succeed(
-        toolCalls.map((tc) => ({
-          toolCallId: tc.id,
-          name: "test_tool",
-          result: "output",
-          success: true,
-        })),
-      ),
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
     );
 
     const strategy: CompletionStrategy = {
@@ -1663,7 +1716,7 @@ describe("executeAgentLoop cost and token caps", () => {
             id: "c1",
             model: "gpt-4",
             content: "done",
-            usage: { promptTokens: 10, completionTokens: 10 },
+            usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
           },
           interrupted: false,
         }),
@@ -1687,5 +1740,63 @@ describe("executeAgentLoop cost and token caps", () => {
 
     expect(result.content).toBe("done");
     expect(result.durationCapped).toBeUndefined();
+  });
+
+  it("warns the model with a token-budget pressure message once past 50% of maxTokens", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
+    );
+
+    const seenMessages: ConversationMessages[] = [];
+    let call = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: (messages) => {
+        call++;
+        seenMessages.push(messages);
+        return Effect.succeed({
+          completion: {
+            id: `c${call}`,
+            model: "gpt-4",
+            content: "",
+            usage: { promptTokens: 30, completionTokens: 30, totalTokens: 60 },
+            toolCalls: [
+              {
+                id: `call_${call}`,
+                type: "function" as const,
+                function: { name: "test_tool", arguments: "{}" },
+              },
+            ],
+          },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    // maxTokens: 100 also stops the run once iteration 2's 120 accumulated tokens cross
+    // it — irrelevant to this test, which only inspects what iterations 1 and 2 were sent.
+    await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: 10 }),
+        makeRunContext({ maxIterations: 10, maxTokens: 100 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    // Iteration 1 sends 0 tokens used so far (no pressure yet); by iteration 2, 60/100
+    // tokens are accumulated (60% — past the 50% notice threshold).
+    const firstIterationMessages = seenMessages[0] ?? [];
+    const secondIterationMessages = seenMessages[1] ?? [];
+    expect(firstIterationMessages.some((m) => m.content?.includes("TOKEN NOTICE"))).toBe(false);
+    expect(secondIterationMessages.some((m) => m.content?.includes("TOKEN NOTICE"))).toBe(true);
   });
 });

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -6,7 +6,7 @@
 
 import { Cause, Effect, Fiber, Option, Ref } from "effect";
 import { isRunParkRequested, withTranscript } from "@/core/agent/run/park-signal";
-import { isLocalServerProvider, isZeroCostLocalModel } from "@/core/constants/local-providers";
+import { isLocalServerProvider } from "@/core/constants/local-providers";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
 import type { LLMService } from "@/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@/core/interfaces/logger";
@@ -27,7 +27,7 @@ import type { StreamEvent } from "@/core/types/streaming";
 import { conversationLogGroup } from "@/core/utils/log-group";
 import { getModelsDevMetadata } from "@/core/utils/models-dev";
 import { formatToolResultForContext } from "@/core/utils/tool-result-formatter";
-import { computeUsageCostUSD, type UsageCostPricing } from "@/core/utils/usage-cost";
+import type { UsageCostPricing } from "@/core/utils/usage-cost";
 import type { AgentLoopObserver } from "./agent-loop-observer";
 import { ToolExecutor } from "./tool-executor";
 import { logContextRung } from "../context/context-telemetry";
@@ -50,6 +50,7 @@ import {
   beginIteration,
   calibrateTokenCounter,
   completeIteration,
+  computeRunCost,
   emitAgentRunFailed,
   emitLLMUsage,
   estimateTokens,
@@ -80,6 +81,41 @@ export function buildBudgetPressureMessage(
     return {
       role: "user",
       content: `[BUDGET WARNING: Iteration ${iteration}/${maxIterations} (${Math.round(pct * 100)}%). Begin consolidating results. Stop spawning new research subagents. Move to consolidation and output phases.]`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Returns an ephemeral time-budget pressure message at 50%/80%/90% of `maxDurationMs`
+ * elapsed. Returns null below 50%. Must NOT be pushed to currentMessages — ephemeral only,
+ * same reasoning as `buildBudgetPressureMessage` above (a persisted warning wastes tokens
+ * and gets summarized into the very compaction it warned about).
+ */
+export function buildTimeBudgetPressureMessage(
+  elapsedMs: number,
+  maxDurationMs: number,
+): { role: "user"; content: string } | null {
+  if (maxDurationMs <= 0) return null;
+  const pct = elapsedMs / maxDurationMs;
+  const minutesUsed = Math.round(elapsedMs / 60_000);
+  const minutesBudget = Math.round(maxDurationMs / 60_000);
+  if (pct >= 0.9) {
+    return {
+      role: "user",
+      content: `[TIME CRITICAL: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). Write your final output NOW. No further research or subagent spawning.]`,
+    };
+  }
+  if (pct >= 0.8) {
+    return {
+      role: "user",
+      content: `[TIME WARNING: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). Begin consolidating results. Stop spawning new research subagents. Move to consolidation and output phases.]`,
+    };
+  }
+  if (pct >= 0.5) {
+    return {
+      role: "user",
+      content: `[TIME NOTICE: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). You are past the halfway point of your time budget — plan to wrap up well before it runs out.]`,
     };
   }
   return null;
@@ -176,6 +212,8 @@ interface LoopDeps {
   observer: AgentLoopObserver;
   logger: LoggerService;
   maxIterations: number;
+  /** Wall-clock budget in ms, for the ephemeral time-pressure nudge. Undefined = uncapped. */
+  maxDurationMs: number | undefined;
   runRecursive: RecursiveRunner;
   /**
    * Attachment modalities this run's model accepts. Passed to tools so `read_file` on a
@@ -281,6 +319,9 @@ interface FinalizeInput {
   iterationsUsed: number;
   finished: boolean;
   interrupted: boolean;
+  costCapped: boolean;
+  tokenCapped: boolean;
+  durationCapped: boolean;
 }
 
 /**
@@ -297,12 +338,25 @@ function finalizeRun(
   finalizeFiberRef: Ref.Ref<Option.Option<Fiber.RuntimeFiber<void, Error>>>,
 ): Effect.Effect<AgentResponse, never, LoggerService> {
   return Effect.gen(function* () {
-    const { response, currentMessages, runMetrics, modelMetadata, finished, interrupted } = input;
+    const {
+      response,
+      currentMessages,
+      runMetrics,
+      modelMetadata,
+      finished,
+      interrupted,
+      costCapped,
+      tokenCapped,
+      durationCapped,
+    } = input;
+    const capped = costCapped || tokenCapped || durationCapped;
     let iterationsUsed = input.iterationsUsed;
 
     if (!finished) {
-      iterationsUsed = maxIterations;
-      yield* observer.onIterationLimit(agentName, maxIterations);
+      iterationsUsed = capped ? input.iterationsUsed : maxIterations;
+      if (!capped) {
+        yield* observer.onIterationLimit(agentName, maxIterations);
+      }
     } else if (
       !response.content?.trim() &&
       !response.reasoning?.trim() &&
@@ -312,11 +366,18 @@ function finalizeRun(
       yield* observer.onEmptyResponse(agentName);
     }
 
-    yield* logger.debug("Finalizing agent run", { interrupted, finished });
+    yield* logger.debug("Finalizing agent run", {
+      interrupted,
+      finished,
+      costCapped,
+      tokenCapped,
+      durationCapped,
+    });
 
     const finalizeFiber = yield* finalizeAgentRun(runMetrics, {
       iterationsUsed,
       finished,
+      costCapped: capped,
     }).pipe(
       Effect.catchAll((error) =>
         logger.warn("Failed to write agent token usage log", { error: error.message }),
@@ -325,29 +386,10 @@ function finalizeRun(
     );
     yield* Ref.set(finalizeFiberRef, Option.some(finalizeFiber));
 
-    const ownCostUSD =
-      computeUsageCostUSD(
-        {
-          promptTokens: runMetrics.totalPromptTokens,
-          completionTokens: runMetrics.totalCompletionTokens,
-          cacheReadTokens: runMetrics.totalCacheReadTokens,
-        },
-        modelMetadata,
-      ) ?? undefined;
-    // Report the run's own cost plus any sub-agent cost. Emit a figure whenever
-    // either side is known — a run with unpriced parent tokens but priced
-    // sub-agents should still surface the sub-agent spend.
-    const costUSD =
-      ownCostUSD !== undefined || runMetrics.childCostUSD > 0
-        ? parseFloat(((ownCostUSD ?? 0) + runMetrics.childCostUSD).toFixed(8))
-        : undefined;
     // A partial figure must never pass for a complete one: cost-capped callers
-    // (bridge daily caps) treat costIncomplete as unpriced spend and pause.
-    const ownCostUnknown =
-      ownCostUSD === undefined &&
-      runMetrics.totalPromptTokens + runMetrics.totalCompletionTokens > 0 &&
-      !isZeroCostLocalModel(runMetrics.provider ?? "", runMetrics.model ?? "");
-    const costIncomplete = ownCostUnknown || runMetrics.childCostUnknown;
+    // (bridge daily caps, the per-run maxCostUSD guard) treat costIncomplete as
+    // unpriced spend and refuse to enforce a cap they cannot verify.
+    const { costUSD, costIncomplete } = computeRunCost(runMetrics, modelMetadata);
 
     return {
       ...response,
@@ -361,6 +403,9 @@ function finalizeRun(
       },
       ...(costUSD !== undefined ? { costUSD } : {}),
       ...(costIncomplete ? { costIncomplete: true } : {}),
+      ...(costCapped ? { costCapped: true } : {}),
+      ...(tokenCapped ? { tokenCapped: true } : {}),
+      ...(durationCapped ? { durationCapped: true } : {}),
     };
   });
 }
@@ -677,6 +722,7 @@ function runIteration(
     observer,
     logger,
     maxIterations,
+    maxDurationMs,
     runRecursive,
   } = deps;
 
@@ -789,7 +835,13 @@ function runIteration(
           runContextWindowManager.thresholdRatios,
         );
     const budgetMsg = buildBudgetPressureMessage(iterationIndex + 1, maxIterations);
-    const pressureContent = [contextMsg?.content, budgetMsg?.content].filter(Boolean).join("\n");
+    const timeBudgetMsg =
+      maxDurationMs !== undefined
+        ? buildTimeBudgetPressureMessage(Date.now() - runMetrics.startedAt.getTime(), maxDurationMs)
+        : null;
+    const pressureContent = [contextMsg?.content, budgetMsg?.content, timeBudgetMsg?.content]
+      .filter(Boolean)
+      .join("\n");
     const messagesForLLM = pressureContent
       ? ([
           ...state.currentMessages,
@@ -1012,6 +1064,9 @@ export function executeAgentLoop(
           provider,
           model,
           maxIterations,
+          maxCostUSD,
+          maxTokens,
+          maxDurationMs,
         } = runContext;
 
         const configService = yield* AgentConfigServiceTag;
@@ -1084,6 +1139,9 @@ export function executeAgentLoop(
         };
         let finished = false;
         let interrupted = false;
+        let costCapped = false;
+        let tokenCapped = false;
+        let durationCapped = false;
 
         // models.dev reports input modalities; absence means text-only. Unlike tool support —
         // which defaults to available so an unknown model is not needlessly crippled — an
@@ -1111,6 +1169,7 @@ export function executeAgentLoop(
           observer,
           logger,
           maxIterations,
+          maxDurationMs,
           runRecursive,
           supportedAttachmentKinds,
         };
@@ -1150,6 +1209,47 @@ export function executeAgentLoop(
           } finally {
             yield* Effect.sync(() => completeIteration(runMetrics));
           }
+
+          // Soft checkpoint, not a preemptive interrupt: checked once between
+          // iterations, same timing as the iteration budget above. A single
+          // expensive iteration (including a whole sub-agent delegation) can push
+          // the total past maxCostUSD before this trips — see docs/internals/agent-loop.md.
+          // Never guess-abort on unpriced usage (a local model, say): costUSD is
+          // only defined once spend is actually known.
+          if (maxCostUSD !== undefined) {
+            const runCost = computeRunCost(runMetrics, modelMetadata);
+            if (runCost.costUSD !== undefined && runCost.costUSD >= maxCostUSD) {
+              costCapped = true;
+              state.iterationsUsed = i + 1;
+              yield* observer.onCostCapReached(agent.name, maxCostUSD, runCost.costUSD);
+              break;
+            }
+          }
+
+          // Same soft-checkpoint timing as maxCostUSD, but needs no pricing lookup —
+          // this still enforces on an unpriced/local model where the cost cap cannot fire.
+          if (maxTokens !== undefined) {
+            const totalTokens = runMetrics.totalPromptTokens + runMetrics.totalCompletionTokens;
+            if (totalTokens >= maxTokens) {
+              tokenCapped = true;
+              state.iterationsUsed = i + 1;
+              yield* observer.onTokenCapReached(agent.name, maxTokens, totalTokens);
+              break;
+            }
+          }
+
+          // Same soft-checkpoint timing as maxCostUSD/maxTokens. The 50/80/90% pressure
+          // nudges are injected per-iteration inside runIteration (see buildTimeBudgetPressureMessage);
+          // this is the hard stop once the budget is actually exhausted.
+          if (maxDurationMs !== undefined) {
+            const elapsedMs = Date.now() - runMetrics.startedAt.getTime();
+            if (elapsedMs >= maxDurationMs) {
+              durationCapped = true;
+              state.iterationsUsed = i + 1;
+              yield* observer.onDurationCapReached(agent.name, maxDurationMs, elapsedMs);
+              break;
+            }
+          }
         }
 
         return yield* finalizeRun(
@@ -1161,6 +1261,9 @@ export function executeAgentLoop(
             iterationsUsed: state.iterationsUsed,
             finished,
             interrupted,
+            costCapped,
+            tokenCapped,
+            durationCapped,
           },
           observer,
           logger,

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -87,38 +87,84 @@ export function buildBudgetPressureMessage(
 }
 
 /**
- * Returns an ephemeral time-budget pressure message at 50%/80%/90% of `maxDurationMs`
- * elapsed. Returns null below 50%. Must NOT be pushed to currentMessages — ephemeral only,
+ * Shared 50%/80%/90% tiering for the maxCostUSD/maxTokens/maxDurationMs pressure nudges
+ * below. Returns null under 50%. Must NOT be pushed to currentMessages — ephemeral only,
  * same reasoning as `buildBudgetPressureMessage` above (a persisted warning wastes tokens
  * and gets summarized into the very compaction it warned about).
+ */
+function budgetPressureMessage(
+  pct: number,
+  label: string,
+  progress: string,
+): { role: "user"; content: string } | null {
+  const percent = Math.round(pct * 100);
+  if (pct >= 0.9) {
+    return {
+      role: "user",
+      content: `[${label} CRITICAL: ${progress} (${percent}%). Write your final output NOW. No further research or subagent spawning.]`,
+    };
+  }
+  if (pct >= 0.8) {
+    return {
+      role: "user",
+      content: `[${label} WARNING: ${progress} (${percent}%). Begin consolidating results. Stop spawning new research subagents. Move to consolidation and output phases.]`,
+    };
+  }
+  if (pct >= 0.5) {
+    return {
+      role: "user",
+      content: `[${label} NOTICE: ${progress} (${percent}%). You are past the halfway point of your ${label.toLowerCase()} budget — plan to wrap up well before it runs out.]`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Returns an ephemeral time-budget pressure message at 50%/80%/90% of `maxDurationMs` elapsed.
  */
 export function buildTimeBudgetPressureMessage(
   elapsedMs: number,
   maxDurationMs: number,
 ): { role: "user"; content: string } | null {
   if (maxDurationMs <= 0) return null;
-  const pct = elapsedMs / maxDurationMs;
   const minutesUsed = Math.round(elapsedMs / 60_000);
   const minutesBudget = Math.round(maxDurationMs / 60_000);
-  if (pct >= 0.9) {
-    return {
-      role: "user",
-      content: `[TIME CRITICAL: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). Write your final output NOW. No further research or subagent spawning.]`,
-    };
-  }
-  if (pct >= 0.8) {
-    return {
-      role: "user",
-      content: `[TIME WARNING: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). Begin consolidating results. Stop spawning new research subagents. Move to consolidation and output phases.]`,
-    };
-  }
-  if (pct >= 0.5) {
-    return {
-      role: "user",
-      content: `[TIME NOTICE: ${minutesUsed}/${minutesBudget} minutes used (${Math.round(pct * 100)}%). You are past the halfway point of your time budget — plan to wrap up well before it runs out.]`,
-    };
-  }
-  return null;
+  return budgetPressureMessage(
+    elapsedMs / maxDurationMs,
+    "TIME",
+    `${minutesUsed}/${minutesBudget} minutes used`,
+  );
+}
+
+/**
+ * Returns an ephemeral token-budget pressure message at 50%/80%/90% of `maxTokens` used
+ * (own prompt + completion tokens accumulated so far).
+ */
+export function buildTokenBudgetPressureMessage(
+  totalTokens: number,
+  maxTokens: number,
+): { role: "user"; content: string } | null {
+  if (maxTokens <= 0) return null;
+  return budgetPressureMessage(
+    totalTokens / maxTokens,
+    "TOKEN",
+    `${totalTokens.toLocaleString()}/${maxTokens.toLocaleString()} tokens used`,
+  );
+}
+
+/**
+ * Returns an ephemeral cost-budget pressure message at 50%/80%/90% of `maxCostUSD` spent.
+ */
+export function buildCostBudgetPressureMessage(
+  costUSD: number,
+  maxCostUSD: number,
+): { role: "user"; content: string } | null {
+  if (maxCostUSD <= 0) return null;
+  return budgetPressureMessage(
+    costUSD / maxCostUSD,
+    "COST",
+    `$${costUSD.toFixed(4)}/$${maxCostUSD.toFixed(4)} spent`,
+  );
 }
 
 /** Share of the context budget past which the agent is told to stop gathering and write. */
@@ -212,8 +258,11 @@ interface LoopDeps {
   observer: AgentLoopObserver;
   logger: LoggerService;
   maxIterations: number;
-  /** Wall-clock budget in ms, for the ephemeral time-pressure nudge. Undefined = uncapped. */
+  /** Cost/token/duration ceilings and pricing, for the ephemeral pressure nudges. Undefined = uncapped. */
+  maxCostUSD: number | undefined;
+  maxTokens: number | undefined;
   maxDurationMs: number | undefined;
+  modelMetadata: UsageCostPricing | undefined;
   runRecursive: RecursiveRunner;
   /**
    * Attachment modalities this run's model accepts. Passed to tools so `read_file` on a
@@ -722,7 +771,10 @@ function runIteration(
     observer,
     logger,
     maxIterations,
+    maxCostUSD,
+    maxTokens,
     maxDurationMs,
+    modelMetadata,
     runRecursive,
   } = deps;
 
@@ -839,7 +891,31 @@ function runIteration(
       maxDurationMs !== undefined
         ? buildTimeBudgetPressureMessage(Date.now() - runMetrics.startedAt.getTime(), maxDurationMs)
         : null;
-    const pressureContent = [contextMsg?.content, budgetMsg?.content, timeBudgetMsg?.content]
+    const tokenBudgetMsg =
+      maxTokens !== undefined
+        ? buildTokenBudgetPressureMessage(
+            runMetrics.totalPromptTokens + runMetrics.totalCompletionTokens,
+            maxTokens,
+          )
+        : null;
+    // Reuses the same cost math as the hard-stop check in the outer loop (computeRunCost),
+    // so the nudge and the eventual cutoff never disagree about how much has been spent.
+    const costBudgetMsg =
+      maxCostUSD !== undefined
+        ? (() => {
+            const runCost = computeRunCost(runMetrics, modelMetadata);
+            return runCost.costUSD !== undefined
+              ? buildCostBudgetPressureMessage(runCost.costUSD, maxCostUSD)
+              : null;
+          })()
+        : null;
+    const pressureContent = [
+      contextMsg?.content,
+      budgetMsg?.content,
+      timeBudgetMsg?.content,
+      tokenBudgetMsg?.content,
+      costBudgetMsg?.content,
+    ]
       .filter(Boolean)
       .join("\n");
     const messagesForLLM = pressureContent
@@ -1169,7 +1245,10 @@ export function executeAgentLoop(
           observer,
           logger,
           maxIterations,
+          maxCostUSD,
+          maxTokens,
           maxDurationMs,
+          modelMetadata,
           runRecursive,
           supportedAttachmentKinds,
         };

--- a/packages/core/src/agent/execution/batch-executor.test.ts
+++ b/packages/core/src/agent/execution/batch-executor.test.ts
@@ -138,6 +138,9 @@ function makeRunContext(): AgentRunContext {
     knownSkills: [],
     maxRetries: 0,
     maxIterations: DEFAULT_MAX_ITERATIONS,
+    maxCostUSD: undefined,
+    maxTokens: undefined,
+    maxDurationMs: undefined,
   };
 }
 

--- a/packages/core/src/agent/execution/streaming-executor.test.ts
+++ b/packages/core/src/agent/execution/streaming-executor.test.ts
@@ -146,6 +146,9 @@ describe("executeWithStreaming", () => {
       connectedMCPServers: [],
       knownSkills: [],
       maxIterations: DEFAULT_MAX_ITERATIONS,
+      maxCostUSD: undefined,
+      maxTokens: undefined,
+      maxDurationMs: undefined,
     };
 
     const displayConfig = {
@@ -353,6 +356,9 @@ describe("executeWithStreaming", () => {
       connectedMCPServers: [],
       knownSkills: [],
       maxIterations: DEFAULT_MAX_ITERATIONS,
+      maxCostUSD: undefined,
+      maxTokens: undefined,
+      maxDurationMs: undefined,
     };
 
     const displayConfig = {
@@ -469,6 +475,9 @@ describe("executeWithStreaming", () => {
       connectedMCPServers: [],
       knownSkills: [],
       maxIterations: DEFAULT_MAX_ITERATIONS,
+      maxCostUSD: undefined,
+      maxTokens: undefined,
+      maxDurationMs: undefined,
     };
 
     const mockLLMService: LLMService = {

--- a/packages/core/src/agent/execution/tool-executor.test.ts
+++ b/packages/core/src/agent/execution/tool-executor.test.ts
@@ -92,6 +92,7 @@ function makeRunMetrics(): ReturnType<typeof createAgentRunMetrics> {
     agentUpdatedAt: new Date(),
     conversationId: "conv-123",
     maxIterations: 10,
+    maxCostUSD: undefined,
     startedAt: new Date(),
     totalPromptTokens: 0,
     totalCompletionTokens: 0,

--- a/packages/core/src/agent/metrics/agent-run-metrics.test.ts
+++ b/packages/core/src/agent/metrics/agent-run-metrics.test.ts
@@ -5,6 +5,7 @@ import { LoggerServiceTag } from "@/core/interfaces/logger";
 import {
   beginIteration,
   completeIteration,
+  computeRunCost,
   createAgentRunMetrics,
   estimateTokens,
   finalizeAgentRun,
@@ -166,5 +167,90 @@ describe("classifier usage", () => {
     expect(logged?.["classifierCompletionTokens"]).toBe(2);
     expect(logged?.["classifierRequests"]).toBe(2);
     expect(logged?.["classifierDurationMs"]).toBe(21);
+  });
+});
+
+describe("computeRunCost", () => {
+  const pricing = { inputPricePerMillion: 1, outputPricePerMillion: 2 };
+
+  it("prices own tokens against the given rates", () => {
+    const metrics = createMetrics();
+    metrics.totalPromptTokens = 100_000;
+    metrics.totalCompletionTokens = 100_000;
+
+    const { costUSD, costIncomplete } = computeRunCost(metrics, pricing);
+
+    expect(costUSD).toBeCloseTo(0.1 + 0.2, 8);
+    expect(costIncomplete).toBe(false);
+  });
+
+  it("prices zero tokens as zero cost when pricing is known", () => {
+    const metrics = createMetrics();
+    const { costUSD, costIncomplete } = computeRunCost(metrics, pricing);
+    expect(costUSD).toBe(0);
+    expect(costIncomplete).toBe(false);
+  });
+
+  it("returns undefined cost when nothing was spent and no pricing is known", () => {
+    const metrics = createMetrics();
+    const { costUSD, costIncomplete } = computeRunCost(metrics, undefined);
+    expect(costUSD).toBeUndefined();
+    expect(costIncomplete).toBe(false);
+  });
+
+  it("flags costIncomplete when tokens were spent but pricing is unavailable", () => {
+    const metrics = createMetrics();
+    metrics.provider = "openai";
+    metrics.model = "gpt-4";
+    metrics.totalPromptTokens = 100;
+    metrics.totalCompletionTokens = 100;
+
+    const { costUSD, costIncomplete } = computeRunCost(metrics, undefined);
+
+    expect(costUSD).toBeUndefined();
+    expect(costIncomplete).toBe(true);
+  });
+
+  it("never flags costIncomplete for a zero-cost local model with no pricing", () => {
+    const metrics = createMetrics();
+    metrics.provider = "ollama";
+    metrics.model = "qwen3.6:27b";
+    metrics.totalPromptTokens = 100;
+    metrics.totalCompletionTokens = 100;
+
+    const { costUSD, costIncomplete } = computeRunCost(metrics, undefined);
+
+    expect(costUSD).toBeUndefined();
+    expect(costIncomplete).toBe(false);
+  });
+
+  it("rolls up sub-agent (child) cost even when the run's own cost is unpriced", () => {
+    const metrics = createMetrics();
+    metrics.childCostUSD = 0.05;
+
+    const { costUSD, costIncomplete } = computeRunCost(metrics, undefined);
+
+    expect(costUSD).toBe(0.05);
+    expect(costIncomplete).toBe(false);
+  });
+
+  it("flags costIncomplete when a sub-agent's spend was itself unpriced", () => {
+    const metrics = createMetrics();
+    metrics.childCostUnknown = true;
+
+    const { costIncomplete } = computeRunCost(metrics, pricing);
+
+    expect(costIncomplete).toBe(true);
+  });
+
+  it("adds own and child cost together", () => {
+    const metrics = createMetrics();
+    metrics.totalPromptTokens = 100_000;
+    metrics.totalCompletionTokens = 0;
+    metrics.childCostUSD = 0.05;
+
+    const { costUSD } = computeRunCost(metrics, pricing);
+
+    expect(costUSD).toBeCloseTo(0.1 + 0.05, 8);
   });
 });

--- a/packages/core/src/agent/metrics/agent-run-metrics.test.ts
+++ b/packages/core/src/agent/metrics/agent-run-metrics.test.ts
@@ -23,10 +23,11 @@ const MINIMAL_AGENT = {
   updatedAt: new Date(),
 };
 
-function createMetrics() {
+function createMetrics(overrides?: { provider?: string; model?: string }) {
   return createAgentRunMetrics({
     agent: MINIMAL_AGENT,
     conversationId: "conv-123",
+    ...overrides,
   });
 }
 
@@ -199,9 +200,7 @@ describe("computeRunCost", () => {
   });
 
   it("flags costIncomplete when tokens were spent but pricing is unavailable", () => {
-    const metrics = createMetrics();
-    metrics.provider = "openai";
-    metrics.model = "gpt-4";
+    const metrics = createMetrics({ provider: "openai", model: "gpt-4" });
     metrics.totalPromptTokens = 100;
     metrics.totalCompletionTokens = 100;
 
@@ -212,9 +211,7 @@ describe("computeRunCost", () => {
   });
 
   it("never flags costIncomplete for a zero-cost local model with no pricing", () => {
-    const metrics = createMetrics();
-    metrics.provider = "ollama";
-    metrics.model = "qwen3.6:27b";
+    const metrics = createMetrics({ provider: "ollama", model: "qwen3.6:27b" });
     metrics.totalPromptTokens = 100;
     metrics.totalCompletionTokens = 100;
 

--- a/packages/core/src/agent/metrics/agent-run-metrics.ts
+++ b/packages/core/src/agent/metrics/agent-run-metrics.ts
@@ -5,12 +5,14 @@
 
 import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
+import { isZeroCostLocalModel } from "@/core/constants/local-providers";
 import type { LoggerService } from "@/core/interfaces/logger";
 import { LoggerServiceTag } from "@/core/interfaces/logger";
 import type { ClassifierUsage, TelemetryService, TokenUsage } from "@/core/interfaces/telemetry";
 import { type Agent } from "@/core/types";
 import type { ChatMessage } from "@/core/types/message";
 import { emitTelemetry } from "@/core/utils/telemetry-emit";
+import { computeUsageCostUSD, type UsageCostPricing } from "@/core/utils/usage-cost";
 import { DEFAULT_TOKEN_COUNTER } from "../context/token-counter";
 
 export interface AgentRunMetricsContext {
@@ -21,6 +23,8 @@ export interface AgentRunMetricsContext {
   readonly model?: string;
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
   readonly maxIterations?: number | undefined;
+  /** Per-run spend ceiling in USD, for telemetry parity with `maxIterations`. Unset = uncapped. */
+  readonly maxCostUSD?: number | undefined;
 }
 
 interface AgentRunIterationSummary {
@@ -47,6 +51,7 @@ export interface AgentRunMetrics {
   readonly model?: string;
   readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
   readonly maxIterations: number | undefined;
+  readonly maxCostUSD: number | undefined;
   readonly startedAt: Date;
   totalPromptTokens: number;
   totalCompletionTokens: number;
@@ -82,8 +87,16 @@ export interface AgentRunMetrics {
 }
 
 export function createAgentRunMetrics(context: AgentRunMetricsContext): AgentRunMetrics {
-  const { agent, conversationId, userId, provider, model, reasoningEffort, maxIterations } =
-    context;
+  const {
+    agent,
+    conversationId,
+    userId,
+    provider,
+    model,
+    reasoningEffort,
+    maxIterations,
+    maxCostUSD,
+  } = context;
 
   return {
     runId: randomUUID(),
@@ -97,6 +110,7 @@ export function createAgentRunMetrics(context: AgentRunMetricsContext): AgentRun
     ...(model ? { model } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     maxIterations,
+    maxCostUSD,
     startedAt: new Date(),
     totalPromptTokens: 0,
     totalCompletionTokens: 0,
@@ -146,6 +160,62 @@ export function recordLLMUsage(
   if (usage.cacheWriteTokens != null) {
     metrics.totalCacheWriteTokens += usage.cacheWriteTokens;
   }
+}
+
+export interface RunCost {
+  /** Own-run cost plus any sub-agent cost. Undefined only when nothing is priced yet. */
+  readonly costUSD: number | undefined;
+  /**
+   * True when some token spend in this run — the run's own turns or any sub-agent's —
+   * lacked pricing metadata, so `costUSD` understates real spend. Cost-capped callers
+   * must treat such runs as unpriced rather than let a cap silently under-enforce.
+   */
+  readonly costIncomplete: boolean;
+}
+
+/**
+ * Price a run's accumulated usage, folding in any sub-agent spend recorded via
+ * `childCostUSD`/`childCostUnknown`. Shared by run finalization (the reported
+ * `AgentResponse.costUSD`) and the live cost-cap check in the agent loop, so the two
+ * never compute cost differently.
+ */
+export function computeRunCost(
+  metrics: Pick<
+    AgentRunMetrics,
+    | "totalPromptTokens"
+    | "totalCompletionTokens"
+    | "totalCacheReadTokens"
+    | "childCostUSD"
+    | "childCostUnknown"
+    | "provider"
+    | "model"
+  >,
+  pricing: UsageCostPricing | undefined,
+): RunCost {
+  const ownCostUSD =
+    computeUsageCostUSD(
+      {
+        promptTokens: metrics.totalPromptTokens,
+        completionTokens: metrics.totalCompletionTokens,
+        cacheReadTokens: metrics.totalCacheReadTokens,
+      },
+      pricing,
+    ) ?? undefined;
+
+  // Report the run's own cost plus any sub-agent cost. Emit a figure whenever either
+  // side is known — a run with unpriced parent tokens but priced sub-agents should
+  // still surface the sub-agent spend.
+  const costUSD =
+    ownCostUSD !== undefined || metrics.childCostUSD > 0
+      ? parseFloat(((ownCostUSD ?? 0) + metrics.childCostUSD).toFixed(8))
+      : undefined;
+
+  const ownCostUnknown =
+    ownCostUSD === undefined &&
+    metrics.totalPromptTokens + metrics.totalCompletionTokens > 0 &&
+    !isZeroCostLocalModel(metrics.provider ?? "", metrics.model ?? "");
+
+  return { costUSD, costIncomplete: ownCostUnknown || metrics.childCostUnknown };
 }
 
 /**
@@ -290,6 +360,7 @@ export function finalizeAgentRun(
   details: {
     readonly iterationsUsed: number;
     readonly finished: boolean;
+    readonly costCapped?: boolean;
   },
 ): Effect.Effect<void, Error, LoggerService> {
   const endedAt = new Date();
@@ -339,7 +410,9 @@ export function finalizeAgentRun(
       }),
       iterations: details.iterationsUsed,
       maxIterations: metrics.maxIterations,
+      ...(metrics.maxCostUSD !== undefined && { maxCostUSD: metrics.maxCostUSD }),
       finished: details.finished,
+      ...(details.costCapped === true && { costCapped: true }),
       startedAt: metrics.startedAt,
       endedAt,
       durationMs,
@@ -391,7 +464,9 @@ interface TokenUsageLogPayload {
   readonly cacheWriteTokens?: number;
   readonly iterations: number;
   readonly maxIterations: number | undefined;
+  readonly maxCostUSD?: number;
   readonly finished: boolean;
+  readonly costCapped?: boolean;
   readonly startedAt: Date;
   readonly endedAt: Date;
   readonly durationMs: number;
@@ -443,7 +518,9 @@ function writeTokenUsageLog(
       reasoningEffort: payload.reasoningEffort ?? "disable",
       iterations: payload.iterations,
       maxIterations: payload.maxIterations,
+      ...(payload.maxCostUSD !== undefined && { maxCostUSD: payload.maxCostUSD }),
       finished: payload.finished,
+      ...(payload.costCapped === true && { costCapped: true }),
       retryCount: payload.retryCount,
       ...(payload.lastError ? { lastError: payload.lastError } : {}),
       promptTokens: payload.promptTokens,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -70,6 +70,30 @@ export interface AgentRunnerOptions {
    */
   readonly maxIterations?: number;
   /**
+   * Per-run spend ceiling in USD (own tokens plus any sub-agent spend). Checked between
+   * iterations, not preemptively mid-call — a run can overshoot by at most one iteration's
+   * cost before stopping. Skipped entirely when cost is unknown (e.g. an unpriced local
+   * model), so it never guess-aborts a run it cannot verify the spend of.
+   * If not specified, falls back to `maxCostUSD` in app config; unset at both means uncapped.
+   */
+  readonly maxCostUSD?: number;
+  /**
+   * Per-run token ceiling (own prompt + completion tokens; sub-agent token spend is not
+   * rolled up, unlike cost). Checked between iterations, same soft-checkpoint timing as
+   * `maxCostUSD`. Needs no pricing metadata, so it still enforces on an unpriced/local model
+   * where a cost cap cannot fire.
+   * If not specified, falls back to `maxTokens` in app config; unset at both means uncapped.
+   */
+  readonly maxTokens?: number;
+  /**
+   * Wall-clock spend budget in ms. The agent gets ephemeral pressure nudges at 50/80/90%
+   * elapsed (mirroring the iteration and context budget nudges), then the run is stopped
+   * between iterations once elapsed time reaches the budget — same soft-checkpoint timing
+   * as `maxCostUSD`/`maxTokens`, not a preemptive interrupt mid-call.
+   * If not specified, falls back to `maxDurationMs` in app config; unset at both means uncapped.
+   */
+  readonly maxDurationMs?: number;
+  /**
    * Full conversation history to date, including prior assistant, user, and tool messages.
    * Use this to preserve context across turns (e.g., approval flows, multi-step tasks).
    */
@@ -284,6 +308,24 @@ export interface AgentResponse {
    * spend. Cost-capped callers must treat such runs as unpriced.
    */
   readonly costIncomplete?: boolean;
+  /**
+   * True when the run was stopped early because cumulative spend reached the configured
+   * `maxCostUSD` cap. The answer is whatever the run had produced at that point — a partial
+   * result, same as hitting the iteration limit.
+   */
+  readonly costCapped?: boolean;
+  /**
+   * True when the run was stopped early because cumulative own tokens reached the
+   * configured `maxTokens` ceiling. The answer is whatever the run had produced at that
+   * point — a partial result, same as hitting the iteration limit or the cost cap.
+   */
+  readonly tokenCapped?: boolean;
+  /**
+   * True when the run was stopped early because elapsed wall-clock time reached the
+   * configured `maxDurationMs` budget. The answer is whatever the run had produced at
+   * that point — a partial result, same as hitting any other cap.
+   */
+  readonly durationCapped?: boolean;
 }
 
 /**
@@ -313,6 +355,12 @@ export interface AgentRunContext {
   readonly maxRetries?: number;
   /** Iteration budget, already resolved from the call site, config, and default. */
   readonly maxIterations: number;
+  /** Spend ceiling in USD, already resolved from the call site and config. Undefined = uncapped. */
+  readonly maxCostUSD: number | undefined;
+  /** Token ceiling, already resolved from the call site and config. Undefined = uncapped. */
+  readonly maxTokens: number | undefined;
+  /** Wall-clock budget in ms, already resolved from the call site and config. Undefined = uncapped. */
+  readonly maxDurationMs: number | undefined;
   readonly knownSkills: readonly {
     readonly name: string;
     readonly description: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -32,6 +32,22 @@ export interface AppConfig {
   readonly maxIterations?: number;
   /** Iteration budget for a sub-agent run. Defaults to 30. */
   readonly maxSubagentIterations?: number;
+  /**
+   * Per-run spend ceiling in USD (own tokens plus any sub-agent spend), checked between
+   * iterations. Unset means uncapped — there is no default ceiling. `--max-cost-usd` wins.
+   */
+  readonly maxCostUSD?: number;
+  /**
+   * Per-run token ceiling (own prompt + completion tokens), checked between iterations.
+   * Unset means uncapped. `--max-tokens` wins. Unlike `maxCostUSD`, needs no pricing
+   * metadata, so it still enforces on an unpriced/local model.
+   */
+  readonly maxTokens?: number;
+  /**
+   * Wall-clock spend budget in ms, checked between iterations, with pressure nudges to the
+   * agent at 50/80/90% elapsed. Unset means uncapped. `--max-duration-ms` wins.
+   */
+  readonly maxDurationMs?: number;
   readonly context?: ContextConfig;
   /**
    * Per-agent total size cap for the workspace scratch directory, in bytes.

--- a/packages/core/src/workflows/catch-up.ts
+++ b/packages/core/src/workflows/catch-up.ts
@@ -281,6 +281,9 @@ export function runCatchUpForWorkflows(
         conversationId: runId,
         pinInitialMessage: true,
         ...(workflow.maxIterations != null ? { maxIterations: workflow.maxIterations } : {}),
+        ...(workflow.maxCostUSD != null ? { maxCostUSD: workflow.maxCostUSD } : {}),
+        ...(workflow.maxTokens != null ? { maxTokens: workflow.maxTokens } : {}),
+        ...(workflow.maxDurationMs != null ? { maxDurationMs: workflow.maxDurationMs } : {}),
         ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
       }).pipe(
         Effect.tap(() =>

--- a/packages/core/src/workflows/workflow-service.ts
+++ b/packages/core/src/workflows/workflow-service.ts
@@ -37,6 +37,12 @@ export interface WorkflowMetadata {
   readonly maxCatchUpAge?: number;
   /** Maximum agent iterations per run. Unset, the run falls back to config `maxIterations`, then `DEFAULT_MAX_ITERATIONS` */
   readonly maxIterations?: number;
+  /** Per-run spend ceiling in USD. Unset, the run falls back to config `maxCostUSD`; unset at both means uncapped. */
+  readonly maxCostUSD?: number;
+  /** Per-run token ceiling. Unset, the run falls back to config `maxTokens`; unset at both means uncapped. */
+  readonly maxTokens?: number;
+  /** Wall-clock spend budget in ms. Unset, the run falls back to config `maxDurationMs`; unset at both means uncapped. */
+  readonly maxDurationMs?: number;
 }
 
 /**
@@ -112,6 +118,9 @@ function parseWorkflowFrontmatter(
     }),
     ...(typeof data["maxCatchUpAge"] === "number" && { maxCatchUpAge: data["maxCatchUpAge"] }),
     ...(typeof data["maxIterations"] === "number" && { maxIterations: data["maxIterations"] }),
+    ...(typeof data["maxCostUSD"] === "number" && { maxCostUSD: data["maxCostUSD"] }),
+    ...(typeof data["maxTokens"] === "number" && { maxTokens: data["maxTokens"] }),
+    ...(typeof data["maxDurationMs"] === "number" && { maxDurationMs: data["maxDurationMs"] }),
   };
 }
 

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -4,7 +4,7 @@ import {
   parseEventCategories,
   resolveStreamOption,
 } from "@jazz/cli/commands/run/flags";
-import { parsePositiveInt } from "@jazz/cli/utils/option-parsers";
+import { parsePositiveFloat, parsePositiveInt } from "@jazz/cli/utils/option-parsers";
 import { setCurrentCommandName } from "@jazz/core/utils/current-command";
 import { parseProviderModel } from "@jazz/core/utils/provider-model";
 import { Command } from "commander";
@@ -118,6 +118,21 @@ function registerRunCommand(program: Command): void {
       parsePositiveInt("--max-iterations"),
     )
     .option(
+      "--max-cost-usd <dollars>",
+      "Abort the run once cumulative spend (own + sub-agent) reaches this many dollars. Checked between iterations, not preemptively — see docs/reference/configuration.md.",
+      parsePositiveFloat("--max-cost-usd"),
+    )
+    .option(
+      "--max-tokens <n>",
+      "Abort the run once cumulative own tokens (prompt + completion) reach this count. Checked between iterations, same as --max-cost-usd but needs no model pricing.",
+      parsePositiveInt("--max-tokens"),
+    )
+    .option(
+      "--max-duration-ms <ms>",
+      "Abort the run once elapsed wall-clock time reaches this many milliseconds. The agent gets pressure nudges at 50/80/90% elapsed, then the run stops between iterations.",
+      parsePositiveInt("--max-duration-ms"),
+    )
+    .option(
       "--events <categories>",
       "Emit selected event categories as NDJSON to stderr during the run (comma-separated: tools,reasoning,text,usage,approval,subagent,all). stdout stays the clean payload.",
     )
@@ -173,6 +188,9 @@ function registerRunCommand(program: Command): void {
           timezone?: string;
           timeout?: number;
           maxIterations?: number;
+          maxCostUsd?: number;
+          maxTokens?: number;
+          maxDurationMs?: number;
           events?: string;
           reasoning?: string;
           conversation?: string;
@@ -290,6 +308,11 @@ function registerRunCommand(program: Command): void {
                 ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
                 ...(options.maxIterations !== undefined
                   ? { maxIterations: options.maxIterations }
+                  : {}),
+                ...(options.maxCostUsd !== undefined ? { maxCostUSD: options.maxCostUsd } : {}),
+                ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+                ...(options.maxDurationMs !== undefined
+                  ? { maxDurationMs: options.maxDurationMs }
                   : {}),
                 ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
                 ...(options.conversation !== undefined
@@ -1026,6 +1049,21 @@ function registerWorkflowCommands(program: Command): void {
       parsePositiveInt("--max-iterations"),
     )
     .option(
+      "--max-cost-usd <dollars>",
+      "Spend ceiling in USD, checked between iterations (overrides the workflow's own setting)",
+      parsePositiveFloat("--max-cost-usd"),
+    )
+    .option(
+      "--max-tokens <n>",
+      "Token ceiling, checked between iterations (overrides the workflow's own setting)",
+      parsePositiveInt("--max-tokens"),
+    )
+    .option(
+      "--max-duration-ms <ms>",
+      "Wall-clock budget in ms with 50/80/90% pressure nudges to the agent, checked between iterations (overrides the workflow's own setting). Distinct from --timeout: that is a hard external kill with no warning.",
+      parsePositiveInt("--max-duration-ms"),
+    )
+    .option(
       "--scheduled",
       "Indicates this run was triggered by the system scheduler (launchd/cron)",
     )
@@ -1054,6 +1092,9 @@ function registerWorkflowCommands(program: Command): void {
           autoApprove?: boolean;
           agent?: string;
           maxIterations?: number;
+          maxCostUsd?: number;
+          maxTokens?: number;
+          maxDurationMs?: number;
           scheduled?: boolean;
           json?: boolean;
           timeout?: number;
@@ -1097,6 +1138,7 @@ function registerWorkflowCommands(program: Command): void {
               mod.runWorkflowCommand(name, {
                 ...options,
                 ...(options.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+                ...(options.maxCostUsd !== undefined ? { maxCostUSD: options.maxCostUsd } : {}),
                 ...(eventCategories?.ok ? { eventTypes: eventCategories.types } : {}),
                 ...resolveStreamOption(options, eventCategories),
               }),


### PR DESCRIPTION
## Summary
- Adds three configurable per-run budgets — `maxCostUSD`, `maxTokens`, and `maxDurationMs` — alongside the existing `maxIterations`, settable via `~/.jazz/config.json`, workflow frontmatter, and new CLI flags (`--max-cost-usd`, `--max-tokens`, `--max-duration-ms`) on `jazz run` and `jazz workflow run`.
- Each is a soft checkpoint evaluated once between iterations (same timing as the existing iteration-budget guard), not a preemptive mid-call interrupt: `maxCostUSD` re-prices accumulated + sub-agent spend and is skipped entirely when pricing is unknown (never guess-aborts an unpriced run); `maxTokens` needs no pricing and still enforces on a local/unpriced model; `maxDurationMs` additionally nudges the agent with ephemeral pressure messages at 50/80/90% elapsed, mirroring the existing iteration and context-window pressure nudges.
- A capped run reports which cap fired (`costCapped` / `tokenCapped` / `durationCapped`) on `AgentResponse` and in the `jazz run --json` / `jazz workflow run --json` envelope, so CI can tell a run was cut short rather than genuinely finished.
- `maxDurationMs` is distinct from the existing `--timeout`: that remains a hard external kill (`Effect.race` against a deadline, no warning), while `maxDurationMs` is the warned, in-loop soft budget — both can be used together.

## Motivation
Jazz workflows run unattended in CI (e.g. daily digest jobs). There was no way to cap what a single run could spend in dollars, tokens, or wall-clock time — only a hard iteration count and an unwarned external timeout. This lets a project set e.g. `maxCostUSD: 0.20` on a workflow so CI never gets an unpleasant surprise, with the agent warned in advance rather than just cut off.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — full suite passes (3363 pass / 0 fail; pre-existing unrelated flakes only, e.g. `afinfo`-dependent media-probe test)
- [x] New unit tests: `computeRunCost` pricing/child-cost/unknown-pricing math, `buildTimeBudgetPressureMessage` thresholds, `parsePositiveFloat` CLI parser, observer message formatting
- [x] New integration tests in `agent-loop.test.ts`: a run trips `costCapped`/`tokenCapped`/`durationCapped` and stops early; a run under all three caps runs normally; a run with unknown pricing is never cost-capped
- [ ] Manual smoke test not run in this environment (no live LLM/network) — recommend a quick `jazz run --agent <id> --max-cost-usd 0.01 --json "<prompt>"` sanity check before merging