### PR TITLE
fix(tools): a batch decides its approvals before it runs any of them

### DIFF
--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -705,9 +705,106 @@ export class ToolExecutor {
       yield* logger.info(`${agentName} is using tools: ${toolsList}`);
 
       const approvalSet = new Set(toolsRequiringApproval);
-      // Only a lone tool call can park. In a batch a sibling may already have executed, and
-      // resuming replays the batch — which would repeat that sibling's effects.
-      const parkable = context.parkWhenUnattended === true && toolCalls.length === 1;
+
+      /**
+       * Park the whole batch before any of it runs, if anything in it needs a person.
+       *
+       * Parking used to be allowed only for a lone tool call, because resuming replays the
+       * batch and a sibling that had already executed would run twice. The consequence was
+       * that a batch went to a presentation which cannot ask anybody — and quiet mode
+       * declines — so an agent that asked to run two commands at once had both silently
+       * refused, with the run reporting success. That is what a webhook caller saw as
+       * nothing happening and no approval to answer.
+       *
+       * The hazard is narrower than "a batch". An approval tool's own call has no side
+       * effect: it returns the request and the effect happens in the execute tool afterwards.
+       * So parking is safe as long as it happens before anything executes, which is what
+       * deciding here rather than inside each fiber buys. Every round either parks having
+       * run nothing, or has every approval in hand and runs the batch once.
+       */
+      const parkTheBatch = Effect.gen(function* () {
+        if (context.parkWhenUnattended !== true) return undefined;
+        if (presentationService.canPromptForApproval?.() === true) return undefined;
+
+        const needsAnswering: ToolCall[] = [];
+        let firstRequest: Parameters<typeof presentationService.requestApproval>[0] | undefined;
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          if (!approvalSet.has(name)) continue;
+          if (context.resolvedApprovals?.get(toolCall.id) !== undefined) continue;
+
+          let args: Record<string, unknown> = {};
+          try {
+            const parsed: unknown = JSON.parse(toolCall.function.arguments);
+            if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+              args = parsed as Record<string, unknown>;
+            }
+          } catch {
+            // Unparseable arguments are the per-call path's error to report, not this one's.
+            continue;
+          }
+          // Side-effect free for an approval tool: this is the call that builds the request.
+          const probe = yield* ToolExecutor.executeTool(name, args, {
+            ...context,
+            toolCallId: toolCall.id,
+          }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+          if (probe === undefined || !isApprovalRequiredResult(probe.result)) continue;
+
+          const request = probe.result;
+          const toolInfo = yield* registry
+            .getTool(name)
+            .pipe(Effect.catchAll(() => Effect.succeed({ riskLevel: "high-risk" as const })));
+          const autoApproved =
+            shouldAutoApprove(toolInfo.riskLevel, context.getAutoApprovePolicy?.(), {
+              canPrompt: false,
+            }) ||
+            isToolNameAutoApproved(name, context.autoApprovedTools) ||
+            isCommandAutoApproved(name, request.executeArgs, context.autoApprovedCommands);
+          if (autoApproved) continue;
+
+          needsAnswering.push(toolCall);
+          if (needsAnswering.length === 1) {
+            firstRequest = {
+              toolCallId: toolCall.id,
+              toolName: name,
+              message: request.message,
+              executeToolName: request.executeToolName,
+              executeArgs: request.executeArgs,
+              isAutoApproved: () => false,
+            };
+          }
+        }
+
+        if (needsAnswering.length === 0 || firstRequest === undefined) return undefined;
+
+        // More than one unanswered approval in one batch cannot be parked yet. Resume
+        // rebuilds `resolvedApprovals` from the single answer it was handed, so answering
+        // the first would park on the second, and answering that would park on the first
+        // again — a loop, which is worse than the decline this replaces. Accumulating
+        // answers across resumes is the fix and it changes the run record's shape.
+        if (needsAnswering.length > 1) {
+          yield* logger.warn("Refusing a batch that needs more than one approval", {
+            toolCalls: needsAnswering.map((toolCall) => toolCall.function.name),
+          });
+          return new Error(
+            `this turn asked to run ${String(needsAnswering.length)} tools needing approval at ` +
+              `once (${needsAnswering.map((toolCall) => toolCall.function.name).join(", ")}), ` +
+              "and only one can be approved per turn — nothing was run",
+          );
+        }
+
+        yield* logger.info("Parking run: approval needed and nobody can answer in-process", {
+          toolName: firstRequest.toolName,
+          toolCallId: firstRequest.toolCallId,
+          batchSize: toolCalls.length,
+        });
+        return new RunParkRequested({
+          pending: { kind: "tool-approval", request: firstRequest },
+        });
+      });
+
+      const park = yield* parkTheBatch;
+      if (park !== undefined) return yield* Effect.fail(park);
 
       // Limit concurrency to prevent resource exhaustion when many tools are requested.
       // Forked as daemon fibers (not structured children of this generator) so a
@@ -728,7 +825,6 @@ export class ToolExecutor {
               agentId,
               conversationId,
               approvalSet,
-              parkable,
             ),
           ),
         ),

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -53,7 +53,21 @@ const TOOL_CALL = {
 /** Set by the execute tool, so the test can prove the side effect happened exactly once. */
 let executions: string[] = [];
 
-function makeLayers(store: InMemoryRunStore) {
+/** A second gated call, so a batch of two approvals can be asked for. */
+const SECOND_TOOL_CALL = {
+  id: "call_park_2",
+  type: "function" as const,
+  function: { name: "danger", arguments: JSON.stringify({ target: "/tmp/y" }) },
+};
+
+/** An ungated call, to sit beside a gated one. Runs on sight, which is the whole hazard. */
+const SAFE_TOOL_CALL = {
+  id: "call_safe_1",
+  type: "function" as const,
+  function: { name: "harmless", arguments: JSON.stringify({}) },
+};
+
+function makeLayers(store: InMemoryRunStore, firstTurnCalls = [TOOL_CALL]) {
   // First completion asks for the gated tool; every later one answers in text. A resumed
   // run must therefore reach the *second* response, which it can only do once the parked
   // tool call has a result.
@@ -61,7 +75,7 @@ function makeLayers(store: InMemoryRunStore) {
   const completion = (): ChatCompletionResponse => {
     completions += 1;
     return completions === 1
-      ? { id: "c1", model: "gpt-4", content: "", toolCalls: [TOOL_CALL] }
+      ? { id: "c1", model: "gpt-4", content: "", toolCalls: firstTurnCalls }
       : { id: "c2", model: "gpt-4", content: "Done." };
   };
 
@@ -279,5 +293,78 @@ describe("park and resume, through the real loop", () => {
     expect(executions).toEqual([]);
     if (exit._tag === "Failure") return;
     expect(isRunParkRequested(exit.value)).toBe(false);
+  });
+});
+
+describe("a batch of gated calls, with nobody in the room to answer", () => {
+  it("parks on the gated one without letting its ungated sibling run", async () => {
+    // A batch used to be unparkable at all, for a real reason: resuming replays it, so a
+    // sibling that had already executed would run twice. Deciding before anything is forked
+    // removes that — nothing has run by the time the run parks, so the replay is clean.
+    executions = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [SAFE_TOOL_CALL, TOOL_CALL]);
+
+    const exit = await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "do one of each",
+        conversationId: "conv-batch",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+    );
+
+    expect(exit._tag).toBe("Failure");
+    // The ungated tool did not run. Before this it would have, and then again on resume.
+    expect(executions).toEqual([]);
+
+    const parked = (await Effect.runPromise(store.list()))[0];
+    if (parked?.state.kind !== "input-required") throw new Error("expected a parked run");
+    if (parked.state.pending.kind !== "tool-approval") throw new Error("expected an approval");
+    expect(parked.state.pending.request.toolCallId).toBe(TOOL_CALL.id);
+
+    // Approving it finishes the batch, and each tool runs exactly once.
+    const resumeExit = await Effect.runPromiseExit(
+      resumeRun({
+        runId: parked.runId,
+        outcome: { kind: "approval", value: { approved: true } },
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+    );
+    expect(resumeExit._tag).toBe("Success");
+    expect(executions.filter((name) => name === "danger_execute")).toHaveLength(1);
+    expect(executions.filter((name) => name === "harmless")).toHaveLength(1);
+  });
+
+  it("says so plainly when it needs more than one approval, and runs nothing", async () => {
+    // Two unanswered approvals in one batch cannot be parked yet: resume rebuilds its
+    // resolved answers from the single one it is handed, so answering the first would park
+    // on the second and answering that would park on the first again. Accumulating answers
+    // across resumes is the fix, and it changes the run record's shape.
+    //
+    // Until then this fails visibly. Before, the decision fell through to whatever
+    // presentation the process happened to have: one that declines refuses both silently,
+    // one that approves runs both without asking. Neither answer reached the caller, and
+    // for a webhook that caller is the only person there is.
+    executions = [];
+    const store = new InMemoryRunStore();
+
+    const exit = await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "do both gated things",
+        conversationId: "conv-batch-2",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]))) as Effect.Effect<
+        unknown,
+        unknown
+      >,
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(executions).toEqual([]);
+    // And it is not parked, because nobody could answer it into a finished state.
+    expect(await Effect.runPromise(store.list())).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What & why

On an unattended run (say, behind a webhook), you were only ever asked to approve a tool if it was the **only** tool the model asked for that turn. A second tool call of any kind in the same turn silently disabled asking — for every tool in it. The request went to a code path with no human behind it, and the run finished as if a decision had been made.

Now the run pauses before any of those tools execute, so you get asked.

## Known limit

If two tools in the same turn *both* need approval, it still can't pause — it now fails and names them instead of deciding for you. Making that work needs a change to how a resumed run remembers earlier answers, which is its own PR.

## How to verify

- Ask an unattended agent for one approval-needing tool plus one that needs none. You should be asked, and the second tool must not have run yet. Approve: both then run, once each.
- Same turn with two approval-needing tools: the run fails naming both, and neither runs.
- A turn with a single approval-needing tool: unchanged.
- `bun test packages/core/src/agent/run/park-resume.integration.test.ts`
