### PR TITLE
fix(cli): only show peer fields that are actually set

### DIFF
--- a/packages/cli/src/chat/commands/handler.test.ts
+++ b/packages/cli/src/chat/commands/handler.test.ts
@@ -488,10 +488,10 @@ describe("handleSpecialCommand /peers", () => {
     expect(output).toContain("bob");
     expect(output).toContain("http://100.101.102.103:4747/peer/ask");
     expect(output).toContain("alice");
-    // alice has no url — no Endpoint row at all, not a placeholder.
-    expect(output).not.toContain("no — not granted");
-    // carol has no disclosure — no "They may learn" row for her (or anyone after her).
-    expect(output.slice(output.indexOf("carol"))).not.toContain("They may learn");
+    // alice has no url — shown as an explicit placeholder, not omitted.
+    expect(output).toContain("none — cannot be asked");
+    // carol has no disclosure — still shown, via describeTier's own "none" default.
+    expect(output.slice(output.indexOf("carol"))).toContain("They may learn");
   });
 
   test("tells you how to add one when none are configured", async () => {

--- a/packages/cli/src/chat/commands/handler.test.ts
+++ b/packages/cli/src/chat/commands/handler.test.ts
@@ -460,6 +460,7 @@ describe("handleSpecialCommand /peers", () => {
         peers: [
           { name: "bob", url: "http://100.101.102.103:4747/peer/ask", disclosure: "internal" },
           { name: "alice", disclosure: "public" },
+          { name: "carol", url: "http://100.101.102.104:4747/peer/ask" },
         ],
       }) as unknown as AgentConfigService["appConfig"],
     };
@@ -487,7 +488,10 @@ describe("handleSpecialCommand /peers", () => {
     expect(output).toContain("bob");
     expect(output).toContain("http://100.101.102.103:4747/peer/ask");
     expect(output).toContain("alice");
-    expect(output).toContain("no — not granted");
+    // alice has no url — no Endpoint row at all, not a placeholder.
+    expect(output).not.toContain("no — not granted");
+    // carol has no disclosure — no "They may learn" row for her (or anyone after her).
+    expect(output.slice(output.indexOf("carol"))).not.toContain("They may learn");
   });
 
   test("tells you how to add one when none are configured", async () => {

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -767,18 +767,19 @@ function handlePeersCommand(
     } else {
       for (const peer of peers) {
         yield* terminal.log(fmt.labeledItem(peer.name));
-        if (peer.url !== undefined) {
-          yield* terminal.log(fmt.keyValue("Endpoint", peer.url));
-        }
-        if (peer.disclosure !== undefined) {
-          yield* terminal.log(fmt.keyValue("They may learn", describeTier(peer.disclosure)));
-        }
-        if (peer.persona !== undefined) {
-          yield* terminal.log(fmt.keyValue("Answers as", peer.persona));
-        }
-        if (peer.allow !== undefined && peer.allow.length > 0) {
-          yield* terminal.log(fmt.keyValue("Extra grants", peer.allow.join(", ")));
-        }
+        yield* terminal.log(fmt.keyValue("Endpoint", peer.url ?? "(none — cannot be asked)"));
+        yield* terminal.log(fmt.keyValue("They may learn", describeTier(peer.disclosure)));
+        yield* terminal.log(
+          fmt.keyValue("Answers as", peer.persona ?? "(agent's default persona)"),
+        );
+        yield* terminal.log(
+          fmt.keyValue(
+            "Extra grants",
+            peer.allow !== undefined && peer.allow.length > 0
+              ? peer.allow.join(", ")
+              : "(none — read-only only)",
+          ),
+        );
         yield* terminal.log(fmt.blank());
       }
 

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -767,10 +767,12 @@ function handlePeersCommand(
     } else {
       for (const peer of peers) {
         yield* terminal.log(fmt.labeledItem(peer.name));
-        yield* terminal.log(
-          fmt.keyValue("Can ask them", peer.url !== undefined ? peer.url : "no — not granted"),
-        );
-        yield* terminal.log(fmt.keyValue("They may learn", describeTier(peer.disclosure)));
+        if (peer.url !== undefined) {
+          yield* terminal.log(fmt.keyValue("Endpoint", peer.url));
+        }
+        if (peer.disclosure !== undefined) {
+          yield* terminal.log(fmt.keyValue("They may learn", describeTier(peer.disclosure)));
+        }
         if (peer.persona !== undefined) {
           yield* terminal.log(fmt.keyValue("Answers as", peer.persona));
         }

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -59,14 +59,16 @@ export function listPeersCommand(options: { readonly json: boolean }) {
       return;
     }
     for (const peer of peers) {
-      const parts = [peer.name];
-      if (peer.url !== undefined) parts.push(`endpoint: ${peer.url}`);
-      if (peer.disclosure !== undefined) parts.push(`may learn: ${describeTier(peer.disclosure)}`);
-      if (peer.persona !== undefined) parts.push(`persona: ${peer.persona}`);
-      if (peer.allow !== undefined && peer.allow.length > 0) {
-        parts.push(`allow: ${peer.allow.join(", ")}`);
-      }
-      process.stdout.write(`${parts.join("  ")}\n`);
+      const endpoint = peer.url ?? "(none — cannot be asked)";
+      const persona = peer.persona ?? "(agent's default persona)";
+      const allow =
+        peer.allow !== undefined && peer.allow.length > 0
+          ? peer.allow.join(", ")
+          : "(none — read-only only)";
+      process.stdout.write(
+        `${peer.name}  endpoint: ${endpoint}  may learn: ${describeTier(peer.disclosure)}  ` +
+          `persona: ${persona}  allow: ${allow}\n`,
+      );
     }
   }).pipe(
     Effect.catchAll((error) =>

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -59,15 +59,14 @@ export function listPeersCommand(options: { readonly json: boolean }) {
       return;
     }
     for (const peer of peers) {
-      const url = peer.url ?? "(cannot be asked — no endpoint)";
-      const persona = peer.persona !== undefined ? `  persona: ${peer.persona}` : "";
-      const allow =
-        peer.allow !== undefined && peer.allow.length > 0
-          ? `  allow: ${peer.allow.join(", ")}`
-          : "";
-      process.stdout.write(
-        `${peer.name}  ${url}  may learn: ${describeTier(peer.disclosure)}${persona}${allow}\n`,
-      );
+      const parts = [peer.name];
+      if (peer.url !== undefined) parts.push(`endpoint: ${peer.url}`);
+      if (peer.disclosure !== undefined) parts.push(`may learn: ${describeTier(peer.disclosure)}`);
+      if (peer.persona !== undefined) parts.push(`persona: ${peer.persona}`);
+      if (peer.allow !== undefined && peer.allow.length > 0) {
+        parts.push(`allow: ${peer.allow.join(", ")}`);
+      }
+      process.stdout.write(`${parts.join("  ")}\n`);
     }
   }).pipe(
     Effect.catchAll((error) =>


### PR DESCRIPTION
## What & why
`/peers` and `jazz peers list` printed "may learn: nothing (suspended)" for any peer that
simply never had disclosure granted — a peer added only so *you* can ask *them* has no
disclosure at all, but the output read like it had been actively suspended. Both commands now
only print a field when it's actually set, and the endpoint field is labeled "Endpoint"
instead of a bare URL or "Can ask them".

## How to verify
- `jazz peers list` with a peer that has a `url` but no `disclosure` — no "may learn" line for
  it, just the endpoint.
- `/peers` in an interactive session, same case — no "They may learn" row.
- A peer with both `url` and `disclosure` set still shows both.
