### PR TITLE
fix(ui): keep a sub-agent's cost line in its own panel

### DIFF
--- a/packages/cli/src/presentation/ink-presentation-service.test.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.test.ts
@@ -651,6 +651,53 @@ describe("InkStreamingRenderer", () => {
         Effect.runSync(renderer.reset());
       }
     });
+
+    test("routes the metrics outro into the sub-agent's ephemeral panel, not scrollback", async () => {
+      const ephemeralAppends: Array<{ id: string; text: string }> = [];
+      const originalAppend = store.appendEphemeral;
+      store.appendEphemeral = (id, text) => {
+        ephemeralAppends.push({ id, text });
+        return originalAppend(id, text);
+      };
+
+      const renderer = new InkStreamingRenderer(
+        "SubAgent",
+        true,
+        { showReasoning: true, showToolExecution: true, mode: "rendered", colorProfile: "full" },
+        { textBufferMs: 0 },
+        0,
+        { kind: "ephemeral", regionId: "eph-sub-2" },
+      );
+
+      try {
+        emitStreamStart(renderer);
+        const scrollbackBaseline = printOutputCalls.length;
+
+        Effect.runSync(
+          renderer.handleEvent({
+            type: "complete",
+            response: completeResponse("done"),
+            totalDurationMs: 100,
+            metrics: { firstTokenLatencyMs: 10, totalTokens: 42 },
+          }),
+        );
+        await new Promise((r) => setTimeout(r, 0));
+
+        const combined = ephemeralAppends
+          .filter((entry) => entry.id === "eph-sub-2")
+          .map((entry) => entry.text)
+          .join("");
+        expect(combined).toContain("42 tok");
+
+        const debugScrollbackEntries = printOutputCalls
+          .slice(scrollbackBaseline)
+          .filter((e) => e.type === "debug");
+        expect(debugScrollbackEntries).toHaveLength(0);
+      } finally {
+        store.appendEphemeral = originalAppend;
+        Effect.runSync(renderer.reset());
+      }
+    });
   });
 
   describe("complete phase", () => {

--- a/packages/cli/src/presentation/ink-presentation-service.test.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.test.ts
@@ -1486,3 +1486,57 @@ describe("InkPresentationService approval rejection", () => {
     expect(printed.filter((entry) => entry.type === "user")).toHaveLength(0);
   });
 });
+
+describe("InkPresentationService sub-agent collapse line", () => {
+  const printed: OutputEntry[] = [];
+  let originalPrintOutput: (typeof store)["printOutput"];
+
+  beforeEach(() => {
+    printed.length = 0;
+    originalPrintOutput = store.printOutput;
+    store.printOutput = (entry: OutputEntry) => {
+      printed.push(entry);
+      return originalPrintOutput(entry);
+    };
+  });
+
+  afterEach(() => {
+    store.printOutput = originalPrintOutput;
+  });
+
+  test("carries the sub-agent's total cost and tokens into the surviving summary line", async () => {
+    const service = new InkPresentationService(DEFAULT_DISPLAY_CONFIG, null);
+    const regionId = await Effect.runPromise(service.openEphemeralRegion("subagent", "Researcher"));
+
+    await Effect.runPromise(
+      service.collapseEphemeralRegion(regionId, "Researcher", {
+        status: "completed",
+        durationMs: 12_300,
+        costUSD: 0.0187,
+        totalTokens: 29_400,
+      }),
+    );
+
+    const summary = printed.find((entry) => entryText(entry).includes("Researcher completed"));
+    expect(summary).toBeDefined();
+    expect(entryText(summary!)).toContain("29k tok");
+    expect(entryText(summary!)).toContain("$0.02");
+  });
+
+  test("omits cost and tokens from the summary line when the run failed", async () => {
+    const service = new InkPresentationService(DEFAULT_DISPLAY_CONFIG, null);
+    const regionId = await Effect.runPromise(service.openEphemeralRegion("subagent", "Researcher"));
+
+    await Effect.runPromise(
+      service.collapseEphemeralRegion(regionId, "Researcher", {
+        status: "failed",
+        durationMs: 4_000,
+      }),
+    );
+
+    const summary = printed.find((entry) => entryText(entry).includes("Researcher failed"));
+    expect(summary).toBeDefined();
+    expect(entryText(summary!)).not.toContain("tok");
+    expect(entryText(summary!)).not.toContain("$");
+  });
+});

--- a/packages/cli/src/presentation/ink-presentation-service.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.ts
@@ -88,10 +88,26 @@ function formatSubagentCollapseLine(label: string, outcome: EphemeralRegionColla
   const glyphs = getGlyphs();
   if (outcome.status === "completed") {
     const seconds = (outcome.durationMs / 1000).toFixed(1);
-    return chalk.dim(chalk.italic(`${glyphs.success} ${label} completed · ${seconds}s`));
+    const parts = [`${label} completed`, `${seconds}s`];
+    if (outcome.totalTokens !== undefined) parts.push(`${compactCount(outcome.totalTokens)} tok`);
+    if (outcome.costUSD !== undefined) parts.push(formatOutroCost(outcome.costUSD));
+    return chalk.dim(chalk.italic(`${glyphs.success} ${parts.join(" · ")}`));
   }
   const verb = outcome.status === "failed" ? "failed" : "interrupted";
   return chalk.dim(chalk.italic(`${glyphs.error} ${label} ${verb}`));
+}
+
+function compactCount(count: number): string {
+  if (count < 1000) return `${count}`;
+  if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
+  return `${Math.round(count / 1000)}k`;
+}
+
+function formatOutroCost(cost: number): string {
+  if (cost === 0) return "$0.00";
+  if (cost >= 0.01) return `$${cost.toFixed(2)}`;
+  if (cost >= 0.0001) return `$${cost.toFixed(4)}`;
+  return `<$0.0001`;
 }
 
 /**
@@ -764,18 +780,6 @@ export class InkStreamingRenderer implements StreamingRenderer {
    * late line is printed after the prompt has already returned.
    */
   private printOutro(event: Extract<StreamEvent, { type: "complete" }>): void {
-    const compactTokens = (count: number): string => {
-      if (count < 1000) return `${count}`;
-      if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
-      return `${Math.round(count / 1000)}k`;
-    };
-    const formatCost = (cost: number): string => {
-      if (cost === 0) return "$0.00";
-      if (cost >= 0.01) return `$${cost.toFixed(2)}`;
-      if (cost >= 0.0001) return `$${cost.toFixed(4)}`;
-      return `<$0.0001`;
-    };
-
     const parts: string[] = [];
     if (event.totalDurationMs > 0) {
       parts.push(`${(event.totalDurationMs / 1000).toFixed(1)}s`);
@@ -789,7 +793,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
           ? ` (${Math.round((cacheReadTokens / usage.promptTokens) * 100)}% cached)`
           : "";
       parts.push(
-        `${compactTokens(usage.promptTokens)} in${cachedShare} → ${compactTokens(usage.completionTokens)} out`,
+        `${compactCount(usage.promptTokens)} in${cachedShare} → ${compactCount(usage.completionTokens)} out`,
       );
       // Push the prompt-side count to the persistent footer so users have
       // visibility on context-window pressure between turns.
@@ -800,7 +804,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         completionTokens: usage.completionTokens,
       });
     } else if (event.metrics?.totalTokens) {
-      parts.push(`${compactTokens(event.metrics.totalTokens)} tok`);
+      parts.push(`${compactCount(event.metrics.totalTokens)} tok`);
     }
 
     const provider = this.acc.currentProvider;
@@ -826,7 +830,7 @@ export class InkStreamingRenderer implements StreamingRenderer {
         const totalCost = computeCost(cachedMeta);
         if (totalCost !== null) {
           rollIntoFooter(totalCost);
-          parts.push(formatCost(totalCost));
+          parts.push(formatOutroCost(totalCost));
         }
       } else {
         // Cold cache: keep the footer accurate without printing a straggler

--- a/packages/cli/src/presentation/ink-presentation-service.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.ts
@@ -693,7 +693,9 @@ export class InkStreamingRenderer implements StreamingRenderer {
     }
 
     if (this.showMetrics && event.metrics) {
-      store.printOutput({ type: "log", message: "", timestamp: new Date() });
+      if (this.streamTarget.kind === "scrollback") {
+        store.printOutput({ type: "log", message: "", timestamp: new Date() });
+      }
       this.printOutro(event);
     }
 
@@ -840,13 +842,23 @@ export class InkStreamingRenderer implements StreamingRenderer {
       }
     }
 
-    if (parts.length > 0) {
-      store.printOutput({
-        type: "debug",
-        message: `${getGlyphs().success} ${parts.join(" · ")}`,
-        timestamp: new Date(),
+    if (parts.length === 0) return;
+
+    const line = `${getGlyphs().success} ${parts.join(" · ")}`;
+    if (this.streamTarget.kind === "ephemeral") {
+      this.bufferStreamDelta({
+        target: "ephemeral",
+        regionId: this.streamTarget.regionId,
+        delta: `\n${line}`,
       });
+      return;
     }
+
+    store.printOutput({
+      type: "debug",
+      message: line,
+      timestamp: new Date(),
+    });
   }
 
   /**

--- a/packages/core/src/agent/tools/perception-tools.ts
+++ b/packages/core/src/agent/tools/perception-tools.ts
@@ -281,6 +281,10 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
       yield* presentation.collapseEphemeralRegion(regionId, label, {
         status: "completed",
         durationMs: Date.now() - startedAt,
+        ...(response.costUSD !== undefined ? { costUSD: response.costUSD } : {}),
+        ...(response.usage
+          ? { totalTokens: response.usage.promptTokens + response.usage.completionTokens }
+          : {}),
       });
       yield* logger.info("Model companion completed", {
         parentAgentId: parentAgent.id,

--- a/packages/core/src/agent/tools/subagent-tools.ts
+++ b/packages/core/src/agent/tools/subagent-tools.ts
@@ -415,6 +415,10 @@ ${args.task}${args.resultSchema ? structuredCompletionInstructions(args.resultSc
           yield* presentation.collapseEphemeralRegion(regionId, subagentLabel, {
             status: "completed",
             durationMs,
+            ...(response.costUSD !== undefined ? { costUSD: response.costUSD } : {}),
+            ...(response.usage
+              ? { totalTokens: response.usage.promptTokens + response.usage.completionTokens }
+              : {}),
           });
 
           const fullResult = result?.trim() || "No output";

--- a/packages/core/src/interfaces/presentation.ts
+++ b/packages/core/src/interfaces/presentation.ts
@@ -326,6 +326,10 @@ export type EphemeralRegionKind = "reasoning" | "subagent";
 export interface EphemeralRegionCollapse {
   readonly status: "completed" | "failed" | "interrupted";
   readonly durationMs: number;
+  /** Total spend for the run this region tracked, when pricing was available. */
+  readonly costUSD?: number;
+  /** Total prompt + completion tokens for the run this region tracked. */
+  readonly totalTokens?: number;
 }
 
 /**


### PR DESCRIPTION
## What & why
When a sub-agent (or any workflow step running in its own panel) made several LLM calls, jazz printed a bare cost/latency line for each one (`✓ 3.4s · 20k in → 276 out · $0.0009`) into the main output — with no sign of which tool calls or sub-agent produced them, since that activity lives in the sub-agent's own bounded panel. The result was a long, unattributed stream of cost rows in the main scrollback.

Sub-agent cost lines now land in that sub-agent's own panel, right alongside the tool calls that caused them, instead of leaking into the shared output. The main agent's own metrics are unaffected.

## How to verify
- Run a task that spawns a sub-agent or workflow step making multiple LLM calls with `output.showMetrics` enabled; confirm cost/latency lines appear inside that sub-agent's panel next to its tool activity, not as standalone rows in the main scrollback.
- Confirm the main agent's own turn still prints its usual `✓ Xs · … in → … out · $cost` line in the main scrollback.
- `bun test packages/cli/src/presentation/ink-presentation-service.test.ts`
