### PR TITLE
feat(website): add spotify link to header nav

### DIFF
--- a/packages/website/src/components/Hero.astro
+++ b/packages/website/src/components/Hero.astro
@@ -11,6 +11,7 @@
       <a href="/blog">blog</a>
       <a href="https://github.com/lvndry/jazz">github</a>
       <a href="https://discord.gg/yBDbS2NZju">discord</a>
+      <a href="https://open.spotify.com/playlist/14CrPS2gOGaIIRIrAKpUD1">spotify</a>
     </div>
   </nav>
   <h1 class="headline shout">


### PR DESCRIPTION
## Summary
- Adds a "spotify" link next to github/discord in the header nav, pointing to the project playlist (tracking `si` param stripped).

## Test plan
- [ ] Visually verify the header renders the new link on the site