### PR TITLE
feat(agent): auto-inject job queue and workspace tools, defer memory

### DIFF
--- a/packages/cli/src/chat-service.ts
+++ b/packages/cli/src/chat-service.ts
@@ -24,6 +24,7 @@ import { JazzStateServiceTag, type JazzStateService } from "@jazz/core/interface
 import { type LLMService } from "@jazz/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@jazz/core/interfaces/logger";
 import { MCPServerManagerTag, type MCPServerManager } from "@jazz/core/interfaces/mcp-server";
+import { type PersonaService } from "@jazz/core/interfaces/persona-service";
 import { type PresentationService } from "@jazz/core/interfaces/presentation";
 import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
 import {
@@ -93,6 +94,7 @@ export class ChatServiceImpl implements ChatService {
     | ToolRequirements
     | SkillService
     | WorkflowService
+    | PersonaService
   > {
     return Effect.gen(function* () {
       const terminal = yield* TerminalServiceTag;

--- a/packages/cli/src/chat/commands/handler.test.ts
+++ b/packages/cli/src/chat/commands/handler.test.ts
@@ -5,9 +5,12 @@ import type { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { createFileSystemContextServiceLayer } from "@jazz/adapters/fs";
 import { saveConversation } from "@jazz/adapters/history/conversation-history-service";
+import { AgentConfigServiceTag, type AgentConfigService } from "@jazz/core/interfaces/agent-config";
 import { JazzStateServiceTag, type JazzStateService } from "@jazz/core/interfaces/jazz-state";
+import { type LLMService, LLMServiceTag } from "@jazz/core/interfaces/llm";
 import { LoggerServiceTag, type LoggerService } from "@jazz/core/interfaces/logger";
 import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
+import { ToolRegistryTag, type ToolRegistry } from "@jazz/core/interfaces/tool-registry";
 import type { Agent } from "@jazz/core/types/agent";
 import type { ChatMessage } from "@jazz/core/types/message";
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
@@ -310,6 +313,78 @@ describe("handleSpecialCommand /reasoning", () => {
     );
 
     expect(result.newAgent?.config.reasoningEffort).toBe("medium");
+  });
+});
+
+describe("handleSpecialCommand /tools", () => {
+  test("includes builtin categories not present in the agent's own config.tools", async () => {
+    const logged: string[] = [];
+    const mockTerminal: Partial<TerminalService> = {
+      log: mock((message: string) => {
+        logged.push(message);
+        return Effect.succeed(undefined);
+      }) as TerminalService["log"],
+      warn: mock(() => Effect.void),
+    };
+
+    // An agent whose config only ever selected file_management/http/shell_commands —
+    // no context/search_tools/todo/etc were ever explicitly picked.
+    const agentToolsByCategory: Record<string, readonly string[]> = {
+      "File Management": ["ls", "read_file"],
+      HTTP: ["http_request"],
+      "Shell Commands": ["execute_command"],
+      Context: ["context_info", "get_time"],
+      "Tool Search": ["search_tools"],
+    };
+
+    const mockToolRegistry: Partial<ToolRegistry> = {
+      listToolsByCategory: () => Effect.succeed(agentToolsByCategory),
+      getToolsInCategory: (categoryId: string) =>
+        Effect.succeed(
+          categoryId === "context"
+            ? ["context_info", "get_time"]
+            : categoryId === "search_tools"
+              ? ["search_tools"]
+              : [],
+        ),
+    };
+
+    const mockAgentConfigService: Partial<AgentConfigService> = {
+      appConfig: Effect.succeed({}) as AgentConfigService["appConfig"],
+    };
+    const mockLLMService: Partial<LLMService> = {
+      supportsNativeWebSearch: () => Effect.succeed(false),
+    };
+
+    const layers = Layer.mergeAll(
+      Layer.succeed(TerminalServiceTag, mockTerminal as unknown as TerminalService),
+      Layer.succeed(ToolRegistryTag, mockToolRegistry as unknown as ToolRegistry),
+      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService as unknown as AgentConfigService),
+      Layer.succeed(LLMServiceTag, mockLLMService as unknown as LLMService),
+      // PersonaServiceTag deliberately not provided: Effect.serviceOption resolves to
+      // None, matching a persona/agent with no explicit toolProfile.
+    );
+
+    const context: CommandContext = {
+      agent: { ...testAgent, config: { ...testAgent.config, tools: ["http_request"] } },
+      conversationHistory: [],
+      conversationId: "test-session",
+      sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionStartedAt: new Date(),
+    };
+
+    await Effect.runPromise(
+      handleSpecialCommand({ type: "tools", args: [] }, context).pipe(
+        Effect.provide(layers),
+      ) as Effect.Effect<CommandResult, unknown, never>,
+    );
+
+    const output = logged.join("\n");
+    expect(output).toContain("http_request");
+    // Builtin categories, auto-injected at runtime, must show even though they were
+    // never in agent.config.tools.
+    expect(output).toContain("context_info");
+    expect(output).toContain("search_tools");
   });
 });
 

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -14,6 +14,7 @@ import {
 } from "@jazz/core/agent/context/work-journal";
 import { formatWorkState, readWorkState } from "@jazz/core/agent/context/work-state";
 import { matchForbiddenCommand, runShellCommand } from "@jazz/core/agent/tools/shell-tools";
+import { BUILTIN_TOOL_CATEGORIES } from "@jazz/core/agent/tools/tool-categories";
 import { WEB_SEARCH_PROVIDERS } from "@jazz/core/agent/tools/web-search-tools";
 import { normalizeToolConfig } from "@jazz/core/agent/utils/tool-config";
 import type { ProviderName } from "@jazz/core/constants/models";
@@ -32,6 +33,7 @@ import {
   isStdioConfig,
   type MCPServerManager,
 } from "@jazz/core/interfaces/mcp-server";
+import { PersonaServiceTag, type PersonaService } from "@jazz/core/interfaces/persona-service";
 import type { PresentationService } from "@jazz/core/interfaces/presentation";
 import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
 import {
@@ -51,7 +53,7 @@ import { getModelsDevMetadata } from "@jazz/core/utils/models-dev";
 import type { WorkflowMetadata } from "@jazz/core/workflows/workflow-service";
 import { WorkflowServiceTag, type WorkflowService } from "@jazz/core/workflows/workflow-service";
 import { groupWorkflows } from "@jazz/core/workflows/workflow-utils";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { getGlyphs } from "@/cli/ui/glyphs";
 import { getThemeVariant, setThemeVariant } from "@/cli/ui/theme";
 import * as fmt from "@/cli/utils/list-format";
@@ -82,6 +84,7 @@ export function handleSpecialCommand(
   | WorkflowService
   | MCPServerManager
   | FileSystem.FileSystem
+  | PersonaService
 > {
   const { agent, conversationId, conversationHistory } = context;
 
@@ -547,7 +550,11 @@ function handleHelpCommand(
 function handleToolsCommand(
   terminal: TerminalService,
   agent: CommandContext["agent"],
-): Effect.Effect<CommandResult, never, ToolRegistry | AgentConfigService | LLMService> {
+): Effect.Effect<
+  CommandResult,
+  never,
+  ToolRegistry | AgentConfigService | LLMService | PersonaService
+> {
   return Effect.gen(function* () {
     const toolRegistry = yield* ToolRegistryTag;
     const allToolsByCategory = yield* toolRegistry.listToolsByCategory();
@@ -555,7 +562,38 @@ function handleToolsCommand(
     const agentToolNames = normalizeToolConfig(agent.config.tools, {
       agentId: agent.id,
     });
-    const agentToolSet = new Set(agentToolNames);
+
+    // Mirrors initializeAgentRun's category resolution (agent-runner.ts) so this
+    // display reflects the tools the agent actually gets at runtime, not just
+    // what's explicitly stored in its config.
+    const personaServiceOption = yield* Effect.serviceOption(PersonaServiceTag);
+    const resolvedPersona = Option.isSome(personaServiceOption)
+      ? yield* personaServiceOption.value
+          .getPersonaByIdentifier(agent.config.persona)
+          .pipe(Effect.catchAll(() => Effect.succeed(null)))
+      : null;
+    const toolProfile = resolvedPersona?.toolProfile;
+
+    const requestedBuiltinCategoryIds: readonly string[] =
+      toolProfile?.categories !== undefined
+        ? toolProfile.categories
+        : agent.config.persona === "summarizer"
+          ? []
+          : BUILTIN_TOOL_CATEGORIES.map((c) => c.id);
+
+    const validBuiltinCategoryIds = new Set(BUILTIN_TOOL_CATEGORIES.map((c) => c.id));
+    const builtInToolNames = (yield* Effect.all(
+      requestedBuiltinCategoryIds
+        .filter((id) => validBuiltinCategoryIds.has(id))
+        .map((id) => toolRegistry.getToolsInCategory(id)),
+    )).flat();
+
+    let combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
+    if (toolProfile?.deny && toolProfile.deny.length > 0) {
+      const denied = new Set(toolProfile.deny);
+      combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
+    }
+    const agentToolSet = new Set(combinedToolNames);
 
     const filteredToolsByCategory: Record<string, readonly string[]> = {};
     for (const [category, tools] of Object.entries(allToolsByCategory)) {

--- a/packages/core/src/agent/tools/tool-categories.ts
+++ b/packages/core/src/agent/tools/tool-categories.ts
@@ -55,12 +55,12 @@ export const TODO_CATEGORY: ToolCategory = { id: "todo", displayName: "Todo", lo
 export const MEMORY_CATEGORY: ToolCategory = {
   id: "memory",
   displayName: "Memory",
-  loadTier: "eager",
+  loadTier: "deferred",
 };
 export const WORKSPACE_CATEGORY: ToolCategory = {
   id: "workspace",
   displayName: "Workspace",
-  loadTier: "deferred",
+  loadTier: "eager",
 };
 export const PEERS_CATEGORY: ToolCategory = {
   id: "peers",
@@ -129,6 +129,8 @@ export const BUILTIN_TOOL_CATEGORIES: readonly ToolCategory[] = [
   CONTEXT_CATEGORY,
   SEARCH_TOOLS_CATEGORY,
   WEB_FETCH_CATEGORY,
+  JOB_QUEUE_CATEGORY,
+  WORKSPACE_CATEGORY,
 ] as const;
 
 /**

--- a/packages/core/src/interfaces/chat-service.ts
+++ b/packages/core/src/interfaces/chat-service.ts
@@ -14,6 +14,7 @@ import type { FileSystemContextService } from "./fs";
 import type { JazzStateService } from "./jazz-state";
 import type { LLMService } from "./llm";
 import type { LoggerService } from "./logger";
+import type { PersonaService } from "./persona-service";
 import type { PresentationService } from "./presentation";
 import type { TerminalService } from "./terminal";
 import type { ToolRegistry, ToolRequirements } from "./tool-registry";
@@ -66,6 +67,7 @@ export interface ChatService {
     | ToolRequirements
     | SkillService
     | WorkflowService
+    | PersonaService
   >;
 }
 


### PR DESCRIPTION
## What & why
Every agent now gets background-job tools (`enqueue_batch`/`list_jobs`/`cancel_batch`) and workspace tools (`view_workspace`/`manage_workspace`) automatically, regardless of when the agent was created or what its tool list was configured with. Previously these were opt-in per agent, so an agent created before either tool existed could never use it without being manually reconfigured — in practice, agents were falling back to polling long-running background commands with sleep loops instead of using the batch-job tool built for exactly that.

Memory tools (`view_memory`/`manage_memory`) move the other way, from always-loaded to loaded-on-demand, since they're used far less often per turn than the always-on tools and don't need full-schema prompt space by default.

Also fixes `/tools`: it only ever showed an agent's explicitly configured tool list, so builtin categories auto-injected at runtime (context, search_tools, job_queue, etc.) never showed up even though the agent actually had access to them. It now resolves the same persona/toolProfile logic the real agent run uses, so the display matches actual capability.

## How to verify
- Run an existing agent created before this change and confirm `enqueue_batch` and `view_workspace`/`manage_workspace` show up in its available tools without editing the agent's config.
- Give an agent a long-running background command and confirm it uses `enqueue_batch` instead of polling with `sleep`.
- Run `/tools` on an agent whose config only lists a couple of tools (e.g. `http_request`) and confirm builtin categories like Context and Tool Search still show up.
- Confirm memory tools are still usable when an agent's config explicitly selects them, just loaded on demand rather than upfront.
