### PR TITLE
fix(daemon): guide headless service installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Jazz is a Bun workspace (`packages/*`), split along clean-architecture lines wit
 structurally enforced by TypeScript project references — `tsc -b` rejects a package importing
 from one it doesn't declare as a dependency, not just a documented convention.
 
+### Prerequisites
+
+- Bun 1.4.0 or newer
+
 | Package             | Purpose                                                          | Depends on                      |
 | -------------------- | ----------------------------------------------------------------- | --------------------------------- |
 | `packages/core`       | Business logic, interfaces, types (no I/O); publishable as `@jazz/core` | nothing else in the workspace     |

--- a/docs/start/peers-setup.md
+++ b/docs/start/peers-setup.md
@@ -183,26 +183,23 @@ token yourself instead of chasing a keyring:
 export JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24)
 ```
 
-and persist that value the way you'd persist any other server secret — a systemd
-`Environment=` line, an `.env` file whatever supervises the process reads, or a secrets
-manager if the host already has one. This is the normal path for a server, not a fallback:
-the keyring exists for a workstation where a human is already logged in, not the other way
-around.
-
-**Running the command above by hand only lasts until you Ctrl+C or close the session** —
-`jazz daemon` forks nothing and writes no pidfile on purpose (supervision is the host's job).
-To make it a real persistent service instead, run it as root:
+then install the daemon as a persistent system service. `-E` passes the exported token through
+`sudo`; the installer writes it to a root-readable service environment file, enables the unit,
+and starts it:
 
 ```bash
-sudo jazz daemon --serve-peers bob --host 100.101.102.103
+sudo -E jazz daemon install --serve-peers bob --host 100.101.102.103 --yes
 ```
 
-and it offers to install itself as a systemd unit (or a launchd daemon on macOS) right there —
-confirm once and it writes the unit, enables it, and starts it via `systemctl`/`launchctl`, so
-it survives reboots and closed sessions. Running the plain command without `sudo` just gives
-you a one-line tip pointing at `jazz daemon install` instead of failing; nothing here ever
-invokes `sudo` on its own. Check on it afterward with `systemctl status jazz-daemon` (or
-`launchctl list | grep jazz` on macOS), and remove it again with `sudo jazz daemon uninstall`.
+This is the normal path for a server, not a fallback: the keyring exists for a workstation where
+a human is already logged in, not the other way around.
+
+**Running `jazz daemon --serve-peers bob --host 100.101.102.103` directly only lasts until you
+Ctrl+C or close the session** — it forks nothing and writes no pidfile on purpose. The install
+command above writes the unit, enables it, and starts it via `systemctl`/`launchctl`, so it
+survives reboots and closed sessions. Nothing here invokes `sudo` on its own. Check on it
+afterward with `systemctl status jazz-daemon` (or `launchctl list | grep jazz` on macOS), and
+remove it again with `sudo jazz daemon uninstall`.
 
 ### 3. Bob invites Alice
 

--- a/packages/cli/src/commands/daemon.test.ts
+++ b/packages/cli/src/commands/daemon.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { formatDaemonTokenProvisionFailure } from "./daemon";
+
+describe("daemon token-provisioning failures", () => {
+  it("directs headless peer servers to the persistent-service installer", () => {
+    const message = formatDaemonTokenProvisionFailure(
+      { ok: false, reason: "no-keyring" },
+      { peerAgent: "bob", host: "100.101.102.103", port: 4748 },
+    );
+
+    expect(message).toContain("export JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24)");
+    expect(message).toContain(
+      "sudo -E jazz daemon install --serve-peers bob --host 100.101.102.103 --port 4748",
+    );
+  });
+
+  it("does not recommend peer-service installation when peer serving is disabled", () => {
+    const message = formatDaemonTokenProvisionFailure(
+      { ok: false, reason: "no-keyring" },
+      { host: "100.101.102.103", port: 4748 },
+    );
+
+    expect(message).not.toContain("daemon install");
+  });
+});

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -65,6 +65,27 @@ export interface DaemonCommandOptions {
 }
 
 /**
+ * Explain a failed non-loopback token provision and, when peer serving was requested, give
+ * the exact persistent-service command that stores the exported token safely for systemd or
+ * launchd. Token provisioning belongs to adapters; this command-specific next step belongs
+ * here, where the agent, host, and port are known.
+ */
+export function formatDaemonTokenProvisionFailure(
+  failure: Parameters<typeof explainDaemonTokenProvisionFailure>[0],
+  options: DaemonCommandOptions,
+): string {
+  const explanation = explainDaemonTokenProvisionFailure(failure);
+  if (options.peerAgent === undefined) return explanation;
+
+  return (
+    `${explanation}\n\n` +
+    `After exporting the token, install the persistent service:\n\n` +
+    `  sudo -E jazz daemon install --serve-peers ${options.peerAgent} ` +
+    `--host ${options.host} --port ${String(options.port)}`
+  );
+}
+
+/**
  * Serve until interrupted.
  *
  * The token comes from the environment or the OS keyring rather than a flag: a token in argv
@@ -86,7 +107,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
         // A precise, OS-aware explanation instead of `refuseReason`'s generic "no token" —
         // provisioning already knows exactly why it failed, so say that instead of making
         // the operator rediscover it themselves.
-        process.stderr.write(`${explainDaemonTokenProvisionFailure(provisioned)}\n`);
+        process.stderr.write(`${formatDaemonTokenProvisionFailure(provisioned, options)}\n`);
         process.exitCode = 1;
         return;
       }

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -802,24 +802,37 @@ function registerDaemonCommand(program: Command): void {
     .description(
       "Install this as a persistent system service (systemd on Linux, launchd on macOS) so it survives reboots and closed sessions. Needs root.",
     )
-    .requiredOption("--serve-peers <agentId>", "Agent that answers peer questions")
-    .option("--host <address>", "Interface to bind", "127.0.0.1")
-    .option("--port <n>", "Port to listen on", parsePositiveInt("--port"), 4747)
     .option("--yes", "Skip the confirmation prompt")
-    .action((options: { servePeers: string; host: string; port: number; yes?: boolean }) =>
-      runCliAction(
+    .action((options: { yes?: boolean }) => {
+      // `daemon` is both a runnable command and the parent of `install`. Commander assigns
+      // duplicate option names to the parent, so defining --serve-peers/--host/--port again
+      // here makes `daemon install --serve-peers …` fail its child's required-option check.
+      // Read the parent's options instead: Commander accepts them after `install`, which keeps
+      // the documented command shape while having one owner for each option.
+      const daemonOptions = daemonCommand.opts<{
+        readonly servePeers?: string | undefined;
+        readonly host: string;
+        readonly port: number;
+      }>();
+      if (daemonOptions.servePeers === undefined) {
+        process.stderr.write("error: required option '--serve-peers <agentId>' not specified\n");
+        process.exitCode = 1;
+        return;
+      }
+      const agentId = daemonOptions.servePeers;
+      return runCliAction(
         () =>
           import("@jazz/cli/commands/daemon").then((mod) =>
             mod.installDaemonServiceCommand({
-              agentId: options.servePeers,
-              host: options.host,
-              port: options.port,
+              agentId,
+              host: daemonOptions.host,
+              port: daemonOptions.port,
               yes: options.yes === true,
             }),
           ),
         cliRuntimeOptions(program),
-      ),
-    );
+      );
+    });
 
   daemonCommand
     .command("uninstall")


### PR DESCRIPTION
## What & why
Makes headless peer-daemon setup lead directly to the persistent-service installer, so operators can safely retain the bearer token across restarts. It also fixes `jazz daemon install --serve-peers …`, which previously rejected its required option before installation could begin.

## How to verify

- On a headless host with no OS keyring, start a non-loopback peer daemon and confirm the failure output includes the exported-token command and `sudo -E jazz daemon install` command.
- Run `jazz daemon install --serve-peers <agent> --host <address> --port <port> --yes` as a non-root user; confirm it accepts the options and explains that root is required.
- Run the same installer with root and a `JAZZ_DAEMON_TOKEN`; confirm the service starts and survives a new shell session.
- Run the installer without `--serve-peers`; confirm it reports the missing required option.
