### PR TITLE
fix(daemon): make daemon install self-validating end to end

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -182,7 +182,7 @@ credential instead — see [`jazz peers`](#jazz-peers).
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `jazz daemon set-token`    | Generate (or store `$JAZZ_DAEMON_TOKEN` if set) a token before the daemon's first run — useful when a client needs the value in advance |
 | `jazz daemon forget-token` | Remove the stored token                                                                                                                 |
-| `jazz daemon install`      | Install this as a persistent system service (systemd/launchd). Needs root; `--serve-peers <agentId>` (required), `--host`, `--port`, `--yes` |
+| `jazz daemon install`      | Install this as a persistent system service (systemd/launchd). Needs root; generates and stores its own token if none is set (no keyring or `$JAZZ_DAEMON_TOKEN` needed); doesn't report success until `/health` answers; `--serve-peers <agentId>` (required), `--host`, `--port`, `--yes` |
 | `jazz daemon uninstall`    | Remove the service installed by `install`. Needs root; `--yes`                                                                          |
 
 Set `$JAZZ_DAEMON_TOKEN` yourself instead of letting Jazz generate one when the value needs to

--- a/docs/start/peers-setup.md
+++ b/docs/start/peers-setup.md
@@ -162,44 +162,40 @@ tailscale ip -4
 MagicDNS gives the same machine a name too (`bob-machine.tailnet-name.ts.net`), if you'd
 rather not hardcode an IP that Tailscale could reassign.
 
-### 2. Bob serves on the tailnet interface — not `0.0.0.0`
+### 2. Bob installs the daemon as a persistent service on the tailnet interface
 
 ```bash
-jazz daemon --serve-peers bob --host 100.101.102.103
+sudo jazz daemon install --serve-peers bob --host 100.101.102.103 --yes
 ```
 
 Bind the specific tailnet address, not `0.0.0.0`. If this machine also has a public interface
 (a cloud VM with a tailnet sidecar, say), `0.0.0.0` would listen on that too — binding the
 `100.x` address keeps the daemon reachable only from the tailnet, which is the whole reason to
-use one. A bearer token is still required to reach the operator routes, because the
-bind-safety check has no way to know *which* non-loopback interface is safe — it treats all of
-them the same, on purpose. The first run generates one and stores it in the OS keyring,
-printing it once — but on a headless server there usually is no keyring (`secret-tool` needs a
-running D-Bus session and a keyring daemon, which nothing ever starts without a desktop
-login), so the daemon will refuse to start and explain exactly that. On a server, set the
-token yourself instead of chasing a keyring:
+use one.
 
-```bash
-export JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24)
-```
+A bearer token is still required to reach the operator routes, because the bind-safety check
+has no way to know *which* non-loopback interface is safe — it treats all of them the same, on
+purpose. `daemon install` generates one itself and writes it straight to a root-owned,
+root-readable service environment file (`/etc/jazz/daemon.env`, `chmod 600`) — it never goes
+through the OS keyring and never needs to be exported first, so there's nothing to set up on a
+headless server with no keyring and no `sudo -E`. (Only running `jazz daemon` directly in the
+foreground on a non-loopback host, without installing it, still needs that token to come from
+somewhere — the keyring on a workstation, or `$JAZZ_DAEMON_TOKEN` yourself.)
 
-then install the daemon as a persistent system service. `-E` passes the exported token through
-`sudo`; the installer writes it to a root-readable service environment file, enables the unit,
-and starts it:
+This writes the unit, enables it, and starts it via `systemctl`/`launchctl`, so it survives
+reboots and closed sessions — and it doesn't report success until it's confirmed the daemon
+actually answers its own `/health` route, not just that the supervisor accepted the unit. On
+failure it prints the exact command to see why the process didn't come up
+(`journalctl -u jazz-daemon` on Linux). Nothing here invokes `sudo` on its own — you're the one
+running it. From a source checkout, use `sudo bun run cli -- daemon install …` instead; the
+installed service runs that checkout's Bun entry point directly.
 
-```bash
-sudo -E jazz daemon install --serve-peers bob --host 100.101.102.103 --yes
-```
+Check on it anytime with `systemctl status jazz-daemon` (or `launchctl list | grep jazz` on
+macOS), and remove it again with `sudo jazz daemon uninstall`.
 
-This is the normal path for a server, not a fallback: the keyring exists for a workstation where
-a human is already logged in, not the other way around.
-
-**Running `jazz daemon --serve-peers bob --host 100.101.102.103` directly only lasts until you
-Ctrl+C or close the session** — it forks nothing and writes no pidfile on purpose. The install
-command above writes the unit, enables it, and starts it via `systemctl`/`launchctl`, so it
-survives reboots and closed sessions. Nothing here invokes `sudo` on its own. Check on it
-afterward with `systemctl status jazz-daemon` (or `launchctl list | grep jazz` on macOS), and
-remove it again with `sudo jazz daemon uninstall`.
+If you'd rather test in a foreground session before committing to a persistent service, run
+`jazz daemon --serve-peers bob --host 100.101.102.103` first — it only lasts until you Ctrl+C or
+close the session, since it forks nothing and writes no pidfile on purpose.
 
 ### 3. Bob invites Alice
 

--- a/packages/adapters/src/daemon/service-install.test.ts
+++ b/packages/adapters/src/daemon/service-install.test.ts
@@ -9,6 +9,7 @@ import {
   reRunWithSudoCommand,
   resolveInvokingUser,
   type ServiceInstallOptions,
+  waitForDaemonHealthy,
 } from "./service-install";
 
 const OPTIONS: ServiceInstallOptions = {
@@ -116,6 +117,67 @@ describe("token safety", () => {
     expect(isSafeToken("token$(whoami)")).toBe(false);
     expect(isSafeToken("token with spaces")).toBe(false);
     expect(isSafeToken("")).toBe(false);
+  });
+});
+
+describe("waiting for the daemon to prove it is reachable", () => {
+  it("succeeds once something answers 200 on /health", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (request) => {
+        const url = new URL(request.url);
+        return url.pathname === "/health"
+          ? new Response(JSON.stringify({ ok: true }), { status: 200 })
+          : new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const result = await Effect.runPromise(
+        Effect.either(
+          waitForDaemonHealthy({ host: "127.0.0.1", port: server.port }, "systemd", 2_000),
+        ),
+      );
+      expect(result._tag).toBe("Right");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("fails with a diagnostic command when nothing is listening — a crashed unit, not a slow one", async () => {
+    // An arbitrary unused port: nothing is bound here, simulating an ExecStart that crashed
+    // immediately after `systemctl restart` still reported success.
+    const unusedPort = 41287;
+    const result = await Effect.runPromise(
+      Effect.either(waitForDaemonHealthy({ host: "127.0.0.1", port: unusedPort }, "systemd", 500)),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.message).toContain("journalctl -u jazz-daemon");
+    }
+  });
+
+  it("treats 0.0.0.0 as a bind address, probing loopback as the destination instead", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "0.0.0.0",
+      fetch: (request) => {
+        const url = new URL(request.url);
+        return url.pathname === "/health"
+          ? new Response(JSON.stringify({ ok: true }), { status: 200 })
+          : new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const result = await Effect.runPromise(
+        Effect.either(
+          waitForDaemonHealthy({ host: "0.0.0.0", port: server.port }, "launchd", 2_000),
+        ),
+      );
+      expect(result._tag).toBe("Right");
+    } finally {
+      server.stop(true);
+    }
   });
 });
 

--- a/packages/adapters/src/daemon/service-install.ts
+++ b/packages/adapters/src/daemon/service-install.ts
@@ -37,7 +37,7 @@ import * as path from "node:path";
 import { getJazzSchedulerInvocation } from "@jazz/core/utils/runtime";
 import { execCommand } from "@jazz/core/utils/shell";
 import { escapeShellArg, getLaunchdPath } from "@jazz/core/workflows/scheduler-service";
-import { Effect } from "effect";
+import { Duration, Effect } from "effect";
 import * as plist from "plist";
 
 export type InitSystem = "systemd" | "launchd" | "unsupported";
@@ -282,12 +282,69 @@ export interface InstalledService {
   readonly unitPath: string;
 }
 
+const HEALTH_CHECK_TIMEOUT_MS = 8_000;
+const HEALTH_CHECK_POLL_INTERVAL_MS = 300;
+
+/**
+ * `systemctl restart`/`launchctl load` reporting success only means the supervisor accepted
+ * the unit — not that the process behind it is actually alive and serving. A unit whose
+ * `ExecStart` is wrong (a stale invocation, a bad `--host`) can "start" and then exit
+ * immediately, over and over, while every command up to here still returned 0. Polling the
+ * daemon's own unauthenticated `/health` route from the outside is the only check that means
+ * what an operator actually cares about: a client can reach this daemon right now.
+ */
+export function waitForDaemonHealthy(
+  options: Pick<ServiceInstallOptions, "host" | "port">,
+  initSystem: InitSystem,
+  timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
+): Effect.Effect<void, ServiceInstallError> {
+  // The probe runs on the same machine the daemon just bound on. "0.0.0.0" is a valid bind
+  // address (all interfaces) but not always a valid *destination* to connect to — reach it via
+  // loopback instead, which a daemon bound to "all interfaces" always also answers on.
+  const probeHost = options.host === "0.0.0.0" ? "127.0.0.1" : options.host;
+  const healthUrl = `http://${probeHost}:${String(options.port)}/health`;
+  const deadline = Date.now() + timeoutMs;
+
+  const probe = (): Effect.Effect<boolean, never> =>
+    Effect.promise(() =>
+      fetch(healthUrl, { signal: AbortSignal.timeout(1_000) })
+        .then((response) => response.ok)
+        .catch(() => false),
+    );
+
+  return Effect.gen(function* () {
+    for (;;) {
+      if (yield* probe()) return;
+      if (Date.now() >= deadline) break;
+      yield* Effect.sleep(Duration.millis(HEALTH_CHECK_POLL_INTERVAL_MS));
+    }
+
+    const diagnosticCommand =
+      initSystem === "systemd"
+        ? "journalctl -u jazz-daemon -n 50 --no-pager"
+        : `log show --predicate 'process == "jazz"' --last 5m`;
+
+    return yield* Effect.fail(
+      new ServiceInstallError(
+        `Installed and started, but ${healthUrl} never answered within ` +
+          `${String(timeoutMs / 1000)}s — the service likely crashed right after starting. ` +
+          `Check why:\n\n  ${diagnosticCommand}\n`,
+      ),
+    );
+  });
+}
+
 /**
  * Write the unit/plist and env file, then reload and enable+start it for real — not a
  * dry-run that prints a script and leaves the rest to the operator. Idempotent: re-running
  * this regenerates and restarts rather than failing on "already exists" — `systemctl enable`
  * alone does not restart an already-running unit, so a changed `--host`/`--port`/token would
  * otherwise silently not take effect; the explicit `restart` after is what makes this true.
+ *
+ * Returns only once the daemon has proven it is actually reachable (see
+ * `waitForDaemonHealthy`) — a supervisor accepting the unit is not the same as the process
+ * behind it staying up, and the whole point of an automated install is to catch that gap
+ * instead of handing the operator a false "success".
  */
 export function installService(
   options: Omit<ServiceInstallOptions, "user">,
@@ -326,6 +383,7 @@ export function installService(
       yield* execCommand("systemctl", ["restart", "jazz-daemon"]).pipe(
         Effect.mapError((error) => new ServiceInstallError(error.message)),
       );
+      yield* waitForDaemonHealthy(fullOptions, initSystem);
       return { initSystem, unitPath: SYSTEMD_UNIT_PATH };
     }
 
@@ -342,6 +400,7 @@ export function installService(
     yield* execCommand("launchctl", ["load", LAUNCHD_PLIST_PATH]).pipe(
       Effect.mapError((error) => new ServiceInstallError(error.message)),
     );
+    yield* waitForDaemonHealthy(fullOptions, initSystem);
     return { initSystem, unitPath: LAUNCHD_PLIST_PATH };
   });
 }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -27,6 +27,7 @@ import {
 import {
   detectInitSystem,
   generateDaemonToken,
+  type InstalledService,
   installService,
   serviceAlreadyInstalled,
   uninstallService,
@@ -82,6 +83,29 @@ export function formatDaemonTokenProvisionFailure(
     `After exporting the token, install the persistent service:\n\n` +
     `  sudo -E jazz daemon install --serve-peers ${options.peerAgent} ` +
     `--host ${options.host} --port ${String(options.port)}`
+  );
+}
+
+/**
+ * The end state an install should leave an operator at: not just "the unit is enabled" but
+ * "reachable, and here is the exact next command" — the whole point of verifying `/health`
+ * inside `installService` is wasted if the message afterward still just points at
+ * `systemctl status` and leaves peer-inviting as an exercise for the operator.
+ */
+function formatServiceInstalledMessage(
+  installed: InstalledService,
+  options: { readonly host: string },
+): string {
+  const statusCommand =
+    installed.initSystem === "launchd"
+      ? "launchctl list | grep jazz"
+      : "systemctl status jazz-daemon";
+  return (
+    `Installed and started — the daemon answered its own health check, so it is actually ` +
+    `reachable at ${options.host}, not just enabled.\n` +
+    `Check on it anytime with '${statusCommand}'.\n\n` +
+    `Next, invite a peer:\n\n` +
+    `  jazz peers invite create <peer-name> --host ${options.host} --disclosure internal --expires 1h\n`
   );
 }
 
@@ -161,8 +185,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
             );
             if (installed !== undefined) {
               yield* terminal.success(
-                `Installed and started. Check on it with 'systemctl status jazz-daemon'` +
-                  `${installed.initSystem === "launchd" ? " (or 'launchctl list | grep jazz' on macOS)" : ""}.`,
+                formatServiceInstalledMessage(installed, { host: options.host }),
               );
             }
             return;
@@ -400,10 +423,7 @@ export function installDaemonServiceCommand(options: {
     );
     if (installed === undefined) return;
 
-    yield* terminal.success(
-      `Installed and started. Check on it with 'systemctl status jazz-daemon'` +
-        `${installed.initSystem === "launchd" ? " (or 'launchctl list | grep jazz' on macOS)" : ""}.`,
-    );
+    yield* terminal.success(formatServiceInstalledMessage(installed, { host: options.host }));
   });
 }
 

--- a/packages/core/src/utils/runtime.test.ts
+++ b/packages/core/src/utils/runtime.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { isOfflineMode, isRunningFromGlobalInstall, isRunningInDevelopmentMode } from "./runtime";
+import { Effect } from "effect";
+import {
+  getJazzSchedulerInvocation,
+  isOfflineMode,
+  isRunningFromGlobalInstall,
+  isRunningInDevelopmentMode,
+} from "./runtime";
 
 describe("isOfflineMode", () => {
   it("accepts only the documented enabled values", () => {
@@ -182,6 +188,20 @@ describe("Runtime detection", () => {
         process.argv[1] = testPath;
         expect(isRunningInDevelopmentMode()).toBe(!isRunningFromGlobalInstall());
       }
+    });
+  });
+
+  describe("getJazzSchedulerInvocation", () => {
+    it("preserves Bun and the absolute source entry point from a checkout", async () => {
+      const entryPoint = path.join(jazzProjectDirectory, "src", "main.ts");
+      fs.mkdirSync(path.dirname(entryPoint), { recursive: true });
+      fs.writeFileSync(entryPoint, "// test");
+      process.argv[1] = entryPoint;
+
+      expect(await Effect.runPromise(getJazzSchedulerInvocation())).toEqual([
+        process.execPath,
+        path.resolve(entryPoint),
+      ]);
     });
   });
 

--- a/packages/core/src/utils/runtime.ts
+++ b/packages/core/src/utils/runtime.ts
@@ -176,6 +176,20 @@ export function getJazzSchedulerInvocation(): Effect.Effect<readonly string[], n
       return [process.execPath];
     }
 
+    // A source checkout is already running the exact entry point a persistent service needs.
+    // Looking up `jazz` as root during `daemon install` is both unreliable (the invoking
+    // user's PATH is not root's) and wrong when it finds a different global installation.
+    // Keep Bun plus the absolute source entry point instead, so systemd can start precisely
+    // the checkout that installed the service.
+    const sourceEntryPoint = process.argv[1];
+    if (
+      sourceEntryPoint !== undefined &&
+      isWithinJazzSourceDirectory(sourceEntryPoint) &&
+      isRunningInDevelopmentMode()
+    ) {
+      return [process.execPath, path.resolve(sourceEntryPoint)];
+    }
+
     const fromShell = yield* findExecutablePathViaShell();
     if (fromShell) {
       return [fromShell];


### PR DESCRIPTION
## What & why
`jazz daemon install` — the documented path for turning a peer-serving daemon into a
persistent systemd/launchd service — was broken and untrustworthy end to end: `--serve-peers`
on the `install` subcommand always failed with "required option not specified" (a Commander
parsing bug), the installed unit pointed at whatever `jazz` happened to be on root's `PATH`
instead of the checkout actually invoked, and a successful `systemctl restart`/`launchctl load`
was reported as success even when the daemon crashed immediately after. The docs also walked
operators through manually exporting and `sudo -E`'ing a token that install never actually
needed.

This fixes the option-parsing bug, preserves the invoking checkout's exact entry point,
verifies the daemon answers its own `/health` route before declaring success (failing with the
exact log command to check when it doesn't), and ends with the concrete next step — a ready-to-run
peer-invite command — instead of leaving that for the operator to find. Docs are simplified to
match: `daemon install` generates and persists its own token, so there's nothing to export first.

## How to verify
- `jazz daemon install --serve-peers <agent> --host <ip> --yes` no longer fails with
  "required option '--serve-peers' not specified".
- From a source checkout, `sudo bun run cli -- daemon install ...` installs a unit whose
  `ExecStart`/`ProgramArguments` point at this checkout's Bun entry point, not a
  PATH-resolved `jazz`.
- After install, `curl http://<host>:<port>/health` directly and confirm it matches the
  printed "reachable" success message, which also shows a ready-to-run
  `jazz peers invite create` command.
- Edge case: break the daemon's `ExecStart` (e.g. bind a port already in use) and reinstall —
  it now fails with a diagnostic log command (`journalctl -u jazz-daemon` / `log show`)
  instead of reporting a false success.
