### PR TITLE
feat(daemon): GET /agents, so a caller can choose one

### DIFF
--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { createRunRecord } from "@jazz/core/agent/run/run-record";
+import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
+import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
+import type { Agent } from "@jazz/core/types/agent";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
 import { describe, expect, it } from "bun:test";
@@ -33,6 +36,37 @@ function runnerFor(store: InMemoryRunStore) {
 
 function request(method: string, path: string, init?: RequestInit): Request {
   return new Request(`http://localhost${path}`, { method, ...init });
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "uGS8WAv4cGBiFH1wHB7r4E",
+    name: "sonnet",
+    description: "everyday assistant",
+    config: {
+      persona: "default",
+      llmProvider: "anthropic",
+      llmModel: "claude-sonnet-4-6",
+      tools: ["read_file", "http_request"],
+      llmApiKeys: { anthropic: "sk-must-not-leak" },
+    },
+    createdAt: new Date("2026-09-01T00:00:00Z"),
+    updatedAt: new Date("2026-09-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+/** Only `listAgents` is reachable from the route under test. */
+function runnerForAgents(agents: readonly Agent[]) {
+  const service = { listAgents: () => Effect.succeed(agents) } as unknown as AgentService;
+  return <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>): Promise<A> =>
+    Effect.runPromise(
+      effect.pipe(Effect.provideService(AgentServiceTag, service)) as Effect.Effect<
+        A,
+        never,
+        never
+      >,
+    );
 }
 
 describe("refusing an unsafe bind", () => {
@@ -406,5 +440,84 @@ describe("which conversation a webhook fire belongs to", () => {
 
     expect(resolved).toStartWith(path.resolve(getJazzHomeDirectory(), "work") + path.sep);
     expect(resolved).not.toContain("etc/pwned");
+  });
+});
+
+describe("listing the agents a daemon can run", () => {
+  it("answers with the fields somebody choosing between them needs", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([agentFixture()]));
+
+    const response = await handle(request("GET", "/agents"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      agents: {
+        id: string;
+        name: string;
+        description?: string;
+        persona: string;
+        provider: string;
+        model: string;
+        tools: string[];
+      }[];
+    };
+    expect(body.ok).toBe(true);
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0]).toEqual({
+      id: "uGS8WAv4cGBiFH1wHB7r4E",
+      name: "sonnet",
+      description: "everyday assistant",
+      persona: "default",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      tools: ["read_file", "http_request"],
+    });
+  });
+
+  it("never hands out an agent's api keys", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([agentFixture()]));
+
+    const response = await handle(request("GET", "/agents"));
+    expect(await response.text()).not.toContain("sk-must-not-leak");
+  });
+
+  it("omits a description rather than sending an empty one", async () => {
+    // Built without the field rather than with it set to undefined, which
+    // exactOptionalPropertyTypes rightly refuses.
+    const { description: _unused, ...withoutDescription } = agentFixture();
+    const handle = makeHandler(LOOPBACK, runnerForAgents([withoutDescription]));
+
+    const response = await handle(request("GET", "/agents"));
+    const body = (await response.json()) as { agents: Record<string, unknown>[] };
+    expect(body.agents[0]).not.toHaveProperty("description");
+  });
+
+  it("reports an agent with no tools as having none, not as missing a field", async () => {
+    const bare = agentFixture({
+      config: { persona: "default", llmProvider: "openai", llmModel: "gpt-5.4-mini" },
+    } as Partial<Agent>);
+    const handle = makeHandler(LOOPBACK, runnerForAgents([bare]));
+
+    const response = await handle(request("GET", "/agents"));
+    const body = (await response.json()) as { agents: { tools: string[] }[] };
+    expect(body.agents[0]?.tools).toEqual([]);
+  });
+
+  it("needs the daemon token when one is configured, like every other route", async () => {
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([agentFixture()]));
+
+    expect((await handle(request("GET", "/agents"))).status).toBe(401);
+    const authorized = await handle(
+      request("GET", "/agents", { headers: { authorization: "Bearer s3cret" } }),
+    );
+    expect(authorized.status).toBe(200);
+  });
+
+  it("answers an empty list rather than a 404 when there are no agents", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/agents"));
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as { agents: unknown[] }).agents).toEqual([]);
   });
 });

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -25,6 +25,7 @@ import { isRunParkRequested } from "@jazz/core/agent/run/park-signal";
 import { resumeRun, type ResumeRunOptions } from "@jazz/core/agent/run/resume";
 import type { PendingInput } from "@jazz/core/agent/run/run-state";
 import type { AgentConfigService } from "@jazz/core/interfaces/agent-config";
+import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
@@ -217,6 +218,10 @@ export function makeHandler(
 
     if (request.method === "GET" && url.pathname === "/runs") {
       return runEffect(listRuns());
+    }
+
+    if (request.method === "GET" && url.pathname === "/agents") {
+      return runEffect(listAgents());
     }
 
     return json({ ok: false, error: "not found" }, 404);
@@ -881,6 +886,31 @@ function listRuns() {
     yield* store.prune({ now: new Date(), maxTerminalAgeMs: TERMINAL_RETENTION_MS });
     const runs = yield* store.list();
     return json({ ok: true, runs });
+  });
+}
+
+/**
+ * The agents this daemon can run, for a caller choosing between them.
+ *
+ * Fields are projected one by one rather than returning the stored agent, because
+ * `AgentConfig` carries `llmApiKeys` and a list endpoint is no place to hand those out.
+ */
+function listAgents() {
+  return Effect.gen(function* () {
+    const agentService = yield* AgentServiceTag;
+    const agents = yield* agentService.listAgents();
+    return json({
+      ok: true,
+      agents: agents.map((agent) => ({
+        id: agent.id,
+        name: agent.name,
+        ...(agent.description !== undefined ? { description: agent.description } : {}),
+        persona: agent.config.persona,
+        provider: agent.config.llmProvider,
+        model: agent.config.llmModel,
+        tools: agent.config.tools ?? [],
+      })),
+    });
   });
 }
 


### PR DESCRIPTION
## What & why

The daemon can run any agent by identifier but has no way to say which agents exist. Anything that wants to offer a choice — a picker in a bridge, a setup wizard, a bot's `/agents` command — has to read `~/.jazz/agents/*.json` itself and work out the storage layout, which couples it to internals that are free to change and breaks the moment someone points `storage.path` elsewhere.

`GET /agents` answers it: id, name, description, persona, provider, model, tools.

Fields are projected one at a time rather than returning the stored agent, because `AgentConfig` carries `llmApiKeys` and a list endpoint is no place to hand those out. A test asserts the response body cannot contain a key.

It sits behind the same `authorized` gate as `/runs`, so a loopback daemon needs no token and a daemon bound anywhere else needs the one it already requires.

The immediate caller is quartet, whose setup asked "which jazz agent should represent you? [default]" and took free text — and `default` is a persona name, so it matched no agent and wrote a webhook pointing at nothing.

## How to verify

- `jazz daemon`, then `curl -s localhost:4747/agents | jq` — every agent, with provider, model and tools.
- `grep -c llmApiKeys` over that output should be 0, including for an agent with a per-agent key set.
- An agent with no tools should report `"tools": []`, not omit the field.
- With a token configured (`jazz daemon --host 0.0.0.0` and a daemon token), the route should 401 without it and 200 with it.
- No agents at all should give `{"ok":true,"agents":[]}`, not a 404.
- `bun test packages/adapters/src/daemon/`
