### PR TITLE
fix(secrets): fall back to a file store when no OS keyring exists

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -173,10 +173,11 @@ instead of leaving that hand-written.
 
 A bearer token authenticates the operator routes (`/runs`, `/health`) whenever `--host` is
 anything but loopback; loopback needs none. The first time this daemon binds a non-loopback
-host with no token already set, Jazz generates one and stores it in the OS keyring, printing
-it once so it can be copied to a client — the daemon works from the first run, with no setup
-command required. `/peer/ask` (when `--serve-peers` is given) uses a separate, per-peer
-credential instead — see [`jazz peers`](#jazz-peers).
+host with no token already set, Jazz generates one and stores it — an OS keyring when one's
+reachable, otherwise a `chmod 600` file at `$JAZZ_HOME/secrets.json` (see
+[Setting up peers](../start/peers-setup.md)) — printing it once so it can be copied to a
+client. No setup command required. `/peer/ask` (when `--serve-peers` is given) uses a separate,
+per-peer credential instead — see [`jazz peers`](#jazz-peers).
 
 | Command                    | Purpose                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -186,8 +187,8 @@ credential instead — see [`jazz peers`](#jazz-peers).
 | `jazz daemon uninstall`    | Remove the service installed by `install`. Needs root; `--yes`                                                                          |
 
 Set `$JAZZ_DAEMON_TOKEN` yourself instead of letting Jazz generate one when the value needs to
-be known ahead of time — a container with no persistent keyring across restarts, or a client
-config that must be written before the daemon has ever started.
+be known ahead of time — a client config written before the daemon has ever run, or an
+ephemeral container whose `$JAZZ_HOME` doesn't survive to the next deploy.
 
 See [Setting up peers](../start/peers-setup.md) for a full walkthrough, and
 [Agent-to-agent](../concepts/agent-to-agent.md) for the tier model this exists to serve.

--- a/docs/start/peers-setup.md
+++ b/docs/start/peers-setup.md
@@ -27,6 +27,13 @@ generate one with `openssl`, run `jazz peers set-token` on both sides, edit conf
 as a fold-out, for when you'd rather not have acceptance write your config for you, or you're
 scripting setup somewhere a human won't be there to confirm a link.
 
+**Where the token lives:** an OS keyring when one's reachable (Keychain on macOS,
+`secret-tool`/libsecret on Linux), otherwise a `chmod 600` file at `$JAZZ_HOME/secrets.json`.
+Not in `config.json`. The file fallback needs no D-Bus session or keyring unlock, so it works
+the same on a workstation and a headless server — `jazz peers invite accept` and
+`jazz peers set-token` need no special-casing either way. `$JAZZ_DISABLE_KEYRING` turns off
+both if you'd rather manage tokens yourself.
+
 ---
 
 ## One machine, two agents
@@ -361,9 +368,9 @@ jazz peers log
 - **The daemon refuses to start** — read the message; it's almost always `--host` set to
   something other than loopback with no token available. That check exists because a daemon
   on a reachable interface is an agent with filesystem access that anyone reaching the port
-  can drive. The message explains specifically why (no keyring found, or one found but the
-  write to it failed) and gives the fix that works regardless — set `$JAZZ_DAEMON_TOKEN`
-  yourself and persist it the way you'd persist any other server secret.
+  can drive. Should be rare (see above) — it means `$JAZZ_DISABLE_KEYRING` is set or
+  `$JAZZ_HOME` isn't writable. Fix: set `$JAZZ_DAEMON_TOKEN` yourself and persist it the way
+  you'd persist any other server secret.
 - **The invite link doesn't work** — check it hasn't expired or already been redeemed
   (`jazz peers invite list` on the inviter's machine), and that the inviter's daemon is
   actually running at the address embedded in the link.

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -414,7 +414,15 @@ function acceptInvite(
           return json({ ok: false, error: "could not verify this invite's secret" }, 401);
         case "no-keyring":
           return json(
-            { ok: false, error: "no OS keyring is available to store the resulting token" },
+            {
+              ok: false,
+              error: "the inviter has $JAZZ_DISABLE_KEYRING set, so it cannot store your token",
+            },
+            500,
+          );
+        case "storage-write-failed":
+          return json(
+            { ok: false, error: "the inviter could not persist the resulting token" },
             500,
           );
       }

--- a/packages/adapters/src/daemon/service-install.test.ts
+++ b/packages/adapters/src/daemon/service-install.test.ts
@@ -135,7 +135,7 @@ describe("waiting for the daemon to prove it is reachable", () => {
     try {
       const result = await Effect.runPromise(
         Effect.either(
-          waitForDaemonHealthy({ host: "127.0.0.1", port: server.port }, "systemd", 2_000),
+          waitForDaemonHealthy({ host: "127.0.0.1", port: server.port ?? 0 }, "systemd", 2_000),
         ),
       );
       expect(result._tag).toBe("Right");
@@ -171,7 +171,7 @@ describe("waiting for the daemon to prove it is reachable", () => {
     try {
       const result = await Effect.runPromise(
         Effect.either(
-          waitForDaemonHealthy({ host: "0.0.0.0", port: server.port }, "launchd", 2_000),
+          waitForDaemonHealthy({ host: "0.0.0.0", port: server.port ?? 0 }, "launchd", 2_000),
         ),
       );
       expect(result._tag).toBe("Right");

--- a/packages/adapters/src/daemon/token.test.ts
+++ b/packages/adapters/src/daemon/token.test.ts
@@ -2,54 +2,35 @@ import { describe, expect, it } from "bun:test";
 import { explainDaemonTokenProvisionFailure } from "./token";
 
 describe("explaining why the daemon token could not be provisioned", () => {
-  it("always leads with the fix that works regardless of platform or cause", () => {
-    for (const platform of ["darwin", "linux", "win32"] as const) {
-      const message = explainDaemonTokenProvisionFailure(
-        { ok: false, reason: "no-keyring" },
-        platform,
-      );
+  it("always leads with the fix that works regardless of cause", () => {
+    for (const reason of ["no-keyring", "keyring-write-failed"] as const) {
+      const message = explainDaemonTokenProvisionFailure({ ok: false, reason });
       expect(message).toContain("JAZZ_DAEMON_TOKEN=$(openssl rand -hex 24)");
       // Not just present — first. A long diagnosis before the fix buries the one line that
       // actually matters, exactly what the doc comment above the function promises it won't.
       const fixIndex = message.indexOf("export JAZZ_DAEMON_TOKEN");
-      const diagnosisIndex = message.indexOf("keyring");
+      const diagnosisIndex = message.lastIndexOf("(");
       expect(fixIndex).toBeGreaterThanOrEqual(0);
       expect(fixIndex).toBeLessThan(diagnosisIndex);
     }
   });
 
-  it("explains the Linux case as the normal, expected state for a headless server", () => {
-    const message = explainDaemonTokenProvisionFailure(
-      { ok: false, reason: "no-keyring" },
-      "linux",
-    );
-    expect(message).toContain("normal for a headless server");
-    expect(message).toContain("D-Bus");
-  });
-
-  it("explains the macOS case as unusual, since Keychain is normally available", () => {
-    const message = explainDaemonTokenProvisionFailure(
-      { ok: false, reason: "no-keyring" },
-      "darwin",
-    );
-    expect(message).toContain("unusual on macOS");
-  });
-
-  it("falls back to a platform-neutral explanation elsewhere", () => {
-    const message = explainDaemonTokenProvisionFailure(
-      { ok: false, reason: "no-keyring" },
-      "win32",
-    );
-    expect(message).toContain("no keyring backend exists for this platform yet");
-  });
-
-  it("gives a different explanation when a keyring exists but the write failed, fix still first", () => {
-    const message = explainDaemonTokenProvisionFailure(
-      { ok: false, reason: "keyring-write-failed" },
-      "darwin",
-    );
-    expect(message).toContain("locked");
+  it("attributes 'no-keyring' to the explicit opt-out, not a missing OS keyring", () => {
+    // detectKeyringBackend() falls through to a $JAZZ_HOME/secrets.json file whenever no real
+    // OS keyring is reachable — the only way to still get "no-keyring" is having set
+    // $JAZZ_DISABLE_KEYRING deliberately, so that's the only explanation left to give.
+    const message = explainDaemonTokenProvisionFailure({ ok: false, reason: "no-keyring" });
+    expect(message).toContain("JAZZ_DISABLE_KEYRING");
     expect(message).not.toContain("headless server");
-    expect(message.indexOf("export JAZZ_DAEMON_TOKEN")).toBeLessThan(message.indexOf("locked"));
+    expect(message).not.toContain("D-Bus");
+  });
+
+  it("attributes 'keyring-write-failed' to both storage paths being unwritable", () => {
+    const message = explainDaemonTokenProvisionFailure({
+      ok: false,
+      reason: "keyring-write-failed",
+    });
+    expect(message).toContain("JAZZ_HOME/secrets.json");
+    expect(message).not.toContain("JAZZ_DISABLE_KEYRING");
   });
 });

--- a/packages/adapters/src/daemon/token.ts
+++ b/packages/adapters/src/daemon/token.ts
@@ -9,7 +9,12 @@
 
 import { randomBytes } from "node:crypto";
 import { Effect } from "effect";
-import { detectKeyringBackend, keyringGet, keyringSet } from "@/adapters/secrets/keyring";
+import {
+  detectKeyringBackend,
+  type KeyringBackend,
+  keyringGet,
+  keyringSet,
+} from "@/adapters/secrets/keyring";
 import { DAEMON_TOKEN_ENV_VAR, DAEMON_TOKEN_PATH } from "@/adapters/secrets/registry";
 
 export function resolveDaemonToken(): Effect.Effect<string | undefined, never> {
@@ -27,6 +32,8 @@ export interface ProvisionedDaemonToken {
   readonly token: string;
   /** True when this call generated the token rather than finding one already set. */
   readonly generated: boolean;
+  /** Where a generated token was stored — absent when `generated` is false. */
+  readonly backend?: KeyringBackend;
 }
 
 /**
@@ -45,9 +52,8 @@ export type ProvisionDaemonTokenResult = ProvisionedDaemonToken | DaemonTokenPro
  * `jazz daemon set-token` by hand first. Nobody else needs to independently know this token
  * (unlike a peer's), so Jazz inventing it costs nothing.
  *
- * Fails only when there is nowhere safe to keep a generated token: no keyring, and no
- * `$JAZZ_DAEMON_TOKEN` already set. The caller decides what to do in that case; this never
- * writes a token to disk in plaintext.
+ * Fails only when there is nowhere to keep a generated token: `$JAZZ_DISABLE_KEYRING` is set
+ * and no `$JAZZ_DAEMON_TOKEN` was given, or the resolved backend refused the write.
  */
 export function resolveOrProvisionDaemonToken(): Effect.Effect<ProvisionDaemonTokenResult, never> {
   return Effect.gen(function* () {
@@ -61,7 +67,7 @@ export function resolveOrProvisionDaemonToken(): Effect.Effect<ProvisionDaemonTo
     const stored = yield* keyringSet(backend, DAEMON_TOKEN_PATH, generatedToken);
     if (!stored) return { ok: false, reason: "keyring-write-failed" };
 
-    return { ok: true, token: generatedToken, generated: true };
+    return { ok: true, token: generatedToken, generated: true, backend };
   });
 }
 

--- a/packages/adapters/src/daemon/token.ts
+++ b/packages/adapters/src/daemon/token.ts
@@ -66,15 +66,13 @@ export function resolveOrProvisionDaemonToken(): Effect.Effect<ProvisionDaemonTo
 }
 
 /**
- * A precise, OS-aware explanation for why provisioning failed, with the one fix that works
- * everywhere (set the token yourself) always given first — the keyring path is a workstation
- * convenience, not the primary mechanism, so it should never be presented as the only way
- * forward.
+ * A precise explanation for why provisioning failed, with the fix that works everywhere (set
+ * the token yourself) always given first.
+ *
+ * `"no-keyring"` no longer means a missing OS keyring — that now falls through to a file under
+ * `$JAZZ_HOME` (see `keyring.ts`) — it means `$JAZZ_DISABLE_KEYRING` was set deliberately.
  */
-export function explainDaemonTokenProvisionFailure(
-  failure: DaemonTokenProvisionFailure,
-  platform: NodeJS.Platform = process.platform,
-): string {
+export function explainDaemonTokenProvisionFailure(failure: DaemonTokenProvisionFailure): string {
   const setItYourself =
     `export ${DAEMON_TOKEN_ENV_VAR}=$(openssl rand -hex 24)\n` +
     `then persist that value yourself — a systemd \`Environment=\` line, your shell profile, ` +
@@ -83,31 +81,14 @@ export function explainDaemonTokenProvisionFailure(
   if (failure.reason === "keyring-write-failed") {
     return (
       `${setItYourself}\n\n` +
-      `(A keyring is available but writing the daemon token to it failed — it may be locked ` +
-      `or read-only, which is why this is the fix regardless.)`
+      `(Neither the OS keyring nor the \`$JAZZ_HOME/secrets.json\` fallback could be written ` +
+      `to — check that $JAZZ_HOME is actually writable, which is why this is the fix regardless.)`
     );
   }
 
-  const why = (() => {
-    switch (platform) {
-      case "darwin":
-        return (
-          `unusual on macOS, since Keychain access ("security") is normally there by default. ` +
-          `This can happen with no login keychain unlocked (a sandboxed or CI environment, say).`
-        );
-      case "linux":
-        return (
-          `normal for a headless server. The Linux path ("secret-tool") needs a running D-Bus ` +
-          `session and a keyring daemon (gnome-keyring or similar), and a server with no ` +
-          `desktop login never starts either. Running one just for this isn't worth it either: ` +
-          `gnome-keyring normally unlocks itself via PAM at login, which a headless server ` +
-          `never triggers, so you'd end up scripting a manual unlock — more operational ` +
-          `overhead than the fix above, not less.`
-        );
-      default:
-        return `no keyring backend exists for this platform yet.`;
-    }
-  })();
-
-  return `${setItYourself}\n\n(No OS keyring is available — ${why})`;
+  return (
+    `${setItYourself}\n\n` +
+    `($JAZZ_DISABLE_KEYRING is set, so Jazz won't generate and store a token on its own — ` +
+    `unset it if that wasn't intentional.)`
+  );
 }

--- a/packages/adapters/src/peers/invites.test.ts
+++ b/packages/adapters/src/peers/invites.test.ts
@@ -279,7 +279,7 @@ describe("acceptInviteOnInviterSide", () => {
       ).pipe(Effect.provide(layer)),
     );
 
-    expect(outcome.kind).toEqual("no-keyring");
+    expect(outcome.kind).toEqual("storage-write-failed");
     expect(currentPeers()).toEqual([]);
     expect((await run(getInvite(created.record.id)))?.redeemedAt).toBeUndefined();
   });

--- a/packages/adapters/src/peers/invites.ts
+++ b/packages/adapters/src/peers/invites.ts
@@ -240,10 +240,14 @@ export function createPeerInviteServiceLayer(): Layer.Layer<PeerInviteService> {
 
 export type AcceptInviteOutcome =
   | { readonly kind: "ok"; readonly inviterAskUrl: string; readonly token: string }
-  /** The invite is otherwise valid, but there is nowhere safe to store the token it would
-   * generate. Checked *before* consuming the invite, so a machine with no keyring does not
-   * burn a single-use link on a redemption it cannot actually complete. */
+  /** `$JAZZ_DISABLE_KEYRING` is set, so there is deliberately nowhere to store the token this
+   * would generate. Checked *before* consuming the invite, so an opted-out machine does not
+   * burn a single-use link on a redemption it cannot actually complete. Distinct from
+   * `"storage-write-failed"`: this one is a choice, that one is a broken write. */
   | { readonly kind: "no-keyring" }
+  /** A storage backend was available (OS keyring or the `$JAZZ_HOME/secrets.json` fallback)
+   * but writing to it failed anyway — a locked keyring, or `$JAZZ_HOME` itself unwritable. */
+  | { readonly kind: "storage-write-failed" }
   | Exclude<RedeemInviteOutcome, { kind: "ok" }>;
 
 /**
@@ -310,7 +314,7 @@ export function acceptInviteOnInviterSide(
     // granted and a retry simply replaces this unused token with a freshly minted one.
     const token = randomBytes(24).toString("hex");
     const stored = yield* keyring.storeToken(backend, peerTokenPath(candidate.inviteeName), token);
-    if (!stored) return { kind: "no-keyring" } as const;
+    if (!stored) return { kind: "storage-write-failed" } as const;
 
     // `outcome.record.inviteeName` — the name *this* side (the inviter) chose at creation
     // time — is the key for this side's own upsert and token storage. `input.redeemedAs` is

--- a/packages/adapters/src/secrets/keyring.test.ts
+++ b/packages/adapters/src/secrets/keyring.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Effect } from "effect";
 import { detectKeyringBackend, keyringGet, keyringSet, keyringDelete } from "./keyring";
 
@@ -27,7 +30,9 @@ describe("keyring opt-out", () => {
       if (process.platform === "darwin") {
         expect(backend).toBe("macos");
       } else {
-        expect(["libsecret", "none"]).toContain(backend);
+        // No real OS keyring on this runner falls through to the file store, not "none" —
+        // "none" is now reachable only via the opt-out env var above.
+        expect(["libsecret", "file"]).toContain(backend);
       }
     }
   });
@@ -38,5 +43,60 @@ describe('the "none" backend', () => {
     expect(await Effect.runPromise(keyringGet("none", "llm.openai.api_key"))).toBeUndefined();
     expect(await Effect.runPromise(keyringSet("none", "llm.openai.api_key", "sk-x"))).toBe(false);
     await Effect.runPromise(keyringDelete("none", "llm.openai.api_key"));
+  });
+});
+
+describe('the "file" backend — the headless-server fallback below both OS keyrings', () => {
+  const originalJazzHome = process.env["JAZZ_HOME"];
+  let tempDirectory: string;
+
+  beforeEach(() => {
+    tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-keyring-file-test-"));
+    process.env["JAZZ_HOME"] = tempDirectory;
+  });
+
+  afterEach(() => {
+    if (originalJazzHome === undefined) delete process.env["JAZZ_HOME"];
+    else process.env["JAZZ_HOME"] = originalJazzHome;
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
+  it("round-trips a secret through a chmod-600 file under $JAZZ_HOME", async () => {
+    expect(await Effect.runPromise(keyringGet("file", "peers.bob.token"))).toBeUndefined();
+
+    const stored = await Effect.runPromise(keyringSet("file", "peers.bob.token", "s3cret"));
+    expect(stored).toBe(true);
+
+    const secretsPath = path.join(tempDirectory, "secrets.json");
+    expect(fs.existsSync(secretsPath)).toBe(true);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(secretsPath).mode & 0o777).toBe(0o600);
+    }
+
+    expect(await Effect.runPromise(keyringGet("file", "peers.bob.token"))).toBe("s3cret");
+  });
+
+  it("keeps other accounts intact when storing or deleting one", async () => {
+    await Effect.runPromise(keyringSet("file", "peers.bob.token", "bob-secret"));
+    await Effect.runPromise(keyringSet("file", "peers.alice.token", "alice-secret"));
+
+    await Effect.runPromise(keyringDelete("file", "peers.bob.token"));
+
+    expect(await Effect.runPromise(keyringGet("file", "peers.bob.token"))).toBeUndefined();
+    expect(await Effect.runPromise(keyringGet("file", "peers.alice.token"))).toBe("alice-secret");
+  });
+
+  it("deleting an absent account is a no-op, not an error", async () => {
+    await Effect.runPromise(keyringDelete("file", "peers.nobody.token"));
+    expect(await Effect.runPromise(keyringGet("file", "peers.nobody.token"))).toBeUndefined();
+  });
+
+  it("treats a corrupt secrets.json as empty rather than failing every lookup", async () => {
+    fs.mkdirSync(tempDirectory, { recursive: true });
+    fs.writeFileSync(path.join(tempDirectory, "secrets.json"), "{not valid json");
+
+    expect(await Effect.runPromise(keyringGet("file", "peers.bob.token"))).toBeUndefined();
+    expect(await Effect.runPromise(keyringSet("file", "peers.bob.token", "s3cret"))).toBe(true);
+    expect(await Effect.runPromise(keyringGet("file", "peers.bob.token"))).toBe("s3cret");
   });
 });

--- a/packages/adapters/src/secrets/keyring.ts
+++ b/packages/adapters/src/secrets/keyring.ts
@@ -1,4 +1,7 @@
 import { spawn } from "node:child_process";
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { Effect } from "effect";
 import { KEYRING_SERVICE_NAME } from "./registry";
 
@@ -9,8 +12,14 @@ import { KEYRING_SERVICE_NAME } from "./registry";
  * binaries per platform behind it. `security` is always present on macOS and
  * `secret-tool` is the standard libsecret client on Linux, so shelling out
  * keeps the dependency footprint at zero.
+ *
+ * `"file"` is the fallback below both: a `chmod 600` JSON file under `$JAZZ_HOME`, used
+ * whenever no OS keyring is reachable (typically a headless server with no D-Bus session).
+ * Not a lower bar than jazz already accepts elsewhere — `service-install.ts` stores the
+ * daemon's own token the same way, and `config.json` already holds API keys in plaintext at
+ * the same permissions in the same directory.
  */
-export type KeyringBackend = "macos" | "libsecret" | "none";
+export type KeyringBackend = "macos" | "libsecret" | "file" | "none";
 
 const PROBE_ACCOUNT = "__jazz_probe__";
 const COMMAND_TIMEOUT_MS = 5_000;
@@ -100,6 +109,9 @@ function keyringDisabledByEnv(): boolean {
  *
  * On Linux this probes an actual lookup: `secret-tool` is frequently installed
  * on machines with no session D-Bus (headless servers), where every call fails.
+ * Neither OS probe succeeding falls through to `"file"` rather than `"none"` — see the
+ * `KeyringBackend` doc comment for why that fallback is safe to take automatically instead
+ * of asking the operator to choose it.
  */
 export function detectKeyringBackend(): Effect.Effect<KeyringBackend, never> {
   return Effect.gen(function* () {
@@ -113,10 +125,8 @@ export function detectKeyringBackend(): Effect.Effect<KeyringBackend, never> {
         "-a",
         PROBE_ACCOUNT,
       ]);
-      return probe.unavailable ? ("none" as const) : ("macos" as const);
-    }
-
-    if (process.platform === "linux") {
+      if (!probe.unavailable) return "macos" as const;
+    } else if (process.platform === "linux") {
       const probe = yield* runCommand("secret-tool", [
         "lookup",
         "service",
@@ -124,13 +134,63 @@ export function detectKeyringBackend(): Effect.Effect<KeyringBackend, never> {
         "account",
         PROBE_ACCOUNT,
       ]);
-      if (probe.unavailable) return "none" as const;
       // A clean "not found" exits non-zero with no diagnostics; a broken or
       // absent secret service always explains itself on stderr.
-      return probe.stderr.trim() === "" ? ("libsecret" as const) : ("none" as const);
+      if (!probe.unavailable && probe.stderr.trim() === "") return "libsecret" as const;
     }
 
-    return "none" as const;
+    return "file" as const;
+  });
+}
+
+const SECRETS_FILE_MODE = 0o600;
+
+function secretsFilePath(): string {
+  return path.join(getJazzHomeDirectory(), "secrets.json");
+}
+
+/** Missing file, unreadable file, or corrupt JSON all read as "nothing stored yet". */
+function readSecretsFile(): Effect.Effect<Record<string, string>, never> {
+  return Effect.promise(async () => {
+    try {
+      const raw = await nodeFs.readFile(secretsFilePath(), "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, string>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  });
+}
+
+/**
+ * Write via a sibling temp file and rename, so a crash mid-write can't leave `secrets.json`
+ * truncated or invalid. No cross-process lock: token writes are rare enough that a lost
+ * update from two concurrent writers is an accepted risk, not worth the complexity.
+ */
+function writeSecretsFile(secrets: Record<string, string>): Effect.Effect<boolean, never> {
+  return Effect.promise(async () => {
+    const filePath = secretsFilePath();
+    const tempPath = path.join(
+      path.dirname(filePath),
+      `.secrets-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+    );
+    try {
+      await nodeFs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+      await nodeFs.writeFile(tempPath, `${JSON.stringify(secrets, null, 2)}\n`, {
+        mode: SECRETS_FILE_MODE,
+      });
+      await nodeFs.rename(tempPath, filePath);
+      // `rename` preserves the temp file's mode, but chmod again in case `secrets.json`
+      // already existed with a wider mode from before this fallback existed.
+      await nodeFs.chmod(filePath, SECRETS_FILE_MODE);
+      return true;
+    } catch {
+      await nodeFs.rm(tempPath, { force: true }).catch(() => undefined);
+      return false;
+    }
   });
 }
 
@@ -141,6 +201,10 @@ export function keyringGet(
 ): Effect.Effect<string | undefined, never> {
   return Effect.gen(function* () {
     if (backend === "none") return undefined;
+    if (backend === "file") {
+      const secrets = yield* readSecretsFile();
+      return secrets[account];
+    }
 
     const result =
       backend === "macos"
@@ -174,6 +238,10 @@ export function keyringSet(
 ): Effect.Effect<boolean, never> {
   return Effect.gen(function* () {
     if (backend === "none") return false;
+    if (backend === "file") {
+      const secrets = yield* readSecretsFile();
+      return yield* writeSecretsFile({ ...secrets, [account]: secret });
+    }
 
     if (backend === "macos") {
       // `security` has no stdin mode for writes, so the value is briefly visible
@@ -208,6 +276,13 @@ export function keyringDelete(
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     if (backend === "none") return;
+    if (backend === "file") {
+      const secrets = yield* readSecretsFile();
+      if (!(account in secrets)) return;
+      const { [account]: _removed, ...rest } = secrets;
+      yield* writeSecretsFile(rest);
+      return;
+    }
 
     if (backend === "macos") {
       yield* runCommand("security", [

--- a/packages/adapters/src/secrets/keyring.ts
+++ b/packages/adapters/src/secrets/keyring.ts
@@ -6,13 +6,19 @@ import { Effect } from "effect";
 import { KEYRING_SERVICE_NAME } from "./registry";
 
 /**
- * OS keyring access via the platform's own CLI rather than a native module.
+ * Which secret store `keyringGet`/`keyringSet`/`keyringDelete` use.
  *
- * Jazz ships a slim install, and every native keyring binding drags prebuilt
- * binaries per platform behind it. `security` is always present on macOS and
- * `secret-tool` is the standard libsecret client on Linux, so shelling out
- * keeps the dependency footprint at zero. `"file"` is the fallback below both: a
- * `chmod 600` JSON file under `$JAZZ_HOME`, used when neither is reachable.
+ * - `"macos"` — Keychain, via the `security` CLI.
+ * - `"libsecret"` — the Linux Secret Service, via the `secret-tool` CLI (gnome-keyring or
+ *   similar).
+ * - `"file"` — a `chmod 600` JSON file under `$JAZZ_HOME`, used when neither OS keyring is
+ *   reachable (typically a headless server with no D-Bus session).
+ * - `"none"` — nothing stored; reads return nothing, writes are refused. Only reachable via
+ *   the `$JAZZ_DISABLE_KEYRING` opt-out, since `"file"` covers every other case.
+ *
+ * `security`/`secret-tool` over a native keyring binding: jazz ships a slim install, and every
+ * native binding drags prebuilt binaries per platform behind it. Both CLIs already ship with
+ * their platform, so shelling out keeps the dependency footprint at zero.
  */
 export type KeyringBackend = "macos" | "libsecret" | "file" | "none";
 

--- a/packages/adapters/src/secrets/keyring.ts
+++ b/packages/adapters/src/secrets/keyring.ts
@@ -22,6 +22,20 @@ import { KEYRING_SERVICE_NAME } from "./registry";
  */
 export type KeyringBackend = "macos" | "libsecret" | "file" | "none";
 
+/** Human-readable name for a backend, for success/status messages. */
+export function describeKeyringBackend(backend: KeyringBackend): string {
+  switch (backend) {
+    case "macos":
+      return "the macOS keychain";
+    case "libsecret":
+      return "the Linux keyring";
+    case "file":
+      return "$JAZZ_HOME/secrets.json";
+    case "none":
+      return "nowhere";
+  }
+}
+
 const PROBE_ACCOUNT = "__jazz_probe__";
 const COMMAND_TIMEOUT_MS = 5_000;
 

--- a/packages/adapters/src/secrets/keyring.ts
+++ b/packages/adapters/src/secrets/keyring.ts
@@ -11,13 +11,8 @@ import { KEYRING_SERVICE_NAME } from "./registry";
  * Jazz ships a slim install, and every native keyring binding drags prebuilt
  * binaries per platform behind it. `security` is always present on macOS and
  * `secret-tool` is the standard libsecret client on Linux, so shelling out
- * keeps the dependency footprint at zero.
- *
- * `"file"` is the fallback below both: a `chmod 600` JSON file under `$JAZZ_HOME`, used
- * whenever no OS keyring is reachable (typically a headless server with no D-Bus session).
- * Not a lower bar than jazz already accepts elsewhere — `service-install.ts` stores the
- * daemon's own token the same way, and `config.json` already holds API keys in plaintext at
- * the same permissions in the same directory.
+ * keeps the dependency footprint at zero. `"file"` is the fallback below both: a
+ * `chmod 600` JSON file under `$JAZZ_HOME`, used when neither is reachable.
  */
 export type KeyringBackend = "macos" | "libsecret" | "file" | "none";
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -39,7 +39,12 @@ import {
 } from "@jazz/adapters/daemon/token";
 import { runDueTriggers } from "@jazz/adapters/daemon/trigger-runner";
 import { resolvePeerToken } from "@jazz/adapters/peers/token";
-import { detectKeyringBackend, keyringDelete, keyringSet } from "@jazz/adapters/secrets/keyring";
+import {
+  describeKeyringBackend,
+  detectKeyringBackend,
+  keyringDelete,
+  keyringSet,
+} from "@jazz/adapters/secrets/keyring";
 import { DAEMON_TOKEN_ENV_VAR, DAEMON_TOKEN_PATH } from "@jazz/adapters/secrets/registry";
 import { makeFileRunStoreLayer } from "@jazz/adapters/storage/run-store";
 import { resolveTriggerToken } from "@jazz/adapters/triggers/token";
@@ -136,9 +141,10 @@ export function daemonCommand(options: DaemonCommandOptions) {
         return;
       }
       token = provisioned.token;
-      if (provisioned.generated) {
+      if (provisioned.generated && provisioned.backend !== undefined) {
         process.stderr.write(
-          `Generated a daemon token and stored it in the OS keyring: ${provisioned.token}\n` +
+          `Generated a daemon token and stored it in ${describeKeyringBackend(provisioned.backend)}: ` +
+            `${provisioned.token}\n` +
             `Use it as a bearer token from any client reaching this daemon over the network.\n`,
         );
       }
@@ -349,7 +355,9 @@ export function setDaemonTokenCommand() {
     const backend = yield* detectKeyringBackend();
     if (backend === "none") {
       process.stderr.write(
-        "No OS keyring is available, and the daemon token is not written to disk in plaintext.\n",
+        "$JAZZ_DISABLE_KEYRING is set, so Jazz won't store this token anywhere — unset it and " +
+          "run this again, or persist the token yourself (a systemd `Environment=` line, your " +
+          "shell profile).\n",
       );
       process.exitCode = 1;
       return;
@@ -357,14 +365,18 @@ export function setDaemonTokenCommand() {
 
     const stored = yield* keyringSet(backend, DAEMON_TOKEN_PATH, token);
     if (!stored) {
-      process.stderr.write("Could not store the daemon token.\n");
+      process.stderr.write(
+        "Could not store the daemon token — neither the OS keyring nor the " +
+          "$JAZZ_HOME/secrets.json fallback could be written to. Check that $JAZZ_HOME is " +
+          "actually writable.\n",
+      );
       process.exitCode = 1;
       return;
     }
     process.stdout.write(
       generated
-        ? `Generated and stored a daemon token in the ${backend} keyring.\n`
-        : `Stored the daemon token in the ${backend} keyring.\n`,
+        ? `Generated and stored a daemon token in ${describeKeyringBackend(backend)}.\n`
+        : `Stored the daemon token in ${describeKeyringBackend(backend)}.\n`,
     );
   });
 }

--- a/packages/cli/src/commands/peer-invites.ts
+++ b/packages/cli/src/commands/peer-invites.ts
@@ -402,8 +402,10 @@ export function acceptInviteCommand(options: AcceptInviteCommandOptions) {
       return yield* Effect.fail(
         new CLIError({
           command: "peers invite accept",
-          message: "no OS keyring is available to store the resulting peer token",
-          suggestion: "Enable a keyring before accepting, so this single-use link is not spent.",
+          message:
+            "$JAZZ_DISABLE_KEYRING is set, so there is nowhere to store the resulting peer token",
+          suggestion:
+            "Unset $JAZZ_DISABLE_KEYRING before accepting, so this single-use link is not spent.",
         }),
       );
     }

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -97,7 +97,9 @@ export function setPeerTokenCommand(options: { readonly name: string; readonly e
     const backend = yield* detectKeyringBackend();
     if (backend === "none") {
       process.stderr.write(
-        "No OS keyring is available, and a peer token is not written to disk in plaintext.\n",
+        "$JAZZ_DISABLE_KEYRING is set, so Jazz won't store this token anywhere — unset it and " +
+          "run this again, or persist the token yourself (a systemd `Environment=` line, your " +
+          "shell profile).\n",
       );
       process.exitCode = 1;
       return;
@@ -105,7 +107,11 @@ export function setPeerTokenCommand(options: { readonly name: string; readonly e
 
     const stored = yield* keyringSet(backend, peerTokenPath(options.name), token);
     if (!stored) {
-      process.stderr.write(`Could not store the token for "${options.name}".\n`);
+      process.stderr.write(
+        `Could not store the token for "${options.name}" — neither the OS keyring nor the ` +
+          `$JAZZ_HOME/secrets.json fallback could be written to. Check that $JAZZ_HOME is ` +
+          `actually writable.\n`,
+      );
       process.exitCode = 1;
       return;
     }

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -7,7 +7,12 @@
  */
 
 import { read as readLedger } from "@jazz/adapters/peers/ledger";
-import { detectKeyringBackend, keyringDelete, keyringSet } from "@jazz/adapters/secrets/keyring";
+import {
+  describeKeyringBackend,
+  detectKeyringBackend,
+  keyringDelete,
+  keyringSet,
+} from "@jazz/adapters/secrets/keyring";
 import { KEYRING_SERVICE_NAME, peerTokenPath } from "@jazz/adapters/secrets/registry";
 import { AgentConfigServiceTag, type AgentConfigService } from "@jazz/core/interfaces/agent-config";
 import { getErrorMessage } from "@jazz/core/presentation/error-handler";
@@ -115,7 +120,9 @@ export function setPeerTokenCommand(options: { readonly name: string; readonly e
       process.exitCode = 1;
       return;
     }
-    process.stdout.write(`Stored a token for "${options.name}" in the ${backend} keyring.\n`);
+    process.stdout.write(
+      `Stored a token for "${options.name}" in ${describeKeyringBackend(backend)}.\n`,
+    );
   });
 }
 


### PR DESCRIPTION
## What & why
`jazz peers set-token` and `jazz peers invite accept` hard-refused on any machine without a
real OS keyring — a headless Linux server with no D-Bus session, most commonly — even though
the daemon's own token already had a working fallback for exactly that case. Setting up a peer
link to or from such a machine meant hand-editing a root-owned systemd env file and restarting
the service, a multi-step workaround discovered live while testing peer-to-peer between two
real machines.

`detectKeyringBackend()` now falls through to a `chmod 600` file at `$JAZZ_HOME/secrets.json`
whenever no OS keyring is reachable — the same permissions and directory `config.json` already
keeps API keys in. Every token consumer (peer, daemon, trigger) goes through this one function,
so they all get a working headless path without their own logic changing. `"none"` is now only
reachable via the explicit `$JAZZ_DISABLE_KEYRING` opt-out, so the error messages that used to
explain a missing OS keyring now explain that instead.

One side effect worth knowing: `config.ts` already migrates plaintext secrets (API keys sitting
in `config.json`) into the keyring the first time it can. That migration used to no-op on a
headless box since the backend was `"none"`; now it runs there too and moves those keys into
`secrets.json`, same as it already does for anyone with a real keyring. Nothing to do about
it — just don't be surprised if `config.json` shrinks on a server's next run.

## How to verify
- On a machine with no OS keyring reachable (or with `JAZZ_DISABLE_KEYRING` unset and
  `security`/`secret-tool` unavailable), run `JAZZ_PEER_TOKEN=x jazz peers set-token bob` — it
  succeeds and writes `$JAZZ_HOME/secrets.json` at `600` instead of refusing.
- `jazz peers invite create`/`accept` between two machines, one of them headless, completes in
  one shot with no manual token handling on either side.
- Edge case: set `$JAZZ_DISABLE_KEYRING=1` and repeat the above — both now fail with a message
  pointing at the opt-out itself, not a generic "no keyring" explanation.
