### PR TITLE
fix(daemon): notice a config file edited by something else

### DIFF
--- a/packages/adapters/src/config.test.ts
+++ b/packages/adapters/src/config.test.ts
@@ -1,6 +1,10 @@
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { join } from "node:path";
 import { FileSystem } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
 import { type AppConfig } from "@jazz/core/types/index";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
@@ -533,5 +537,55 @@ describe("createConfigLayer", () => {
     expect(result.endpoint).toBe("http://collector:4318");
     expect(result.captureContent).toBe(true);
     expect(result.retentionDays).toBe(7);
+  });
+});
+
+describe("noticing an edit made by another process", () => {
+  it("picks up a webhook added to the file after startup", async () => {
+    const home = await mkdtemp(join(tmpdir(), "jazz-reload-"));
+    const configPath = join(home, "config.json");
+    const write = (webhooks: { name: string; agentId: string; promptTemplate: string }[]) =>
+      writeFile(configPath, JSON.stringify({ webhooks }));
+
+    await write([{ name: "first", agentId: "a", promptTemplate: "x" }]);
+
+    const layer = createConfigLayer(false, configPath).pipe(Layer.provide(NodeFileSystem.layer));
+
+    const program = Effect.gen(function* () {
+      const service = yield* AgentConfigServiceTag;
+      const before = ((yield* service.appConfig).webhooks ?? []).length;
+
+      // Something else edits the file — a setup tool, or an operator with an editor. The
+      // mtime has one-second resolution on some filesystems, so move it on explicitly.
+      yield* Effect.promise(async () => {
+        await write([
+          { name: "first", agentId: "a", promptTemplate: "x" },
+          { name: "second", agentId: "b", promptTemplate: "y" },
+        ]);
+        const later = new Date(Date.now() + 2_000);
+        await utimes(configPath, later, later);
+      });
+
+      const stale = ((yield* service.appConfig).webhooks ?? []).length;
+      const changed = yield* service.reloadIfChanged();
+      const after = ((yield* service.appConfig).webhooks ?? []).length;
+      return { before, stale, changed, after };
+    });
+
+    const result = await Effect.runPromise(
+      Effect.provide(program, layer) as Effect.Effect<
+        { before: number; stale: number; changed: boolean; after: number },
+        never,
+        never
+      >,
+    );
+
+    expect(result.before).toBe(1);
+    // `appConfig` answers from memory, which is the whole reason a reload is needed.
+    expect(result.stale).toBe(1);
+    expect(result.changed).toBe(true);
+    expect(result.after).toBe(2);
+
+    await rm(home, { recursive: true, force: true });
   });
 });

--- a/packages/adapters/src/config.ts
+++ b/packages/adapters/src/config.ts
@@ -100,6 +100,8 @@ export class AgentConfigServiceImpl implements AgentConfigService {
   private configPath: string | undefined;
   private fs: FileSystem.FileSystem;
   private currentRevision: number;
+  /** When config.json was last read, so an external edit can be noticed. */
+  private loadedAt: number | undefined;
   private keyringBackend: KeyringBackend;
   private secretOrigins: Map<string, SecretOrigin>;
   private fileSecrets: Map<string, string>;
@@ -302,6 +304,49 @@ export class AgentConfigServiceImpl implements AgentConfigService {
 
   get appConfig(): Effect.Effect<AppConfig, never> {
     return Effect.succeed(this.currentConfig);
+  }
+
+  /**
+   * Re-read config.json when its mtime has moved, returning whether anything changed.
+   *
+   * `appConfig` answers from memory, so a caller that must see an edit made by another
+   * process asks for this first. Takes `webhooks` and `peers`; secrets stay in the keyring.
+   */
+  reloadIfChanged(): Effect.Effect<boolean, never> {
+    return Effect.gen(
+      function* (this: AgentConfigServiceImpl) {
+        const path = this.configPath;
+        if (path === undefined) return false;
+
+        const stat = yield* this.fs
+          .stat(path)
+          .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+        const modified = stat?.mtime;
+        const at = Option.isOption(modified)
+          ? Option.getOrUndefined(modified)?.getTime()
+          : undefined;
+        if (at === undefined || at === this.loadedAt) return false;
+        this.loadedAt = at;
+
+        const content = yield* this.fs
+          .readFileString(path)
+          .pipe(Effect.catchAll(() => Effect.succeed("")));
+        const parsed = safeParseJson<Partial<AppConfig>>(content);
+        if (Option.isNone(parsed) || typeof parsed.value !== "object" || parsed.value === null) {
+          return false;
+        }
+
+        const fromFile = parsed.value;
+        migrateConfigProviderName(fromFile);
+        this.currentConfig = {
+          ...this.currentConfig,
+          ...(fromFile.webhooks !== undefined ? { webhooks: fromFile.webhooks } : {}),
+          ...(fromFile.peers !== undefined ? { peers: fromFile.peers } : {}),
+        };
+        this.currentRevision += 1;
+        return true;
+      }.bind(this),
+    ).pipe(Effect.catchAll(() => Effect.succeed(false)));
   }
 }
 

--- a/packages/adapters/src/daemon/peer-invite-flow.test.ts
+++ b/packages/adapters/src/daemon/peer-invite-flow.test.ts
@@ -72,6 +72,7 @@ function fakeConfigLayer() {
       }),
     revision: Effect.sync(() => revision),
     secretStorageUnavailable: () => false,
+    reloadIfChanged: () => Effect.succeed(false),
     appConfig: Effect.sync((): AppConfig => ({ ...({} as AppConfig), peers })),
   };
   return { layer: Layer.succeed(AgentConfigServiceTag, service) };

--- a/packages/adapters/src/peers/invites.test.ts
+++ b/packages/adapters/src/peers/invites.test.ts
@@ -186,6 +186,7 @@ function fakeConfigLayer(initialPeers: readonly PeerConfig[] = []) {
       }),
     revision: Effect.sync(() => revision),
     secretStorageUnavailable: () => false,
+    reloadIfChanged: () => Effect.succeed(false),
     appConfig: Effect.sync((): AppConfig => ({ ...({} as AppConfig), peers })),
   };
   return { layer: Layer.succeed(AgentConfigServiceTag, service), currentPeers: () => peers };

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -242,6 +242,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
         run(
           Effect.gen(function* () {
             const service = yield* AgentConfigServiceTag;
+            yield* service.reloadIfChanged();
             return select(yield* service.appConfig);
           }),
         );

--- a/packages/core/src/agent/context/summarizer.test.ts
+++ b/packages/core/src/agent/context/summarizer.test.ts
@@ -62,6 +62,7 @@ const mockAgentConfigService: AgentConfigService = {
   set: () => Effect.void,
   revision: Effect.succeed(0),
   secretStorageUnavailable: () => false,
+  reloadIfChanged: () => Effect.succeed(false),
 };
 
 // Mock LLMService (minimal implementation for model selection)

--- a/packages/core/src/interfaces/agent-config.ts
+++ b/packages/core/src/interfaces/agent-config.ts
@@ -21,6 +21,8 @@ export interface AgentConfigService {
    * home in the config file. Lets a command report that instead of claiming success.
    */
   readonly secretStorageUnavailable: (key: string) => boolean;
+  /** Re-read the config file when another process has changed it. */
+  readonly reloadIfChanged: () => Effect.Effect<boolean, never>;
 }
 
 export const AgentConfigServiceTag = Context.GenericTag<AgentConfigService>("AgentConfigService");


### PR DESCRIPTION
## What & why

The daemon reads its webhook and peer lists per request, but through `appConfig`, which answers from an in-memory snapshot taken at startup:

## The part worth reviewing

Only `webhooks` and `peers` are taken from the file. Replacing the whole config would drop the secrets this service resolved at startup and holds nowhere else — they live in the keyring and are resolved per use, so a reload has nothing to restore.

## How to verify

- Start `jazz daemon` with `"webhooks": []`, `curl` one → `404`.
- Add a webhook to `config.json` from outside, `curl` again with a wrong token → `401`. Found, refused only for its token, no restart.
- `bun test` — 3550 pass, including a new case asserting `appConfig` stays stale until `reloadIfChanged` is asked.