### PR TITLE
feat(daemon): tell a webhook caller what the run is doing

### DIFF
--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -147,38 +147,74 @@ curl -X POST http://localhost:4747/webhooks/room \
   -d 'what is in my calendar on Thursday?'
 ```
 
-Each event is a `POST` of one JSON object:
+Every event is a `POST` of one JSON object to that URL.
 
-| field | |
-|---|---|
-| `kind` | `tool-started`, `tool-finished`, or `approval-required` |
-| `toolName` | the tool it concerns |
-| `toolCallId` | which call, when the model asked for several at once |
-| `ok` | on `tool-finished` only: whether the call succeeded |
+### The events
 
-`approval-required` means the run has stopped and is waiting for a person — the fire is about
-to answer `202` with a `runId` you can answer through
-[`POST /runs/:id/answer`](daemon.md).
+| `kind` | Sent when | Also carries |
+|---|---|---|
+| `tool-started` | a tool call begins | — |
+| `tool-finished` | that call returns | `ok` |
+| `approval-required` | the run has stopped and needs a person | — |
 
-To receive only some kinds, name them:
+Every event carries `kind`, `toolName`, and `toolCallId`. The id is the model's own id for
+that call, so a turn asking for several tools at once gives you a distinct id per call and
+`tool-started` can be paired with its `tool-finished`.
+
+A tool beginning:
+
+```json
+{ "kind": "tool-started", "toolName": "read_file", "toolCallId": "call_zx1" }
+```
+
+The same call returning. `ok` is `false` whenever the call did not succeed — an error, a
+timeout, or an approval that was declined:
+
+```json
+{ "kind": "tool-finished", "toolName": "read_file", "toolCallId": "call_zx1", "ok": true }
+```
+
+And a run that has stopped for a person:
+
+```json
+{ "kind": "approval-required", "toolName": "execute_command", "toolCallId": "call_zx2" }
+```
+
+That last one is the useful one to act on. It means the fire is about to answer `202` with a
+`runId`, and the run stays parked until somebody answers it through
+[`POST /runs/:id/answer`](daemon.md). Nothing in the batch has run yet at that point.
+
+### Choosing which events
+
+Leave the header off and you get all of them, including kinds added in later versions —
+handing over a URL is already the act of subscribing. To narrow it, name the kinds you want,
+comma-separated:
+
+```bash
+  -H "X-Jazz-Progress-Events: tool-started,tool-finished,approval-required"
+```
+
+That example is the full list, so it is the same as sending no header at all. A caller that
+only wants to know when it is being asked something would send:
 
 ```bash
   -H "X-Jazz-Progress-Events: approval-required"
 ```
 
-A few details worth knowing:
+### Details worth knowing
 
 - **The URL must be on localhost.** Anywhere else is refused with a `400`. Posting to an
   address the caller chose would let it use jazz to make requests on its behalf.
-- **Leaving the events header off means all of them,** including kinds added in later
-  versions. Handing over a URL is already the act of subscribing.
 - **An event kind jazz does not send is refused** with a `400` naming it, rather than
   ignored. A caller that misspelled one would otherwise wait forever for something never
-  sent.
+  sent. The `400` lists the kinds this version does send.
 - **Reporting never affects the run.** A listener that is slow, gone, or returning errors
   cannot fail a turn or hold up a tool call — events are posted and forgotten.
-- **There is no replay.** An event posted while nothing was listening is lost. The fire's
-  own answer is the thing to rely on; this is for watching, not for bookkeeping.
+- **There is no replay and no ordering guarantee.** An event posted while nothing was
+  listening is lost, and two tools running at once report as they go. The fire's own answer
+  is the thing to rely on; this is for watching, not for bookkeeping.
+- **Tools that need no approval are reported too.** These events say what the agent is
+  doing, not what it is asking permission for.
 
 ---
 

--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -132,6 +132,56 @@ A few details worth knowing:
 
 ---
 
+## Watching a run while it happens
+
+A fire answers once, when the run is finished. For a turn that reads a calendar and searches
+the web that is minutes of silence, and a caller has no way to tell a slow run from a broken
+one.
+
+Give it somewhere to report to and it will say what it is doing:
+
+```bash
+curl -X POST http://localhost:4747/webhooks/room \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Jazz-Progress-Url: http://127.0.0.1:7777/progress/abc123" \
+  -d 'what is in my calendar on Thursday?'
+```
+
+Each event is a `POST` of one JSON object:
+
+| field | |
+|---|---|
+| `kind` | `tool-started`, `tool-finished`, or `approval-required` |
+| `toolName` | the tool it concerns |
+| `toolCallId` | which call, when the model asked for several at once |
+| `ok` | on `tool-finished` only: whether the call succeeded |
+
+`approval-required` means the run has stopped and is waiting for a person — the fire is about
+to answer `202` with a `runId` you can answer through
+[`POST /runs/:id/answer`](daemon.md).
+
+To receive only some kinds, name them:
+
+```bash
+  -H "X-Jazz-Progress-Events: approval-required"
+```
+
+A few details worth knowing:
+
+- **The URL must be on localhost.** Anywhere else is refused with a `400`. Posting to an
+  address the caller chose would let it use jazz to make requests on its behalf.
+- **Leaving the events header off means all of them,** including kinds added in later
+  versions. Handing over a URL is already the act of subscribing.
+- **An event kind jazz does not send is refused** with a `400` naming it, rather than
+  ignored. A caller that misspelled one would otherwise wait forever for something never
+  sent.
+- **Reporting never affects the run.** A listener that is slow, gone, or returning errors
+  cannot fail a turn or hold up a tool call — events are posted and forgotten.
+- **There is no replay.** An event posted while nothing was listening is lost. The fire's
+  own answer is the thing to rely on; this is for watching, not for bookkeeping.
+
+---
+
 ## What a fire can and cannot do
 
 The agent runs with whatever tools its own configuration gives it — a webhook does not widen

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -4,7 +4,7 @@ import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
 import type { Agent } from "@jazz/core/types/agent";
-import { isLoopbackProgressUrl } from "@jazz/core/types/webhook";
+import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
 import { describe, expect, it } from "bun:test";
@@ -574,5 +574,60 @@ describe("a webhook caller that wants to know what the run is doing", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("loopback");
+  });
+});
+
+describe("choosing which progress events to receive", () => {
+  it("treats a missing or empty list as every kind", () => {
+    // Handing over a URL is already the act of subscribing; a caller that wants the lot
+    // should not have to enumerate it.
+    for (const raw of [null, "", "  ", ",,"]) {
+      const parsed = parseProgressEvents(raw);
+      if ("unknownKind" in parsed) throw new Error("expected kinds");
+      expect(parsed.kinds.size, JSON.stringify(raw)).toBe(3);
+    }
+  });
+
+  it("narrows to what was asked for", () => {
+    const parsed = parseProgressEvents("approval-required, tool-started");
+    if ("unknownKind" in parsed) throw new Error("expected kinds");
+
+    expect([...parsed.kinds].sort()).toEqual(["approval-required", "tool-started"]);
+    expect(parsed.kinds.has("tool-finished")).toBe(false);
+  });
+
+  it("names a kind it does not know rather than dropping it", () => {
+    // A caller that misspelled one would otherwise wait forever for events never sent.
+    const parsed = parseProgressEvents("tool-startd");
+    expect(parsed).toEqual({ unknownKind: "tool-startd" });
+  });
+
+  it("refuses the fire, so the caller finds out before the run goes ahead", async () => {
+    const webhook: WebhookConfig = {
+      name: "quartet",
+      agentId: "agt_1",
+      promptTemplate: "{{payload}}",
+    };
+    const handle = makeWebhookHandler(
+      async () => [webhook],
+      async () => "hook-token",
+      async () => {
+        throw new Error("a bad subscription must not reach the runner");
+      },
+    );
+
+    const response = await handle(
+      request("POST", "/webhooks/quartet", {
+        body: "{}",
+        headers: {
+          authorization: "Bearer hook-token",
+          "x-jazz-progress-url": "http://127.0.0.1:7777/p",
+          "x-jazz-progress-events": "tool-started,nonsense",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("nonsense");
   });
 });

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -4,6 +4,7 @@ import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
 import type { Agent } from "@jazz/core/types/agent";
+import { isLoopbackProgressUrl } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
 import { describe, expect, it } from "bun:test";
@@ -519,5 +520,59 @@ describe("listing the agents a daemon can run", () => {
     const response = await handle(request("GET", "/agents"));
     expect(response.status).toBe(200);
     expect(((await response.json()) as { agents: unknown[] }).agents).toEqual([]);
+  });
+});
+
+describe("a webhook caller that wants to know what the run is doing", () => {
+  it("accepts a loopback progress url", () => {
+    for (const url of [
+      "http://127.0.0.1:7777/progress",
+      "http://localhost:7777/progress",
+      "https://localhost:8443/progress",
+      "http://[::1]:7777/progress",
+    ]) {
+      expect(isLoopbackProgressUrl(url), url).toBe(true);
+    }
+  });
+
+  it("refuses anywhere else, so a caller cannot make jazz knock on doors for them", () => {
+    for (const url of [
+      "http://example.com/progress",
+      "http://169.254.169.254/latest/meta-data",
+      "http://10.0.0.5/progress",
+      "file:///etc/passwd",
+      "not a url",
+      "",
+    ]) {
+      expect(isLoopbackProgressUrl(url), url).toBe(false);
+    }
+  });
+
+  it("tells a caller its progress url was rejected rather than ignoring it", async () => {
+    const webhook: WebhookConfig = {
+      name: "quartet",
+      agentId: "agt_1",
+      promptTemplate: "{{payload}}",
+    };
+    const handle = makeWebhookHandler(
+      async () => [webhook],
+      async () => "hook-token",
+      async () => {
+        throw new Error("a rejected progress url must not reach the runner");
+      },
+    );
+
+    const response = await handle(
+      request("POST", "/webhooks/quartet", {
+        body: "{}",
+        headers: {
+          authorization: "Bearer hook-token",
+          "x-jazz-progress-url": "http://example.com/steal",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("loopback");
   });
 });

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -37,8 +37,12 @@ import type { WebhookConfig } from "@jazz/core/types/webhook";
 import {
   isLoopbackProgressUrl,
   MAX_WEBHOOK_THREAD_KEY_LENGTH,
+  parseProgressEvents,
+  TOOL_PROGRESS_KINDS,
+  WEBHOOK_PROGRESS_EVENTS_HEADER,
   WEBHOOK_PROGRESS_HEADER,
   WEBHOOK_THREAD_HEADER,
+  type ToolProgressKind,
 } from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
@@ -630,12 +634,26 @@ export function makeWebhookHandler(
       return json({ ok: false, error: `${WEBHOOK_PROGRESS_HEADER} must be a loopback URL` }, 400);
     }
 
+    const wanted = parseProgressEvents(request.headers.get(WEBHOOK_PROGRESS_EVENTS_HEADER));
+    if ("unknownKind" in wanted) {
+      return json(
+        {
+          ok: false,
+          error:
+            `${WEBHOOK_PROGRESS_EVENTS_HEADER} names no such event "${wanted.unknownKind}" — ` +
+            `this jazz sends ${TOOL_PROGRESS_KINDS.join(", ")}`,
+        },
+        400,
+      );
+    }
+
     return runEffect(
       fireWebhook(
         webhook,
         truncated,
         threadKey.length > 0 ? threadKey : undefined,
         progressUrl.length > 0 ? progressUrl : undefined,
+        wanted.kinds,
       ),
     );
   };
@@ -688,7 +706,12 @@ export function webhookConversationId(
  * Fire-and-forget on purpose: a caller that has stopped listening, or is slow, must not
  * fail somebody's turn or hold a tool call open behind it.
  */
-function reportProgress(progressUrl: string, event: ToolProgressEvent): void {
+function reportProgress(
+  progressUrl: string,
+  wanted: ReadonlySet<ToolProgressKind>,
+  event: ToolProgressEvent,
+): void {
+  if (!wanted.has(event.kind)) return;
   void fetch(progressUrl, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -702,6 +725,7 @@ function fireWebhook(
   payload: string,
   threadKey?: string,
   progressUrl?: string,
+  wantedProgress: ReadonlySet<ToolProgressKind> = new Set(TOOL_PROGRESS_KINDS),
 ) {
   return Effect.gen(function* () {
     const agent = yield* getAgentByIdentifier(webhook.agentId);
@@ -730,7 +754,10 @@ function fireWebhook(
       conversationId,
       parkWhenUnattended: true,
       ...(progressUrl !== undefined
-        ? { onToolEvent: (event: ToolProgressEvent) => reportProgress(progressUrl, event) }
+        ? {
+            onToolEvent: (event: ToolProgressEvent) =>
+              reportProgress(progressUrl, wantedProgress, event),
+          }
         : {}),
       ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
     });

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -32,8 +32,14 @@ import { RunStoreTag } from "@jazz/core/interfaces/run-store";
 import type { ToolRegistry, ToolRequirements } from "@jazz/core/interfaces/tool-registry";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
+import type { ToolProgressEvent } from "@jazz/core/types/tools";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
-import { MAX_WEBHOOK_THREAD_KEY_LENGTH, WEBHOOK_THREAD_HEADER } from "@jazz/core/types/webhook";
+import {
+  isLoopbackProgressUrl,
+  MAX_WEBHOOK_THREAD_KEY_LENGTH,
+  WEBHOOK_PROGRESS_HEADER,
+  WEBHOOK_THREAD_HEADER,
+} from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
 import { buildPublicAgentCard, handleA2ARpc, normalizeProtocolVersion } from "@/adapters/peers/a2a";
@@ -616,7 +622,22 @@ export function makeWebhookHandler(
       );
     }
 
-    return runEffect(fireWebhook(webhook, truncated, threadKey.length > 0 ? threadKey : undefined));
+    // A caller with somewhere to listen gets told what the run is doing. Refused outright
+    // rather than quietly ignored when it is not loopback, because a caller that believes
+    // it is subscribed would otherwise wait forever for events that never come.
+    const progressUrl = request.headers.get(WEBHOOK_PROGRESS_HEADER) ?? "";
+    if (progressUrl.length > 0 && !isLoopbackProgressUrl(progressUrl)) {
+      return json({ ok: false, error: `${WEBHOOK_PROGRESS_HEADER} must be a loopback URL` }, 400);
+    }
+
+    return runEffect(
+      fireWebhook(
+        webhook,
+        truncated,
+        threadKey.length > 0 ? threadKey : undefined,
+        progressUrl.length > 0 ? progressUrl : undefined,
+      ),
+    );
   };
 }
 
@@ -661,7 +682,27 @@ export function webhookConversationId(
  * with `costIncomplete` alongside rather than folded in: an unpriced run understates its
  * spend, and a caller enforcing a ceiling needs to know the figure is a floor.
  */
-function fireWebhook(webhook: WebhookConfig, payload: string, threadKey?: string) {
+/**
+ * Post one progress event, and never let it matter.
+ *
+ * Fire-and-forget on purpose: a caller that has stopped listening, or is slow, must not
+ * fail somebody's turn or hold a tool call open behind it.
+ */
+function reportProgress(progressUrl: string, event: ToolProgressEvent): void {
+  void fetch(progressUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(event),
+    signal: AbortSignal.timeout(5_000),
+  }).catch(() => undefined);
+}
+
+function fireWebhook(
+  webhook: WebhookConfig,
+  payload: string,
+  threadKey?: string,
+  progressUrl?: string,
+) {
   return Effect.gen(function* () {
     const agent = yield* getAgentByIdentifier(webhook.agentId);
     const quotedPayload =
@@ -688,6 +729,9 @@ function fireWebhook(webhook: WebhookConfig, payload: string, threadKey?: string
       userInput: prompt,
       conversationId,
       parkWhenUnattended: true,
+      ...(progressUrl !== undefined
+        ? { onToolEvent: (event: ToolProgressEvent) => reportProgress(progressUrl, event) }
+        : {}),
       ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
     });
 

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -484,6 +484,7 @@ function initializeAgentRun(
       // A sub-agent never parks: resuming one would mean replaying a child context that no
       // longer exists, so nested runs keep declining and the parent reasons about it.
       parkWhenUnattended: options.parkWhenUnattended === true && options.internal !== true,
+      ...(options.onToolEvent !== undefined ? { onToolEvent: options.onToolEvent } : {}),
       ...(options.resolvedApprovals !== undefined
         ? { resolvedApprovals: options.resolvedApprovals }
         : {}),

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -189,6 +189,9 @@ export class ToolExecutor {
         // approval UI when multiple tools run in parallel (approval wrapper returns
         // immediately; the real "Executing tool" is emitted after user approval)
         const isApprovalTool = toolsRequiringApproval.has(name);
+        // Reported regardless of display config: a caller watching over HTTP is not a
+        // terminal that can be told to be quiet, and this is its only view of a long turn.
+        context.onToolEvent?.({ kind: "tool-started", toolName: name, toolCallId: toolCall.id });
         if (displayConfig.showToolExecution && !isApprovalTool) {
           // Build metadata for specific tools (e.g., web_search provider)
           const metadata = yield* resolveToolDisplayMetadata(name, context);
@@ -798,6 +801,11 @@ export class ToolExecutor {
           toolCallId: firstRequest.toolCallId,
           batchSize: toolCalls.length,
         });
+        context.onToolEvent?.({
+          kind: "approval-required",
+          toolName: firstRequest.toolName,
+          toolCallId: firstRequest.toolCallId,
+        });
         return new RunParkRequested({
           pending: { kind: "tool-approval", request: firstRequest },
         });
@@ -816,6 +824,8 @@ export class ToolExecutor {
       const toolFibers = yield* Effect.all(
         toolCalls.map((toolCall) =>
           Effect.forkDaemon(
+            // Tapped once here rather than at each of the several places a call can
+            // finish, so a new return path cannot quietly stop reporting.
             ToolExecutor.executeToolCall(
               toolCall,
               context,
@@ -825,6 +835,17 @@ export class ToolExecutor {
               agentId,
               conversationId,
               approvalSet,
+            ).pipe(
+              Effect.tap((outcome) =>
+                Effect.sync(() => {
+                  context.onToolEvent?.({
+                    kind: "tool-finished",
+                    toolName: outcome.name,
+                    toolCallId: outcome.toolCallId,
+                    ok: outcome.success,
+                  });
+                }),
+              ),
             ),
           ),
         ),

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -4,6 +4,7 @@ import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { MessageAttachment } from "@/core/types/attachment";
 import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import type { DisplayConfig } from "@/core/types/output";
+import type { ToolProgressEvent } from "@/core/types/tools";
 import type {
   ApprovalOutcome,
   AutoApprovePolicy,
@@ -152,6 +153,8 @@ export interface AgentRunnerOptions {
    * process resumes from. Off by default, and never set for sub-agent runs.
    */
   readonly parkWhenUnattended?: boolean;
+  /** Told what the run is doing while it does it. See `ToolExecutionContext.onToolEvent`. */
+  readonly onToolEvent?: (event: ToolProgressEvent) => void;
   /**
    * Approvals already answered, keyed by `toolCallId`. Set when resuming a parked run.
    */

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -38,6 +38,15 @@ export type AutoApprovePolicy = boolean | "read-only" | "low-risk" | "high-risk"
  * prompt is only a kindness where a prompt was the alternative. Callers that
  * cannot answer the question leave it out and get the conservative reading.
  */
+/** What a run reports about itself while it is still going. */
+export interface ToolProgressEvent {
+  readonly kind: "tool-started" | "tool-finished" | "approval-required";
+  readonly toolName: string;
+  readonly toolCallId?: string;
+  /** Set on "tool-finished": whether the call succeeded. */
+  readonly ok?: boolean;
+}
+
 export function shouldAutoApprove(
   riskLevel: ToolRiskLevel,
   policy: AutoApprovePolicy | undefined,
@@ -283,6 +292,19 @@ export interface ToolExecutionContext {
    * how the run was started, not of the tool, so the runner decides it once.
    */
   readonly parkWhenUnattended?: boolean;
+  /**
+   * Told, as it happens, what this run is doing.
+   *
+   * For a caller that is not in the room: a webhook holds one HTTP request open and returns
+   * a finished answer, so anything watching learns nothing until the run ends. A turn that
+   * reads a calendar and searches the web is minutes of unexplained silence to the person
+   * who asked for it.
+   *
+   * Deliberately fire-and-forget and deliberately not a service: it is per-run, the run
+   * must not fail because somebody stopped listening, and a slow consumer must not hold up
+   * a tool call.
+   */
+  readonly onToolEvent?: (event: ToolProgressEvent) => void;
   /** Iteration budget for a sub-agent spawned here — its own, not the parent's remainder. */
   readonly maxSubagentIterations?: number;
   /**

--- a/packages/core/src/types/webhook.ts
+++ b/packages/core/src/types/webhook.ts
@@ -60,6 +60,47 @@ export const WEBHOOK_THREAD_HEADER = "x-jazz-thread";
  */
 export const WEBHOOK_PROGRESS_HEADER = "x-jazz-progress-url";
 
+/**
+ * Request header naming which progress events the caller wants.
+ *
+ * Comma-separated kinds. Absent means all of them: handing over a URL is already the act of
+ * subscribing, and a caller that wants everything should not have to enumerate it. Naming
+ * kinds narrows that, which is worth having because a tool-heavy run is chatty and most
+ * callers care about one or two of these.
+ *
+ * An unknown kind is refused rather than ignored, for the same reason a non-loopback URL is:
+ * a caller that misspelled one would otherwise wait forever for events that never come.
+ */
+export const WEBHOOK_PROGRESS_EVENTS_HEADER = "x-jazz-progress-events";
+
+/** Every kind a caller may ask for. Must match `ToolProgressEvent["kind"]`. */
+export const TOOL_PROGRESS_KINDS = ["tool-started", "tool-finished", "approval-required"] as const;
+
+export type ToolProgressKind = (typeof TOOL_PROGRESS_KINDS)[number];
+
+/**
+ * Which events this caller asked for, or which name it got wrong.
+ *
+ * An empty or absent header is every kind, not none — see the header's own note.
+ */
+export function parseProgressEvents(
+  raw: string | null,
+): { readonly kinds: ReadonlySet<ToolProgressKind> } | { readonly unknownKind: string } {
+  const named = (raw ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (named.length === 0) return { kinds: new Set(TOOL_PROGRESS_KINDS) };
+
+  const kinds = new Set<ToolProgressKind>();
+  for (const name of named) {
+    const known = TOOL_PROGRESS_KINDS.find((kind) => kind === name);
+    if (known === undefined) return { unknownKind: name };
+    kinds.add(known);
+  }
+  return { kinds };
+}
+
 /** Whether a progress URL is one the daemon will agree to post to. */
 export function isLoopbackProgressUrl(raw: string): boolean {
   let url: URL;

--- a/packages/core/src/types/webhook.ts
+++ b/packages/core/src/types/webhook.ts
@@ -48,6 +48,32 @@ export type WebhookConversationMode = "ephemeral" | "threaded";
 export const WEBHOOK_THREAD_HEADER = "x-jazz-thread";
 
 /**
+ * Request header giving a URL to report progress to while the run is going.
+ *
+ * A webhook is one held-open request that answers when the run finishes, so a caller learns
+ * nothing in between — and a turn that reads a calendar and searches the web is minutes of
+ * unexplained silence. A caller that has somewhere to listen can say so here.
+ *
+ * Loopback only, and not negotiable: this makes the daemon issue requests to an address
+ * somebody else chose, which anywhere but the local machine is a way to make jazz knock on
+ * doors on their behalf.
+ */
+export const WEBHOOK_PROGRESS_HEADER = "x-jazz-progress-url";
+
+/** Whether a progress URL is one the daemon will agree to post to. */
+export function isLoopbackProgressUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const host = url.hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+}
+
+/**
  * Longest thread key accepted.
  *
  * `storageSafeSegment` would make any length safe as a path segment, so this is not a


### PR DESCRIPTION
## What & why

A webhook answers only when the whole run is finished, so a caller sees nothing while it works. A turn that reads a calendar and searches the web is minutes of silence.

Callers can now pass `X-Jazz-Progress-Url` and get told when each tool starts, finishes, or stops for an approval. `X-Jazz-Progress-Events` narrows that to the kinds they care about; leaving it off means all of them.

Two things are refused rather than ignored — a non-localhost URL, and an event kind this jazz doesn't send. Posting elsewhere would let a caller use jazz to make requests on their behalf, and a caller that misspelled an event would otherwise wait forever for something never sent.

## How to verify

- Start `jazz daemon`, fire a webhook with `X-Jazz-Progress-Url` pointing at something that logs POSTs. You should see each tool start and finish.
- Add `X-Jazz-Progress-Events: approval-required` — only that kind should arrive.
- Pass `http://example.com/x`, or an event kind like `tool-startd`: both should fail with 400 and the run should not start.
- Pass no progress header at all: nothing changes.
- Point the URL at a dead port: the run must still finish normally.
