### PR TITLE
fix(cli): give every text input the same editing keybinds

### DIFF
--- a/packages/cli/src/ui/components/FilePicker.tsx
+++ b/packages/cli/src/ui/components/FilePicker.tsx
@@ -6,6 +6,7 @@ import {
   resolveFilePickerPath,
   scanFilePickerEntries,
 } from "../file-picker-files";
+import { useTextInput } from "../hooks/use-input-service";
 import { THEME } from "../theme";
 
 interface FilePickerProps {
@@ -27,12 +28,29 @@ export function FilePicker({
   onSelect,
   onCancel,
 }: FilePickerProps): React.ReactElement {
-  const [query, setQuery] = useState("");
   const [cursorIndex, setCursorIndex] = useState(0);
   const [windowStart, setWindowStart] = useState(0);
   const [files, setFiles] = useState<FilePickerEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const pageSize = 10;
+
+  const {
+    value: query,
+    cursor: queryCursor,
+    setValue: setQuery,
+  } = useTextInput({
+    id: "file-picker-query",
+    isActive: true,
+    onSubmit: () => {
+      void submit();
+    },
+  });
+
+  // The text-input store is keyed by id and persists across mounts, so a
+  // freshly opened file picker must clear out whatever a previous one left.
+  useEffect(() => {
+    setQuery("", 0);
+  }, []);
 
   // Scan for files matching the query asynchronously
   useEffect(() => {
@@ -124,7 +142,7 @@ export function FilePicker({
     setSubmitError("No file selected");
   }
 
-  useInput((input, key) => {
+  useInput((_input, key) => {
     // Handle escape for cancellation
     if (key.escape) {
       onCancel?.();
@@ -142,12 +160,6 @@ export function FilePicker({
       return;
     }
 
-    // Selection
-    if (key.return) {
-      void submit();
-      return;
-    }
-
     // Tab for autocomplete to common prefix
     if (key.tab && files.length > 0) {
       const selected = files[cursorIndex];
@@ -158,17 +170,6 @@ export function FilePicker({
       }
       return;
     }
-
-    // Backspace handling
-    if (key.backspace || key.delete) {
-      setQuery((prev) => prev.slice(0, -1));
-      return;
-    }
-
-    // Text input - only printable characters
-    if (input && !key.ctrl && !key.meta) {
-      setQuery((prev) => prev + input);
-    }
   });
 
   return (
@@ -176,8 +177,11 @@ export function FilePicker({
       {/* Search input */}
       <Box>
         <Text color={THEME.muted}>Path: </Text>
-        <Text color={THEME.primary}>{query}</Text>
-        <Text color={THEME.muted}>│</Text>
+        <Text color={THEME.primary}>
+          {query.slice(0, queryCursor)}
+          <Text inverse>{queryCursor < query.length ? query[queryCursor] : " "}</Text>
+          {queryCursor < query.length ? query.slice(queryCursor + 1) : ""}
+        </Text>
       </Box>
 
       {/* Base path info */}

--- a/packages/cli/src/ui/components/SearchSelect.tsx
+++ b/packages/cli/src/ui/components/SearchSelect.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput } from "ink";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { getGlyphs } from "../glyphs";
+import { useTextInput } from "../hooks/use-input-service";
 import { PICKER_WINDOW_SIZE, pickerWindowStart } from "../picker-window";
 import {
   originalValueFromPicker,
@@ -50,9 +51,30 @@ export function SearchSelect<T = unknown>({
   });
 
   const { view, state, dispatch } = picker;
-  const query = state.query;
 
-  useInput((input, key) => {
+  const {
+    value: query,
+    cursor: queryCursor,
+    setValue: setQueryValue,
+  } = useTextInput({
+    id: "search-select-query",
+    isActive: true,
+    onSubmit: () => dispatch({ kind: "submit" }),
+  });
+
+  // The text-input store is keyed by id and persists across mounts, so a
+  // freshly opened search picker must clear out whatever a previous one left.
+  useEffect(() => {
+    setQueryValue("", 0);
+  }, []);
+
+  useEffect(() => {
+    if (query !== state.query) {
+      dispatch({ kind: "setQuery", query });
+    }
+  }, [query, state.query, dispatch]);
+
+  useInput((_input, key) => {
     if (key.escape) {
       onCancel?.();
       return;
@@ -64,17 +86,6 @@ export function SearchSelect<T = unknown>({
     if (key.downArrow) {
       dispatch({ kind: "move", delta: 1 });
       return;
-    }
-    if (key.return) {
-      dispatch({ kind: "submit" });
-      return;
-    }
-    if (key.backspace || key.delete) {
-      dispatch({ kind: "setQuery", query: query.slice(0, -1) });
-      return;
-    }
-    if (input && !key.ctrl && !key.meta) {
-      dispatch({ kind: "setQuery", query: query + input });
     }
   });
 
@@ -97,10 +108,11 @@ export function SearchSelect<T = unknown>({
             {placeholder.slice(1)}
           </Text>
         ) : (
-          <>
-            <Text color={THEME.primary}>{query}</Text>
-            <Text inverse> </Text>
-          </>
+          <Text color={THEME.primary}>
+            {query.slice(0, queryCursor)}
+            <Text inverse>{queryCursor < query.length ? query[queryCursor] : " "}</Text>
+            {queryCursor < query.length ? query.slice(queryCursor + 1) : ""}
+          </Text>
         )}
       </Box>
 

--- a/packages/cli/src/ui/fullscreen/bridge.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.tsx
@@ -67,7 +67,6 @@ import {
   isComposerNewline,
   isCtrlLetter,
   isInterruptChord,
-  isPrintableSequence,
   isRedoChord,
   isSelectAllChord,
   isUndoChord,
@@ -80,6 +79,7 @@ import type { TextPromptModel } from "./overlays/TextPrompt";
 import { AgentPicker } from "./screens/AgentPicker";
 import { Home } from "./screens/Home";
 import { pathFromFileArgsPreview, sourceLanguageFromPath } from "./syntax-spans";
+import { applyTextFieldKey, wordEndAfter, wordStartBefore } from "./text-field-edit";
 import {
   LIVE_ZONE_MAX_ROWS,
   type ApprovalOverlay,
@@ -127,10 +127,12 @@ interface PromptQuestionState {
   readonly checked: readonly number[];
   readonly custom: PromptEditorState;
   readonly filter: string;
+  readonly filterCaret: number;
 }
 
 interface PromptFileState {
   readonly filter: string;
+  readonly filterCaret: number;
   readonly selected: number;
   readonly entries: readonly FilePickerEntry[];
   readonly scanning: boolean;
@@ -149,9 +151,11 @@ const EMPTY_QUESTION: PromptQuestionState = {
   checked: [],
   custom: EMPTY_EDITOR,
   filter: "",
+  filterCaret: 0,
 };
 const EMPTY_FILE: PromptFileState = {
   filter: "",
+  filterCaret: 0,
   selected: 0,
   entries: [],
   scanning: false,
@@ -328,19 +332,6 @@ function initialPromptControls(prompt: PromptState | null): PromptControlsState 
   };
 }
 
-function editorCaretForKey(state: PromptEditorState, name: string): number {
-  switch (name) {
-    case "home":
-      return 0;
-    case "end":
-      return [...state.value].length;
-    case "left":
-      return Math.max(0, state.caret - 1);
-    default:
-      return Math.min([...state.value].length, state.caret + 1);
-  }
-}
-
 function selectedAnswerIndices(
   checked: readonly number[],
   selectedIndex: number | undefined,
@@ -431,6 +422,7 @@ function overlayFromPrompt(
         })),
         selected: file.selected,
         filter: file.filter,
+        filterCaret: file.filterCaret,
         scanning: file.scanning,
         ...(file.error === undefined ? {} : { error: file.error }),
       };
@@ -463,7 +455,9 @@ function overlayFromPrompt(
           indices,
         ),
         selected: question.selected,
-        ...(filterable ? { filterable: true, filter: question.filter } : {}),
+        ...(filterable
+          ? { filterable: true, filter: question.filter, filterCaret: question.filterCaret }
+          : {}),
         ...(prompt.type === "checkbox"
           ? { checked: question.checked.map((index) => `choice-${String(index)}`) }
           : {}),
@@ -499,24 +493,10 @@ function overlayFromPrompt(
  *
  * All four take and return a code-point offset, never a JS string index, so a
  * multi-byte character is a single step rather than a surrogate half.
+ *
+ * Word-boundary motion (`wordStartBefore`/`wordEndAfter`) lives in
+ * `text-field-edit.ts` now, shared with every single-line overlay field.
  */
-
-/** Start of the word before `at`: skip whitespace, then the run before it. */
-function wordStartBefore(characters: readonly string[], at: number): number {
-  let index = Math.max(0, Math.min(at, characters.length));
-  while (index > 0 && /\s/.test(characters[index - 1] as string)) index -= 1;
-  while (index > 0 && !/\s/.test(characters[index - 1] as string)) index -= 1;
-  return index;
-}
-
-/** End of the word after `at`: skip whitespace, then the run after it. */
-function wordEndAfter(characters: readonly string[], at: number): number {
-  const limit = characters.length;
-  let index = Math.max(0, Math.min(at, limit));
-  while (index < limit && /\s/.test(characters[index] as string)) index += 1;
-  while (index < limit && !/\s/.test(characters[index] as string)) index += 1;
-  return index;
-}
 
 /**
  * Start of the current logical line — just past the previous newline.
@@ -1056,6 +1036,7 @@ export function FullscreenBridge(): React.ReactNode {
   const currentConversation = session.currentConversation;
   const workingDirectory = session.workingDirectory;
   const [searchQuery, searchQueryRef, setSearchQuery] = useSynchronizedState<string | null>(null);
+  const [searchCaret, searchCaretRef, setSearchCaret] = useSynchronizedState(0);
   const [searchHits, searchHitsRef, setSearchHits] = useSynchronizedState<readonly SearchHit[]>([]);
   const [searchScope, , setSearchScope] = useSynchronizedState<"conversation" | "all">("all");
   const [searchIndex, searchIndexRef, setSearchIndex] = useSynchronizedState(0);
@@ -1363,7 +1344,9 @@ export function FullscreenBridge(): React.ReactNode {
 
       if (searchQueryRef.current !== null) {
         const flat = flattenPaste(pasted);
-        setSearchQuery((value) => (value === null ? null : value + flat));
+        const next = insertTextAt(searchQueryRef.current, searchCaretRef.current, flat);
+        setSearchQuery(next.value);
+        setSearchCaret(next.caret);
         return true;
       }
 
@@ -1371,11 +1354,10 @@ export function FullscreenBridge(): React.ReactNode {
       if (active !== null && active.type !== "chat") {
         if (active.type === "filepicker") {
           const flat = flattenPaste(pasted);
-          updatePromptFile((state) => ({
-            ...state,
-            filter: state.filter + flat,
-            selected: 0,
-          }));
+          updatePromptFile((state) => {
+            const next = insertTextAt(state.filter, state.filterCaret, flat);
+            return { ...state, filter: next.value, filterCaret: next.caret, selected: 0 };
+          });
           return true;
         }
         if (active.type === "text" || active.type === "password") {
@@ -1391,12 +1373,17 @@ export function FullscreenBridge(): React.ReactNode {
           const suggestions = promptSuggestions(active);
           const sourceChoices = choicesForQuestion(active, suggestions);
           updatePromptQuestion((state) => {
-            const filter = state.filter + flat;
+            const nextFilter = insertTextAt(state.filter, state.filterCaret, flat);
             const choices = choicesAtIndices(
               sourceChoices,
-              matchingChoiceIndices(sourceChoices, filter),
+              matchingChoiceIndices(sourceChoices, nextFilter.value),
             );
-            return { ...state, filter, selected: firstEnabledChoice(choices) };
+            return {
+              ...state,
+              filter: nextFilter.value,
+              filterCaret: nextFilter.caret,
+              selected: firstEnabledChoice(choices),
+            };
           });
           return true;
         }
@@ -1634,12 +1621,16 @@ export function FullscreenBridge(): React.ReactNode {
           setSearchIndex((index) => Math.max(0, index - 1));
           return true;
         }
-        if (name === "backspace") {
-          setSearchQuery((value) => (value === null ? null : [...value].slice(0, -1).join("")));
-          return true;
-        }
-        if (isPrintableSequence(sequence, ctrl, superKey)) {
-          setSearchQuery((value) => (value ?? "") + sequence);
+        const activeQuery = searchQueryRef.current;
+        if (activeQuery !== null) {
+          const nextField = applyTextFieldKey(
+            { value: activeQuery, caret: searchCaretRef.current },
+            { name, sequence, ctrl, meta, option, super: superKey },
+          );
+          if (nextField !== null) {
+            setSearchQuery(nextField.value);
+            setSearchCaret(nextField.caret);
+          }
         }
         return true;
       }
@@ -1679,17 +1670,29 @@ export function FullscreenBridge(): React.ReactNode {
           if (name === "tab") {
             const entry = fileState.entries[fileState.selected];
             if (entry !== undefined) {
-              updatePromptFile((state) => ({ ...state, filter: entry.name, selected: 0 }));
+              updatePromptFile((state) => ({
+                ...state,
+                filter: entry.name,
+                filterCaret: [...entry.name].length,
+                selected: 0,
+              }));
             }
             return true;
           }
-          if (name === "backspace") {
-            updatePromptFile((state) => ({
-              ...state,
-              filter: [...state.filter].slice(0, -1).join(""),
-              selected: 0,
-            }));
-            return true;
+          {
+            const nextFilterField = applyTextFieldKey(
+              { value: fileState.filter, caret: fileState.filterCaret },
+              { name, sequence, ctrl, meta, option, super: superKey },
+            );
+            if (nextFilterField !== null) {
+              updatePromptFile((state) => ({
+                ...state,
+                filter: nextFilterField.value,
+                filterCaret: nextFilterField.caret,
+                selected: 0,
+              }));
+              return true;
+            }
           }
           if (name === "return" || name === "enter") {
             const selected = fileState.entries[fileState.selected];
@@ -1715,13 +1718,6 @@ export function FullscreenBridge(): React.ReactNode {
             });
             return true;
           }
-          if (isPrintableSequence(sequence, ctrl, superKey)) {
-            updatePromptFile((state) => ({
-              ...state,
-              filter: state.filter + sequence,
-              selected: 0,
-            }));
-          }
           return true;
         }
 
@@ -1733,34 +1729,16 @@ export function FullscreenBridge(): React.ReactNode {
             else updatePromptEditor((state) => ({ ...state, error }));
             return true;
           }
-          if (name === "backspace") {
-            updatePromptEditor((state) => {
-              const characters = [...state.value];
-              const at = Math.max(0, Math.min(state.caret, characters.length));
-              if (at === 0) return state;
-              return {
-                value: [...characters.slice(0, at - 1), ...characters.slice(at)].join(""),
-                caret: at - 1,
-              };
-            });
-            return true;
-          }
-          if (name === "left" || name === "right" || name === "home" || name === "end") {
-            updatePromptEditor((state) => ({
-              value: state.value,
-              caret: editorCaretForKey(state, name),
-            }));
-            return true;
-          }
-          if (isPrintableSequence(sequence, ctrl, superKey)) {
-            updatePromptEditor((state) => {
-              const characters = [...state.value];
-              const at = Math.max(0, Math.min(state.caret, characters.length));
-              return {
-                value: [...characters.slice(0, at), sequence, ...characters.slice(at)].join(""),
-                caret: at + [...sequence].length,
-              };
-            });
+          {
+            const editorState = promptControlsRef.current.editor;
+            const nextField = applyTextFieldKey(
+              { value: editorState.value, caret: editorState.caret },
+              { name, sequence, ctrl, meta, option, super: superKey },
+            );
+            if (nextField !== null) {
+              updatePromptEditor(() => nextField);
+              return true;
+            }
           }
           return true;
         }
@@ -1787,16 +1765,26 @@ export function FullscreenBridge(): React.ReactNode {
           }));
           return true;
         }
-        if (promptIsFilterable(active) && name === "backspace") {
-          updatePromptQuestion((state) => {
-            const filter = [...state.filter].slice(0, -1).join("");
-            const choices = choicesAtIndices(
-              sourceChoices,
-              matchingChoiceIndices(sourceChoices, filter),
-            );
-            return { ...state, filter, selected: firstEnabledChoice(choices) };
-          });
-          return true;
+        if (promptIsFilterable(active)) {
+          const nextFilterField = applyTextFieldKey(
+            { value: questionState.filter, caret: questionState.filterCaret },
+            { name, sequence, ctrl, meta, option, super: superKey },
+          );
+          if (nextFilterField !== null) {
+            updatePromptQuestion((state) => {
+              const choices = choicesAtIndices(
+                sourceChoices,
+                matchingChoiceIndices(sourceChoices, nextFilterField.value),
+              );
+              return {
+                ...state,
+                filter: nextFilterField.value,
+                filterCaret: nextFilterField.caret,
+                selected: firstEnabledChoice(choices),
+              };
+            });
+            return true;
+          }
         }
 
         const selectedVisibleChoice = visibleChoices[questionState.selected];
@@ -1844,36 +1832,17 @@ export function FullscreenBridge(): React.ReactNode {
           return true;
         }
 
-        if (promptIsFilterable(active) && isPrintableSequence(sequence, ctrl, superKey)) {
-          updatePromptQuestion((state) => {
-            const filter = state.filter + sequence;
-            const choices = choicesAtIndices(
-              sourceChoices,
-              matchingChoiceIndices(sourceChoices, filter),
-            );
-            return { ...state, filter, selected: firstEnabledChoice(choices) };
-          });
-          return true;
-        }
         if (selectedCustom) {
-          if (name === "backspace") {
-            updatePromptQuestion((state) => ({
-              ...state,
-              custom: {
-                value: [...state.custom.value].slice(0, -1).join(""),
-                caret: Math.max(0, state.custom.caret - 1),
-              },
-            }));
-            return true;
-          }
-          if (isPrintableSequence(sequence, ctrl, superKey)) {
-            updatePromptQuestion((state) => ({
-              ...state,
-              custom: {
-                value: state.custom.value + sequence,
-                caret: state.custom.caret + [...sequence].length,
-              },
-            }));
+          const nextCustomField = applyTextFieldKey(questionState.custom, {
+            name,
+            sequence,
+            ctrl,
+            meta,
+            option,
+            super: superKey,
+          });
+          if (nextCustomField !== null) {
+            updatePromptQuestion((state) => ({ ...state, custom: nextCustomField }));
             return true;
           }
         }
@@ -1900,6 +1869,7 @@ export function FullscreenBridge(): React.ReactNode {
       }
       if (isCtrlLetter({ name, ctrl }, "f")) {
         setSearchQuery("");
+        setSearchCaret(0);
         return true;
       }
 
@@ -2206,6 +2176,7 @@ export function FullscreenBridge(): React.ReactNode {
       next = {
         kind: "search",
         query: searchQuery,
+        caret: searchCaret,
         scope: searchScope,
         // `current` means the hit is in this session; `selected` is the cursor.
         // Conflating them would show recency wrong on every row but one.
@@ -2221,6 +2192,7 @@ export function FullscreenBridge(): React.ReactNode {
     prompt,
     promptControls,
     searchQuery,
+    searchCaret,
     searchScope,
     searchHits,
     searchIndex,

--- a/packages/cli/src/ui/fullscreen/overlays/FilePicker.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/FilePicker.tsx
@@ -32,7 +32,7 @@ import {
 } from "../terminal-cells";
 import type { Viewport } from "../types";
 import { centeredOffset, OVERLAY_Z_INDEX } from "./centered";
-import { HintRow, type Hint } from "./TextPrompt";
+import { CaretValue, HintRow, type Hint } from "./TextPrompt";
 
 const MAX_WIDTH = 96;
 const MIN_WINDOWED_HEIGHT = 20;
@@ -76,6 +76,8 @@ export interface FilePickerModel {
   readonly selected: number;
   /** What the user has typed to narrow the list. */
   readonly filter: string;
+  /** Caret offset into `filter`, in characters. */
+  readonly filterCaret: number;
   /** Set while the tree is still being walked. */
   readonly scanning?: boolean;
   /** A failed selection, in prose. */
@@ -237,9 +239,11 @@ export function FilePicker({ model, viewport }: FilePickerProps): ReactNode {
           <text style={{ fg: THEME.primary, width: MARKER_COLUMN, flexShrink: 0 }}>
             {`${glyphs.promptCursor} `}
           </text>
-          <text style={{ fg: THEME.selected, flexShrink: 0 }}>
-            {clipLeft(oneLine(model.filter), Math.max(4, inner - MARKER_COLUMN))}
-          </text>
+          <CaretValue
+            value={oneLine(model.filter)}
+            caret={model.filterCaret}
+            width={Math.max(4, inner - MARKER_COLUMN)}
+          />
         </box>
 
         <box style={{ height: 1, flexShrink: 0, flexDirection: "row" }}>

--- a/packages/cli/src/ui/fullscreen/overlays/Question.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/Question.tsx
@@ -98,6 +98,8 @@ export interface QuestionModel {
   readonly customCaret?: number;
   /** Incremental filter shown on a row under the question. */
   readonly filter?: string;
+  /** Caret offset into `filter`, in characters. */
+  readonly filterCaret?: number;
   /** When set, typing filters the list and an empty match is not a custom row. */
   readonly filterable?: boolean;
 }
@@ -389,19 +391,12 @@ export function Question({ model, viewport }: QuestionProps): ReactNode {
             <text style={{ fg: THEME.primary, width: GUTTER, flexShrink: 0 }}>
               {`${glyphs.promptCursor} `}
             </text>
-            <text
-              style={{
-                fg: (model.filter ?? "").length > 0 ? THEME.selected : THEME.muted,
-                flexShrink: 0,
-              }}
-            >
-              {clip(
-                oneLine(
-                  (model.filter ?? "").length > 0 ? (model.filter ?? "") : FILTER_PLACEHOLDER,
-                ),
-                Math.max(4, inner - GUTTER),
-              )}
-            </text>
+            <CaretValue
+              value={oneLine(model.filter ?? "")}
+              caret={model.filterCaret ?? displayWidth(model.filter ?? "")}
+              width={Math.max(4, inner - GUTTER)}
+              placeholder={FILTER_PLACEHOLDER}
+            />
           </box>
         ) : null}
 

--- a/packages/cli/src/ui/fullscreen/overlays/Search.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/Search.tsx
@@ -27,6 +27,7 @@ import {
 } from "../terminal-cells";
 import type { SearchHit, SearchOverlay, Viewport } from "../types";
 import { OVERLAY_Z_INDEX } from "./centered";
+import { CaretValue } from "./TextPrompt";
 
 const MAX_WIDTH = 96;
 const MIN_WINDOWED_HEIGHT = 20;
@@ -194,7 +195,11 @@ export function Search({ model, viewport }: SearchProps): ReactNode {
       >
         <box style={{ height: 1, flexShrink: 0, flexDirection: "row" }}>
           <text style={{ fg: THEME.primary, flexShrink: 0 }}>{`${glyphs.promptCursor} `}</text>
-          <text style={{ fg: THEME.selected }}>{clip(oneLine(model.query), queryWidth)}</text>
+          <CaretValue
+            value={oneLine(model.query)}
+            caret={model.caret}
+            width={queryWidth}
+          />
           <box style={{ flexGrow: 1 }} />
           <text style={{ flexShrink: 0 }}>
             <span style={{ fg: THEME.muted }}>{"[ "}</span>

--- a/packages/cli/src/ui/fullscreen/overlays/overlays.test.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/overlays.test.tsx
@@ -463,7 +463,7 @@ describe("search overlay", () => {
       WIDE,
     );
     const marked = allSpans(captureSpans()).filter(
-      (span) => (span.attributes & (TextAttributes.UNDERLINE | TextAttributes.INVERSE)) !== 0,
+      (span) => (span.attributes & TextAttributes.UNDERLINE) !== 0,
     );
 
     // One marked run per hit, and the marked run is the query text itself.

--- a/packages/cli/src/ui/fullscreen/sample.ts
+++ b/packages/cli/src/ui/fullscreen/sample.ts
@@ -113,6 +113,7 @@ const APPROVAL: ApprovalOverlay = {
 const SEARCH: SearchOverlay = {
   kind: "search",
   query: "basel",
+  caret: 5,
   scope: "all",
   hits: [
     {

--- a/packages/cli/src/ui/fullscreen/text-field-edit.ts
+++ b/packages/cli/src/ui/fullscreen/text-field-edit.ts
@@ -1,0 +1,123 @@
+/**
+ * Single-line text-field editing, shared by every overlay field that is not
+ * the chat composer: the text/password prompt, the AskUserQuestion custom
+ * answer, the select/search filter box, the file-picker filter, and the
+ * transcript search query.
+ *
+ * The composer earned its own richer buffer (`composer-edit.ts`) because it is
+ * multi-line and carries undo/redo/selection. These fields are flat strings
+ * with a caret and nothing else, so one pure function covers all of them
+ * instead of every overlay hand-rolling append-and-backspace-from-the-end.
+ */
+
+import { isCtrlLetter } from "./keymap";
+
+export interface FieldState {
+  readonly value: string;
+  readonly caret: number;
+}
+
+export interface FieldKeyChord {
+  readonly name: string;
+  readonly sequence: string;
+  readonly ctrl: boolean;
+  readonly meta: boolean;
+  readonly option: boolean;
+  readonly super: boolean;
+}
+
+/** Start of the word before `at`: skip whitespace, then the run before it. */
+export function wordStartBefore(characters: readonly string[], at: number): number {
+  let index = Math.max(0, Math.min(at, characters.length));
+  while (index > 0 && /\s/.test(characters[index - 1] as string)) index -= 1;
+  while (index > 0 && !/\s/.test(characters[index - 1] as string)) index -= 1;
+  return index;
+}
+
+/** End of the word after `at`: skip whitespace, then the run after it. */
+export function wordEndAfter(characters: readonly string[], at: number): number {
+  const limit = characters.length;
+  let index = Math.max(0, Math.min(at, limit));
+  while (index < limit && /\s/.test(characters[index] as string)) index += 1;
+  while (index < limit && !/\s/.test(characters[index] as string)) index += 1;
+  return index;
+}
+
+/**
+ * Applies one key to a single-line field, mirroring the composer's bindings
+ * (Option word-jump/word-delete, Cmd/Ctrl+U delete-to-start, Home/End,
+ * Ctrl+A/E) without the composer's line-wrap or undo/redo concerns. Returns
+ * `null` when the key is not a text-editing key, so the caller falls through
+ * to whatever else it does with that key (list navigation, submit, cancel).
+ */
+export function applyTextFieldKey(field: FieldState, key: FieldKeyChord): FieldState | null {
+  const { name, sequence, ctrl, meta, option, super: superKey } = key;
+  const characters = [...field.value];
+  const caret = Math.max(0, Math.min(field.caret, characters.length));
+
+  // Cmd+Backspace and the classic readline Ctrl+U both mean "delete to the
+  // start of the line" — checked first since Cmd is reported via `super`,
+  // not `meta`/`option`, so it must not fall into the word-delete branch.
+  if ((name === "backspace" && superKey) || isCtrlLetter({ name, ctrl }, "u")) {
+    return { value: characters.slice(caret).join(""), caret: 0 };
+  }
+  // Option+Backspace on macOS and Ctrl+Backspace elsewhere both mean "delete
+  // the previous word". This keyboard library reports Option as `meta`, not
+  // `option`, so both are checked alongside `ctrl`.
+  if (name === "backspace" && (meta || option || ctrl)) {
+    const boundary = wordStartBefore(characters, caret);
+    return {
+      value: [...characters.slice(0, boundary), ...characters.slice(caret)].join(""),
+      caret: boundary,
+    };
+  }
+  if (name === "backspace") {
+    if (caret === 0) return field;
+    return {
+      value: [...characters.slice(0, caret - 1), ...characters.slice(caret)].join(""),
+      caret: caret - 1,
+    };
+  }
+  if (name === "delete") {
+    if (caret >= characters.length) return field;
+    return {
+      value: [...characters.slice(0, caret), ...characters.slice(caret + 1)].join(""),
+      caret,
+    };
+  }
+
+  // Caret motion, widest jump to narrowest: Cmd goes to the edge of the line,
+  // Option/Ctrl move by word, Home/End and Ctrl+A/E work everywhere else.
+  const wordJump = meta || option || ctrl;
+  if (name === "left" && superKey) return { value: field.value, caret: 0 };
+  if (name === "right" && superKey) return { value: field.value, caret: characters.length };
+  if (name === "left" && wordJump) {
+    return { value: field.value, caret: wordStartBefore(characters, caret) };
+  }
+  if (name === "right" && wordJump) {
+    return { value: field.value, caret: wordEndAfter(characters, caret) };
+  }
+  if (name === "home" || isCtrlLetter({ name, ctrl }, "a")) {
+    return { value: field.value, caret: 0 };
+  }
+  if (name === "end" || isCtrlLetter({ name, ctrl }, "e")) {
+    return { value: field.value, caret: characters.length };
+  }
+  if (name === "left") return { value: field.value, caret: Math.max(0, caret - 1) };
+  if (name === "right")
+    return { value: field.value, caret: Math.min(characters.length, caret + 1) };
+
+  // Typing, from the sequence the terminal actually sent — see the composer's
+  // identical check for why `name` cannot be used to compose text.
+  if (!ctrl && !superKey && [...sequence].length === 1) {
+    const code = sequence.codePointAt(0) ?? 0;
+    if (code >= 0x20 && code !== 0x7f) {
+      return {
+        value: [...characters.slice(0, caret), sequence, ...characters.slice(caret)].join(""),
+        caret: caret + [...sequence].length,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/cli/src/ui/fullscreen/types.ts
+++ b/packages/cli/src/ui/fullscreen/types.ts
@@ -305,6 +305,8 @@ export interface SearchHit {
 export interface SearchOverlay {
   readonly kind: "search";
   readonly query: string;
+  /** Caret offset into `query`, in characters. */
+  readonly caret: number;
   readonly scope: "conversation" | "all";
   readonly hits: readonly SearchHit[];
   readonly selected: number;


### PR DESCRIPTION
## What & why
Most text inputs in the app (chat box, password prompt, main composer) already supported standard editing keybinds — word-jump, word-delete, jump-to-line-start/end. A handful of others were missed and only supported typing at the end of the text with single-character backspace: the search and file-path pickers in the classic terminal UI, and five fields in the fullscreen UI (text/password prompt, the "type your own answer" field, filter boxes, and transcript search). This brings every text input to the same keybind behavior: option+←/→ to jump by word, option+Backspace to delete a word, cmd+Backspace to clear to the start of the line, plus Home/End and ctrl+A/E.

In the fullscreen UI this introduced one new shared building block (`applyTextFieldKey`) that all of those fields now call instead of each hand-rolling its own key handling, so future fields get this behavior for free.

## How to verify
- Classic UI: open the search picker or the `@`-file picker, type a query, then use option+←/→ and option+Backspace to jump/delete by word — cursor updates as expected, and arrow-key list navigation, Tab autocomplete, Enter, and Esc still work.
- Fullscreen UI: open a text/password prompt and the "type your own answer" field on a question, confirm the same word-jump/word-delete/cmd+Backspace keys work and the cursor renders at the right spot; open the file-picker filter, a question's filter box, and transcript search (Ctrl+F) and confirm the same.
- Confirm the main fullscreen chat composer (which already had this) is unchanged — still has undo/redo and select-all, which are intentionally not added to the other fields.
