### PR TITLE
feat(subagents): add validated structured results

### DIFF
--- a/docs/internals/subagents.md
+++ b/docs/internals/subagents.md
@@ -47,9 +47,9 @@ flowchart TB
 ```ts
 spawn_subagent({
   task: "Research the current state of WASM GC proposals. Return a 5-bullet summary with source URLs.",
-  name: "WASM researcher",        // optional — label for the UI panel
-  persona: "researcher",           // "default" | "coder" | "researcher"
-})
+  name: "WASM researcher", // optional — label for the UI panel
+  persona: "researcher", // "default" | "coder" | "researcher"
+});
 ```
 
 | Field     | Purpose                                                                                                                                                         |
@@ -58,8 +58,54 @@ spawn_subagent({
 | `name`    | Short role label shown in the sub-agent panel, so parallel children are distinguishable.                                                                        |
 | `persona` | `coder` for code and git work, `researcher` for investigation, `default` for general.                                                                           |
 
+## Structured results (experimental)
+
+Most sub-agents return a concise text answer. For a parent that needs a dependable
+machine-readable handoff, pass a JSON Schema in `resultSchema`:
+
+```ts
+spawn_subagent({
+  name: "Release researcher",
+  task: "Find the three most relevant releases this week.",
+  resultName: "release candidates",
+  resultSchema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["candidates"],
+    properties: {
+      candidates: { type: "array", items: { type: "string" } },
+    },
+  },
+});
+```
+
+Jazz tells the child to return exactly this envelope and validates `result` before
+giving it to the parent:
+
+```json
+{
+  "summary": "Found three releases worth reviewing.",
+  "result": { "candidates": ["…"] }
+}
+```
+
+On success, the parent receives the text `summary`, `structuredResult`, and child
+duration/cost metadata. An invalid envelope or result returns a tool error with
+validation details, so the parent can retry or change course rather than treating
+unstructured prose as data. `resultSchema` is opt-in; calls without it preserve
+the existing text-only return shape.
+
+The schema must be a local JSON Schema object. Jazz caps schema and result sizes,
+does not allow a root `$ref`, and validates it with its supported JSON Schema
+subset. Use a file or database for large durable research artifacts; structured
+results are for bounded handoffs, not a shared workspace.
+
+When streaming `--events subagent`, Jazz also emits `subagent_result` for a
+structured call. It records the child id, duration, known/unknown cost, and
+whether validation succeeded—never the result payload itself.
+
 A sub-agent always runs as the parent agent itself — same provider, same model, same config —
-varying only the persona. Delegating to a *different* saved agent, or running the child on a
+varying only the persona. Delegating to a _different_ saved agent, or running the child on a
 different model, is deliberately not offered.
 
 ---
@@ -188,7 +234,7 @@ that, a parent can spend its whole budget delegating and never write the answer 
 
 ## `summarize_context` — the other context tool
 
-Registered alongside `spawn_subagent`, `summarize_context` lets the agent compact its *own*
+Registered alongside `spawn_subagent`, `summarize_context` lets the agent compact its _own_
 history on purpose rather than waiting for the automatic 80% threshold. Useful when it knows
 it's about to go deep and would rather enter that phase with a clean window.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -239,7 +239,7 @@ state.
 
 | Tool                | Risk        | Approval pair | What it does                                                                                                 |
 | ------------------- | ----------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
-| `spawn_subagent`    | `low-risk`  | —             | Spawn a sub-agent with fresh context for a specific task. Personas: coder, researcher, default. Pass a shor… |
+| `spawn_subagent`    | `low-risk`  | —             | Spawn a sub-agent with fresh context for a specific task. Personas: coder, researcher, default. Optionally validate a bounded JSON handoff with `resultSchema`; see Sub-agents internals. |
 | `summarize_context` | `read-only` | —             | Compact conversation by summarizing older messages to free token budget. Always performs summarization when… |
 
 ### Perception Delegation

--- a/packages/cli/src/commands/run/flags.test.ts
+++ b/packages/cli/src/commands/run/flags.test.ts
@@ -60,6 +60,7 @@ describe("parseEventCategories", () => {
       "command_risk_classified",
       "subagent_start",
       "subagent_complete",
+      "subagent_result",
     ];
     expect([...result.types].sort()).toEqual(expected.sort());
   });

--- a/packages/cli/src/commands/run/flags.ts
+++ b/packages/cli/src/commands/run/flags.ts
@@ -33,7 +33,7 @@ const EVENT_CATEGORY_TYPES = {
     "command_risk_classifying",
     "command_risk_classified",
   ],
-  subagent: ["subagent_start", "subagent_complete"],
+  subagent: ["subagent_start", "subagent_complete", "subagent_result"],
 } as const satisfies Record<string, readonly StreamEvent["type"][]>;
 
 type EventCategory = keyof typeof EVENT_CATEGORY_TYPES;

--- a/packages/cli/src/presentation/activity-reducer.ts
+++ b/packages/cli/src/presentation/activity-reducer.ts
@@ -562,6 +562,7 @@ export function reduceEvent(
     case "approval_resolved":
     case "subagent_start":
     case "subagent_complete":
+    case "subagent_result":
       return { activity: null, outputs };
 
     // ---- Error ----------------------------------------------------------

--- a/packages/core/src/agent/tools/subagent-tools.test.ts
+++ b/packages/core/src/agent/tools/subagent-tools.test.ts
@@ -82,6 +82,14 @@ function runSpawn(
   presentation: PresentationService,
   context: Record<string, unknown> = {},
 ): Promise<unknown> {
+  return runSpawnArgs(presentation, { task: "do a thing", persona: "default" }, context);
+}
+
+function runSpawnArgs(
+  presentation: PresentationService,
+  args: Record<string, unknown>,
+  context: Record<string, unknown> = {},
+): Promise<unknown> {
   const tool = getSpawnTool();
   const testLayer = Layer.mergeAll(
     Layer.succeed(LoggerServiceTag, mockLogger),
@@ -89,13 +97,23 @@ function runSpawn(
   );
   return Effect.runPromise(
     (
-      tool.execute(
-        { task: "do a thing", persona: "default" },
-        { agentId: parentAgent.id, parentAgent, ...context },
-      ) as Effect.Effect<unknown, unknown, LoggerService | PresentationService>
+      tool.execute(args, { agentId: parentAgent.id, parentAgent, ...context }) as Effect.Effect<
+        unknown,
+        unknown,
+        LoggerService | PresentationService
+      >
     ).pipe(Effect.provide(testLayer)),
   );
 }
+
+const candidateResultSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["candidates"],
+  properties: {
+    candidates: { type: "array", items: { type: "string" } },
+  },
+} as const;
 
 describe("spawn_subagent auto-approve inheritance", () => {
   it("forwards the parent's auto-approve policy and allowlists to the sub-agent", async () => {
@@ -126,6 +144,117 @@ describe("spawn_subagent auto-approve inheritance", () => {
       expect(captured?.autoApprovedCommands).toEqual(["git status"]);
       expect(captured?.autoApprovedTools).toEqual(["read_file"]);
       expect(captured?.ephemeralRegionId).toBe("eph-test");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("spawn_subagent structured results", () => {
+  it("returns a validated result and child telemetry alongside the summary", async () => {
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation(() => {
+      return Effect.succeed({
+        content: JSON.stringify({
+          summary: "Found two candidates.",
+          result: { candidates: ["first", "second"] },
+        }),
+        costUSD: 0.0125,
+        conversationId: "conv-test",
+        messages: [],
+      }) as ReturnType<typeof AgentRunner.runRecursive>;
+    });
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const events: Array<Record<string, unknown>> = [];
+      const response = (await runSpawnArgs(
+        presentation,
+        {
+          task: "return candidates",
+          resultSchema: candidateResultSchema,
+          resultName: "research candidates",
+        },
+        {
+          emitEvent: (event: Record<string, unknown>) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+        },
+      )) as {
+        success: boolean;
+        result: {
+          summary: string;
+          structuredResult: { candidates: string[] };
+          child: { costUSD?: number; costKnown: boolean };
+        };
+      };
+
+      expect(response.success).toBe(true);
+      expect(response.result.summary).toBe("Found two candidates.");
+      expect(response.result.structuredResult).toEqual({ candidates: ["first", "second"] });
+      expect(response.result.child.costUSD).toBe(0.0125);
+      expect(response.result.child.costKnown).toBe(true);
+      expect(events.find((event) => event["type"] === "subagent_result")).toMatchObject({
+        subagentId: expect.any(String),
+        durationMs: expect.any(Number),
+        costUSD: 0.0125,
+        costKnown: true,
+        structuredResult: { requested: true, valid: true, resultName: "research candidates" },
+      });
+      expect(spy.mock.calls[0]?.[0].userInput).toContain("STRUCTURED COMPLETION REQUIRED");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns validation errors and telemetry when the child result misses required data", async () => {
+    const spy = spyOn(AgentRunner, "runRecursive").mockImplementation(() => {
+      return Effect.succeed({
+        content: JSON.stringify({ summary: "Incomplete result.", result: {} }),
+        conversationId: "conv-test",
+        messages: [],
+      }) as ReturnType<typeof AgentRunner.runRecursive>;
+    });
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const events: Array<Record<string, unknown>> = [];
+      const response = (await runSpawnArgs(
+        presentation,
+        { task: "return candidates", resultSchema: candidateResultSchema },
+        {
+          emitEvent: (event: Record<string, unknown>) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+        },
+      )) as { success: boolean; error?: string; result: { validationErrors: string[] } };
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("failed validation");
+      expect(response.result.validationErrors).toHaveLength(1);
+      expect(events.find((event) => event["type"] === "subagent_result")).toMatchObject({
+        structuredResult: { requested: true, valid: false, errorCount: 1 },
+        costKnown: false,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects an unsupported result schema before starting a child", async () => {
+    const spy = spyOn(AgentRunner, "runRecursive");
+
+    try {
+      const { presentation } = createPresentationHarness();
+      const response = (await runSpawnArgs(presentation, {
+        task: "return candidates",
+        resultSchema: { type: "array" },
+      })) as { success: boolean; error?: string };
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("root type");
+      expect(spy).not.toHaveBeenCalled();
     } finally {
       spy.mockRestore();
     }

--- a/packages/core/src/agent/tools/subagent-tools.ts
+++ b/packages/core/src/agent/tools/subagent-tools.ts
@@ -65,9 +65,140 @@ const spawnSubagentSchema = z.object({
       "Reasoning effort for this sub-agent. Omit to inherit the parent's effort. " +
         "Raise it for hard analysis tasks (deep review, root-cause hunting); lower it for mechanical ones.",
     ),
+  resultSchema: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe(
+      "Experimental JSON Schema for a structured child result. When supplied, the child must return a JSON envelope with a text summary and a result that validates against this schema.",
+    ),
+  resultName: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .describe(
+      "Optional human-readable label for the structured result, used in prompts and validation errors.",
+    ),
 });
 
 type SpawnSubagentArgs = z.infer<typeof spawnSubagentSchema>;
+
+type StructuredSubagentResult = {
+  readonly summary: string;
+  readonly structuredResult: unknown;
+  readonly child: {
+    readonly id: string;
+    readonly durationMs: number;
+    readonly costUSD?: number;
+    readonly costKnown: boolean;
+  };
+};
+
+type StructuredResultValidation =
+  | { readonly ok: true; readonly value: StructuredSubagentResult }
+  | { readonly ok: false; readonly errors: readonly string[] };
+
+const MAX_RESULT_SCHEMA_BYTES = 32 * 1024;
+const MAX_STRUCTURED_RESULT_BYTES = 128 * 1024;
+
+function describeJsonSchemaError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validateResultSchema(resultSchema: Record<string, unknown>): readonly string[] {
+  const errors: string[] = [];
+  const serialized = JSON.stringify(resultSchema);
+  if (serialized.length > MAX_RESULT_SCHEMA_BYTES) {
+    errors.push(`resultSchema must be at most ${MAX_RESULT_SCHEMA_BYTES} bytes`);
+  }
+  if (resultSchema["type"] !== "object") {
+    errors.push('resultSchema must declare a root type of "object"');
+  }
+  if ("$ref" in resultSchema) {
+    errors.push("resultSchema must not use a root $ref");
+  }
+  try {
+    z.fromJSONSchema(resultSchema);
+  } catch (error) {
+    errors.push(`resultSchema is not supported: ${describeJsonSchemaError(error)}`);
+  }
+  return errors;
+}
+
+function structuredCompletionInstructions(
+  resultSchema: Record<string, unknown>,
+  resultName: string | undefined,
+): string {
+  const label = resultName ?? "structured result";
+  return `\n\nSTRUCTURED COMPLETION REQUIRED\nReturn ONLY one valid JSON object, with no markdown fence or surrounding prose:\n{\n  "summary": "A concise plain-text summary for the parent",\n  "result": <${label} matching this JSON Schema>\n}\n\nThe result must validate against this JSON Schema:\n${JSON.stringify(resultSchema)}\n`;
+}
+
+function validateStructuredResult(
+  content: string,
+  resultSchema: Record<string, unknown>,
+  child: StructuredSubagentResult["child"],
+): StructuredResultValidation {
+  if (Buffer.byteLength(content, "utf8") > MAX_STRUCTURED_RESULT_BYTES) {
+    return {
+      ok: false,
+      errors: [`Structured child output must be at most ${MAX_STRUCTURED_RESULT_BYTES} bytes`],
+    };
+  }
+
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(content);
+  } catch {
+    return {
+      ok: false,
+      errors: ["Child did not return a valid JSON structured-result envelope"],
+    };
+  }
+
+  const parsedEnvelope = z
+    .object({ summary: z.string().min(1), result: z.unknown() })
+    .strict()
+    .safeParse(envelope);
+  if (!parsedEnvelope.success) {
+    return {
+      ok: false,
+      errors: parsedEnvelope.error.issues.map((issue) => {
+        const path = issue.path.join(".");
+        return path.length > 0 ? `${path}: ${issue.message}` : issue.message;
+      }),
+    };
+  }
+
+  let resultValidator: z.ZodType;
+  try {
+    resultValidator = z.fromJSONSchema(resultSchema);
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [`resultSchema is not supported: ${describeJsonSchemaError(error)}`],
+    };
+  }
+
+  const parsedResult = resultValidator.safeParse(parsedEnvelope.data.result);
+  if (!parsedResult.success) {
+    return {
+      ok: false,
+      errors: parsedResult.error.issues.map((issue) => {
+        const path = issue.path.join("result.");
+        return path.length > 0 ? `${path}: ${issue.message}` : issue.message;
+      }),
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      summary: parsedEnvelope.data.summary,
+      structuredResult: parsedResult.data,
+      child,
+    },
+  };
+}
 
 // ─── Summarize Tool ──────────────────────────────────────────────────
 
@@ -95,7 +226,8 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
         "The child cannot see this conversation, so put every fact, path, constraint, and the exact output shape in task. Only the child's final answer comes back. " +
         "Use this when the work would flood this context, when two or more independent investigations can run in parallel in one turn, or when you need a specialist (coder for code and git, researcher for read-only investigation). " +
         "Do not use this when a few greps or reads would finish the work, when the child would need to remember this conversation, when the work must mutate the same files in order, or when you are already under context pressure. " +
-        "The child inherits at most your tools, the same model, a 30-minute timeout, and 30 iterations. Nesting deeper than 3 is refused. Label parallel children with name.",
+        "The child inherits at most your tools, the same model, a 30-minute timeout, and 30 iterations. Nesting deeper than 3 is refused. Label parallel children with name. " +
+        "When resultSchema is supplied, Jazz validates the child's final JSON envelope and returns its summary plus structured result.",
       parameters: spawnSubagentSchema,
       hidden: false,
       riskLevel: "low-risk",
@@ -132,6 +264,17 @@ export function createSubagentTools(): Tool<ToolRequirements>[] {
                 `Sub-agent nesting limit reached (depth ${currentDepth} of ${maxDepth}). ` +
                 `Do this task yourself instead of delegating it further.`,
             };
+          }
+
+          if (args.resultSchema) {
+            const schemaErrors = validateResultSchema(args.resultSchema);
+            if (schemaErrors.length > 0) {
+              return {
+                success: false,
+                result: null,
+                error: `Invalid resultSchema: ${schemaErrors.join("; ")}`,
+              };
+            }
           }
 
           yield* logger.info("Spawning sub-agent", {
@@ -175,7 +318,7 @@ Rules:
 - Your response will be returned directly to the parent agent
 
 TASK:
-${args.task}`;
+${args.task}${args.resultSchema ? structuredCompletionInstructions(args.resultSchema, args.resultName) : ""}`;
 
           if (context.emitEvent) {
             yield* context.emitEvent({
@@ -275,6 +418,68 @@ ${args.task}`;
           });
 
           const fullResult = result?.trim() || "No output";
+
+          if (args.resultSchema) {
+            const structured = validateStructuredResult(fullResult, args.resultSchema, {
+              id: subAgent.id,
+              durationMs,
+              ...(response.costUSD !== undefined ? { costUSD: response.costUSD } : {}),
+              costKnown: !childCostUnknown,
+            });
+            if (!structured.ok) {
+              yield* logger.warn("Sub-agent structured result failed validation", {
+                parentAgentId: parentAgent.id,
+                subagentId: subAgent.id,
+                errorCount: structured.errors.length,
+              });
+              if (context.emitEvent) {
+                yield* context.emitEvent({
+                  type: "subagent_result",
+                  subagentId: subAgent.id,
+                  agentName: subagentLabel,
+                  durationMs,
+                  ...(response.costUSD !== undefined ? { costUSD: response.costUSD } : {}),
+                  costKnown: !childCostUnknown,
+                  structuredResult: {
+                    requested: true,
+                    valid: false,
+                    ...(args.resultName ? { resultName: args.resultName } : {}),
+                    errorCount: structured.errors.length,
+                  },
+                });
+              }
+              return {
+                success: false,
+                result: { rawSummary: fullResult, validationErrors: structured.errors },
+                error: `Sub-agent structured result failed validation: ${structured.errors.join("; ")}`,
+              };
+            }
+
+            if (context.emitEvent) {
+              yield* context.emitEvent({
+                type: "subagent_result",
+                subagentId: subAgent.id,
+                agentName: subagentLabel,
+                durationMs,
+                ...(response.costUSD !== undefined ? { costUSD: response.costUSD } : {}),
+                costKnown: !childCostUnknown,
+                structuredResult: {
+                  requested: true,
+                  valid: true,
+                  ...(args.resultName ? { resultName: args.resultName } : {}),
+                },
+              });
+            }
+
+            yield* logger.info("Sub-agent returned a validated structured result", {
+              parentAgentId: parentAgent.id,
+              subagentId: subAgent.id,
+              durationMs,
+            });
+            yield* presentation.writeOutput(`     ${structured.value.summary}`, subagentLabel);
+            return { success: true, result: structured.value };
+          }
+
           const maxLines = 10;
           const previewLines = fullResult.split("\n").slice(-maxLines).join("\n");
           const indentedLines = previewLines.split("\n").map((line) => `     ${line}`);

--- a/packages/core/src/types/streaming.ts
+++ b/packages/core/src/types/streaming.ts
@@ -142,7 +142,22 @@ export type StreamEvent =
    * and the event reaches the stream through the *parent's* renderer, which would
    * otherwise attribute it to the parent.
    */
-  | { type: "subagent_complete"; agentName?: string; durationMs?: number };
+  | { type: "subagent_complete"; agentName?: string; durationMs?: number }
+  /** Structured result status emitted when spawn_subagent was called with resultSchema. */
+  | {
+      type: "subagent_result";
+      subagentId: string;
+      agentName?: string;
+      durationMs: number;
+      costUSD?: number;
+      costKnown: boolean;
+      structuredResult: {
+        requested: true;
+        valid: boolean;
+        resultName?: string;
+        errorCount?: number;
+      };
+    };
 
 export interface StreamingResult {
   readonly stream: Stream.Stream<StreamEvent, LLMError>;


### PR DESCRIPTION
## What & why

Adds an opt-in structured result contract for subagents, so parent agents can receive schema-validated data rather than parsing prose. It also emits result-validation, duration, and cost telemetry for delegated work, making failed handoffs observable.

`resultSchema` is experimental and opt-in; text-only subagent calls continue unchanged.

## How to verify

- Run `bun test packages/core/src/agent/tools/subagent-tools.test.ts packages/cli/src/commands/run/flags.test.ts`.
- Start a parent that requests an object result; confirm it receives `summary`, `structuredResult`, and `subagent_result` telemetry.
- Return malformed JSON or omit a required field; confirm the child handoff fails with validation errors while legacy text-only calls still succeed.