### PR TITLE
fix(webhooks): raise the body cap, and keep the anonymous one tight

### DIFF
--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -76,7 +76,7 @@ export JAZZ_WEBHOOK_TOKEN_DEPLOYS="…"            # or the environment, for a c
 ```
 
 The token never lives in `config.json`. A request without a matching one gets a `401`, and
-a body over 20 KB is refused with a `413` while it is still being read.
+a body over 1 MB is refused with a `413` while it is still being read.
 
 ---
 

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -183,10 +183,31 @@ describe("the daemon's routes", () => {
     const response = await handle(
       request("POST", "/webhooks/hook", {
         headers: { authorization: "Bearer webhook-secret" },
-        body: "x".repeat(20_001),
+        body: "x".repeat(1_048_577),
       }),
     );
     expect(response.status).toBe(413);
+  });
+
+  it("accepts a body the size of an ordinary webhook payload", async () => {
+    // The old cap sat under a routine GitHub push event, so the door refused traffic it
+    // exists to receive. Reaching the runner at all is the assertion.
+    const handle = makeWebhookHandler(
+      async () => [{ name: "hook", agentId: "default", promptTemplate: "Process {{payload}}" }],
+      async () => "webhook-secret",
+      async () => {
+        throw new Error("reached the runner");
+      },
+    );
+
+    await expect(
+      handle(
+        request("POST", "/webhooks/hook", {
+          headers: { authorization: "Bearer webhook-secret" },
+          body: "x".repeat(512_000),
+        }),
+      ),
+    ).rejects.toThrow("reached the runner");
   });
 
   it("returns 404 for malformed webhook URL encoding", async () => {

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -380,7 +380,7 @@ export function makePeerInviteHandler(
 
     const acceptMatch = /^\/peer-invites\/([^/]+)\/accept$/.exec(url.pathname);
     if (request.method === "POST" && acceptMatch?.[1] !== undefined) {
-      const raw = await readWebhookPayload(request);
+      const raw = await readBody(request, MAX_ANONYMOUS_PAYLOAD_LENGTH);
       if (raw instanceof Response) return raw;
       let body: { secret?: unknown; as?: unknown };
       try {
@@ -445,13 +445,27 @@ function acceptInvite(
 
 /**
  * Cap on the raw HTTP request body accepted by a `POST /webhooks/<name>` call.
- * Oversized bodies are rejected while streaming, before they can consume unbounded memory.
+ *
+ * Oversized bodies are rejected while streaming, before they can consume unbounded memory —
+ * the point of the cap is that a caller cannot make the daemon buffer without bound, not
+ * that payloads are expected to be small. At 20 KB it sat under a routine GitHub push event
+ * and under a relayed conversation, so it rejected the traffic the door exists to receive.
+ * A megabyte covers those with room to spare and still bounds what one request can buffer.
  */
-const MAX_WEBHOOK_PAYLOAD_LENGTH = 20_000;
+const MAX_WEBHOOK_PAYLOAD_LENGTH = 1_048_576;
 
-async function readWebhookPayload(request: Request): Promise<string | Response> {
+/**
+ * Cap on an unauthenticated body.
+ *
+ * Redeeming a peer invite is the one route that answers before knowing who is calling, so it
+ * keeps the tight bound: the body is a secret and a handle, and nothing legitimate comes
+ * close. It is deliberately not the webhook cap, which a bearer token already gates.
+ */
+const MAX_ANONYMOUS_PAYLOAD_LENGTH = 20_000;
+
+async function readBody(request: Request, limit: number): Promise<string | Response> {
   const declaredLength = request.headers.get("content-length");
-  if (declaredLength !== null && Number(declaredLength) > MAX_WEBHOOK_PAYLOAD_LENGTH) {
+  if (declaredLength !== null && Number(declaredLength) > limit) {
     return json({ ok: false, error: "request body too large" }, 413);
   }
 
@@ -464,7 +478,7 @@ async function readWebhookPayload(request: Request): Promise<string | Response> 
       const next = await reader.read();
       if (next.done) break;
       totalBytes += next.value.byteLength;
-      if (totalBytes > MAX_WEBHOOK_PAYLOAD_LENGTH) {
+      if (totalBytes > limit) {
         await reader.cancel();
         return json({ ok: false, error: "request body too large" }, 413);
       }
@@ -535,7 +549,7 @@ export function makeWebhookHandler(
       return json({ ok: false, error: "unauthorized" }, 401);
     }
 
-    const body = await readWebhookPayload(request);
+    const body = await readBody(request, MAX_WEBHOOK_PAYLOAD_LENGTH);
     if (body instanceof Response) return body;
     const truncated = body;
 


### PR DESCRIPTION
## What & why

A webhook body over 20 KB was refused with a `413`. That sits under a routine GitHub push event, so the door rejected the traffic it exists to receive. The cap is there to bound what a single request can buffer, not because payloads are expected to be small — a megabyte does that with room to spare.

## The part worth reviewing

One constant governed two routes. Raising it would also have widened `POST /peer-invites/<id>/accept`, which is the **one route that answers before knowing who is calling**. That keeps 20 KB: its body is a secret and a handle, and nothing legitimate comes close.

| Route | Cap | Gated by |
| --- | --- | --- |
| `POST /webhooks/<name>` | 1 MB | bearer token |
| `POST /peer-invites/<id>/accept` | 20 KB | nothing |

## How to verify

- `curl` a 512 KB body at a webhook and confirm it runs.
- `curl` a 2 MB body and confirm `413`, rejected while streaming rather than buffered.
- `curl` a 20 KB+ body at an invite accept and confirm it is still refused.