### PR TITLE
fix(runs): a resumed run remembers the approvals already given

### DIFF
--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -780,34 +780,25 @@ export class ToolExecutor {
 
         if (needsAnswering.length === 0 || firstRequest === undefined) return undefined;
 
-        // More than one unanswered approval in one batch cannot be parked yet. Resume
-        // rebuilds `resolvedApprovals` from the single answer it was handed, so answering
-        // the first would park on the second, and answering that would park on the first
-        // again — a loop, which is worse than the decline this replaces. Accumulating
-        // answers across resumes is the fix and it changes the run record's shape.
-        if (needsAnswering.length > 1) {
-          yield* logger.warn("Refusing a batch that needs more than one approval", {
-            toolCalls: needsAnswering.map((toolCall) => toolCall.function.name),
-          });
-          return new Error(
-            `this turn asked to run ${String(needsAnswering.length)} tools needing approval at ` +
-              `once (${needsAnswering.map((toolCall) => toolCall.function.name).join(", ")}), ` +
-              "and only one can be approved per turn — nothing was run",
-          );
-        }
-
+        // One at a time, however many the turn needs. Each park carries the answers already
+        // given, so the next round sees them and stops on the next unanswered one rather
+        // than going round in a circle. Nothing has run at this point on any round, which
+        // is what makes replaying the batch on resume safe.
         yield* logger.info("Parking run: approval needed and nobody can answer in-process", {
           toolName: firstRequest.toolName,
           toolCallId: firstRequest.toolCallId,
           batchSize: toolCalls.length,
+          stillToAnswer: needsAnswering.length,
         });
         context.onToolEvent?.({
           kind: "approval-required",
           toolName: firstRequest.toolName,
           toolCallId: firstRequest.toolCallId,
         });
+        const answeredApprovals = Object.fromEntries(context.resolvedApprovals ?? []);
         return new RunParkRequested({
           pending: { kind: "tool-approval", request: firstRequest },
+          ...(Object.keys(answeredApprovals).length > 0 ? { answeredApprovals } : {}),
         });
       });
 

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -52,6 +52,14 @@ const TOOL_CALL = {
 
 /** Set by the execute tool, so the test can prove the side effect happened exactly once. */
 let executions: string[] = [];
+/**
+ * The `target` of each gated call that actually ran.
+ *
+ * `executions` records tool names, and two calls of the same gated tool are
+ * indistinguishable in it — which is no use for proving an answer landed on the call it was
+ * given for rather than its sibling.
+ */
+let executedTargets: string[] = [];
 
 /** A second gated call, so a batch of two approvals can be asked for. */
 const SECOND_TOOL_CALL = {
@@ -63,6 +71,13 @@ const SECOND_TOOL_CALL = {
 /** An ungated call, to sit beside a gated one. Runs on sight, which is the whole hazard. */
 const SAFE_TOOL_CALL = {
   id: "call_safe_1",
+  type: "function" as const,
+  function: { name: "harmless", arguments: JSON.stringify({}) },
+};
+
+/** A second ungated call, so gated ones can be asked about with others in between. */
+const SECOND_SAFE_TOOL_CALL = {
+  id: "call_safe_2",
   type: "function" as const,
   function: { name: "harmless", arguments: JSON.stringify({}) },
 };
@@ -160,6 +175,7 @@ function makeLayers(store: InMemoryRunStore, firstTurnCalls = [TOOL_CALL]) {
         });
       }
       executions.push(name);
+      if (typeof args["target"] === "string") executedTargets.push(args["target"]);
       return Effect.succeed({ success: true, result: "did the gated thing" });
     }),
   } as unknown as ToolRegistry;
@@ -409,5 +425,117 @@ describe("a batch of gated calls, with nobody in the room to answer", () => {
     if (second?.state.kind !== "input-required") throw new Error("expected a second park");
     // The second one is where it matters: without this the next resume forgets round one.
     expect(Object.keys(second.state.snapshot.answeredApprovals ?? {})).toEqual([TOOL_CALL.id]);
+  });
+});
+
+describe("the order approvals are asked in, and who each answer belongs to", () => {
+  /** Answer each park in turn, recording which call was asked about. */
+  async function answerEach(
+    store: InMemoryRunStore,
+    layers: ReturnType<typeof makeLayers>,
+    decide: (toolCallId: string) => boolean,
+  ): Promise<string[]> {
+    const askedAbout: string[] = [];
+    for (let round = 0; round < 6; round += 1) {
+      const parked = (await Effect.runPromise(store.list()))[0];
+      if (parked === undefined) break;
+      if (parked.state.kind !== "input-required") throw new Error("expected a parked run");
+      if (parked.state.pending.kind !== "tool-approval") throw new Error("expected an approval");
+      const toolCallId = parked.state.pending.request.toolCallId;
+      askedAbout.push(toolCallId);
+      await Effect.runPromiseExit(
+        resumeRun({
+          runId: parked.runId,
+          outcome: { kind: "approval", value: { approved: decide(toolCallId) } },
+        }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+      );
+    }
+    return askedAbout;
+  }
+
+  async function fire(
+    layers: ReturnType<typeof makeLayers>,
+    conversationId: string,
+  ): Promise<void> {
+    await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "do the things",
+        conversationId,
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+    );
+  }
+
+  it("asks in the order the model asked, with ungated calls in between", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [
+      SAFE_TOOL_CALL,
+      TOOL_CALL,
+      SECOND_SAFE_TOOL_CALL,
+      SECOND_TOOL_CALL,
+    ]);
+    await fire(layers, "conv-order-1");
+
+    const askedAbout = await answerEach(store, layers, () => true);
+
+    // The model's own order, not the order the scan happened to reach them in.
+    expect(askedAbout).toEqual([TOOL_CALL.id, SECOND_TOOL_CALL.id]);
+    expect(executedTargets).toEqual(["/tmp/x", "/tmp/y"]);
+  });
+
+  it("asks in that order even when the first is rejected", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
+    await fire(layers, "conv-order-2");
+
+    const askedAbout = await answerEach(store, layers, (id) => id !== TOOL_CALL.id);
+
+    // A rejection is an answer, so it does not come round again.
+    expect(askedAbout).toEqual([TOOL_CALL.id, SECOND_TOOL_CALL.id]);
+  });
+
+  it("applies a rejection to the call it was given for, not its sibling", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
+    await fire(layers, "conv-order-3");
+
+    await answerEach(store, layers, (id) => id !== TOOL_CALL.id);
+
+    // Both are calls of the same gated tool, so only the arguments tell them apart. The
+    // rejected one must not have run and the approved one must have.
+    expect(executedTargets).toEqual(["/tmp/y"]);
+  });
+
+  it("applies a rejection of the second call the same way round", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
+    await fire(layers, "conv-order-4");
+
+    await answerEach(store, layers, (id) => id !== SECOND_TOOL_CALL.id);
+
+    expect(executedTargets).toEqual(["/tmp/x"]);
+  });
+
+  it("runs nothing at all when every call is rejected", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
+    await fire(layers, "conv-order-5");
+
+    await answerEach(store, layers, () => false);
+
+    expect(executedTargets).toEqual([]);
+    expect(await Effect.runPromise(store.list())).toHaveLength(0);
   });
 });

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -336,35 +336,78 @@ describe("a batch of gated calls, with nobody in the room to answer", () => {
     expect(executions.filter((name) => name === "harmless")).toHaveLength(1);
   });
 
-  it("says so plainly when it needs more than one approval, and runs nothing", async () => {
-    // Two unanswered approvals in one batch cannot be parked yet: resume rebuilds its
-    // resolved answers from the single one it is handed, so answering the first would park
-    // on the second and answering that would park on the first again. Accumulating answers
-    // across resumes is the fix, and it changes the run record's shape.
-    //
-    // Until then this fails visibly. Before, the decision fell through to whatever
-    // presentation the process happened to have: one that declines refuses both silently,
-    // one that approves runs both without asking. Neither answer reached the caller, and
-    // for a webhook that caller is the only person there is.
+  it("asks for each approval in turn, and runs each tool exactly once", async () => {
+    // Two approvals in one turn used to be refused outright, because each resume rebuilt its
+    // answers from the one outcome it was handed: answering the first stopped on the second,
+    // and answering that stopped on the first again. A parked run now carries what has
+    // already been answered, so the rounds converge.
     executions = [];
     const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
 
-    const exit = await Effect.runPromiseExit(
+    await Effect.runPromiseExit(
       AgentRunner.run({
         agent: AGENT,
         userInput: "do both gated things",
         conversationId: "conv-batch-2",
         stream: false,
         parkWhenUnattended: true,
-      }).pipe(Effect.provide(makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]))) as Effect.Effect<
-        unknown,
-        unknown
-      >,
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
     );
 
-    expect(exit._tag).toBe("Failure");
-    expect(executions).toEqual([]);
-    // And it is not parked, because nobody could answer it into a finished state.
+    const askedAbout: string[] = [];
+    for (let round = 0; round < 5; round += 1) {
+      const parked = (await Effect.runPromise(store.list()))[0];
+      if (parked === undefined) break;
+      if (parked.state.kind !== "input-required") throw new Error("expected a parked run");
+      if (parked.state.pending.kind !== "tool-approval") throw new Error("expected an approval");
+      askedAbout.push(parked.state.pending.request.toolCallId);
+      // Nothing may have run while approvals are still outstanding.
+      if (round === 0) expect(executions).toEqual([]);
+      await Effect.runPromiseExit(
+        resumeRun({
+          runId: parked.runId,
+          outcome: { kind: "approval", value: { approved: true } },
+        }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+      );
+    }
+
+    // Asked about each call once, in order, and never asked about the same one twice.
+    expect(askedAbout).toEqual([TOOL_CALL.id, SECOND_TOOL_CALL.id]);
+    expect(executions).toEqual(["danger_execute", "danger_execute"]);
     expect(await Effect.runPromise(store.list())).toHaveLength(0);
+  });
+
+  it("remembers an answer across the park that follows it", async () => {
+    executions = [];
+    const store = new InMemoryRunStore();
+    const layers = makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL]);
+
+    await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "do both gated things",
+        conversationId: "conv-batch-3",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+    );
+
+    const first = (await Effect.runPromise(store.list()))[0];
+    if (first?.state.kind !== "input-required") throw new Error("expected a parked run");
+    // The first park has nothing to remember yet.
+    expect(first.state.snapshot.answeredApprovals).toBeUndefined();
+
+    await Effect.runPromiseExit(
+      resumeRun({
+        runId: first.runId,
+        outcome: { kind: "approval", value: { approved: true } },
+      }).pipe(Effect.provide(layers)) as Effect.Effect<unknown, unknown>,
+    );
+
+    const second = (await Effect.runPromise(store.list()))[0];
+    if (second?.state.kind !== "input-required") throw new Error("expected a second park");
+    // The second one is where it matters: without this the next resume forgets round one.
+    expect(Object.keys(second.state.snapshot.answeredApprovals ?? {})).toEqual([TOOL_CALL.id]);
   });
 });

--- a/packages/core/src/agent/run/park-signal.ts
+++ b/packages/core/src/agent/run/park-signal.ts
@@ -15,10 +15,18 @@
 
 import { Data } from "effect";
 import type { ChatMessage } from "@/core/types/message";
+import type { ApprovalOutcome } from "@/core/types/tools";
 import type { PendingInput } from "./run-state";
 
 export class RunParkRequested extends Data.TaggedError("RunParkRequested")<{
   readonly pending: PendingInput;
+  /**
+   * Approvals already given for this turn, raised with the signal so they survive the park.
+   *
+   * Every reconstruction of this signal must carry it — see `withTranscript`, which builds
+   * a new one from a handful of fields and would otherwise drop this silently.
+   */
+  readonly answeredApprovals?: Readonly<Record<string, ApprovalOutcome>>;
   /** Attached by the agent loop on the way out; absent while the signal is still inside the executor. */
   readonly messages?: readonly ChatMessage[];
   readonly iteration?: number;
@@ -58,5 +66,12 @@ export function withTranscript(
   iteration: number,
 ): RunParkRequested {
   if (signal.messages !== undefined) return signal;
-  return new RunParkRequested({ pending: signal.pending, messages, iteration });
+  return new RunParkRequested({
+    pending: signal.pending,
+    ...(signal.answeredApprovals !== undefined
+      ? { answeredApprovals: signal.answeredApprovals }
+      : {}),
+    messages,
+    iteration,
+  });
 }

--- a/packages/core/src/agent/run/resume.ts
+++ b/packages/core/src/agent/run/resume.ts
@@ -123,9 +123,19 @@ export function resumeRun(options: ResumeRunOptions) {
       );
     }
 
+    // Every approval this turn has already collected, plus the one just given. Building the
+    // map from the new answer alone was the bug: a turn needing two approvals would stop on
+    // the first, then on the second, then on the first again, because each resume had
+    // forgotten the round before it.
+    const alreadyAnswered = Object.entries(snapshot.answeredApprovals ?? {});
     const resolved =
       options.outcome.kind === "approval" && pending.kind === "tool-approval"
-        ? { resolvedApprovals: new Map([[pending.request.toolCallId, options.outcome.value]]) }
+        ? {
+            resolvedApprovals: new Map([
+              ...alreadyAnswered,
+              [pending.request.toolCallId, options.outcome.value] as const,
+            ]),
+          }
         : options.outcome.kind === "question" && pending.kind === "question"
           ? { resolvedUserInputs: new Map([[pending.toolCallId, options.outcome.value]]) }
           : options.outcome.kind === "file-picker" && pending.kind === "file-picker"

--- a/packages/core/src/agent/run/run-recorder.ts
+++ b/packages/core/src/agent/run/run-recorder.ts
@@ -34,6 +34,9 @@ function parkedState(signal: RunParkRequested, expiresAt: string): RunState {
     snapshot: {
       messages: signal.messages ?? [],
       iteration: signal.iteration ?? 0,
+      ...(signal.answeredApprovals !== undefined
+        ? { answeredApprovals: signal.answeredApprovals }
+        : {}),
     },
     expiresAt,
   };
@@ -124,6 +127,9 @@ export function withRunRecording<E, R>(
             Effect.fail(
               new RunParkRequested({
                 pending: error.pending,
+                ...(error.answeredApprovals !== undefined
+                  ? { answeredApprovals: error.answeredApprovals }
+                  : {}),
                 ...(error.messages !== undefined ? { messages: error.messages } : {}),
                 ...(error.iteration !== undefined ? { iteration: error.iteration } : {}),
                 runId: input.runId,

--- a/packages/core/src/agent/run/run-state.ts
+++ b/packages/core/src/agent/run/run-state.ts
@@ -23,6 +23,7 @@
 import type { FilePickerRequest, UserInputRequest } from "@/core/interfaces/presentation";
 import type { GeneratedArtifact } from "@/core/types/artifact";
 import type { ChatMessage } from "@/core/types/message";
+import type { ApprovalOutcome } from "@/core/types/tools";
 import type { ApprovalRequest } from "@/core/types/tools";
 
 /**
@@ -73,6 +74,18 @@ export type PendingInput =
 export interface ParkedRunSnapshot {
   readonly messages: readonly ChatMessage[];
   readonly iteration: number;
+  /**
+   * Approvals a person has already given for this turn, by tool call id.
+   *
+   * A turn can need more than one, and they arrive one at a time. Without carrying the
+   * earlier ones forward, resuming rebuilt its answers from the single outcome it was
+   * handed — so answering the first would stop on the second, and answering that would
+   * stop on the first again, forever.
+   *
+   * A plain object rather than a `Map` because a run record is stored as JSON, and a `Map`
+   * does not survive the round trip.
+   */
+  readonly answeredApprovals?: Readonly<Record<string, ApprovalOutcome>>;
 }
 
 export type RunState =


### PR DESCRIPTION
## What & why

A turn needing two approvals was refused outright. Each resume rebuilt its answers from the single outcome it was handed, so approving the first stopped on the second, and approving that stopped on the first again — round and round. #518 refused it rather than loop, which was safe but not a fix.

A parked run now carries the approvals already given, and resume merges them with the new one. You get asked about each tool once, in order, and nothing runs until the last approval is in.

One at a time is also the better shape — it's what the CLI has always done, and what a person expects: this tool, then the next, rather than a dialogue listing everything the model asked for.

## How to verify

- Have an unattended agent ask for two approval-needing tools in one turn. You should be asked about the first, then the second, then both run — once each.
- While either approval is outstanding, nothing should have executed.
- Decline one: that tool should not run, and the other should behave as it would on its own.
- A turn with a single approval, or with none: unchanged.
- `bun test packages/core/src/agent/run/park-resume.integration.test.ts`

## Note for reviewers

The park signal is rebuilt in two places — `withTranscript` and the recorder's re-raise — and both construct a fresh one from named fields, so both had to be taught to carry the new field or it would vanish silently. There's a test asserting the *second* park contains the first answer, which is what catches that.

Stored as a plain object, not a `Map`: a run record is JSON and a `Map` doesn't survive the round trip.
