### PR TITLE
fix(cli): show provider/model in agent picker and agent list

### DIFF
--- a/packages/cli/src/commands/wizard-list-agents.test.ts
+++ b/packages/cli/src/commands/wizard-list-agents.test.ts
@@ -55,14 +55,14 @@ describe("showAgentList", () => {
     expect(menu.agents[0]).toMatchObject({
       id: "a1",
       name: "doitall",
-      model: "claude-sonnet-4",
+      model: "anthropic/claude-sonnet-4",
       description: "does everything",
       lastUsed: true,
     });
     expect(menu.agents[1]).toMatchObject({
       id: "a2",
       name: "qwen-coder",
-      model: "qwen2.5-coder",
+      model: "anthropic/qwen2.5-coder",
     });
 
     store.completePrompt({ kind: "exit" });

--- a/packages/cli/src/commands/wizard.ts
+++ b/packages/cli/src/commands/wizard.ts
@@ -293,7 +293,7 @@ function agentChoicesFor(
   return agents.map((agent) => ({
     id: agent.id,
     name: agent.name,
-    model: agent.config.llmModel,
+    model: agentModelString(agent.config),
     persona: agent.config.persona,
     ...(agent.description !== undefined && agent.description !== agent.name
       ? { description: agent.description }

--- a/packages/cli/src/ui/AgentsList.tsx
+++ b/packages/cli/src/ui/AgentsList.tsx
@@ -1,3 +1,4 @@
+import { agentModelString } from "@jazz/core/utils/provider-model";
 import { Box, Text } from "ink";
 import React from "react";
 import { formatToolsLine, getTerminalWidth, padRight } from "@/cli/utils/string-utils";
@@ -52,7 +53,7 @@ export function AgentsList(props: {
   const reasoningW = 9;
   const personaW = Math.max(8, Math.min(12, Math.floor(inner * 0.1)));
   const nameW = Math.max(12, Math.min(22, Math.floor(inner * 0.22)));
-  const modelW = Math.max(16, Math.min(30, Math.floor(inner * 0.26)));
+  const modelW = Math.max(16, Math.min(38, Math.floor(inner * 0.32)));
   const fixed = idxW + gap + nameW + gap + modelW + gap + personaW + gap + reasoningW;
   const descW = inner - fixed - gap;
   const showDescription = descW >= 12;
@@ -127,7 +128,7 @@ export function AgentsList(props: {
                 </Text>
                 {sp}
                 <Text color={THEME.agent}>
-                  {padRight(truncateEnd(agent.config.llmModel, modelW), modelW)}
+                  {padRight(truncateEnd(agentModelString(agent.config), modelW), modelW)}
                 </Text>
                 {sp}
                 <Text color={THEME.secondary}>

--- a/packages/cli/src/ui/fullscreen/screens/AgentPicker.tsx
+++ b/packages/cli/src/ui/fullscreen/screens/AgentPicker.tsx
@@ -5,8 +5,8 @@
  *
  * `jazz` with no arguments lands on the home screen and comes straight here, so
  * this is the last screen before a session starts. What it shows is what tells
- * two agents apart at the moment of choosing: a name, the model behind it, and
- * a one-line description. The id, the provider and the creation date — the
+ * two agents apart at the moment of choosing: a name, the provider/model behind
+ * it, and a one-line description. The id and the creation date — two of the
  * three things the Ink table led with — are lookups, not decisions, so they are
  * not here.
  *
@@ -47,7 +47,7 @@ const COLUMN_GAP = 2;
 const NAME_MIN = 10;
 const NAME_MAX = 24;
 const MODEL_MIN = 8;
-const MODEL_MAX = 28;
+const MODEL_MAX = 36;
 const PERSONA_MIN = 8;
 const PERSONA_MAX = 20;
 
@@ -74,7 +74,7 @@ const DEFAULT_ACTION = "start";
 export interface AgentChoice {
   readonly id: string;
   readonly name: string;
-  /** The model as the reader would say it, without the provider prefix. */
+  /** The provider and model as the reader would say it, e.g. "anthropic/sonnet-4.5". */
   readonly model: string;
   readonly persona: string;
   readonly description?: string;


### PR DESCRIPTION
## What & why
Picking an agent (and the `list-agents` table) showed only the bare model id, e.g. "sonnet-4.5" — ambiguous when the same model name exists across multiple providers. Both now show "provider/model" (e.g. "anthropic/sonnet-4.5"), matching how the agent details card and the `/agents` chat-switch command already display it.

## How to verify
- Run `jazz` with a couple of agents configured on different providers, land on the agent picker, and confirm each row shows "provider/model" instead of just the model name.
- Run `jazz list-agents` and confirm the model column shows the same "provider/model" format.
- Check a long provider/model string still truncates cleanly rather than overflowing or wrapping.