### PR TITLE
docs(concepts): document the daemon

### DIFF
--- a/docs/concepts/agent-to-agent.md
+++ b/docs/concepts/agent-to-agent.md
@@ -279,6 +279,7 @@ Grant `private` to nobody you would not hand an unlocked laptop.
 
 - [Setting up peers](../start/peers-setup.md) — a hands-on walkthrough, one machine first
 - [Agent-to-agent](./agent-to-agent.md) — becoming peers by sending a link, instead of a shared secret typed by hand
+- [Daemon](./daemon.md) — what `--serve-peers` turns on, and what else the same process serves
 - [Tools](./tools.md#what-each-tool-reveals) — the disclosure levels tiers are built on
 - [Lexicon](./lexicon.md) — peer, tier, ledger, run
 - [Security](../../SECURITY.md) — the threat model this sits inside

--- a/docs/concepts/daemon.md
+++ b/docs/concepts/daemon.md
@@ -1,0 +1,118 @@
+---
+description: "The daemon is what lets Jazz act without a terminal open: serving runs over HTTP, owning the schedule ticker, answering peers, and serving webhooks."
+---
+
+# Daemon — Jazz without a terminal attached
+
+`jazz chat` and `jazz run` are one process talking to one terminal. That's fine until you
+need something to happen when nobody's typing: a scheduled workflow firing at 6 AM, a
+webhook from GitHub landing at 2 PM, a run parked on an approval that the person who can
+answer it is on a different machine entirely.
+
+`jazz daemon` is that "something." It's the same agent runtime, but reachable over HTTP
+instead of a REPL, and able to sit there running with nobody attached.
+
+---
+
+## The short version
+
+```bash
+# Start it
+jazz daemon
+
+# From another terminal (or another machine): start a run
+curl -X POST http://localhost:4747/runs \
+  -d '{"agent":"default","prompt":"summarize today'\''s deploys"}'
+
+# Poll it
+curl http://localhost:4747/runs/<runId>
+
+# If it parked on an approval, answer it
+curl -X POST http://localhost:4747/runs/<runId>/answer -d '{"approved":true}'
+```
+
+`jazz runs` (list/show/approve/reject) is the same thing from the CLI, and works whether or
+not a daemon is involved — a daemon just means the run can be answered from somewhere other
+than the process that started it.
+
+---
+
+## What it actually does
+
+One process, four jobs, each opt-in:
+
+- **Serves runs over HTTP.** `POST /runs` starts one, `GET /runs/:id` polls it, `POST
+  /runs/:id/answer` approves or rejects what it's parked on, `GET /runs` lists what's in
+  flight. This is the only way to answer a parked run from a different process than the one
+  that started it.
+- **Owns the schedule ticker**, if `scheduler.mode` is set to `in-process`. Workflow
+  schedules normally ride your OS scheduler (`launchd`/`cron`), which only fires while the
+  machine is awake; the daemon's own ticker is the alternative for a host you mean to leave
+  running. See [Scheduling](./scheduling.md).
+- **Answers peers**, if started with `--serve-peers <agentId>`. `POST /peer/ask` and `POST
+  /a2a` both need a running daemon to have anyone to ask — without it, your agent can still
+  ask *other* peers, but nobody can ask yours. See [Peers](./agent-to-agent.md).
+- **Serves webhooks.** `POST /webhooks/<name>` wakes the agent that webhook is configured
+  for. See [Webhooks](./webhooks.md).
+
+It's also the fallback ticker for [wake triggers](../reference/tools.md#wake-triggers): a
+trigger normally fires via a one-shot `launchd`/`at` job the host schedules directly, with
+no daemon required. The daemon's in-process ticker only matters on a host with neither
+(most containers).
+
+None of this needs all of it. A daemon started plain, with no flags, only serves runs and —
+if `scheduler.mode` is `in-process` — ticks workflows. Peers and webhooks activate on top of
+that, not instead of it.
+
+---
+
+## Authentication
+
+`GET /health` is unauthenticated on purpose — a process supervisor should be able to check
+that the daemon is alive without holding a credential that can drive an agent.
+
+Everything else needs a bearer token, but only when it matters: binding to `127.0.0.1` (the
+default) needs no token at all, since reaching it already means being on the machine.
+Binding anywhere else does. The first time a daemon binds a non-loopback host with no token
+already set, Jazz generates one, stores it (OS keyring, or a `chmod 600`
+`$JAZZ_HOME/secrets.json` where there's no keyring), and prints it once so you can copy it to
+a client.
+
+```bash
+jazz daemon set-token      # generate (or store $JAZZ_DAEMON_TOKEN) ahead of the daemon's first run
+jazz daemon forget-token   # remove it
+```
+
+Set `$JAZZ_DAEMON_TOKEN` yourself instead of letting Jazz generate one when the value needs
+to be known in advance — a client config written before the daemon has ever run, or an
+ephemeral container whose `$JAZZ_HOME` won't survive to the next deploy.
+
+Peers and webhooks don't use this token — each has its own, checked separately, because a
+credential that can start and approve runs is a much bigger grant than one that can only
+ask a question or fire one fixed prompt.
+
+---
+
+## Running it persistently
+
+`jazz daemon` runs in the foreground. Restarting it on crash and starting it on boot is your
+host's job, not the daemon's — that's what a process supervisor is for. `jazz daemon
+install` wires it into your OS's supervisor (`systemd` on Linux, `launchd` on macOS) instead
+of leaving that hand-written:
+
+```bash
+sudo jazz daemon install --serve-peers my-agent
+sudo jazz daemon uninstall
+```
+
+Both need root, and `install` doesn't report success until `/health` actually answers.
+
+---
+
+## Related
+
+- [Scheduling](./scheduling.md) — the ticker the daemon owns in `in-process` mode
+- [Peers](./agent-to-agent.md) — what `--serve-peers` turns on, and its own credential model
+- [Webhooks](./webhooks.md) — the other thing a daemon serves
+- [CLI reference → `jazz daemon`](../reference/cli.md#jazz-daemon) — every flag and command
+- [Lexicon](./lexicon.md) — run, park, approval

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -12,6 +12,7 @@ Understand the building blocks of Jazz.
 - **[Tools](./tools.md)**: What agents can actually do, and what the risk tiers mean.
 - **[Workflows](./workflows.md)**: Multi-step procedures that can be automated.
 - **[Scheduling](./scheduling.md)**: Automate workflows to run on a schedule.
+- **[Daemon](./daemon.md)**: Serving runs, schedules, peers, and webhooks without a terminal attached.
 - **[Lexicon](./lexicon.md)**: What each of Jazz's words means, and which two are not the same thing.
 - **[Agent-to-agent](./agent-to-agent.md)**: Becoming peers by sending a link, instead of typing a shared secret onto two machines by hand.
 - **[Webhooks](./webhooks.md)**: Letting any HTTP-capable system wake an agent with a fixed prompt, one-shot or threaded.

--- a/docs/concepts/scheduling.md
+++ b/docs/concepts/scheduling.md
@@ -319,6 +319,7 @@ jazz workflow history market-analysis
 - [Creating Workflows](./workflows.md#quick-start)
 - [Troubleshooting Workflows](./workflows.md#troubleshooting)
 - [Airgapped & Self-Hosted](../start/airgapped.md)
+- [Daemon](./daemon.md) — what owns the `in-process` ticker, and everything else it serves
 
 ---
 

--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -167,3 +167,4 @@ when it parked.
   from someone else's agent, under disclosure tiers.
 - [Scheduling](./scheduling.md) — for work that runs on a clock rather than on an event, and
   home of the unrelated wake triggers.
+- [Daemon](./daemon.md) — what's actually serving `/webhooks/<name>`, and what else it does.


### PR DESCRIPTION
## What & why
The daemon (`jazz daemon`) is what lets Jazz serve runs, workflow schedules, peers, and webhooks without a terminal attached — but it was never documented as a concept, only as a flag reference. This adds a proper concepts page explaining what it is and when you'd run one, and links it in from the pages that already depended on it (scheduling, webhooks, peers) without ever explaining it.

## How to verify
- Read `docs/concepts/daemon.md` cold — it should explain what the daemon does and why without needing the CLI reference open.
- Check `docs/concepts/index.md` lists the new page alongside the other core concepts.
- Follow the new "Related" links from `scheduling.md`, `webhooks.md`, and `agent-to-agent.md` back to `daemon.md` and confirm they land correctly.
