### PR TITLE
chore(adapters): update OpenRouter attribution headers

### DIFF
--- a/packages/adapters/src/llm/ai-sdk-service.ts
+++ b/packages/adapters/src/llm/ai-sdk-service.ts
@@ -784,7 +784,8 @@ function selectModel(
       const apiKey: string | undefined = llmConfig?.openrouter?.api_key;
       const headers: Record<string, string> = {
         "HTTP-Referer": "https://github.com/lvndry/jazz",
-        "X-Title": "Jazz CLI",
+        "X-Title": "Jazz",
+        "X-OpenRouter-Categories": "cli-agent,personal-agent",
       };
       const config: OpenRouterProviderSettings = {
         ...(apiKey ? { apiKey } : {}),


### PR DESCRIPTION
## Summary
- Renames the OpenRouter `X-Title` header from `Jazz CLI` to `Jazz`
- Adds `X-OpenRouter-Categories: cli-agent,personal-agent` for marketplace categorization

## Test plan
- [ ] Confirm requests to OpenRouter succeed and show updated title/categories on the OpenRouter activity dashboard