### PR TITLE
fix(llm): flatten top-level oneOf/anyOf/allOf in tool schemas

### DIFF
--- a/packages/adapters/src/llm/ai-sdk-service.test.ts
+++ b/packages/adapters/src/llm/ai-sdk-service.test.ts
@@ -1218,9 +1218,10 @@ describe("buildToolInputSchema", () => {
     expect(inputSchema).toBe(parameters);
   });
 
-  it("converts and patches a top-level discriminated union, which otherwise has no top-level type", () => {
+  it("flattens a top-level discriminated union, which Anthropic rejects both for a missing type and for the oneOf keyword itself", () => {
     // Matches manage_memory/manage_workspace's shape: argument shape keyed by a
-    // "command" field, which serializes to `oneOf` with no top-level `type`.
+    // "command" field, which serializes to `oneOf` with no top-level `type` —
+    // and Anthropic separately rejects `oneOf` at the top level regardless.
     const parameters = z.discriminatedUnion("command", [
       z.object({ command: z.literal("read"), path: z.string() }),
       z.object({ command: z.literal("write"), path: z.string(), content: z.string() }),
@@ -1228,12 +1229,20 @@ describe("buildToolInputSchema", () => {
 
     const rawConversion = z.toJSONSchema(parameters) as Record<string, unknown>;
     expect(rawConversion["type"]).toBeUndefined();
+    expect(rawConversion["oneOf"]).toBeDefined();
 
     const inputSchema = buildToolInputSchema({ function: { parameters } });
     const schema = schemaOf(inputSchema);
 
     expect(schema["type"]).toBe("object");
-    expect(schema["oneOf"]).toBeDefined();
+    expect(schema["oneOf"]).toBeUndefined();
+    expect(schema["properties"]).toMatchObject({
+      path: { type: "string" },
+      content: { type: "string" },
+    });
+    // Required in only one branch, so it drops out rather than being required always.
+    expect((schema["required"] as string[] | undefined) ?? []).not.toContain("content");
+    expect((schema["required"] as string[] | undefined) ?? []).toContain("path");
   });
 });
 

--- a/packages/cli/src/ui/fullscreen/overlays/overlays.test.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/overlays.test.tsx
@@ -58,6 +58,7 @@ const APPROVAL: ApprovalOverlay = {
 const SEARCH: SearchOverlay = {
   kind: "search",
   query: "deploy",
+  caret: 6,
   scope: "all",
   hits: [
     {

--- a/packages/cli/src/ui/fullscreen/overlays/prompts.test.tsx
+++ b/packages/cli/src/ui/fullscreen/overlays/prompts.test.tsx
@@ -117,6 +117,7 @@ const FILES: FilePickerModel = {
   ],
   selected: 1,
   filter: "src",
+  filterCaret: 3,
 };
 
 function rows(frame: string): string[] {

--- a/packages/core/src/utils/mcp-schema-converter.test.ts
+++ b/packages/core/src/utils/mcp-schema-converter.test.ts
@@ -320,6 +320,41 @@ describe("MCP Schema Converter", () => {
       });
     });
 
+    it("flattens a top-level oneOf, since Anthropic rejects the keyword itself at the top level", () => {
+      const schema = {
+        oneOf: [
+          {
+            type: "object",
+            properties: { command: { const: "read" }, path: { type: "string" } },
+            required: ["command", "path"],
+          },
+          {
+            type: "object",
+            properties: {
+              command: { const: "write" },
+              path: { type: "string" },
+              content: { type: "string" },
+            },
+            required: ["command", "path", "content"],
+          },
+        ],
+      };
+
+      const unwrapped = unwrapMCPJsonSchema(schema);
+
+      expect(unwrapped?.["oneOf"]).toBeUndefined();
+      expect(unwrapped?.["type"]).toBe("object");
+      expect(unwrapped?.["properties"]).toEqual({
+        // The discriminant's const values merge into an enum instead of the last
+        // branch silently winning — a model reading this still sees both commands.
+        command: { enum: ["read", "write"] },
+        path: { type: "string" },
+        content: { type: "string" },
+      });
+      // Only fields required in every branch stay required.
+      expect(unwrapped?.["required"]).toEqual(["command", "path"]);
+    });
+
     it("should handle nested object schemas", () => {
       const schema = {
         type: "object",

--- a/packages/core/src/utils/mcp-schema-converter.ts
+++ b/packages/core/src/utils/mcp-schema-converter.ts
@@ -182,16 +182,106 @@ function isArrayType(type: string | readonly string[] | undefined): boolean {
   return false;
 }
 
+/** Read a branch's `properties` object, or an empty one if it has none. */
+function branchProperties(branch: Record<string, unknown>): Record<string, unknown> {
+  const properties = branch["properties"];
+  return typeof properties === "object" && properties !== null
+    ? (properties as Record<string, unknown>)
+    : {};
+}
+
+/** Read a branch's `required` array as a set of field names. */
+function branchRequired(branch: Record<string, unknown>): Set<string> {
+  const required = branch["required"];
+  return new Set(
+    Array.isArray(required) ? required.filter((key): key is string => typeof key === "string") : [],
+  );
+}
+
 /**
- * Ensure a JSON Schema object has a top-level `type`, defaulting to `"object"`.
+ * Merge two branches' schema for the same property key.
  *
- * A tool's input is always a JSON object, but some producers omit `type` when they
- * consider it implied by `properties` alone (some MCP servers), or have no single
- * `type` to state (a top-level union, which serializes as `oneOf` with none).
- * Providers like Anthropic require `input_schema.type` and reject a schema without it.
+ * A discriminant field (e.g. `command`) typically differs by `const` per branch —
+ * merging by last-branch-wins would silently drop every value but one, so those
+ * collapse into an `enum` of every value seen instead. Anything else keeps the
+ * first branch's schema for that key: a full structural merge isn't attempted, so
+ * that case accepts some precision loss rather than growing a general merger.
+ */
+function mergeBranchProperty(existing: unknown, incoming: unknown): unknown {
+  if (
+    typeof existing !== "object" ||
+    existing === null ||
+    typeof incoming !== "object" ||
+    incoming === null
+  ) {
+    return existing;
+  }
+  const existingObj = existing as Record<string, unknown>;
+  const incomingObj = incoming as Record<string, unknown>;
+
+  const existingValues: unknown[] | undefined = Array.isArray(existingObj["enum"])
+    ? (existingObj["enum"] as unknown[])
+    : "const" in existingObj
+      ? [existingObj["const"]]
+      : undefined;
+  const incomingValues: unknown[] | undefined = Array.isArray(incomingObj["enum"])
+    ? (incomingObj["enum"] as unknown[])
+    : "const" in incomingObj
+      ? [incomingObj["const"]]
+      : undefined;
+  if (existingValues === undefined || incomingValues === undefined) {
+    return existing;
+  }
+
+  const { const: _existingConst, enum: _existingEnum, ...rest } = existingObj;
+  return { ...rest, enum: [...new Set([...existingValues, ...incomingValues])] };
+}
+
+/**
+ * Flatten a top-level `oneOf`/`anyOf`/`allOf` into one object schema, and default a
+ * missing top-level `type` to `"object"`.
+ *
+ * A tool's input is always a JSON object. Some producers state it as a combinator
+ * instead — a Zod discriminated union serializes to `{ oneOf: [...] }`, for instance —
+ * and some omit `type` entirely when they consider it implied by `properties` alone
+ * (some MCP servers). Providers like Anthropic reject `input_schema` for either reason:
+ * a missing top-level `type`, or `oneOf`/`allOf`/`anyOf` used at the top level at all.
+ *
+ * Flattening loses the constraint that a field only appears with certain other
+ * fields (each combinator branch merges into one permissive object); a field stays
+ * `required` only when every branch requires it, since a field required by just one
+ * branch could be absent under another.
  */
 export function ensureObjectSchemaType(schema: Record<string, unknown>): Record<string, unknown> {
-  return schema["type"] === undefined ? { ...schema, type: "object" } : schema;
+  const branches = schema["oneOf"] ?? schema["anyOf"] ?? schema["allOf"];
+  if (!Array.isArray(branches) || branches.length === 0) {
+    return schema["type"] === undefined ? { ...schema, type: "object" } : schema;
+  }
+
+  const properties: Record<string, unknown> = {};
+  let requiredEverywhere: Set<string> | undefined;
+  for (const branch of branches) {
+    if (typeof branch !== "object" || branch === null) continue;
+    const branchObj = branch as Record<string, unknown>;
+    for (const [key, value] of Object.entries(branchProperties(branchObj))) {
+      properties[key] = key in properties ? mergeBranchProperty(properties[key], value) : value;
+    }
+    const required = branchRequired(branchObj);
+    requiredEverywhere =
+      requiredEverywhere === undefined
+        ? required
+        : new Set([...requiredEverywhere].filter((key) => required.has(key)));
+  }
+
+  const { oneOf: _oneOf, anyOf: _anyOf, allOf: _allOf, ...rest } = schema;
+  return {
+    ...rest,
+    type: "object",
+    properties,
+    ...(requiredEverywhere && requiredEverywhere.size > 0
+      ? { required: [...requiredEverywhere] }
+      : {}),
+  };
 }
 
 /**


### PR DESCRIPTION
## What & why
A follow-up to #508: that fix patched `manage_memory`/`manage_workspace`'s missing `input_schema.type` by adding `type: "object"` next to the existing `oneOf`, but Anthropic separately rejects `oneOf`/`allOf`/`anyOf` at the top level of a tool's schema outright — confirmed live, not just by a unit test. The schema now flattens a top-level combinator into a single object schema (merging each branch's properties, keeping a field required only where every branch requires it, and collapsing a discriminant field's per-branch `const` values into one `enum` rather than the last branch silently winning) before defaulting `type`.

## How to verify
- On an Anthropic model, ask the agent to remember something (triggers `manage_memory`) and to create a workspace file (triggers `manage_workspace`); both should succeed instead of failing with `input_schema does not support oneOf, allOf, or anyOf at the top level`.
- Confirm the `command` field a model sees for these tools still lists every valid value (e.g. both `create` and `delete`), not just one.
