### PR TITLE
feat(run): park and resume ask_user_question and ask_file_picker

### DIFF
--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -22,7 +22,8 @@ import { FileSystem } from "@effect/platform";
 import { AgentRunner } from "@jazz/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
 import { isRunParkRequested } from "@jazz/core/agent/run/park-signal";
-import { resumeRun } from "@jazz/core/agent/run/resume";
+import { resumeRun, type ResumeRunOptions } from "@jazz/core/agent/run/resume";
+import type { PendingInput } from "@jazz/core/agent/run/run-state";
 import type { AgentConfigService } from "@jazz/core/interfaces/agent-config";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
@@ -196,15 +197,22 @@ export function makeHandler(
 
     const answerMatch = /^\/runs\/([^/]+)\/answer$/.exec(url.pathname);
     if (request.method === "POST" && answerMatch?.[1] !== undefined) {
-      let body: { approved?: unknown; note?: unknown };
+      let body: { approved?: unknown; note?: unknown; response?: unknown; filePath?: unknown };
       try {
-        body = (await request.json()) as { approved?: unknown; note?: unknown };
+        body = (await request.json()) as {
+          approved?: unknown;
+          note?: unknown;
+          response?: unknown;
+          filePath?: unknown;
+        };
       } catch {
         return json({ ok: false, error: "body must be JSON" }, 400);
       }
       const approved = body.approved === true;
       const note = typeof body.note === "string" ? body.note : undefined;
-      return runEffect(answerRun(answerMatch[1], approved, note));
+      const response = typeof body.response === "string" ? body.response.trim() : undefined;
+      const filePath = typeof body.filePath === "string" ? body.filePath.trim() : undefined;
+      return runEffect(answerRun(answerMatch[1], approved, note, response, filePath));
     }
 
     if (request.method === "GET" && url.pathname === "/runs") {
@@ -713,7 +721,15 @@ function fireWebhook(webhook: WebhookConfig, payload: string, threadKey?: string
     Effect.catchAll((error) =>
       Effect.gen(function* () {
         if (isRunParkRequested(error) && error.runId !== undefined) {
-          return json({ ok: false, state: "input-required", runId: error.runId }, 202);
+          return json(
+            {
+              ok: false,
+              state: "input-required",
+              runId: error.runId,
+              pending: describePendingInput(error.pending),
+            },
+            202,
+          );
         }
         const logger = yield* Effect.serviceOption(LoggerServiceTag);
         if (logger._tag === "Some") {
@@ -826,18 +842,13 @@ function startRun(
     Effect.catchAll((error) =>
       Effect.gen(function* () {
         if (isRunParkRequested(error) && error.runId !== undefined) {
-          const request =
-            error.pending.kind === "tool-approval" ? error.pending.request : undefined;
           return json(
             {
               ok: false,
               state: "input-required",
               runId: error.runId,
               expiresAt: error.expiresAt,
-              pending: {
-                toolName: request?.toolName,
-                message: request?.message,
-              },
+              pending: describePendingInput(error.pending),
             },
             202,
           );
@@ -873,6 +884,36 @@ function listRuns() {
   });
 }
 
+/** What a remote client needs to render and answer a parked run, one shape per pending kind. */
+function describePendingInput(pending: PendingInput) {
+  switch (pending.kind) {
+    case "tool-approval":
+      return {
+        kind: pending.kind,
+        toolName: pending.request.toolName,
+        message: pending.request.message,
+      };
+    case "question":
+      return {
+        kind: pending.kind,
+        question: pending.request.question,
+        suggestions: pending.request.suggestions,
+        allowCustom: pending.request.allowCustom,
+        ...(pending.request.allowMultiple === true ? { allowMultiple: true } : {}),
+      };
+    case "file-picker":
+      return {
+        kind: pending.kind,
+        message: pending.request.message,
+        ...(pending.request.basePath !== undefined ? { basePath: pending.request.basePath } : {}),
+        ...(pending.request.extensions !== undefined
+          ? { extensions: pending.request.extensions }
+          : {}),
+        ...(pending.request.includeDirectories === true ? { includeDirectories: true } : {}),
+      };
+  }
+}
+
 /**
  * Answer a parked run and let it finish.
  *
@@ -880,13 +921,32 @@ function listRuns() {
  * and a claim carries the pid of whoever made it. A remote client claiming a run it cannot
  * be seen to abandon would leave it stranded in `working` if that client died.
  */
-function answerRun(runId: string, approved: boolean, note: string | undefined) {
-  return resumeRun({
-    runId,
-    outcome: approved
-      ? { approved: true }
-      : { approved: false, ...(note ? { userMessage: note } : {}) },
-  }).pipe(
+function answerRun(
+  runId: string,
+  approved: boolean,
+  note: string | undefined,
+  response: string | undefined,
+  filePath: string | undefined,
+) {
+  const outcome: ResumeRunOptions["outcome"] =
+    response !== undefined
+      ? {
+          kind: "question",
+          value: response.length > 0 ? { kind: "answered", response } : { kind: "declined" },
+        }
+      : filePath !== undefined
+        ? {
+            kind: "file-picker",
+            value:
+              filePath.length > 0 ? { kind: "selected", path: filePath } : { kind: "cancelled" },
+          }
+        : {
+            kind: "approval",
+            value: approved
+              ? { approved: true }
+              : { approved: false, ...(note ? { userMessage: note } : {}) },
+          };
+  return resumeRun({ runId, outcome }).pipe(
     Effect.map((response) => json({ ok: true, runId, answer: response.content })),
     Effect.catchAll((error) =>
       Effect.succeed(

--- a/packages/cli/src/commands/run/lifecycle.ts
+++ b/packages/cli/src/commands/run/lifecycle.ts
@@ -7,7 +7,7 @@
  */
 
 import { makeFileRunStoreLayer } from "@jazz/adapters/storage/run-store";
-import { resumeRun } from "@jazz/core/agent/run/resume";
+import { resumeRun, type ResumeRunOptions } from "@jazz/core/agent/run/resume";
 import type { RunRecord } from "@jazz/core/agent/run/run-record";
 import { isParked } from "@jazz/core/agent/run/run-state";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
@@ -123,13 +123,39 @@ export function answerRunCommand(options: {
   readonly runId: string;
   readonly approved: boolean;
   readonly note?: string;
+  readonly response?: string;
+  readonly filePath?: string;
   readonly json: boolean;
 }) {
+  const outcome: ResumeRunOptions["outcome"] =
+    options.response !== undefined
+      ? {
+          kind: "question",
+          value:
+            options.response.length > 0
+              ? { kind: "answered", response: options.response }
+              : { kind: "declined" },
+        }
+      : options.filePath !== undefined
+        ? {
+            kind: "file-picker",
+            value:
+              options.filePath.length > 0
+                ? { kind: "selected", path: options.filePath }
+                : { kind: "cancelled" },
+          }
+        : {
+            kind: "approval",
+            value: options.approved
+              ? { approved: true }
+              : {
+                  approved: false,
+                  ...(options.note !== undefined ? { userMessage: options.note } : {}),
+                },
+          };
   return resumeRun({
     runId: options.runId,
-    outcome: options.approved
-      ? { approved: true }
-      : { approved: false, ...(options.note !== undefined ? { userMessage: options.note } : {}) },
+    outcome,
   }).pipe(
     Effect.tap((response) =>
       Effect.sync(() => {

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -487,6 +487,12 @@ function initializeAgentRun(
       ...(options.resolvedApprovals !== undefined
         ? { resolvedApprovals: options.resolvedApprovals }
         : {}),
+      ...(options.resolvedUserInputs !== undefined
+        ? { resolvedUserInputs: options.resolvedUserInputs }
+        : {}),
+      ...(options.resolvedFilePickers !== undefined
+        ? { resolvedFilePickers: options.resolvedFilePickers }
+        : {}),
       subagentDepth: options.subagentDepth ?? 0,
       maxSubagentDepth: Math.max(
         0,

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -213,7 +213,12 @@ export class ToolExecutor {
         }
 
         // Execute tool — pass pre-fetched timeout to avoid redundant getTool lookup
-        let result = yield* ToolExecutor.executeTool(name, args, context, toolMeta?.timeoutMs);
+        let result = yield* ToolExecutor.executeTool(
+          name,
+          args,
+          { ...context, toolCallId: toolCall.id },
+          toolMeta?.timeoutMs,
+        );
         let toolDuration = Date.now() - toolStartTime;
         let finalToolName = name;
         let classifiedRisk: ToolRiskLevel | undefined;

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -247,9 +247,10 @@ describe("park and resume, through the real loop", () => {
     ).toBe(true);
 
     const resumeExit = await Effect.runPromiseExit(
-      resumeRun({ runId: parked.runId, outcome: { approved: true } }).pipe(
-        Effect.provide(layers),
-      ) as Effect.Effect<unknown, unknown>,
+      resumeRun({
+        runId: parked.runId,
+        outcome: { kind: "approval", value: { approved: true } },
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
     );
 
     expect(resumeExit._tag).toBe("Success");

--- a/packages/core/src/agent/run/resume.ts
+++ b/packages/core/src/agent/run/resume.ts
@@ -28,7 +28,18 @@ export class RunNotResumableError extends Error {
 
 export interface ResumeRunOptions {
   readonly runId: RunId;
-  readonly outcome: ApprovalOutcome;
+  readonly outcome:
+    | { readonly kind: "approval"; readonly value: ApprovalOutcome }
+    | {
+        readonly kind: "question";
+        readonly value:
+          { readonly kind: "answered"; readonly response: string } | { readonly kind: "declined" };
+      }
+    | {
+        readonly kind: "file-picker";
+        readonly value:
+          { readonly kind: "selected"; readonly path: string } | { readonly kind: "cancelled" };
+      };
   /** Approve tools of the same kind for the rest of the resumed run, as an interactive session would. */
   readonly autoApprovedTools?: readonly string[];
 }
@@ -50,9 +61,11 @@ export function resumeRun(options: ResumeRunOptions) {
         ),
       );
     }
-    if (record.state.pending.kind !== "tool-approval") {
+    const expectedOutcomeKind =
+      record.state.pending.kind === "tool-approval" ? "approval" : record.state.pending.kind;
+    if (expectedOutcomeKind !== options.outcome.kind) {
       return yield* Effect.fail(
-        new RunNotResumableError(options.runId, "it is waiting on an answer, not an approval"),
+        new RunNotResumableError(options.runId, "its pending input has a different kind"),
       );
     }
 
@@ -110,6 +123,20 @@ export function resumeRun(options: ResumeRunOptions) {
       );
     }
 
+    const resolved =
+      options.outcome.kind === "approval" && pending.kind === "tool-approval"
+        ? { resolvedApprovals: new Map([[pending.request.toolCallId, options.outcome.value]]) }
+        : options.outcome.kind === "question" && pending.kind === "question"
+          ? { resolvedUserInputs: new Map([[pending.toolCallId, options.outcome.value]]) }
+          : options.outcome.kind === "file-picker" && pending.kind === "file-picker"
+            ? { resolvedFilePickers: new Map([[pending.toolCallId, options.outcome.value]]) }
+            : undefined;
+    if (resolved === undefined) {
+      return yield* Effect.fail(
+        new RunNotResumableError(options.runId, "its pending input has a different kind"),
+      );
+    }
+
     const response: AgentResponse = yield* AgentRunner.run({
       agent,
       runId: options.runId,
@@ -118,7 +145,7 @@ export function resumeRun(options: ResumeRunOptions) {
       conversationId: record.conversationId,
       conversationHistory: [...snapshot.messages],
       pendingToolCalls,
-      resolvedApprovals: new Map([[pending.request.toolCallId, options.outcome]]),
+      ...resolved,
       parkWhenUnattended: true,
       ...(options.autoApprovedTools !== undefined
         ? { autoApprovedTools: options.autoApprovedTools }

--- a/packages/core/src/agent/run/run-state.ts
+++ b/packages/core/src/agent/run/run-state.ts
@@ -20,6 +20,7 @@
  * over.
  */
 
+import type { FilePickerRequest, UserInputRequest } from "@/core/interfaces/presentation";
 import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { ChatMessage } from "@/core/types/message";
 import type { ApprovalRequest } from "@/core/types/tools";
@@ -52,7 +53,13 @@ export type PendingInput =
     }
   | {
       readonly kind: "question";
-      readonly prompt: string;
+      readonly request: UserInputRequest;
+      readonly toolCallId: string;
+    }
+  | {
+      readonly kind: "file-picker";
+      readonly request: FilePickerRequest;
+      readonly toolCallId: string;
     };
 
 /**

--- a/packages/core/src/agent/tools/user-interaction-tools.test.ts
+++ b/packages/core/src/agent/tools/user-interaction-tools.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
+import { isRunParkRequested } from "@/core/agent/run/park-signal";
 import { PresentationServiceTag } from "@/core/interfaces/presentation";
 import { userInteractionTools } from "./user-interaction-tools";
 
 const askUserQuestion = userInteractionTools.find((tool) => tool.name === "ask_user_question");
+const askFilePicker = userInteractionTools.find((tool) => tool.name === "ask_file_picker");
 
 function harness(outcome: Record<string, unknown>) {
   return Layer.succeed(PresentationServiceTag, {
@@ -35,6 +37,38 @@ async function ask(outcome: Record<string, unknown>): Promise<{
 }
 
 describe("ask_user_question", () => {
+  it("parks an unattended run with the full question instead of inventing an answer", async () => {
+    const effect = askUserQuestion!.execute(
+      {
+        question: "What is your budget?",
+        suggested_responses: [{ value: "500" }, { value: "1000" }],
+      },
+      { agentId: "a", conversationId: "c", toolCallId: "call_1", parkWhenUnattended: true },
+    );
+    const exit = await Effect.runPromiseExit(
+      effect.pipe(
+        Effect.provide(
+          Layer.succeed(PresentationServiceTag, {
+            canPromptForApproval: () => false,
+            requestUserInput: () => Effect.die("must not prompt in-process"),
+          } as never),
+        ),
+      ) as Effect.Effect<unknown, unknown>,
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const error = exit.cause._tag === "Fail" ? exit.cause.error : undefined;
+      expect(isRunParkRequested(error)).toBe(true);
+      if (isRunParkRequested(error)) {
+        expect(error.pending).toMatchObject({
+          kind: "question",
+          toolCallId: "call_1",
+          request: { question: "What is your budget?" },
+        });
+      }
+    }
+  });
+
   it("passes a real answer through", async () => {
     const result = await ask({ kind: "answered", response: "next Tuesday at 3pm" });
     expect(result.success).toBe(true);
@@ -64,5 +98,82 @@ describe("ask_user_question", () => {
     expect(declined.result).toContain("do not pick an answer");
     expect(unavailable.result).toContain("Decide yourself");
     expect(declined.result).not.toBe(unavailable.result);
+  });
+});
+
+describe("ask_file_picker", () => {
+  it("parks an unattended run with the file picker request instead of auto-cancelling", async () => {
+    const effect = askFilePicker!.execute(
+      { message: "Pick the config file", extensions: ["json"] },
+      { agentId: "a", conversationId: "c", toolCallId: "call_2", parkWhenUnattended: true },
+    );
+    const exit = await Effect.runPromiseExit(
+      effect.pipe(
+        Effect.provide(
+          Layer.succeed(PresentationServiceTag, {
+            canPromptForApproval: () => false,
+            requestFilePicker: () => Effect.die("must not prompt in-process"),
+          } as never),
+        ),
+      ) as Effect.Effect<unknown, unknown>,
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const error = exit.cause._tag === "Fail" ? exit.cause.error : undefined;
+      expect(isRunParkRequested(error)).toBe(true);
+      if (isRunParkRequested(error)) {
+        expect(error.pending).toMatchObject({
+          kind: "file-picker",
+          toolCallId: "call_2",
+          request: { message: "Pick the config file" },
+        });
+      }
+    }
+  });
+
+  it("uses a resolved selection from a resumed run instead of prompting again", async () => {
+    const effect = askFilePicker!.execute(
+      { message: "Pick the config file" },
+      {
+        agentId: "a",
+        conversationId: "c",
+        toolCallId: "call_3",
+        resolvedFilePickers: new Map([["call_3", { kind: "selected", path: "/tmp/config.json" }]]),
+      },
+    ) as never as Effect.Effect<{ success: boolean; result: string }, never, never>;
+    const result = await Effect.runPromise(
+      effect.pipe(
+        Effect.provide(
+          Layer.succeed(PresentationServiceTag, {
+            requestFilePicker: () => Effect.die("must not prompt again once resolved"),
+          } as never),
+        ),
+      ) as Effect.Effect<{ success: boolean; result: string }, never, never>,
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("User selected: /tmp/config.json");
+  });
+
+  it("honors a resolved cancellation without prompting again", async () => {
+    const effect = askFilePicker!.execute(
+      { message: "Pick the config file" },
+      {
+        agentId: "a",
+        conversationId: "c",
+        toolCallId: "call_4",
+        resolvedFilePickers: new Map([["call_4", { kind: "cancelled" }]]),
+      },
+    ) as never as Effect.Effect<{ success: boolean; result: string }, never, never>;
+    const result = await Effect.runPromise(
+      effect.pipe(
+        Effect.provide(
+          Layer.succeed(PresentationServiceTag, {
+            requestFilePicker: () => Effect.die("must not prompt again once resolved"),
+          } as never),
+        ),
+      ) as Effect.Effect<{ success: boolean; result: string }, never, never>,
+    );
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("User cancelled file selection");
   });
 });

--- a/packages/core/src/agent/tools/user-interaction-tools.ts
+++ b/packages/core/src/agent/tools/user-interaction-tools.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { z } from "zod";
+import { RunParkRequested } from "@/core/agent/run/park-signal";
 import {
   PresentationServiceTag,
   type FilePickerRequest,
@@ -66,7 +67,7 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
     hidden: false,
     riskLevel: "read-only",
     validate: makeZodValidator(askUserSchema),
-    handler: (args: AskUserArgs) =>
+    handler: (args: AskUserArgs, context) =>
       Effect.gen(function* () {
         const presentation = yield* PresentationServiceTag;
 
@@ -76,6 +77,32 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
           allowCustom: true,
           allowMultiple: args.allow_multiple === true,
         };
+
+        const prior =
+          context.toolCallId === undefined
+            ? undefined
+            : context.resolvedUserInputs?.get(context.toolCallId);
+        if (prior !== undefined) {
+          if (prior.kind === "declined") {
+            return {
+              success: false,
+              result:
+                "The human saw this question and declined to answer. Treat that as their decision, not as a gap to fill: do not pick an answer for them.",
+            };
+          }
+          return { success: true, result: `User responded: ${prior.response}` };
+        }
+
+        if (context.parkWhenUnattended === true && presentation.canPromptForApproval?.() !== true) {
+          if (context.toolCallId === undefined) {
+            return { success: false, result: "The human cannot be reached from this run." };
+          }
+          return yield* Effect.fail(
+            new RunParkRequested({
+              pending: { kind: "question", request, toolCallId: context.toolCallId },
+            }),
+          );
+        }
 
         const outcome = yield* presentation.requestUserInput(request);
 
@@ -114,7 +141,7 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
     hidden: false,
     riskLevel: "read-only",
     validate: makeZodValidator(filePickerSchema),
-    handler: (args: FilePickerArgs) =>
+    handler: (args: FilePickerArgs, context) =>
       Effect.gen(function* () {
         const presentation = yield* PresentationServiceTag;
 
@@ -124,6 +151,31 @@ export const userInteractionTools: Tool<ToolRequirements>[] = [
           extensions: args.extensions,
           includeDirectories: args.include_directories === true,
         };
+
+        const prior =
+          context.toolCallId === undefined
+            ? undefined
+            : context.resolvedFilePickers?.get(context.toolCallId);
+        if (prior !== undefined) {
+          return {
+            success: true,
+            result:
+              prior.kind === "selected"
+                ? `User selected: ${prior.path}`
+                : "User cancelled file selection",
+          };
+        }
+
+        if (context.parkWhenUnattended === true && presentation.canPromptForApproval?.() !== true) {
+          if (context.toolCallId === undefined) {
+            return { success: false, result: "The human cannot be reached from this run." };
+          }
+          return yield* Effect.fail(
+            new RunParkRequested({
+              pending: { kind: "file-picker", request, toolCallId: context.toolCallId },
+            }),
+          );
+        }
 
         const selectedPath = yield* presentation.requestFilePicker(request);
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -156,6 +156,16 @@ export interface AgentRunnerOptions {
    * Approvals already answered, keyed by `toolCallId`. Set when resuming a parked run.
    */
   readonly resolvedApprovals?: ReadonlyMap<string, ApprovalOutcome>;
+  /** Answers supplied when resuming an ask_user_question parked in another process. */
+  readonly resolvedUserInputs?: ReadonlyMap<
+    string,
+    { readonly kind: "answered"; readonly response: string } | { readonly kind: "declined" }
+  >;
+  /** Selections supplied when resuming an ask_file_picker parked in another process. */
+  readonly resolvedFilePickers?: ReadonlyMap<
+    string,
+    { readonly kind: "selected"; readonly path: string } | { readonly kind: "cancelled" }
+  >;
   /**
    * This run is continuing a parked one. Its history already ends mid-turn, so no user
    * message is appended.

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -262,6 +262,18 @@ export interface ToolExecutionContext {
    * yesterday, and the executor uses the stored outcome instead of asking again.
    */
   readonly resolvedApprovals?: ReadonlyMap<string, ApprovalOutcome>;
+  /** Answers supplied by a human after a run parked on ask_user_question. */
+  readonly resolvedUserInputs?: ReadonlyMap<
+    string,
+    { readonly kind: "answered"; readonly response: string } | { readonly kind: "declined" }
+  >;
+  /** Selections supplied by a human after a run parked on ask_file_picker. */
+  readonly resolvedFilePickers?: ReadonlyMap<
+    string,
+    { readonly kind: "selected"; readonly path: string } | { readonly kind: "cancelled" }
+  >;
+  /** The individual call currently executing. Set on a per-call context copy. */
+  readonly toolCallId?: string;
   /**
    * Whether an unanswerable approval should park the run instead of declining it.
    *


### PR DESCRIPTION
## What & why
An unattended run that hit `ask_user_question` used to guess an answer, and one that hit `ask_file_picker` silently cancelled — neither ever reached a human. Both tools now park the run instead, the same way a risky tool call needing approval already does, so someone can answer the question or pick the file later, from another process, over the daemon's `/runs/:id/answer` endpoint or the `jazz runs` CLI.

## How to verify
- Start a headless/unattended run (`parkWhenUnattended`) whose agent calls `ask_user_question`; confirm the run parks with state `input-required` and the daemon's park payload includes the question, suggestions, and options instead of the model inventing an answer.
- Resume it via `POST /runs/:id/answer` with a `response` body field; confirm the run picks back up with that answer.
- Repeat for `ask_file_picker`: confirm an unattended call parks (rather than returning "cancelled"), and resuming with a `filePath` field completes the run with that selection; resuming with an empty `filePath` reports a cancellation instead.
- Confirm a run resumed twice for the same tool call (a race) rejects the second answer rather than replaying the tool twice.
