### PR TITLE
fix(subagents): stop calling structured results experimental

### DIFF
--- a/packages/core/src/agent/tools/subagent-tools.ts
+++ b/packages/core/src/agent/tools/subagent-tools.ts
@@ -69,7 +69,7 @@ const spawnSubagentSchema = z.object({
     .record(z.string(), z.unknown())
     .optional()
     .describe(
-      "Experimental JSON Schema for a structured child result. When supplied, the child must return a JSON envelope with a text summary and a result that validates against this schema.",
+      "JSON Schema for a structured child result. When supplied, the child must return a JSON envelope with a text summary and a result that validates against this schema.",
     ),
   resultName: z
     .string()
@@ -77,7 +77,7 @@ const spawnSubagentSchema = z.object({
     .max(120)
     .optional()
     .describe(
-      "Optional human-readable label for the structured result, used in prompts and validation errors.",
+      "Human-readable label for the structured result, used in prompts and validation errors.",
     ),
 });
 


### PR DESCRIPTION
## What & why
Removes "Experimental" from the structured-child-result JSON Schema description in `spawn_subagent` — there's nothing experimental about structured output for subagents at this point, and the description shouldn't hedge on it. Also drops the redundant "Optional" from `resultName`'s description, since the field's own `.optional()` already conveys that.

## How to verify
- `bun test packages/core/src/agent/tools/subagent-tools.test.ts` — passes unchanged (wording-only change, no behavior change).