### PR TITLE
feat(peers): add A2A as a second transport into the same peer core

### DIFF
--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -32,6 +32,7 @@ import { inviteStatus } from "@jazz/core/types/peer-invite";
 import type { TriggerConfig } from "@jazz/core/types/trigger";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
+import { buildPublicAgentCard, handleA2ARpc } from "@/adapters/peers/a2a";
 import {
   acceptInviteOnInviterSide,
   getInvite,
@@ -202,6 +203,31 @@ export function makeHandler(
 }
 
 /**
+ * Which configured peer presented this bearer token, if any.
+ *
+ * Read fresh on every request rather than once at startup: an invite accepted five minutes
+ * into this process's life must be usable without restarting it, or the whole point of
+ * accepting one over HTTP — no manual config edit, no restart — is undone by a daemon that
+ * only ever sees the peer list it booted with. Shared by every peer-facing door (`/peer/ask`
+ * and `/a2a`) so a token identifies its holder the same way regardless of which protocol
+ * they used to present it.
+ */
+async function resolveCallerPeer(
+  resolvePeers: () => Promise<readonly PeerConfig[]>,
+  resolveToken: (peerName: string) => Promise<string | undefined>,
+  presented: string,
+): Promise<PeerConfig | undefined> {
+  const peers = await resolvePeers();
+  for (const peer of peers) {
+    const expected = await resolveToken(peer.name);
+    if (expected !== undefined && expected.length > 0 && tokenMatches(expected, presented)) {
+      return peer;
+    }
+  }
+  return undefined;
+}
+
+/**
  * The peer-facing handler, separate from the operator's.
  *
  * A different door with a different credential. Everything on the operator's routes assumes
@@ -228,22 +254,7 @@ export function makePeerHandler(
       return json({ ok: false, error: "unauthorized" }, 401);
     }
 
-    // Read fresh on every request rather than once at startup: an invite accepted five
-    // minutes into this process's life must be usable without restarting it, or the whole
-    // point of accepting one over HTTP — no manual config edit, no restart — is undone by a
-    // daemon that only ever sees the peer list it booted with.
-    const peers = await resolvePeers();
-
-    // Which peer is this? Resolved by matching the presented token against each configured
-    // peer's own, so a token identifies its holder rather than merely admitting them.
-    let caller: PeerConfig | undefined;
-    for (const peer of peers) {
-      const expected = await resolveToken(peer.name);
-      if (expected !== undefined && expected.length > 0 && tokenMatches(expected, presented)) {
-        caller = peer;
-        break;
-      }
-    }
+    const caller = await resolveCallerPeer(resolvePeers, resolveToken, presented);
     if (caller === undefined) {
       return json({ ok: false, error: "unauthorized" }, 401);
     }
@@ -260,6 +271,55 @@ export function makePeerHandler(
     }
 
     return runEffect(answerPeer(caller, options.peerAgent, question));
+  };
+}
+
+/**
+ * A2A's own doors: an unauthenticated capability card, and an authenticated JSON-RPC
+ * endpoint. Not a second implementation of peer authorization — `answerA2A` resolves the
+ * same persona override and calls the same `servePeerRequest` `/peer/ask` does; this handler
+ * only exists to speak a different wire format to it.
+ */
+export function makeA2AHandler(
+  options: DaemonOptions,
+  resolvePeers: () => Promise<readonly PeerConfig[]>,
+  resolveToken: (peerName: string) => Promise<string | undefined>,
+  runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
+): (request: Request) => Promise<Response> {
+  return async function handleA2A(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/.well-known/agent-card.json") {
+      if (options.peerAgent === undefined) {
+        return json({ ok: false, error: "not accepting peer questions" }, 404);
+      }
+      return json(buildPublicAgentCard(options.peerAgent));
+    }
+
+    if (request.method !== "POST" || url.pathname !== "/a2a") {
+      return json({ ok: false, error: "not found" }, 404);
+    }
+    if (options.peerAgent === undefined) {
+      return json({ ok: false, error: "not accepting peer questions" }, 404);
+    }
+
+    const presented = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");
+    if (presented.length === 0) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+    const caller = await resolveCallerPeer(resolvePeers, resolveToken, presented);
+    if (caller === undefined) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ ok: false, error: "body must be JSON" }, 400);
+    }
+
+    return runEffect(answerA2A(caller, options.peerAgent, body));
   };
 }
 
@@ -497,17 +557,25 @@ function fireTrigger(trigger: TriggerConfig, payload: string) {
   ) as Effect.Effect<Response, unknown, AgentService>;
 }
 
+/**
+ * A peer's `persona` swaps only the persona on the daemon's peer-serving agent, not the
+ * whole agent — capability lives on the persona (`PersonaToolProfile`), so this is enough to
+ * give one peer a narrower or differently-wired identity than another while both share the
+ * same model/provider config. Shared by every peer-facing door.
+ */
+function agentForPeer<T extends { readonly config: { readonly persona: string } }>(
+  base: T,
+  peer: PeerConfig,
+): T {
+  return peer.persona !== undefined
+    ? { ...base, config: { ...base.config, persona: peer.persona } }
+    : base;
+}
+
 function answerPeer(peer: PeerConfig, agentIdentifier: string, question: string) {
   return Effect.gen(function* () {
     const base = yield* getAgentByIdentifier(agentIdentifier);
-    // A peer's `persona` swaps only the persona on the daemon's peer-serving agent, not the
-    // whole agent — capability lives on the persona (`PersonaToolProfile`), so this is
-    // enough to give one peer a narrower or differently-wired identity than another while
-    // both share the same model/provider config.
-    const agent =
-      peer.persona !== undefined
-        ? { ...base, config: { ...base.config, persona: peer.persona } }
-        : base;
+    const agent = agentForPeer(base, peer);
     const outcome = yield* servePeerRequest({ peer, agent, question });
 
     switch (outcome.kind) {
@@ -520,6 +588,25 @@ function answerPeer(peer: PeerConfig, agentIdentifier: string, question: string)
     Effect.catchAll((error) =>
       Effect.succeed(
         json({ ok: false, error: error instanceof Error ? error.message : String(error) }, 500),
+      ),
+    ),
+  );
+}
+
+function answerA2A(peer: PeerConfig, agentIdentifier: string, body: unknown) {
+  return Effect.gen(function* () {
+    const base = yield* getAgentByIdentifier(agentIdentifier);
+    const agent = agentForPeer(base, peer);
+    const response = yield* handleA2ARpc(agentIdentifier, peer, agent, body);
+    return json(response);
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.succeed(
+        json({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
+        }),
       ),
     ),
   );

--- a/packages/adapters/src/peers/a2a.test.ts
+++ b/packages/adapters/src/peers/a2a.test.ts
@@ -26,13 +26,13 @@ describe("the public agent card", () => {
 
 describe("the extended agent card", () => {
   it("reflects exactly what this peer's tier admits", () => {
-    const peer: PeerConfig = { name: "sam", may: "public" };
+    const peer: PeerConfig = { name: "sam", disclosure: "public" };
     const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
     expect(card.skills[0]?.tags).toEqual(["web_search"]);
   });
 
   it("adds a granted riskier tool without needing a wider tier", () => {
-    const peer: PeerConfig = { name: "sam", may: "public", allow: ["send_message"] };
+    const peer: PeerConfig = { name: "sam", disclosure: "public", allow: ["send_message"] };
     const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
     expect(card.skills[0]?.tags).toContain("send_message");
     expect(card.skills[0]?.tags).toContain("web_search");

--- a/packages/adapters/src/peers/a2a.test.ts
+++ b/packages/adapters/src/peers/a2a.test.ts
@@ -1,0 +1,63 @@
+import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
+import type { PeerConfig } from "@jazz/core/types/peer";
+import { describe, expect, it } from "bun:test";
+import { buildExtendedAgentCard, buildPublicAgentCard, parseA2ARequest } from "./a2a";
+
+const TOOLS: readonly {
+  name: string;
+  riskLevel: string;
+  disclosure: ToolDisclosure;
+}[] = [
+  { name: "get_time", riskLevel: "read-only", disclosure: "internal" },
+  { name: "web_search", riskLevel: "read-only", disclosure: "public" },
+  { name: "read_file", riskLevel: "read-only", disclosure: "private" },
+  { name: "send_message", riskLevel: "high-risk", disclosure: "public" },
+];
+
+describe("the public agent card", () => {
+  it("is the same for every caller, and advertises the bearer scheme it actually accepts", () => {
+    const card = buildPublicAgentCard("my-agent");
+    expect(card.securitySchemes).toEqual([{ id: "peer-token", type: "http", scheme: "bearer" }]);
+    expect(card.capabilities.extendedAgentCard).toBe(true);
+    // No peer-specific detail: this is the discovery document, not a grant.
+    expect(card.skills).toHaveLength(1);
+  });
+});
+
+describe("the extended agent card", () => {
+  it("reflects exactly what this peer's tier admits", () => {
+    const peer: PeerConfig = { name: "sam", may: "public" };
+    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    expect(card.skills[0]?.tags).toEqual(["web_search"]);
+  });
+
+  it("adds a granted riskier tool without needing a wider tier", () => {
+    const peer: PeerConfig = { name: "sam", may: "public", allow: ["send_message"] };
+    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    expect(card.skills[0]?.tags).toContain("send_message");
+    expect(card.skills[0]?.tags).toContain("web_search");
+    expect(card.skills[0]?.tags).not.toContain("read_file");
+  });
+
+  it("reflects a suspended peer as reaching nothing", () => {
+    const peer: PeerConfig = { name: "sam" };
+    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    expect(card.skills[0]?.tags).toEqual([]);
+    expect(card.skills[0]?.description).toContain("suspended");
+  });
+});
+
+describe("parsing a JSON-RPC request", () => {
+  it("accepts a well-formed envelope", () => {
+    const parsed = parseA2ARequest({ jsonrpc: "2.0", id: 1, method: "a2a.SendMessage" });
+    expect(parsed?.method).toBe("a2a.SendMessage");
+  });
+
+  it("rejects anything missing jsonrpc, id, or method", () => {
+    expect(parseA2ARequest({ id: 1, method: "a2a.SendMessage" })).toBeUndefined();
+    expect(parseA2ARequest({ jsonrpc: "2.0", method: "a2a.SendMessage" })).toBeUndefined();
+    expect(parseA2ARequest({ jsonrpc: "2.0", id: 1 })).toBeUndefined();
+    expect(parseA2ARequest("not an object")).toBeUndefined();
+    expect(parseA2ARequest(null)).toBeUndefined();
+  });
+});

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -100,7 +100,7 @@ export function buildExtendedAgentCard(
     readonly disclosure: ToolDisclosure;
   }[],
 ): AgentCard {
-  const tier = peer.may ?? "none";
+  const tier = peer.disclosure ?? "none";
   const allow = peer.allow ?? [];
   const reachable = allowedToolsForPeer(tier, allow, tools);
   const base = buildPublicAgentCard(agentName);

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -1,0 +1,232 @@
+/**
+ * @fileoverview A second door into the same room.
+ *
+ * `/peer/ask` is jazz's own protocol: a plain question in, a plain answer out. A2A
+ * (Google's Agent2Agent protocol, now Linux Foundation-governed alongside MCP) is the
+ * emerging standard for the same thing between agents that were never built to know about
+ * each other. Its authorization model is deliberately unopinionated — a server must reject
+ * an unauthorized caller, but the spec never says who counts as authorized — which is
+ * exactly the gap jazz's tier/persona/`allow` model fills.
+ *
+ * So this is not a second trust system. Every request here is authenticated the same way
+ * `/peer/ask` already is (a peer's own bearer token) and answered by the same
+ * `servePeerRequest` — same ledger, same `toolAllowlist`, same persona resolution. What A2A
+ * adds is a standards-shaped wire format and a capability-discovery document, nothing more.
+ *
+ * Deliberately minimal: one synchronous message method, one card-fetch method. No task
+ * lifecycle, no streaming, no push notifications, no OAuth2/OIDC/mTLS — none of that has a
+ * caller yet, and bolting it on speculatively is exactly the scope creep this feature nearly
+ * shipped with the first time around.
+ */
+
+import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
+import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
+import type { Agent } from "@jazz/core/types";
+import type { PeerConfig } from "@jazz/core/types/peer";
+import { Effect } from "effect";
+import { allowedToolsForPeer, servePeerRequest } from "./serve";
+
+/** The one security scheme this server actually accepts: a peer's own bearer token. */
+const SECURITY_SCHEME_ID = "peer-token";
+
+export interface AgentSkill {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly tags: readonly string[];
+}
+
+export interface AgentCard {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly capabilities: {
+    readonly streaming: boolean;
+    readonly pushNotifications: boolean;
+    readonly extendedAgentCard: boolean;
+  };
+  readonly securitySchemes: readonly {
+    readonly id: string;
+    readonly type: "http";
+    readonly scheme: "bearer";
+  }[];
+  readonly security: readonly Record<string, readonly string[]>[];
+  readonly skills: readonly AgentSkill[];
+}
+
+/**
+ * The unauthenticated card. Same for every caller, on purpose — this is the "what kind of
+ * thing is this" advertisement, not a peer-specific capability list. See
+ * `buildExtendedAgentCard` for the one that actually reflects a relationship.
+ */
+export function buildPublicAgentCard(agentName: string): AgentCard {
+  return {
+    id: agentName,
+    name: agentName,
+    description:
+      "A jazz agent. Answers questions from established peers, within a disclosure tier " +
+      "and tool grant its operator configured for each one. Fetch the extended card after " +
+      "authenticating to see what a specific relationship can actually reach.",
+    capabilities: { streaming: false, pushNotifications: false, extendedAgentCard: true },
+    securitySchemes: [{ id: SECURITY_SCHEME_ID, type: "http", scheme: "bearer" }],
+    security: [{ [SECURITY_SCHEME_ID]: [] }],
+    skills: [
+      {
+        id: "answer_question",
+        name: "Answer a question",
+        description:
+          "Answers a plain-text question, subject to the caller's configured trust tier " +
+          "and tool grant. Capability is fixed per relationship, not negotiable per request.",
+        tags: ["read-only", "trust-scoped"],
+      },
+    ],
+  };
+}
+
+/**
+ * The authenticated card: skills reflect exactly what this peer's effective tool set is
+ * right now, so a real caller can discover what they can reach instead of guessing from a
+ * generic description.
+ */
+export function buildExtendedAgentCard(
+  agentName: string,
+  peer: PeerConfig,
+  tools: readonly {
+    readonly name: string;
+    readonly riskLevel: string;
+    readonly disclosure: ToolDisclosure;
+  }[],
+): AgentCard {
+  const tier = peer.may ?? "none";
+  const allow = peer.allow ?? [];
+  const reachable = allowedToolsForPeer(tier, allow, tools);
+  const base = buildPublicAgentCard(agentName);
+  return {
+    ...base,
+    skills: [
+      {
+        id: "answer_question",
+        name: "Answer a question",
+        description: `Answers a plain-text question using: ${reachable.length > 0 ? reachable.join(", ") : "nothing — this peer is suspended"}.`,
+        tags: reachable,
+      },
+    ],
+  };
+}
+
+interface JsonRpcRequest {
+  readonly jsonrpc: "2.0";
+  readonly id: string | number;
+  readonly method: string;
+  readonly params?: unknown;
+}
+
+interface JsonRpcSuccess {
+  readonly jsonrpc: "2.0";
+  readonly id: string | number;
+  readonly result: unknown;
+}
+
+interface JsonRpcFailure {
+  readonly jsonrpc: "2.0";
+  readonly id: string | number | null;
+  readonly error: { readonly code: number; readonly message: string };
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure;
+
+export function parseA2ARequest(body: unknown): JsonRpcRequest | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const candidate = body as Record<string, unknown>;
+  if (
+    candidate["jsonrpc"] === "2.0" &&
+    (typeof candidate["id"] === "string" || typeof candidate["id"] === "number") &&
+    typeof candidate["method"] === "string"
+  ) {
+    return {
+      jsonrpc: "2.0",
+      id: candidate["id"],
+      method: candidate["method"],
+      params: candidate["params"],
+    };
+  }
+  return undefined;
+}
+
+function extractQuestion(params: unknown): string | undefined {
+  if (typeof params !== "object" || params === null) return undefined;
+  const message = (params as Record<string, unknown>)["message"];
+  if (typeof message !== "object" || message === null) return undefined;
+  const parts = (message as Record<string, unknown>)["parts"];
+  if (!Array.isArray(parts)) return undefined;
+  const texts = parts
+    .map((part) =>
+      typeof part === "object" &&
+      part !== null &&
+      typeof (part as Record<string, unknown>)["text"] === "string"
+        ? ((part as Record<string, unknown>)["text"] as string)
+        : undefined,
+    )
+    .filter((text): text is string => text !== undefined);
+  const question = texts.join("\n").trim();
+  return question.length > 0 ? question : undefined;
+}
+
+function methodNotFound(id: string | number, method: string): JsonRpcFailure {
+  return { jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } };
+}
+
+function invalidParams(id: string | number, detail: string): JsonRpcFailure {
+  return { jsonrpc: "2.0", id, error: { code: -32602, message: `Invalid params: ${detail}` } };
+}
+
+/**
+ * The JSON-RPC dispatch. Both methods this server understands go through the exact same
+ * `servePeerRequest` `/peer/ask` already calls — this is a wire-format translation, not a
+ * second implementation of the authorization decision.
+ */
+export function handleA2ARpc(agentName: string, peer: PeerConfig, agent: Agent, raw: unknown) {
+  return Effect.gen(function* () {
+    const request = parseA2ARequest(raw);
+    if (request === undefined) {
+      return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Invalid Request" } };
+    }
+
+    if (request.method === "a2a.GetExtendedAgentCard") {
+      const registry = yield* ToolRegistryTag;
+      const names = yield* registry.listTools();
+      const described: { name: string; riskLevel: string; disclosure: ToolDisclosure }[] = [];
+      for (const name of names) {
+        const tool = yield* registry.getTool(name);
+        described.push({ name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
+      }
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: buildExtendedAgentCard(agentName, peer, described),
+      };
+    }
+
+    if (request.method === "a2a.SendMessage") {
+      const question = extractQuestion(request.params);
+      if (question === undefined) {
+        return invalidParams(request.id, "params.message.parts must include non-empty text");
+      }
+      const outcome = yield* servePeerRequest({ peer, agent, question });
+      if (outcome.kind === "answered") {
+        return {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            messageId: `a2a-${Date.now().toString(36)}`,
+            role: "ROLE_AGENT",
+            parts: [{ text: outcome.answer }],
+          },
+        };
+      }
+      return { jsonrpc: "2.0", id: request.id, error: { code: -32001, message: outcome.reason } };
+    }
+
+    return methodNotFound(request.id, request.method);
+  });
+}

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -19,6 +19,7 @@
  * shipped with the first time around.
  */
 
+import { resolveAgentToolNames } from "@jazz/core/agent/tools/agent-tool-resolution";
 import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
 import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
 import type { Agent } from "@jazz/core/types";
@@ -76,7 +77,9 @@ export function buildPublicAgentCard(agentName: string): AgentCard {
         name: "Answer a question",
         description:
           "Answers a plain-text question, subject to the caller's configured trust tier " +
-          "and tool grant. Capability is fixed per relationship, not negotiable per request.",
+          "and tool grant. Capability is fixed by the operator's own agent configuration, " +
+          "the same for every peer — not negotiable per request, and not something a " +
+          "relationship's tier or grant can ever widen.",
         tags: ["read-only", "trust-scoped"],
       },
     ],
@@ -193,10 +196,19 @@ export function handleA2ARpc(agentName: string, peer: PeerConfig, agent: Agent, 
     }
 
     if (request.method === "a2a.GetExtendedAgentCard") {
+      // Scoped to what `agent` (the actual identity answering this peer) can really reach —
+      // not the global registry, which lists every tool registered for every agent on this
+      // machine. Advertising from the wrong source is how a card ends up promising a tool
+      // this agent was never even given.
       const registry = yield* ToolRegistryTag;
-      const names = yield* registry.listTools();
+      const allToolNames = yield* registry.listAllTools();
+      // Same defensive filter `initializeAgentRun` applies: a custom tool an agent still
+      // names in config can outlive its own MCP server or registration.
+      const reachableNames = (yield* resolveAgentToolNames(agent)).filter((name) =>
+        allToolNames.includes(name),
+      );
       const described: { name: string; riskLevel: string; disclosure: ToolDisclosure }[] = [];
-      for (const name of names) {
+      for (const name of reachableNames) {
         const tool = yield* registry.getTool(name);
         described.push({ name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
       }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -11,6 +11,7 @@ import { randomBytes } from "node:crypto";
 import {
   DEFAULT_DAEMON_PORT,
   isLoopback,
+  makeA2AHandler,
   makeHandler,
   makePeerHandler,
   makePeerInviteHandler,
@@ -127,11 +128,21 @@ export function daemonCommand(options: DaemonCommandOptions) {
         (triggerName) => Effect.runPromise(resolveTriggerToken(triggerName)),
         run,
       );
+      // A2A is a second door into the same peer-serving logic `handlePeer` already
+      // authenticates and answers through — see `makeA2AHandler`'s own comment.
+      const handleA2A = makeA2AHandler(
+        daemonOptions,
+        resolvePeers,
+        (peerName) => Effect.runPromise(resolvePeerToken(peerName)),
+        run,
+      );
 
       const routes: readonly { readonly prefix: string; readonly handle: typeof handle }[] = [
         { prefix: "/peer/", handle: handlePeer },
         { prefix: "/peer-invites/", handle: handlePeerInvite },
         { prefix: "/triggers/", handle: handleTrigger },
+        { prefix: "/a2a", handle: handleA2A },
+        { prefix: "/.well-known/", handle: handleA2A },
       ];
 
       const server = Bun.serve({

--- a/packages/core/src/agent/tools/agent-tool-resolution.ts
+++ b/packages/core/src/agent/tools/agent-tool-resolution.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview What a specific configured agent actually resolves its tool set to.
+ *
+ * Mirrors `initializeAgentRun`'s own category/deny resolution (`agent-runner.ts`) — the same
+ * logic `/tools` already duplicated once to answer "what can this agent do" without running
+ * a turn (`packages/cli/src/chat/commands/handler.ts`). A second caller needing the same
+ * answer (an A2A capability card advertising a peer's actual reach) is the second time this
+ * exact duplication showed up, which is the point past which it becomes a shared function
+ * instead of a third copy.
+ *
+ * Not a statement that persona carries capability — it doesn't. Persona is a mindset: a
+ * system prompt, nothing about what an agent can touch. Capability is fixed by which agent
+ * an operator chooses to run (its own tool config), the same for every peer who reaches it.
+ * `PersonaToolProfile` exists as a field on `Persona` and, mechanically, `agent-runner.ts`
+ * still applies it if one is ever set — so this function stays accurate to whatever the
+ * agent's *current* persona actually resolves to, purely so nothing here can advertise more
+ * than a real run would honor. It is not an endorsement of scoping capability through
+ * persona; an operator wanting a narrower peer-facing identity should build a dedicated
+ * agent with its own tool config, not lean on a persona's `toolProfile`.
+ *
+ * Deliberately partial: this resolves built-in categories and `deny`, not MCP tools, custom
+ * per-agent registrations, or run-scoped exclusions like `disablePersistence`/
+ * `withholdInteractiveTools`. Those depend on state only a live run has.
+ */
+
+import { Effect, Option } from "effect";
+import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
+import { PersonaServiceTag } from "@/core/interfaces/persona-service";
+import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import type { Agent } from "@/core/types";
+import { BUILTIN_TOOL_CATEGORIES } from "./tool-categories";
+
+export function resolveAgentToolNames(
+  agent: Agent,
+): Effect.Effect<readonly string[], never, ToolRegistry> {
+  return Effect.gen(function* () {
+    const toolRegistry = yield* ToolRegistryTag;
+    const agentToolNames = normalizeToolConfig(agent.config.tools, { agentId: agent.id });
+
+    // Optional on purpose, same as `/tools`: a caller that never wired PersonaService gets
+    // the unrestricted default rather than a hard failure — persona narrowing is a
+    // refinement on top of an agent's own tools, not a precondition for answering at all.
+    const personaServiceOption = yield* Effect.serviceOption(PersonaServiceTag);
+    const resolvedPersona = Option.isSome(personaServiceOption)
+      ? yield* personaServiceOption.value
+          .getPersonaByIdentifier(agent.config.persona)
+          .pipe(Effect.catchAll(() => Effect.succeed(null)))
+      : null;
+    const toolProfile = resolvedPersona?.toolProfile;
+
+    const requestedBuiltinCategoryIds: readonly string[] =
+      toolProfile?.categories !== undefined
+        ? toolProfile.categories
+        : agent.config.persona === "summarizer"
+          ? []
+          : BUILTIN_TOOL_CATEGORIES.map((category) => category.id);
+
+    const validBuiltinCategoryIds = new Set(BUILTIN_TOOL_CATEGORIES.map((category) => category.id));
+    const builtInToolNames = (yield* Effect.all(
+      requestedBuiltinCategoryIds
+        .filter((id) => validBuiltinCategoryIds.has(id))
+        .map((id) => toolRegistry.getToolsInCategory(id)),
+    )).flat();
+
+    let combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
+    if (toolProfile?.deny && toolProfile.deny.length > 0) {
+      const denied = new Set(toolProfile.deny);
+      combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
+    }
+    return combinedToolNames;
+  });
+}


### PR DESCRIPTION
## What & why
Adds Google's A2A protocol as a second way to reach a jazz agent, alongside jazz's own `/peer/ask`. A caller can fetch `GET /.well-known/agent-card.json` to discover what a jazz agent is, and — once authenticated with the same peer bearer token `/peer/ask` already uses — send it a question over a standards JSON-RPC endpoint (`POST /a2a`) and get back what it's actually allowed to reach via `a2a.GetExtendedAgentCard`.

This is deliberately not a second trust system: both routes call straight into the same authorization core #490 introduced — capability fixed by whichever agent an operator runs `--serve-peers` with (not persona, which is voice only), a per-peer `disclosure` tier, an `allow` grant for anything riskier than read-only, and the ledger — same bearer token, same ledger entries, same refusal behavior. Scope is intentionally minimal: one synchronous message method and one capability-discovery method, no task lifecycle, streaming, push notifications, or OAuth2/OIDC/mTLS. None of that has a caller yet.

## Breaking changes / migration
None — these are new routes on `jazz daemon --serve-peers`; existing peers and `/peer/ask` behavior are unchanged.

## How to verify
- Start `jazz daemon --serve-peers <agent>`, then `curl http://127.0.0.1:4747/.well-known/agent-card.json` unauthenticated and confirm it returns a generic card.
- With a configured peer's bearer token, `POST /a2a` with `{"jsonrpc":"2.0","id":1,"method":"a2a.SendMessage","params":{"message":{"parts":[{"text":"<question>"}]}}}` and confirm the answer matches what `/peer/ask` gives that same peer the same question.
- Confirm a missing/wrong token on `/a2a` gets a 401, same as `/peer/ask`.
- Confirm `a2a.GetExtendedAgentCard` for a peer with a non-empty `allow` lists those tools in `skills`, and a peer without one does not.
- Confirm an unknown JSON-RPC method returns a `-32601` error rather than a crash.
