### PR TITLE
fix(runtime): harden persistent runtime state

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,7 +99,9 @@ never transmitted. `JAZZ_OFFLINE=1` stops Jazz initiating any outbound request o
 [Airgapped & self-hosted](docs/start/airgapped.md).
 
 **Audit trail.** Every tool invocation is logged under `~/.jazz/logs/`, with per-run token and
-cost records under `~/.jazz/telemetry/`.
+cost records under `~/.jazz/telemetry/`. Credential-bearing fields in tool arguments and
+structured metadata — including nested headers — are replaced with `<redacted>` before a log is
+written. Logs can still contain other sensitive user content, so protect the directory.
 
 ---
 
@@ -195,7 +197,8 @@ covered by the keyring — treat them as sensitive in their own right.
 ## If something goes wrong
 
 1. **Stop the run** — double-Escape interrupts generation and any running tool; otherwise exit the process.
-2. **Check what happened** — `~/.jazz/logs/` has every tool invocation with its arguments.
+2. **Check what happened** — `~/.jazz/logs/` has every tool invocation with its arguments;
+   credential-bearing fields are shown as `<redacted>`.
 3. **Recover** — `git reflog` finds the pre-mistake state, then `git reset --hard <commit>`. For files, restore from backup or your trash.
 4. **Report it** — if the cause was Jazz acting without approval rather than an approval you granted, that is [in scope](#scope).
 

--- a/docs/internals/providers-and-models.md
+++ b/docs/internals/providers-and-models.md
@@ -160,6 +160,14 @@ A 15-minute ceiling exists because slow reasoning models on a long prompt genuin
 minutes, and a tighter timeout would fail runs that were about to succeed. Rate-limit errors
 are typed (`LLMRateLimitError`) so they're distinguishable from real failures.
 
+## Large attachments
+
+Attachments over the inline request limit are uploaded to OpenAI or Gemini and then sent by
+provider reference. Jazz keeps up to 256 recently used references per process so a replayed
+conversation does not upload the same large file on every turn. The cache is LRU-bounded: an
+inactive attachment is evicted as newer uploads arrive, preventing long-lived chat bridges from
+retaining an unbounded number of references.
+
 ---
 
 ## Cost accounting

--- a/docs/internals/providers-and-models.md
+++ b/docs/internals/providers-and-models.md
@@ -160,14 +160,6 @@ A 15-minute ceiling exists because slow reasoning models on a long prompt genuin
 minutes, and a tighter timeout would fail runs that were about to succeed. Rate-limit errors
 are typed (`LLMRateLimitError`) so they're distinguishable from real failures.
 
-## Large attachments
-
-Attachments over the inline request limit are uploaded to OpenAI or Gemini and then sent by
-provider reference. Jazz keeps up to 256 recently used references per process so a replayed
-conversation does not upload the same large file on every turn. The cache is LRU-bounded: an
-inactive attachment is evicted as newer uploads arrive, preventing long-lived chat bridges from
-retaining an unbounded number of references.
-
 ---
 
 ## Cost accounting

--- a/packages/adapters/src/llm/attachment-resolver.test.ts
+++ b/packages/adapters/src/llm/attachment-resolver.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Upload-reference cache behavior for large attachments.
+ *
+ * The AI SDK upload call is mocked because this suite verifies cache lifetime, not a provider
+ * integration. Each path below resolves to one tiny fixture file while declaring a large byte
+ * size, which exercises the provider-upload path without allocating hundreds of megabytes.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import type { MessageAttachment } from "@jazz/core/types/attachment";
+import type { ChatMessage } from "@jazz/core/types/message";
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const actualAiModule = { ...(await import("ai")) };
+let uploadCalls = 0;
+
+mock.module("ai", () => ({
+  ...actualAiModule,
+  uploadFile: mock(async () => ({ providerReference: { upload: ++uploadCalls } })),
+}));
+
+const { ATTACHMENT_UPLOAD_CACHE_CAPACITY, clearAttachmentUploadCache, resolveAttachments } =
+  await import("./attachment-resolver");
+
+function largeVideo(path: string): MessageAttachment {
+  return {
+    kind: "video",
+    mediaType: "video/mp4",
+    path,
+    byteSize: 7 * 1024 * 1024,
+  };
+}
+
+async function resolveLargeVideo(path: string): Promise<void> {
+  const messages: ChatMessage[] = [
+    { role: "user", content: "watch", attachments: [largeVideo(path)] },
+  ];
+  await resolveAttachments(messages, "openai");
+}
+
+beforeEach(() => {
+  clearAttachmentUploadCache();
+  uploadCalls = 0;
+});
+
+afterEach(() => {
+  clearAttachmentUploadCache();
+});
+
+afterAll(() => {
+  mock.module("ai", () => actualAiModule);
+});
+
+describe("attachment upload cache", () => {
+  it("evicts the least-recently-used reference while preserving a refreshed entry", async () => {
+    const directory = await mkdtemp(`${tmpdir()}/jazz-attachment-cache-`);
+    const fixture = `${directory}/clip.mp4`;
+    await writeFile(fixture, "fixture");
+
+    try {
+      const pathAt = (index: number): string => `${directory}${"/.".repeat(index)}/clip.mp4`;
+
+      for (let index = 0; index < ATTACHMENT_UPLOAD_CACHE_CAPACITY; index++) {
+        await resolveLargeVideo(pathAt(index));
+      }
+      expect(uploadCalls).toBe(ATTACHMENT_UPLOAD_CACHE_CAPACITY);
+
+      await resolveLargeVideo(pathAt(0));
+      await resolveLargeVideo(pathAt(ATTACHMENT_UPLOAD_CACHE_CAPACITY));
+      await resolveLargeVideo(pathAt(0));
+      await resolveLargeVideo(pathAt(1));
+
+      expect(uploadCalls).toBe(ATTACHMENT_UPLOAD_CACHE_CAPACITY + 2);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/src/llm/attachment-resolver.ts
+++ b/packages/adapters/src/llm/attachment-resolver.ts
@@ -21,9 +21,10 @@
  * survivable because video and audio are Gemini-family capabilities to begin with — but it does
  * mean "attachment too large to inline" is a hard failure on Anthropic rather than a slow path.
  *
- * Uploads are cached for the life of the process. Without the cache, a conversation that
+ * Uploads are retained in a bounded LRU cache. Without the cache, a conversation that
  * references a video would re-upload it on every turn as history replays — slow, and billed
- * per upload on metered providers.
+ * per upload on metered providers. The bound prevents inactive conversations from growing a
+ * long-lived bot process indefinitely.
  */
 
 import { readFile, stat } from "node:fs/promises";
@@ -93,7 +94,48 @@ function uploadCacheKey(
   return `${providerName}:${attachment.path}:${attachment.byteSize}:${modifiedTimeMs}`;
 }
 
-const uploadCache = new Map<string, unknown>();
+/**
+ * Maximum provider references retained across active conversations in one process.
+ *
+ * References are small, opaque provider handles rather than attachment bytes. Still, this is
+ * a process-global cache used by long-lived chat bridges, so it needs a firm bound. 256 entries
+ * comfortably covers active replayed conversations while ensuring abandoned paths are released.
+ */
+export const ATTACHMENT_UPLOAD_CACHE_CAPACITY = 256;
+
+/**
+ * A minimal insertion-ordered LRU cache for provider upload references.
+ *
+ * `Map` preserves insertion order. Moving a hit to the end makes its first key the least
+ * recently used entry, which can be evicted without timers or background work.
+ */
+class AttachmentUploadCache {
+  private readonly entries = new Map<string, unknown>();
+
+  get(key: string): unknown {
+    const value = this.entries.get(key);
+    if (value === undefined) return undefined;
+
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  set(key: string, value: unknown): void {
+    this.entries.delete(key);
+    this.entries.set(key, value);
+
+    if (this.entries.size <= ATTACHMENT_UPLOAD_CACHE_CAPACITY) return;
+    const leastRecentlyUsedKey = this.entries.keys().next().value;
+    if (leastRecentlyUsedKey !== undefined) this.entries.delete(leastRecentlyUsedKey);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+const uploadCache = new AttachmentUploadCache();
 
 /** Test seam: drops cached references so the next resolve re-uploads. */
 export function clearAttachmentUploadCache(): void {

--- a/packages/adapters/src/logger.test.ts
+++ b/packages/adapters/src/logger.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it, beforeEach } from "bun:test";
-import { setLogFormat, getLogFormat, formatLogLineAsJson, formatLogLineAsPlain } from "./logger";
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  formatLogLineAsJson,
+  formatLogLineAsPlain,
+  formatToolCallLogLine,
+  getLogFormat,
+  setLogFormat,
+} from "./logger";
 
 describe("LoggerService", () => {
   beforeEach(() => {
@@ -39,6 +45,24 @@ describe("LoggerService", () => {
       expect(parsed.code).toBe(500);
       expect(parsed.detail).toBe("DB error");
     });
+
+    it("redacts credential-bearing metadata keys at every depth", () => {
+      const args = {
+        apiKey: "top-secret",
+        headers: { authorization: "Bearer also-secret", accept: "application/json" },
+      };
+      const output = formatLogLineAsJson("info", "Request", args);
+      const parsed = JSON.parse(output);
+
+      expect(parsed.apiKey).toBe("<redacted>");
+      expect(parsed.headers).toEqual({ authorization: "<redacted>", accept: "application/json" });
+      expect(output).not.toContain("top-secret");
+      expect(output).not.toContain("also-secret");
+      expect(args).toEqual({
+        apiKey: "top-secret",
+        headers: { authorization: "Bearer also-secret", accept: "application/json" },
+      });
+    });
   });
 
   describe("formatLogLineAsPlain", () => {
@@ -50,5 +74,30 @@ describe("LoggerService", () => {
       expect(output).toContain('{"foo":"bar"}');
       expect(output.endsWith("\n")).toBe(true);
     });
+
+    it("redacts credential-bearing metadata keys", () => {
+      const output = formatLogLineAsPlain("info", "Request", {
+        credentials: { password: "top-secret" },
+      });
+
+      expect(output).toContain('"credentials":"<redacted>"');
+      expect(output).not.toContain("top-secret");
+    });
+  });
+
+  it("redacts tool arguments in plain and JSON session logs", () => {
+    const args = {
+      headers: { authorization: "Bearer tool-secret" },
+      query: { access_token: "nested-tool-secret", page: 1 },
+    };
+
+    for (const format of ["plain", "json"] as const) {
+      setLogFormat(format);
+      const output = formatToolCallLogLine("session-123", "http_request", args);
+
+      expect(output).toContain("<redacted>");
+      expect(output).not.toContain("tool-secret");
+      expect(output).not.toContain("nested-tool-secret");
+    }
   });
 });

--- a/packages/adapters/src/logger.ts
+++ b/packages/adapters/src/logger.ts
@@ -26,6 +26,55 @@ const LOG_LEVEL_PRIORITY: Record<"debug" | "info" | "warn" | "error", number> = 
 };
 
 /**
+ * Metadata keys whose values are credentials and must never be persisted in a log.
+ *
+ * Tool arguments and structured metadata commonly carry HTTP headers or provider
+ * credentials. Match keys at every depth so a nested `headers.authorization` is
+ * protected just as a top-level `apiKey` is.
+ */
+const SENSITIVE_LOG_KEY_PATTERN =
+  /authorization|api[-_]?key|token|secret|password|credential|cookie|passphrase/i;
+
+/**
+ * Return a deep, non-mutating copy of log metadata with credential-bearing fields
+ * replaced. The logger is the final persistence boundary, so every structured log
+ * format must pass through this function before serialization.
+ */
+export function redactLogMetadata(
+  metadata: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  return redactLogValue(metadata, new WeakMap<object, unknown>()) as Record<string, unknown>;
+}
+
+function redactLogValue(value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (value === null || typeof value !== "object") return value;
+
+  const existing = seen.get(value);
+  if (existing !== undefined) return existing;
+
+  if (Array.isArray(value)) {
+    const redacted: unknown[] = [];
+    seen.set(value, redacted);
+    for (const item of value) {
+      redacted.push(redactLogValue(item, seen));
+    }
+    return redacted;
+  }
+
+  const prototype = Reflect.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+
+  const redacted: Record<string, unknown> = {};
+  seen.set(value, redacted);
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = SENSITIVE_LOG_KEY_PATTERN.test(key)
+      ? "<redacted>"
+      : redactLogValue(nestedValue, seen);
+  }
+  return redacted;
+}
+
+/**
  * Check if a log at the given level should be written based on the configured level
  */
 function shouldLog(level: "debug" | "info" | "warn" | "error"): boolean {
@@ -265,7 +314,7 @@ export function formatLogLineAsJson(
 
   if (meta && Object.keys(meta).length > 0) {
     // Spread meta fields at top level for easier querying
-    Object.assign(logEntry, meta);
+    Object.assign(logEntry, redactLogMetadata(meta));
   }
 
   return JSON.stringify(logEntry, jsonBigIntReplacer) + "\n";
@@ -281,7 +330,9 @@ export function formatLogLineAsPlain(
 ): string {
   const now = new Date();
   const metaText =
-    meta && Object.keys(meta).length > 0 ? " " + JSON.stringify(meta, jsonBigIntReplacer) : "";
+    meta && Object.keys(meta).length > 0
+      ? " " + JSON.stringify(redactLogMetadata(meta), jsonBigIntReplacer)
+      : "";
   return `${now.toLocaleDateString()} ${now.toLocaleTimeString()} [${level.toUpperCase()}] ${message}${metaText}\n`;
 }
 
@@ -381,20 +432,23 @@ function writeToolCallToSessionFile(
   const sanitizedId = conversationId.replace(/[^a-zA-Z0-9_-]/g, "_");
   const logFilePath = path.join(logsDir, `${sanitizedId}.log`);
 
+  logQueue.enqueue(logFilePath, formatToolCallLogLine(conversationId, toolName, args));
+}
+
+/** Format a redacted tool call as a session log entry in the selected format. */
+export function formatToolCallLogLine(
+  conversationId: string,
+  toolName: string,
+  args: Readonly<Record<string, unknown>>,
+): string {
+  const redactedArgs = redactLogMetadata(args);
   if (getLogFormat() === "json") {
-    const line = formatLogLineAsJson("info", `Tool Call: ${toolName}`, args, conversationId);
-    logQueue.enqueue(logFilePath, line);
-    return;
+    return formatLogLineAsJson("info", `Tool Call: ${toolName}`, redactedArgs, conversationId);
   }
 
   const timestamp = new Date().toISOString();
-
-  // Format arguments as JSON
-  const argsJson = JSON.stringify(args);
-  const content = `${toolName} ${argsJson}`;
-  const line = `[${timestamp}] [TOOL_CALL] ${content}\n`;
-
-  logQueue.enqueue(logFilePath, line);
+  const argsJson = JSON.stringify(redactedArgs, jsonBigIntReplacer);
+  return `[${timestamp}] [TOOL_CALL] ${toolName} ${argsJson}\n`;
 }
 
 /**

--- a/packages/adapters/src/storage/run-store.test.ts
+++ b/packages/adapters/src/storage/run-store.test.ts
@@ -319,4 +319,45 @@ describe("FileRunStore hardening", () => {
     expect(loaded?.runId).toBe(RUN_ID);
     await nodeFs.rm(directory, { recursive: true, force: true });
   });
+
+  it("never silently drops a completed transition to a concurrent prune's stale repark decision", async () => {
+    const directory = await nodeFs.mkdtemp(path.join(os.tmpdir(), "jazz-runs-"));
+    const store = new FileRunStore(directory);
+
+    const deadRecoveryState: RunState = {
+      kind: "working",
+      iteration: 3,
+      recovery: {
+        pending: parkedApproval,
+        snapshot: { messages: [], iteration: 3 },
+        expiresAt: "2026-08-23T13:00:00.000Z",
+        pid: 999_999,
+        host: hostname(),
+      },
+    };
+    await Effect.runPromise(store.save({ ...record(RUN_ID), state: deadRecoveryState }));
+
+    const [pruneResult, transitionOutcome] = await Promise.all([
+      Effect.runPromise(
+        store.prune({ now: new Date("2026-08-23T12:00:00.000Z"), maxTerminalAgeMs: 1_000_000 }),
+      ),
+      Effect.runPromise(store.transition(RUN_ID, { kind: "completed", content: "done" })).then(
+        () => "succeeded" as const,
+        () => "failed" as const,
+      ),
+    ]);
+
+    // Whichever operation reached the run's lock first, the loser must act on the winner's
+    // fresh state rather than the stale pre-race snapshot: a transition that reports success
+    // can never have its result clobbered by prune's repark decision.
+    const final = await Effect.runPromise(store.get(RUN_ID));
+    if (transitionOutcome === "succeeded") {
+      expect(final?.state.kind).toBe("completed");
+      expect(pruneResult.reparked).toBe(0);
+    } else {
+      expect(final?.state.kind).toBe("input-required");
+      expect(pruneResult.reparked).toBe(1);
+    }
+    await nodeFs.rm(directory, { recursive: true, force: true });
+  });
 });

--- a/packages/adapters/src/storage/run-store.ts
+++ b/packages/adapters/src/storage/run-store.ts
@@ -89,6 +89,71 @@ function recoveredState(record: RunRecord): RunState | undefined {
   };
 }
 
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRY_DELAY_MS = 25;
+const LOCK_MAX_WAIT_MS = 5_000;
+
+interface LockPayload {
+  readonly pid: number;
+  readonly host: string;
+  readonly acquiredAt: number;
+}
+
+async function readLockPayload(lockPath: string): Promise<LockPayload | undefined> {
+  try {
+    return JSON.parse(await nodeFs.readFile(lockPath, "utf-8")) as LockPayload;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Staleness is decided from the lock file's own mtime, not from parsing its content: a
+ * holder that just created the file has a real window, between the create and the payload
+ * write landing, where the file exists but reads as empty. Judging staleness by content
+ * would misread that window as an abandoned lock and let a second caller steal it out from
+ * under the first — the exact double-acquire this lock exists to prevent. An unparseable
+ * payload on a fresh file is "still being written", not "stale": say so, not stale.
+ */
+async function isLockStale(lockPath: string): Promise<boolean> {
+  const stats = await nodeFs.stat(lockPath).catch(() => undefined);
+  if (stats === undefined) return true;
+  if (Date.now() - stats.mtimeMs > LOCK_STALE_MS) return true;
+  const payload = await readLockPayload(lockPath);
+  if (payload === undefined) return false;
+  return ownerIsGone(payload);
+}
+
+/**
+ * Exclusive-create (`writeFile(path, content, { flag: "wx" })` fails with EEXIST if the
+ * lock file already exists) is what makes this safe across processes without a native
+ * flock binding. Creation and content land in one call rather than an `open` followed by a
+ * separate `writeFile`, so there is no `await` boundary between them for a concurrent
+ * stale-check to observe an empty file through. A lock is stale — its holder crashed
+ * mid-write — if the owning process is gone or it has sat past LOCK_STALE_MS; either way we
+ * reclaim it rather than wait out a dead holder.
+ */
+async function acquireRunLock(lockPath: string): Promise<() => Promise<void>> {
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+  for (;;) {
+    try {
+      const payload: LockPayload = { pid: process.pid, host: hostname(), acquiredAt: Date.now() };
+      await nodeFs.writeFile(lockPath, JSON.stringify(payload), { flag: "wx" });
+      return () => nodeFs.rm(lockPath, { force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (await isLockStale(lockPath)) {
+        await nodeFs.rm(lockPath, { force: true }).catch(() => undefined);
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for the run lock at "${lockPath}".`, { cause: error });
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_DELAY_MS));
+    }
+  }
+}
+
 const ABANDONED: RunState = {
   kind: "failed",
   cause: "abandoned",
@@ -224,19 +289,42 @@ export class FileRunStore implements RunStore {
     }).pipe(Effect.catchAll(() => Effect.succeed([] as readonly RunRecord[])));
   }
 
+  private lockPathFor(runId: RunId): string {
+    return `${this.pathFor(runId)}.lock`;
+  }
+
+  private async writeRecordFile(record: RunRecord): Promise<void> {
+    const destination = this.pathFor(record.runId);
+    // A reader polling mid-write would otherwise parse a truncated record as a
+    // missing one, which for a parked run reads as "your approval is gone".
+    const temporary = `${destination}.${process.pid}.tmp`;
+    await nodeFs.writeFile(temporary, JSON.stringify(record, null, 2), "utf-8");
+    await nodeFs.rename(temporary, destination);
+  }
+
+  /** Serializes read-modify-write on one run id across processes so a losing writer's update isn't silently dropped. */
+  private withRunLock<A, E>(runId: RunId, use: Effect.Effect<A, E>): Effect.Effect<A, E | Error> {
+    return Effect.acquireUseRelease(
+      Effect.tryPromise({
+        try: async () => {
+          await nodeFs.mkdir(this.directory, { recursive: true });
+          return acquireRunLock(this.lockPathFor(runId));
+        },
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }),
+      () => use,
+      (release) => Effect.promise(() => release()),
+    );
+  }
+
   save(record: RunRecord): Effect.Effect<void, never> {
-    return Effect.tryPromise({
-      try: async () => {
-        await nodeFs.mkdir(this.directory, { recursive: true });
-        const destination = this.pathFor(record.runId);
-        // A reader polling mid-write would otherwise parse a truncated record as a
-        // missing one, which for a parked run reads as "your approval is gone".
-        const temporary = `${destination}.${process.pid}.tmp`;
-        await nodeFs.writeFile(temporary, JSON.stringify(record, null, 2), "utf-8");
-        await nodeFs.rename(temporary, destination);
-      },
-      catch: (error) => error,
-    }).pipe(Effect.catchAll(() => Effect.void));
+    return this.withRunLock(
+      record.runId,
+      Effect.tryPromise({
+        try: () => this.writeRecordFile(record),
+        catch: (error) => error,
+      }),
+    ).pipe(Effect.catchAll(() => Effect.void));
   }
 
   get(runId: RunId): Effect.Effect<RunRecord | undefined, never> {
@@ -250,22 +338,77 @@ export class FileRunStore implements RunStore {
   }
 
   transition(runId: RunId, next: RunState): Effect.Effect<RunRecord, Error> {
-    return Effect.gen(this, function* () {
-      const existing = yield* this.get(runId);
-      if (existing === undefined) {
-        return yield* Effect.fail(new Error(`No run with id "${runId}".`));
-      }
-      const updated = yield* Effect.try({
-        try: () => withState(existing, next, this.clock()),
-        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-      });
-      yield* this.save(updated);
-      return updated;
-    });
+    return this.withRunLock(
+      runId,
+      Effect.gen(this, function* () {
+        const existing = yield* this.get(runId);
+        if (existing === undefined) {
+          return yield* Effect.fail(new Error(`No run with id "${runId}".`));
+        }
+        const updated = yield* Effect.try({
+          try: () => withState(existing, next, this.clock()),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        });
+        yield* Effect.tryPromise({
+          try: () => this.writeRecordFile(updated),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        });
+        return updated;
+      }),
+    );
   }
 
   list(filter?: RunListFilter): Effect.Effect<readonly RunRecord[], never> {
     return this.readAll().pipe(Effect.map((records) => selectRecords(records, filter)));
+  }
+
+  /**
+   * `readAll()` only enumerates which run ids might need pruning; the decision itself is
+   * re-made here against a freshly locked read, so a run a live process just moved past
+   * (say, to `completed`) can't be reparked or abandoned from the stale snapshot.
+   */
+  private prunableRunOutcome(
+    runId: RunId,
+    now: Date,
+    maxTerminalAgeMs: number,
+  ): Effect.Effect<"abandoned" | "deleted" | "reparked" | "kept", Error> {
+    return this.withRunLock(
+      runId,
+      Effect.gen(this, function* () {
+        const current = yield* this.get(runId);
+        if (current === undefined) return "kept" as const;
+
+        const recovered = recoveredState(current);
+        if (recovered !== undefined) {
+          yield* Effect.tryPromise({
+            try: () => this.writeRecordFile(withState(current, recovered, now)),
+            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+          });
+          return "reparked" as const;
+        }
+
+        if (isExpired(current, now)) {
+          yield* Effect.tryPromise({
+            try: () => this.writeRecordFile(withState(current, ABANDONED, now)),
+            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+          });
+          return "abandoned" as const;
+        }
+
+        if (
+          isTerminal(current.state) &&
+          now.getTime() - new Date(current.updatedAt).getTime() > maxTerminalAgeMs
+        ) {
+          yield* Effect.tryPromise({
+            try: () => nodeFs.rm(this.pathFor(runId), { force: true }),
+            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+          });
+          return "deleted" as const;
+        }
+
+        return "kept" as const;
+      }),
+    );
   }
 
   prune(options: {
@@ -281,27 +424,14 @@ export class FileRunStore implements RunStore {
       let deleted = 0;
       let reparked = 0;
       for (const record of records) {
-        const recovered = recoveredState(record);
-        if (recovered !== undefined) {
-          yield* this.save(withState(record, recovered, options.now));
-          reparked += 1;
-          continue;
-        }
-        if (isExpired(record, options.now)) {
-          yield* this.save(withState(record, ABANDONED, options.now));
-          abandoned += 1;
-          continue;
-        }
-        if (
-          isTerminal(record.state) &&
-          options.now.getTime() - new Date(record.updatedAt).getTime() > options.maxTerminalAgeMs
-        ) {
-          yield* Effect.tryPromise({
-            try: () => nodeFs.rm(this.pathFor(record.runId), { force: true }),
-            catch: (error) => error,
-          }).pipe(Effect.catchAll(() => Effect.void));
-          deleted += 1;
-        }
+        const outcome = yield* this.prunableRunOutcome(
+          record.runId,
+          options.now,
+          options.maxTerminalAgeMs,
+        ).pipe(Effect.catchAll(() => Effect.succeed("kept" as const)));
+        if (outcome === "reparked") reparked += 1;
+        else if (outcome === "abandoned") abandoned += 1;
+        else if (outcome === "deleted") deleted += 1;
       }
       return { abandoned, deleted, reparked };
     });

--- a/packages/cli/src/presentation/ink-presentation-service.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.ts
@@ -79,6 +79,7 @@ function echoUserTurn(text: string): void {
   store.printOutput({
     type: "user",
     message: wrapToWidth(text, getTerminalWidth() - USER_ECHO_WIDTH_OFFSET),
+    meta: { plainText: text }, // unwrapped source for non-Ink renderers
     timestamp: new Date(),
   });
 }

--- a/packages/cli/src/terminal.ts
+++ b/packages/cli/src/terminal.ts
@@ -62,6 +62,7 @@ function printUserMessage(message: string): void {
   store.printOutput({
     type: "user",
     message: wrapped,
+    meta: { plainText: message }, // unwrapped source for non-Ink renderers
     timestamp: new Date(),
   });
 }
@@ -303,6 +304,7 @@ export class InkTerminalService implements TerminalService {
             store.printOutput({
               type: "user",
               message: wrapToWidth(rawMessage, getTerminalWidth() - USER_ECHO_WIDTH_OFFSET),
+              meta: { plainText: `${message} ${displayValue}` },
               timestamp: new Date(),
             });
           }

--- a/packages/cli/src/ui/fullscreen/Input.tsx
+++ b/packages/cli/src/ui/fullscreen/Input.tsx
@@ -88,16 +88,7 @@ export interface InputRow {
   readonly segments: readonly InputSegment[];
 }
 
-/**
- * Character wrapping, not word wrapping.
- *
- * A composer is not prose being typeset — it is a window onto a buffer, and it
- * has to show that buffer exactly. Word wrap eats the space at a break, so a
- * trailing space typed at the wrap boundary would vanish and the caret would
- * appear one cell to the left of where the next character will actually land.
- * Char wrap cannot lie about what has been typed. Explicit newlines are
- * paragraph breaks and survive.
- */
+// Per-paragraph wrap; see `wrapTerminalCells` for the wrap itself.
 export function wrapCells(value: string, columns: number): string[] {
   const width = Math.max(1, columns);
   const lines: string[] = [];
@@ -282,15 +273,21 @@ export function inputRows(
   }
   const lines = wrapped.map((line) => line.text);
 
-  const valueBeforeCaret = [...model.value].slice(0, caretAt).join("");
-  const linesBeforeCaret = empty ? [""] : wrapCells(valueBeforeCaret, contentWidth);
-  let caretLine = Math.max(0, linesBeforeCaret.length - 1);
-  let caretColumn = terminalCellWidth(linesBeforeCaret.at(-1) ?? "");
-  if (!empty && caretColumn >= contentWidth) {
-    caretLine += 1;
-    caretColumn = 0;
+  // Reuse `wrapped` rather than re-wrapping the text before the caret — a
+  // prefix alone can't know a word will later get carried to the next line.
+  let caretLine = 0;
+  for (let index = 0; index < wrapped.length; index += 1) {
+    const entry = wrapped[index];
+    if (entry === undefined || entry.start > caretAt) break;
+    caretLine = index;
   }
-  caretLine = Math.min(lines.length - 1, caretLine);
+  const caretLineEntry = wrapped[caretLine];
+  const caretColumn =
+    caretLineEntry === undefined
+      ? 0
+      : terminalCellWidth(
+          [...caretLineEntry.text].slice(0, caretAt - caretLineEntry.start).join(""),
+        );
 
   const queued = model.queued;
   const queuedCount = queued.length;

--- a/packages/cli/src/ui/fullscreen/Transcript.tsx
+++ b/packages/cli/src/ui/fullscreen/Transcript.tsx
@@ -722,14 +722,15 @@ function tableRows(
 
 const BLANK_CELL: Segment = { text: " ", fg: THEME.border };
 
-function railCell(color: string, glyphs: GlyphSet, deep = false): Segment {
-  return { text: deep ? glyphs.railDeep : glyphs.rail, fg: color };
+// Blank, not the rail glyph — copy-pasting a reply must not drag a bar along.
+function railCell(color: string): Segment {
+  return { text: " ", fg: color };
 }
 
-function blankRow(key: string, contentWidth: number, glyphs: GlyphSet): RenderRow {
+function blankRow(key: string, contentWidth: number): RenderRow {
   return {
     key,
-    gutter: [railCell(THEME.border, glyphs), BLANK_CELL],
+    gutter: [railCell(THEME.border), BLANK_CELL],
     content: [],
     contentWidth,
     meta: [],
@@ -870,7 +871,7 @@ function userRows(
   geometry: Geometry,
   glyphs: GlyphSet,
 ): RenderRow[] {
-  const rail = railCell(THEME.border, glyphs);
+  const rail = railCell(THEME.border);
   const meta: readonly Segment[] =
     block.at !== undefined && geometry.metadata > 0 ? [{ text: block.at, fg: THEME.muted }] : [];
   // What you typed is an echo; the agent's answer is the bright thing on screen.
@@ -897,7 +898,7 @@ function agentRows(
 ): RenderRow[] {
   // Colour is state, not speaker: the rail is accent only while tokens land.
   const railColor = block.streaming === true ? THEME.agent : THEME.border;
-  const rail = railCell(railColor, glyphs);
+  const rail = railCell(railColor);
   const marker: Segment = {
     text: glyphs.diamond,
     fg: block.streaming === true ? THEME.agent : THEME.secondary,
@@ -987,7 +988,7 @@ function reasoningRows(
   geometry: Geometry,
   glyphs: GlyphSet,
 ): RenderRow[] {
-  const rail = railCell(THEME.border, glyphs, true);
+  const rail = railCell(THEME.border);
   const meta: readonly Segment[] =
     block.durationMs !== undefined && geometry.metadata > 0
       ? [{ text: formatDuration(block.durationMs), fg: THEME.muted }]
@@ -1106,7 +1107,7 @@ function receiptRows(
   geometry: Geometry,
   glyphs: GlyphSet,
 ): RenderRow[] {
-  const rail = railCell(THEME.border, glyphs);
+  const rail = railCell(THEME.border);
   const rows: RenderRow[] = [];
   let packed: Segment[] = [];
   let packedKey = "";
@@ -1202,10 +1203,7 @@ function noticeRows(
     if (line === undefined) continue;
     rows.push({
       key: `${block.id}:${String(index)}`,
-      gutter: [
-        index === 0 ? { text: glyph, fg: tone } : railCell(THEME.border, glyphs),
-        BLANK_CELL,
-      ],
+      gutter: [index === 0 ? { text: glyph, fg: tone } : railCell(THEME.border), BLANK_CELL],
       content: line,
       contentWidth: geometry.prose,
       meta: [],
@@ -1224,7 +1222,7 @@ function dividerRows(
   return [
     {
       key: `${block.id}:0`,
-      gutter: [railCell(THEME.border, glyphs), BLANK_CELL],
+      gutter: [railCell(THEME.border), BLANK_CELL],
       content: [
         { text: label, fg: THEME.muted },
         { text: rule, fg: THEME.border },
@@ -1251,7 +1249,7 @@ function laneRows(
 ): RenderRow[] {
   const live = block.state === "running";
   const railColor = live ? THEME.accentDim : THEME.border;
-  const rail = railCell(railColor, glyphs, true);
+  const rail = railCell(railColor);
   // Holds the gutter at two cells so every block's content starts in the same
   // column, whether or not it is delegated.
   const tag: Segment = { text: " ", fg: THEME.border };
@@ -1350,7 +1348,7 @@ export function transcriptRows(blocks: readonly Block[], viewport: Viewport): Re
     const block = blocks[index];
     if (block === undefined) break;
     if (needsBreathingRow(block, blocks[index - 1])) {
-      rows.push(blankRow(`gap:${block.id}`, geometry.prose, glyphs));
+      rows.push(blankRow(`gap:${block.id}`, geometry.prose));
     }
 
     if (block.kind === "tool") {

--- a/packages/cli/src/ui/fullscreen/live-input.test.tsx
+++ b/packages/cli/src/ui/fullscreen/live-input.test.tsx
@@ -690,4 +690,30 @@ describe("input", () => {
       .join("");
     expect(selected).toBe("world");
   });
+
+  it("carries a whole word onto the next composer row instead of splitting it", () => {
+    // width 14, GUTTER_CELLS 4 -> 10 columns of content
+    const rows = inputRows({ ...base, value: "abc helloworld" }, { width: 14, height: HEIGHT });
+    const lineText = (row: (typeof rows)[number]): string =>
+      row.segments
+        .slice(2)
+        .map((segment) => segment.text)
+        .join("");
+    expect(lineText(rows[0] as (typeof rows)[number])).toBe("abc ");
+    expect(lineText(rows[1] as (typeof rows)[number])).toBe("helloworld");
+  });
+
+  it("places the caret on the row a wrapped word actually lands on", () => {
+    // caret sits inside "helloworld", which only wraps to row 2 as a whole word
+    const rows = inputRows(
+      { ...base, value: "abc helloworld", caret: 8 },
+      { width: 14, height: HEIGHT },
+    );
+    const caretRow = rows.findIndex((row) =>
+      row.segments.some((segment) => segment.bg === THEME.prompt),
+    );
+    expect(caretRow).toBe(1);
+    const caretRowText = rows[caretRow]?.segments.map((segment) => segment.text).join("") ?? "";
+    expect(caretRowText).toContain("helloworld");
+  });
 });

--- a/packages/cli/src/ui/fullscreen/terminal-cells.test.ts
+++ b/packages/cli/src/ui/fullscreen/terminal-cells.test.ts
@@ -36,6 +36,22 @@ describe("terminal cell measurement", () => {
     expect(wrapTerminalCells("A漢👨‍👩‍👧‍👦e\u0301Z", 3)).toEqual(["A漢", "👨‍👩‍👧‍👦e\u0301", "Z"]);
   });
 
+  it("carries a whole word onto the next line instead of splitting it", () => {
+    expect(wrapTerminalCells("abc helloworld", 10)).toEqual(["abc ", "helloworld"]);
+    expect(wrapTerminalCells("hello world", 8)).toEqual(["hello ", "world"]);
+  });
+
+  it("still breaks mid-word when a single word cannot fit any line", () => {
+    expect(wrapTerminalCells("supercalifragilistic", 8)).toEqual(["supercal", "ifragili", "stic"]);
+  });
+
+  it("keeps every character across wrapped lines, including the space", () => {
+    const text = "abc helloworld and more words";
+    for (let width = 1; width <= text.length; width += 1) {
+      expect(wrapTerminalCells(text, width).join("")).toBe(text);
+    }
+  });
+
   it("fits styled segments across segment boundaries", () => {
     const fitted = fitTerminalSegments(
       [

--- a/packages/cli/src/ui/fullscreen/terminal-cells.ts
+++ b/packages/cli/src/ui/fullscreen/terminal-cells.ts
@@ -97,21 +97,37 @@ export function fitTerminalSegments<Segment extends TextSegment>(
   return fitted;
 }
 
+// Word-aware wrap that never drops a character (spaces included), so a
+// caret tracked by counting into the joined output never drifts.
 export function wrapTerminalCells(text: string, maxCells: number): string[] {
   const width = Math.max(1, maxCells);
   const lines: string[] = [];
-  let line = "";
+  let line: string[] = [];
   let used = 0;
+  let breakIndex = -1;
+  let breakUsed = 0;
   for (const grapheme of terminalGraphemes(text)) {
     const graphemeWidth = terminalCellWidth(grapheme);
-    if (used > 0 && used + graphemeWidth > width) {
-      lines.push(line);
-      line = "";
-      used = 0;
+    while (used > 0 && used + graphemeWidth > width) {
+      if (breakIndex > 0) {
+        lines.push(line.slice(0, breakIndex).join(""));
+        line = line.slice(breakIndex);
+        used -= breakUsed;
+        breakIndex = -1;
+        breakUsed = 0;
+      } else {
+        lines.push(line.join(""));
+        line = [];
+        used = 0;
+      }
     }
-    line += grapheme;
+    line.push(grapheme);
     used += graphemeWidth;
+    if (/^\s$/.test(grapheme)) {
+      breakIndex = line.length;
+      breakUsed = used;
+    }
   }
-  if (line.length > 0) lines.push(line);
+  if (line.length > 0) lines.push(line.join(""));
   return lines.length > 0 ? lines : [""];
 }

--- a/packages/cli/src/ui/fullscreen/transcript.test.tsx
+++ b/packages/cli/src/ui/fullscreen/transcript.test.tsx
@@ -565,8 +565,7 @@ describe("reasoning is subordinate by geometry", () => {
     expect(widest).toBeLessThan(measureFor(WIDE.width).prose);
     for (const row of rows) {
       for (const segment of row.content) expect(segment.bold).not.toBe(true);
-      // The deep rail, not a new hue, is what says "one level down".
-      expect(row.gutter[0]?.text).toBe(getGlyphs().railDeep);
+      expect(row.gutter[0]?.text).toBe(" ");
     }
 
     const { spans } = await render(transcript(expanded, WIDE), WIDE);
@@ -633,7 +632,12 @@ describe("colour is state, not speaker", () => {
     expect(colorOf(spans, "gmail")).toBe(THEME.muted.toUpperCase());
     // The user's own marker is the one speaker-coloured cell; the rail is not.
     expect(colorOf(spans, getGlyphs().promptCursor)).toBe(THEME.primary.toUpperCase());
-    expect(colorOf(spans, getGlyphs().rail)).toBe(THEME.border.toUpperCase());
+
+    const rows = transcriptRows(SESSION, WIDE);
+    const continuation = rows.find(
+      (row) => row.key.startsWith("a1:") && row.gutter[0]?.text === " ",
+    );
+    expect(continuation?.gutter[0]?.fg).toBe(THEME.border);
   });
 
   it("puts the accent on a streaming rail and takes it away once settled", async () => {


### PR DESCRIPTION
## What & why
Makes long-running Jazz deployments safer to operate. Large attachment uploads are bounded, concurrent run recovery cannot overwrite a completed transition, and credentials in tool arguments or structured metadata are redacted before disk logs are written.

## How to verify
- Replay a large attachment and confirm a recently used upload reference is reused; add more than 256 distinct uploads and confirm the least-recent reference is uploaded again.
- Race a completed transition with run pruning and confirm a successful completion is never replaced by stale recovery state.
- Log tool arguments containing nested `authorization`, `apiKey`, or `access_token` fields in both log formats and confirm only `<redacted>` reaches the log.
