### PR TITLE
fix(ui): pin overlay z-index and opaque hint rows

### DIFF
--- a/packages/cli/src/ui/fullscreen/overlays/Approval.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/Approval.tsx
@@ -31,6 +31,7 @@ import { getGlyphs, type GlyphSet } from "../../glyphs";
 import { THEME } from "../../theme";
 import { clipTerminalCells, sliceTerminalCells, terminalCellWidth } from "../terminal-cells";
 import type { ApprovalOverlay, Viewport } from "../types";
+import { OVERLAY_Z_INDEX } from "./centered";
 
 /** Windowed width, and the floor below which windowing stops making sense. */
 const MAX_WIDTH = 96;
@@ -263,6 +264,7 @@ export function Approval({ model, viewport }: ApprovalProps): ReactNode {
     <box
       style={{
         position: "absolute",
+        zIndex: OVERLAY_Z_INDEX,
         left,
         top,
         width,
@@ -319,6 +321,7 @@ export function Approval({ model, viewport }: ApprovalProps): ReactNode {
           height: CONTROL_ROWS,
           flexShrink: 0,
           flexDirection: "row",
+          backgroundColor: THEME.canvas,
           paddingLeft: CARD_PAD + 1,
           paddingRight: CARD_PAD + 1,
         }}

--- a/packages/cli/src/ui/fullscreen/overlays/FilePicker.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/FilePicker.tsx
@@ -31,7 +31,7 @@ import {
   terminalCellWidth,
 } from "../terminal-cells";
 import type { Viewport } from "../types";
-import { centeredOffset } from "./centered";
+import { centeredOffset, OVERLAY_Z_INDEX } from "./centered";
 import { HintRow, type Hint } from "./TextPrompt";
 
 const MAX_WIDTH = 96;
@@ -201,6 +201,7 @@ export function FilePicker({ model, viewport }: FilePickerProps): ReactNode {
     <box
       style={{
         position: "absolute",
+        zIndex: OVERLAY_Z_INDEX,
         left,
         top,
         width,

--- a/packages/cli/src/ui/fullscreen/overlays/Question.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/Question.tsx
@@ -25,7 +25,7 @@
 
 import type { BorderCharacters } from "@opentui/core";
 import type { ReactNode } from "react";
-import { centeredOffset } from "./centered";
+import { centeredOffset, OVERLAY_Z_INDEX } from "./centered";
 import { CaretValue, HintRow, type Hint } from "./TextPrompt";
 import { getGlyphs, type GlyphSet } from "../../glyphs";
 import { PICKER_WINDOW_SIZE, pickerWindowStart } from "../../picker-window";
@@ -351,6 +351,7 @@ export function Question({ model, viewport }: QuestionProps): ReactNode {
     <box
       style={{
         position: "absolute",
+        zIndex: OVERLAY_Z_INDEX,
         left,
         top,
         width,

--- a/packages/cli/src/ui/fullscreen/overlays/Search.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/Search.tsx
@@ -26,6 +26,7 @@ import {
   terminalGraphemes,
 } from "../terminal-cells";
 import type { SearchHit, SearchOverlay, Viewport } from "../types";
+import { OVERLAY_Z_INDEX } from "./centered";
 
 const MAX_WIDTH = 96;
 const MIN_WINDOWED_HEIGHT = 20;
@@ -170,6 +171,7 @@ export function Search({ model, viewport }: SearchProps): ReactNode {
     <box
       style={{
         position: "absolute",
+        zIndex: OVERLAY_Z_INDEX,
         left,
         top,
         width,
@@ -284,6 +286,7 @@ export function Search({ model, viewport }: SearchProps): ReactNode {
           height: HINT_ROWS,
           flexShrink: 0,
           flexDirection: "row",
+          backgroundColor: THEME.canvas,
           paddingLeft: CARD_PAD + 1,
           paddingRight: CARD_PAD + 1,
         }}

--- a/packages/cli/src/ui/fullscreen/overlays/TextPrompt.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/TextPrompt.tsx
@@ -23,6 +23,7 @@
 
 import { TextAttributes, type BorderCharacters } from "@opentui/core";
 import type { ReactNode } from "react";
+import { OVERLAY_Z_INDEX } from "./centered";
 import { getGlyphs, type GlyphSet } from "../../glyphs";
 import { maskSecret, maskSecretCaret } from "../../mask-secret";
 import { THEME } from "../../theme";
@@ -278,6 +279,7 @@ export function HintRow({ hints, width, tally }: HintRowProps): ReactNode {
         height: HINT_ROWS,
         flexShrink: 0,
         flexDirection: "row",
+        backgroundColor: THEME.canvas,
         paddingLeft: HINT_PAD,
         paddingRight: HINT_PAD,
       }}
@@ -346,6 +348,7 @@ export function TextPrompt({ model, viewport }: TextPromptProps): ReactNode {
     <box
       style={{
         position: "absolute",
+        zIndex: OVERLAY_Z_INDEX,
         left,
         top,
         width,

--- a/packages/cli/src/ui/fullscreen/overlays/centered.ts
+++ b/packages/cli/src/ui/fullscreen/overlays/centered.ts
@@ -1,6 +1,13 @@
 import { terminalCellWidth } from "../terminal-cells";
 
 /**
+ * Only one overlay is ever open at a time, but painting order otherwise falls
+ * back to source position among siblings with equal zIndex. Pinning it this
+ * high keeps the overlay on top regardless of where it sits in App.tsx's tree.
+ */
+export const OVERLAY_Z_INDEX = 1000;
+
+/**
  * Horizontal centering for overlay option blocks, shared by every picker-style
  * overlay so the treatment cannot drift between them.
  *


### PR DESCRIPTION
## What & why
Fixes a visual bug where interactive prompts (approval, ask-a-question, text input, file picker, search) could show transcript text overlapping their frame. These overlays only ever floated above the rest of the UI by luck — nothing pinned them to the front, so their stacking depended on source order — and the keys/hint row beneath each card had no background, letting the transcript paint through it. This pins overlays to the front and makes that row opaque.

## How to verify
- Open jazz, trigger an `ask_user_question` prompt (or any tool approval) over a scrolled transcript with long lines, and confirm the hint row under the card shows no transcript text bleeding through.
- Repeat for the search overlay (`/` or history search) and the file picker — same check on their hint rows.
- Resize the terminal narrow enough to force fullscreen mode on an overlay and confirm it still renders cleanly on top.
