### PR TITLE
fix(peers): make /a2a work with real A2A clients

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "jazz-ai",
       "devDependencies": {
+        "@a2a-js/sdk": "^1.1.0",
         "@ai-sdk/alibaba": "^2.0.35",
         "@ai-sdk/anthropic": "^4.0.42",
         "@ai-sdk/cerebras": "^3.0.37",
@@ -191,6 +192,8 @@
     },
   },
   "packages": {
+    "@a2a-js/sdk": ["@a2a-js/sdk@1.1.0", "", { "dependencies": { "jose": "^6.2.3" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-/Mhzw9C6VW7pFbY2Rq0pnrjT0Fy9PV0c46A7Gx1ppRlYq2u/6OV/bNRIoVBKChb8UZ8bE0WzzCc0pIr2CdmG+w=="],
+
     "@ai-sdk/alibaba": ["@ai-sdk/alibaba@2.0.35", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zWD1jkTmZbvg6fN6Hi2zQoND2GogGmNdn75tEsmsm7sPt6rL2JuYH+6l9WnDGCCy2r+gvSFXm+j4j7jNBCwrOQ=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.42", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-U3RJDo2/rWdH6SjSbA2Owd30ZawKwt4zFTqteTTn6Po0vEW1ec1KXf6s1nwNE3mxCqKrQWEavU21C46AfGYaeg=="],

--- a/docs/concepts/agent-to-agent.md
+++ b/docs/concepts/agent-to-agent.md
@@ -186,8 +186,53 @@ Riskier than read-only, so — like any tool that isn't — it stays behind an e
 discovers that declining-and-asking is even an option; their agent just answers or refuses.
 
 On the wire, this is additive to jazz's own `/peer/ask` protocol only. The `/a2a` door stays
-exactly as minimal as before: a parked answer surfaces there as an ordinary refusal, with the
-clarifying question as the error message, not a new task-lifecycle state.
+exactly as minimal as before: a parked answer arrives there as an ordinary message carrying
+the clarifying question, marked as parked rather than answered, not a new task-lifecycle
+state.
+
+### Answering over A2A
+
+`/peer/ask` is jazz's own shape. [A2A](https://a2a-protocol.org) is the open standard for the
+same conversation between agents that were never built to know about each other, and the same
+daemon serves it — so a peer running LangGraph, ADK, or anything else with an A2A client can
+ask your agent a question without either side writing code for the other.
+
+It is the same door, not a second one. Same token, same tier, same `allow`, same ledger; only
+the wire format differs.
+
+```bash
+# What kind of thing is this? No token needed.
+curl https://me.example/.well-known/agent-card.json
+
+# Ask it something.
+curl https://me.example/a2a \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "A2A-Version: 1.0" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"SendMessage",
+       "params":{"message":{"role":"ROLE_USER","parts":[{"text":"free Thursday?"}]}}}'
+```
+
+Two methods exist: `SendMessage`, and `GetExtendedAgentCard` for the authenticated card whose
+skills list what *your* relationship can actually reach. There is no streaming, no task
+lifecycle, and no push notification — the card says so, so a client knows before it asks.
+
+**Send `A2A-Version: 1.0`.** A caller that names another version, or none, is refused with
+`VersionNotSupportedError` naming the one this door speaks. Being told precisely beats being
+answered in a shape you cannot parse.
+
+A refusal comes back as a message, not a protocol error — the agent understood the question
+and would not answer it, which is not the same as the request being malformed. What separates
+the two is metadata on the reply:
+
+```json
+{ "message": { "role": "ROLE_AGENT",
+               "parts": [{ "text": "I cannot." }],
+               "metadata": { "ai.jazz/outcome": "refused" } } }
+```
+
+`refused` and `parked` are marked; a real answer carries no marker. A client that ignores
+metadata still sees the text, and still cannot mistake silence for consent — but one that
+reads it can tell a decline from a reply.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/lvndry/jazz.git"
   },
   "devDependencies": {
+    "@a2a-js/sdk": "^1.1.0",
     "@ai-sdk/alibaba": "^2.0.35",
     "@ai-sdk/anthropic": "^4.0.42",
     "@ai-sdk/cerebras": "^3.0.37",

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -317,7 +317,7 @@ describe("the address an agent card tells a peer to call", () => {
       },
     );
 
-  async function advertisedUrl(headers?: Record<string, string>): Promise<string> {
+  async function advertisedUrl(headers: Record<string, string> = {}): Promise<string> {
     const response = await cardHandler("alice")(
       new Request("http://127.0.0.1:4321/.well-known/agent-card.json", { headers }),
     );

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
 import { InMemoryRunStore } from "@/adapters/storage/run-store";
 import {
+  makeA2AHandler,
   makeHandler,
   makePeerInviteHandler,
   makeWebhookHandler,
@@ -296,6 +297,59 @@ describe("the daemon's routes", () => {
     );
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("too long");
+  });
+});
+
+/**
+ * The card is the only thing a peer reads before it knows where to send anything, so the
+ * endpoint it names has to be an address that peer can actually reach. The daemon is told a
+ * bind address, which is a different question — the documented way to be reachable at all is
+ * a tunnel in front of a loopback bind.
+ */
+describe("the address an agent card tells a peer to call", () => {
+  const cardHandler = (peerAgent?: string) =>
+    makeA2AHandler(
+      { ...LOOPBACK, peerAgent },
+      async () => [],
+      async () => undefined,
+      async () => {
+        throw new Error("fetching a card must not run an effect");
+      },
+    );
+
+  async function advertisedUrl(headers?: Record<string, string>): Promise<string> {
+    const response = await cardHandler("alice")(
+      new Request("http://127.0.0.1:4321/.well-known/agent-card.json", { headers }),
+    );
+    const card = (await response.json()) as { supportedInterfaces: { url: string }[] };
+    return card.supportedInterfaces[0]!.url;
+  }
+
+  it("names the address the card was fetched on when nothing is in front of it", async () => {
+    expect(await advertisedUrl()).toBe("http://127.0.0.1:4321/a2a");
+  });
+
+  it("names the tunnel rather than a loopback address no peer could reach", async () => {
+    const url = await advertisedUrl({
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "me.example",
+    });
+    expect(url).toBe("https://me.example/a2a");
+  });
+
+  it("takes the first hop of a chain, which is the address the client used", async () => {
+    const url = await advertisedUrl({
+      "x-forwarded-proto": "https, http",
+      "x-forwarded-host": "me.example, inner.internal",
+    });
+    expect(url).toBe("https://me.example/a2a");
+  });
+
+  it("is not served at all by a daemon that is not answering peers", async () => {
+    const response = await cardHandler(undefined)(
+      new Request("http://127.0.0.1:4321/.well-known/agent-card.json"),
+    );
+    expect(response.status).toBe(404);
   });
 });
 

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -34,7 +34,7 @@ import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { MAX_WEBHOOK_THREAD_KEY_LENGTH, WEBHOOK_THREAD_HEADER } from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
-import { buildPublicAgentCard, handleA2ARpc } from "@/adapters/peers/a2a";
+import { buildPublicAgentCard, handleA2ARpc, normalizeProtocolVersion } from "@/adapters/peers/a2a";
 import {
   acceptInviteOnInviterSide,
   getInvite,
@@ -287,6 +287,32 @@ export function makePeerHandler(
   };
 }
 
+/** Where a caller announces which A2A protocol version it is speaking. */
+const A2A_VERSION_HEADER = "A2A-Version";
+
+/**
+ * The JSON-RPC endpoint to advertise in an agent card, derived from the address this very
+ * request arrived on rather than from configuration.
+ *
+ * The daemon is told a bind address, which is a different thing from the address peers reach
+ * it at: the documented way to be reachable at all is a tunnel or reverse proxy in front of
+ * a loopback bind, and a card advertising `127.0.0.1` there points every caller at their own
+ * machine. Proxy headers are trusted because the alternative is being reliably wrong, and
+ * the blast radius is small — this URL only ever appears in the response to the caller who
+ * set the header, so a caller who forges it misdirects nobody but itself.
+ */
+function a2aEndpointUrl(request: Request): string {
+  const url = new URL(request.url);
+  const forwardedProtocol = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost = request.headers.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const protocol =
+    forwardedProtocol !== undefined && forwardedProtocol.length > 0
+      ? `${forwardedProtocol}:`
+      : url.protocol;
+  const host = forwardedHost !== undefined && forwardedHost.length > 0 ? forwardedHost : url.host;
+  return `${protocol}//${host}/a2a`;
+}
+
 /**
  * A2A's own doors: an unauthenticated capability card, and an authenticated JSON-RPC
  * endpoint. Not a second implementation of peer authorization — `answerA2A` resolves the
@@ -306,7 +332,7 @@ export function makeA2AHandler(
       if (options.peerAgent === undefined) {
         return json({ ok: false, error: "not accepting peer questions" }, 404);
       }
-      return json(buildPublicAgentCard(options.peerAgent));
+      return json(buildPublicAgentCard(options.peerAgent, a2aEndpointUrl(request)));
     }
 
     if (request.method !== "POST" || url.pathname !== "/a2a") {
@@ -332,7 +358,15 @@ export function makeA2AHandler(
       return json({ ok: false, error: "body must be JSON" }, 400);
     }
 
-    return runEffect(answerA2A(caller, options.peerAgent, body));
+    return runEffect(
+      answerA2A(
+        caller,
+        options.peerAgent,
+        a2aEndpointUrl(request),
+        normalizeProtocolVersion(request.headers.get(A2A_VERSION_HEADER)),
+        body,
+      ),
+    );
   };
 }
 
@@ -738,11 +772,24 @@ function answerPeer(peer: PeerConfig, agentIdentifier: string, question: string)
   );
 }
 
-function answerA2A(peer: PeerConfig, agentIdentifier: string, body: unknown) {
+function answerA2A(
+  peer: PeerConfig,
+  agentIdentifier: string,
+  endpointUrl: string,
+  protocolVersion: string,
+  body: unknown,
+) {
   return Effect.gen(function* () {
     const base = yield* getAgentByIdentifier(agentIdentifier);
     const agent = agentForPeer(base, peer);
-    const response = yield* handleA2ARpc(agentIdentifier, peer, agent, body);
+    const response = yield* handleA2ARpc(
+      agentIdentifier,
+      endpointUrl,
+      protocolVersion,
+      peer,
+      agent,
+      body,
+    );
     return json(response);
   }).pipe(
     Effect.catchAll((error) =>

--- a/packages/adapters/src/peers/a2a.test.ts
+++ b/packages/adapters/src/peers/a2a.test.ts
@@ -1,7 +1,16 @@
+import { AgentCard as A2AAgentCard, SendMessageResponse } from "@a2a-js/sdk";
 import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { describe, expect, it } from "bun:test";
-import { buildExtendedAgentCard, buildPublicAgentCard, parseA2ARequest } from "./a2a";
+import {
+  buildExtendedAgentCard,
+  buildMessageResult,
+  buildPublicAgentCard,
+  normalizeProtocolVersion,
+  parseA2ARequest,
+} from "./a2a";
+
+const ENDPOINT = "https://me.example/a2a";
 
 const TOOLS: readonly {
   name: string;
@@ -16,24 +25,89 @@ const TOOLS: readonly {
 
 describe("the public agent card", () => {
   it("is the same for every caller, and advertises the bearer scheme it actually accepts", () => {
-    const card = buildPublicAgentCard("my-agent");
-    expect(card.securitySchemes).toEqual([{ id: "peer-token", type: "http", scheme: "bearer" }]);
+    const card = buildPublicAgentCard("my-agent", ENDPOINT);
+    expect(card.securitySchemes["peer-token"]?.httpAuthSecurityScheme.scheme).toBe("bearer");
+    expect(card.securityRequirements[0]?.schemes["peer-token"]).toBeDefined();
     expect(card.capabilities.extendedAgentCard).toBe(true);
     // No peer-specific detail: this is the discovery document, not a grant.
     expect(card.skills).toHaveLength(1);
+  });
+
+  it("points callers at the address the card was fetched on", () => {
+    const card = buildPublicAgentCard("my-agent", ENDPOINT);
+    expect(card.supportedInterfaces).toEqual([
+      { url: ENDPOINT, protocolBinding: "JSONRPC", protocolVersion: "1.0" },
+    ]);
+  });
+
+  it("promises no capability this door does not implement", () => {
+    const card = buildPublicAgentCard("my-agent", ENDPOINT);
+    expect(card.capabilities.streaming).toBe(false);
+    expect(card.capabilities.pushNotifications).toBe(false);
+    expect(card.defaultInputModes).toEqual(["text/plain"]);
+    expect(card.defaultOutputModes).toEqual(["text/plain"]);
+  });
+});
+
+/**
+ * The card and the reply envelope are the two documents a client nobody here wrote has to
+ * read before it will talk at all, so they are checked against the protocol's own parser
+ * rather than against this repo's idea of the shape. A field renamed or nested wrongly reads
+ * as an empty string or a dropped array on the far side, which is silent — the client simply
+ * behaves as though the agent advertised nothing.
+ */
+describe("what a stock A2A client makes of what this door emits", () => {
+  it("reads back every field of the card it needs to place a call", () => {
+    const parsed = A2AAgentCard.fromJSON(buildPublicAgentCard("my-agent", ENDPOINT));
+    expect(parsed.name).toBe("my-agent");
+    expect(parsed.version).not.toBe("");
+    expect(parsed.supportedInterfaces[0]?.url).toBe(ENDPOINT);
+    expect(parsed.supportedInterfaces[0]?.protocolBinding).toBe("JSONRPC");
+    expect(parsed.capabilities?.extendedAgentCard).toBe(true);
+    expect(parsed.skills[0]?.id).toBe("answer_question");
+    expect(parsed.securitySchemes["peer-token"]?.scheme?.$case).toBe("httpAuthSecurityScheme");
+    expect(parsed.securityRequirements[0]?.schemes["peer-token"]).toBeDefined();
+    expect(parsed.defaultInputModes).toEqual(["text/plain"]);
+  });
+
+  it("unwraps an answer as an agent message rather than an empty payload", () => {
+    const result = buildMessageResult(1, "Thursday afternoon is clear.", "answered");
+    const parsed = SendMessageResponse.fromJSON(result.result);
+    expect(parsed.payload?.$case).toBe("message");
+    const message = parsed.payload?.$case === "message" ? parsed.payload.value : undefined;
+    expect(message?.parts[0]?.content).toEqual({
+      $case: "text",
+      value: "Thursday afternoon is clear.",
+    });
+    expect(message?.messageId).not.toBe("");
+  });
+});
+
+describe("telling an answer apart from a refusal", () => {
+  it("leaves a straight answer unmarked", () => {
+    const result = buildMessageResult(1, "Thursday is clear.", "answered");
+    expect((result.result as { message: { metadata?: unknown } }).message.metadata).toBeUndefined();
+  });
+
+  it("marks a refusal and a parked question so a caller cannot log either as a reply", () => {
+    for (const outcome of ["refused", "parked"] as const) {
+      const result = buildMessageResult(1, "no", outcome);
+      const message = (result.result as { message: { metadata?: Record<string, string> } }).message;
+      expect(message.metadata?.["ai.jazz/outcome"]).toBe(outcome);
+    }
   });
 });
 
 describe("the extended agent card", () => {
   it("reflects exactly what this peer's tier admits", () => {
     const peer: PeerConfig = { name: "sam", disclosure: "public" };
-    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
     expect(card.skills[0]?.tags).toEqual(["web_search"]);
   });
 
   it("adds a granted riskier tool without needing a wider tier", () => {
     const peer: PeerConfig = { name: "sam", disclosure: "public", allow: ["send_message"] };
-    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
     expect(card.skills[0]?.tags).toContain("send_message");
     expect(card.skills[0]?.tags).toContain("web_search");
     expect(card.skills[0]?.tags).not.toContain("read_file");
@@ -41,21 +115,36 @@ describe("the extended agent card", () => {
 
   it("reflects a suspended peer as reaching nothing", () => {
     const peer: PeerConfig = { name: "sam" };
-    const card = buildExtendedAgentCard("my-agent", peer, TOOLS);
+    const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
     expect(card.skills[0]?.tags).toEqual([]);
     expect(card.skills[0]?.description).toContain("suspended");
   });
 });
 
+describe("reducing an announced protocol version to what compatibility turns on", () => {
+  it("assumes the version the protocol fixes for a caller that announces none", () => {
+    expect(normalizeProtocolVersion(undefined)).toBe("0.3");
+    expect(normalizeProtocolVersion(null)).toBe("0.3");
+    expect(normalizeProtocolVersion("   ")).toBe("0.3");
+  });
+
+  it("keeps major and minor, and drops a patch that carries no wire difference", () => {
+    expect(normalizeProtocolVersion("1.0")).toBe("1.0");
+    expect(normalizeProtocolVersion(" 1.0 ")).toBe("1.0");
+    expect(normalizeProtocolVersion("1.0.3")).toBe("1.0");
+    expect(normalizeProtocolVersion("0.3")).toBe("0.3");
+  });
+});
+
 describe("parsing a JSON-RPC request", () => {
   it("accepts a well-formed envelope", () => {
-    const parsed = parseA2ARequest({ jsonrpc: "2.0", id: 1, method: "a2a.SendMessage" });
-    expect(parsed?.method).toBe("a2a.SendMessage");
+    const parsed = parseA2ARequest({ jsonrpc: "2.0", id: 1, method: "SendMessage" });
+    expect(parsed?.method).toBe("SendMessage");
   });
 
   it("rejects anything missing jsonrpc, id, or method", () => {
-    expect(parseA2ARequest({ id: 1, method: "a2a.SendMessage" })).toBeUndefined();
-    expect(parseA2ARequest({ jsonrpc: "2.0", method: "a2a.SendMessage" })).toBeUndefined();
+    expect(parseA2ARequest({ id: 1, method: "SendMessage" })).toBeUndefined();
+    expect(parseA2ARequest({ jsonrpc: "2.0", method: "SendMessage" })).toBeUndefined();
     expect(parseA2ARequest({ jsonrpc: "2.0", id: 1 })).toBeUndefined();
     expect(parseA2ARequest("not an object")).toBeUndefined();
     expect(parseA2ARequest(null)).toBeUndefined();

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -17,6 +17,12 @@
  * lifecycle, no streaming, no push notifications, no OAuth2/OIDC/mTLS — none of that has a
  * caller yet, and bolting it on speculatively is exactly the scope creep this feature nearly
  * shipped with the first time around.
+ *
+ * Minimal, but not approximate. Everything this door does emit is the shape a stock A2A
+ * client parses: PascalCase JSON-RPC method names, a `SendMessageResponse` envelope around
+ * the reply, and an agent card carrying the fields a client reads before it will talk at
+ * all. A door that is A2A-shaped but not A2A-speaking is decorative, since interoperability
+ * with clients nobody here wrote is the entire reason to have it.
  */
 
 import { resolveAgentToolNames } from "@jazz/core/agent/tools/agent-tool-resolution";
@@ -26,9 +32,33 @@ import type { Agent } from "@jazz/core/types";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { Effect } from "effect";
 import { allowedToolsForPeer, servePeerRequest } from "./serve";
+import packageJson from "../../../../package.json";
 
 /** The one security scheme this server actually accepts: a peer's own bearer token. */
 const SECURITY_SCHEME_ID = "peer-token";
+
+/**
+ * The one protocol version this door speaks, as `Major.Minor`.
+ *
+ * A2A pins wire details to the version a caller asks for, so supporting several means
+ * carrying several serializations of the same message. This door carries one. A caller
+ * asking for anything else gets told so precisely, which is a better outcome than being
+ * answered in a shape it cannot parse.
+ */
+const SUPPORTED_PROTOCOL_VERSION = "1.0";
+
+/**
+ * The version assumed when a caller sends no `A2A-Version` at all, which the protocol fixes
+ * rather than leaving to each server to guess. It is not the version this door speaks, so a
+ * caller who omits the header is refused the same as one who names an unsupported version.
+ */
+const ASSUMED_PROTOCOL_VERSION = "0.3";
+
+/** The only content this door takes in or gives back: one question, one answer, as text. */
+const TEXT_MODE = "text/plain";
+
+/** JSON-RPC codes from A2A's own error range, distinct from the JSON-RPC 2.0 standard ones. */
+const VERSION_NOT_SUPPORTED = -32009;
 
 export interface AgentSkill {
   readonly id: string;
@@ -37,21 +67,32 @@ export interface AgentSkill {
   readonly tags: readonly string[];
 }
 
+/** One endpoint a client can reach this agent on, and what it speaks there. */
+export interface AgentInterface {
+  readonly url: string;
+  readonly protocolBinding: "JSONRPC";
+  readonly protocolVersion: string;
+}
+
 export interface AgentCard {
-  readonly id: string;
   readonly name: string;
   readonly description: string;
+  readonly version: string;
+  readonly supportedInterfaces: readonly AgentInterface[];
   readonly capabilities: {
     readonly streaming: boolean;
     readonly pushNotifications: boolean;
     readonly extendedAgentCard: boolean;
   };
-  readonly securitySchemes: readonly {
-    readonly id: string;
-    readonly type: "http";
-    readonly scheme: "bearer";
+  readonly securitySchemes: Record<
+    string,
+    { readonly httpAuthSecurityScheme: { readonly scheme: string; readonly description: string } }
+  >;
+  readonly securityRequirements: readonly {
+    readonly schemes: Record<string, { readonly list: readonly string[] }>;
   }[];
-  readonly security: readonly Record<string, readonly string[]>[];
+  readonly defaultInputModes: readonly string[];
+  readonly defaultOutputModes: readonly string[];
   readonly skills: readonly AgentSkill[];
 }
 
@@ -59,18 +100,41 @@ export interface AgentCard {
  * The unauthenticated card. Same for every caller, on purpose — this is the "what kind of
  * thing is this" advertisement, not a peer-specific capability list. See
  * `buildExtendedAgentCard` for the one that actually reflects a relationship.
+ *
+ * `endpointUrl` is where a client should send its JSON-RPC calls. The daemon derives it from
+ * the address the card was fetched on rather than from configuration, so a card served
+ * through a tunnel advertises the tunnel rather than a loopback address no peer can reach.
  */
-export function buildPublicAgentCard(agentName: string): AgentCard {
+export function buildPublicAgentCard(agentName: string, endpointUrl: string): AgentCard {
   return {
-    id: agentName,
     name: agentName,
     description:
       "A jazz agent. Answers questions from established peers, within a disclosure tier " +
       "and tool grant its operator configured for each one. Fetch the extended card after " +
       "authenticating to see what a specific relationship can actually reach.",
+    version: packageJson.version,
+    supportedInterfaces: [
+      {
+        url: endpointUrl,
+        protocolBinding: "JSONRPC",
+        protocolVersion: SUPPORTED_PROTOCOL_VERSION,
+      },
+    ],
     capabilities: { streaming: false, pushNotifications: false, extendedAgentCard: true },
-    securitySchemes: [{ id: SECURITY_SCHEME_ID, type: "http", scheme: "bearer" }],
-    security: [{ [SECURITY_SCHEME_ID]: [] }],
+    securitySchemes: {
+      [SECURITY_SCHEME_ID]: {
+        httpAuthSecurityScheme: {
+          scheme: "bearer",
+          description:
+            "The bearer token this agent's operator issued to one specific peer. It " +
+            "identifies which relationship is calling, which is what selects the tier and " +
+            "tool grant the answer is produced under.",
+        },
+      },
+    },
+    securityRequirements: [{ schemes: { [SECURITY_SCHEME_ID]: { list: [] } } }],
+    defaultInputModes: [TEXT_MODE],
+    defaultOutputModes: [TEXT_MODE],
     skills: [
       {
         id: "answer_question",
@@ -93,6 +157,7 @@ export function buildPublicAgentCard(agentName: string): AgentCard {
  */
 export function buildExtendedAgentCard(
   agentName: string,
+  endpointUrl: string,
   peer: PeerConfig,
   tools: readonly {
     readonly name: string;
@@ -103,7 +168,7 @@ export function buildExtendedAgentCard(
   const tier = peer.disclosure ?? "none";
   const allow = peer.allow ?? [];
   const reachable = allowedToolsForPeer(tier, allow, tools);
-  const base = buildPublicAgentCard(agentName);
+  const base = buildPublicAgentCard(agentName, endpointUrl);
   return {
     ...base,
     skills: [
@@ -133,7 +198,11 @@ interface JsonRpcSuccess {
 interface JsonRpcFailure {
   readonly jsonrpc: "2.0";
   readonly id: string | number | null;
-  readonly error: { readonly code: number; readonly message: string };
+  readonly error: {
+    readonly code: number;
+    readonly message: string;
+    readonly data?: readonly unknown[];
+  };
 }
 
 export type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure;
@@ -156,6 +225,40 @@ export function parseA2ARequest(body: unknown): JsonRpcRequest | undefined {
   return undefined;
 }
 
+/**
+ * Reduces an `A2A-Version` header to the `Major.Minor` pair that decides compatibility. A
+ * patch component carries no wire difference and is dropped rather than rejected, so a
+ * caller announcing `1.0.3` is treated as the `1.0` caller it is.
+ */
+export function normalizeProtocolVersion(header: string | undefined | null): string {
+  const trimmed = (header ?? "").trim();
+  if (trimmed.length === 0) return ASSUMED_PROTOCOL_VERSION;
+  const parts = trimmed.split(".");
+  return parts.length >= 2 ? `${parts[0]}.${parts[1]}` : trimmed;
+}
+
+function methodNotFound(id: string | number, method: string): JsonRpcFailure {
+  return { jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } };
+}
+
+function invalidParams(id: string | number, detail: string): JsonRpcFailure {
+  return { jsonrpc: "2.0", id, error: { code: -32602, message: `Invalid params: ${detail}` } };
+}
+
+function versionNotSupported(id: string | number, requested: string): JsonRpcFailure {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: VERSION_NOT_SUPPORTED,
+      message:
+        `A2A protocol version ${requested} is not supported. Send ` +
+        `A2A-Version: ${SUPPORTED_PROTOCOL_VERSION}.`,
+      data: [{ supportedVersions: [SUPPORTED_PROTOCOL_VERSION] }],
+    },
+  };
+}
+
 function extractQuestion(params: unknown): string | undefined {
   if (typeof params !== "object" || params === null) return undefined;
   const message = (params as Record<string, unknown>)["message"];
@@ -175,12 +278,35 @@ function extractQuestion(params: unknown): string | undefined {
   return question.length > 0 ? question : undefined;
 }
 
-function methodNotFound(id: string | number, method: string): JsonRpcFailure {
-  return { jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } };
-}
+/**
+ * Marks a reply as something other than a straight answer.
+ *
+ * A2A has one shape for "the agent said something" and no notion of an agent that declined,
+ * so refusing and answering would otherwise arrive identically and a caller could log a
+ * refusal as a reply. The distinction rides in message metadata, which the protocol leaves
+ * free-form for exactly this, under a key namespaced to jazz so it cannot collide with a
+ * field the protocol later defines.
+ */
+const OUTCOME_METADATA_KEY = "ai.jazz/outcome";
 
-function invalidParams(id: string | number, detail: string): JsonRpcFailure {
-  return { jsonrpc: "2.0", id, error: { code: -32602, message: `Invalid params: ${detail}` } };
+/** Wraps an agent's text in the `SendMessageResponse` envelope a client unwraps. */
+export function buildMessageResult(
+  id: string | number,
+  text: string,
+  outcome: "answered" | "refused" | "parked",
+): JsonRpcSuccess {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result: {
+      message: {
+        messageId: crypto.randomUUID(),
+        role: "ROLE_AGENT",
+        parts: [{ text }],
+        ...(outcome === "answered" ? {} : { metadata: { [OUTCOME_METADATA_KEY]: outcome } }),
+      },
+    },
+  };
 }
 
 /**
@@ -188,14 +314,25 @@ function invalidParams(id: string | number, detail: string): JsonRpcFailure {
  * `servePeerRequest` `/peer/ask` already calls — this is a wire-format translation, not a
  * second implementation of the authorization decision.
  */
-export function handleA2ARpc(agentName: string, peer: PeerConfig, agent: Agent, raw: unknown) {
+export function handleA2ARpc(
+  agentName: string,
+  endpointUrl: string,
+  protocolVersion: string,
+  peer: PeerConfig,
+  agent: Agent,
+  raw: unknown,
+) {
   return Effect.gen(function* () {
     const request = parseA2ARequest(raw);
     if (request === undefined) {
       return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Invalid Request" } };
     }
 
-    if (request.method === "a2a.GetExtendedAgentCard") {
+    if (protocolVersion !== SUPPORTED_PROTOCOL_VERSION) {
+      return versionNotSupported(request.id, protocolVersion);
+    }
+
+    if (request.method === "GetExtendedAgentCard") {
       // Scoped to what `agent` (the actual identity answering this peer) can really reach —
       // not the global registry, which lists every tool registered for every agent on this
       // machine. Advertising from the wrong source is how a card ends up promising a tool
@@ -215,33 +352,31 @@ export function handleA2ARpc(agentName: string, peer: PeerConfig, agent: Agent, 
       return {
         jsonrpc: "2.0",
         id: request.id,
-        result: buildExtendedAgentCard(agentName, peer, described),
+        result: buildExtendedAgentCard(agentName, endpointUrl, peer, described),
       };
     }
 
-    if (request.method === "a2a.SendMessage") {
+    if (request.method === "SendMessage") {
       const question = extractQuestion(request.params);
       if (question === undefined) {
         return invalidParams(request.id, "params.message.parts must include non-empty text");
       }
       const outcome = yield* servePeerRequest({ peer, agent, question });
+      // Every outcome comes back as a message rather than a JSON-RPC error, including the
+      // ones that declined. A2A's error codes name protocol and task-lifecycle failures; an
+      // agent that considered a question and would not answer it is neither, and reporting
+      // it as one would tell a caller its request was malformed when it was understood
+      // perfectly and turned down. What separates them on the wire is the outcome metadata.
       if (outcome.kind === "answered") {
-        return {
-          jsonrpc: "2.0",
-          id: request.id,
-          result: {
-            messageId: `a2a-${Date.now().toString(36)}`,
-            role: "ROLE_AGENT",
-            parts: [{ text: outcome.answer }],
-          },
-        };
+        return buildMessageResult(request.id, outcome.answer, "answered");
       }
       // `parked` (the answering agent wants to ask something back before committing) has no
-      // A2A task-lifecycle state to carry it — this door is deliberately staying that minimal,
-      // see the file header. It surfaces as an ordinary refusal, with the clarifying question
-      // as the message, same as any other reason this door declines to answer outright.
-      const message = outcome.kind === "parked" ? outcome.question : outcome.reason;
-      return { jsonrpc: "2.0", id: request.id, error: { code: -32001, message } };
+      // A2A task-lifecycle state to carry it — this door is deliberately staying that
+      // minimal, see the file header. The clarifying question rides back as the message text,
+      // tagged so a caller can tell it apart from a flat refusal.
+      return outcome.kind === "parked"
+        ? buildMessageResult(request.id, outcome.question, "parked")
+        : buildMessageResult(request.id, outcome.reason, "refused");
     }
 
     return methodNotFound(request.id, request.method);

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -48,11 +48,16 @@ const SECURITY_SCHEME_ID = "peer-token";
 const SUPPORTED_PROTOCOL_VERSION = "1.0";
 
 /**
- * The version assumed when a caller sends no `A2A-Version` at all, which the protocol fixes
- * rather than leaving to each server to guess. It is not the version this door speaks, so a
- * caller who omits the header is refused the same as one who names an unsupported version.
+ * What a caller who sends no `A2A-Version` at all is taken to have said.
+ *
+ * Not this door's own version, and not a default to be widened to it. The protocol fixes the
+ * meaning of a missing header rather than leaving each server to guess, precisely so that a
+ * client too old to know the header exists cannot be mistaken for a current one. Reading
+ * silence as the version we happen to speak would answer exactly that client in a shape it
+ * cannot parse — the silent failure this door is built to avoid — so an unstated version is
+ * refused the same as an unsupported one, and the refusal names what to send instead.
  */
-const ASSUMED_PROTOCOL_VERSION = "0.3";
+const UNSTATED_VERSION_MEANS = "0.3";
 
 /** The only content this door takes in or gives back: one question, one answer, as text. */
 const TEXT_MODE = "text/plain";
@@ -232,7 +237,7 @@ export function parseA2ARequest(body: unknown): JsonRpcRequest | undefined {
  */
 export function normalizeProtocolVersion(header: string | undefined | null): string {
   const trimmed = (header ?? "").trim();
-  if (trimmed.length === 0) return ASSUMED_PROTOCOL_VERSION;
+  if (trimmed.length === 0) return UNSTATED_VERSION_MEANS;
   const parts = trimmed.split(".");
   return parts.length >= 2 ? `${parts[0]}.${parts[1]}` : trimmed;
 }


### PR DESCRIPTION
## Problem

The `/a2a` endpoint didn't match the A2A spec, so a standard A2A client could fetch jazz's agent card and then fail on every call. Running the old output through the official `@a2a-js/sdk` parser:

| jazz sent | client got |
| --- | --- |
| agent card | `supportedInterfaces: []` — no endpoint to call |
| agent card | `version: ""`, `defaultInputModes: []` |
| `securitySchemes: [{id: "peer-token", …}]` | `{ "0": { scheme: undefined } }` |
| `SendMessage` reply | `payload: undefined` → client throws |
| method `a2a.SendMessage` | method not found |

No errors on our side. The client just sees empty fields.

## Changes

- Method names are `SendMessage` and `GetExtendedAgentCard` (were `a2a.`-prefixed).
- Agent card uses the v1.0 shape: `supportedInterfaces`, `version`, `defaultInputModes`/`defaultOutputModes`, `securitySchemes` keyed by name, `securityRequirements`.
- The endpoint URL in the card is derived from the request, honouring `X-Forwarded-Proto`/`X-Forwarded-Host`. Previously there was no URL at all; building one from the bind address would point peers at their own loopback, since the documented setup is a tunnel in front of a loopback bind.
- `SendMessage` replies are wrapped in a `SendMessageResponse` envelope.
- Requires `A2A-Version: 1.0`. Anything else, including no header (which the spec defines as meaning 0.3), gets `VersionNotSupportedError` saying which version to use.
- Refusals and parked questions return as messages tagged `{"ai.jazz/outcome": "refused" | "parked"}` instead of JSON-RPC `-32001`, which means `TaskNotFoundError` in 1.0. Declining to answer isn't a protocol error, but a caller still needs to tell a refusal from a reply.

No new capability. Still no streaming, tasks, or push notifications — the card says so.

## Why not a `@jazz/a2a` package

This started as "should we ship an SDK like `a2a-python`?" No: the JS equivalent is `@a2a-js/sdk`, maintained by the A2A project. A third-party copy means tracking someone else's spec churn for no gain. jazz's differentiator is the peer trust model (tiers, `allow`, ledger), which is tied to jazz config and the tool registry and wouldn't factor out into a library.

## Testing

- Card and reply envelope are asserted against `@a2a-js/sdk`'s parsers (new devDependency). Testing them against our own types wouldn't catch a renamed field, since mismatches fail silently.
- Endpoint URL derivation covered for direct bind, forwarded headers, and forwarded chains.
- Served the real handler over HTTP and resolved it with the SDK's `DefaultAgentCardResolver`:

```text
name:               alice
version:            0.15.15
interfaces:         [{"url":"http://127.0.0.1:54601/a2a","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]
skills:             [ "answer_question" ]
extendedAgentCard:  true
securityScheme:     [ "peer-token" ] httpAuthSecurityScheme
defaultInputModes:  [ "text/plain" ]
```

- `bun test` (3558), `typecheck`, `test:typecheck`, `lint` pass.
- `docs/concepts/agent-to-agent.md` gains an "Answering over A2A" section.

Not covered: `SendMessage` end-to-end against a live LLM, which needs provider credentials. The wire format is verified; the answer path is the unchanged `servePeerRequest` that `/peer/ask` already uses.