### PR TITLE
refactor(runs): name the turn scratchpad for what it is

### DIFF
--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -795,10 +795,10 @@ export class ToolExecutor {
           toolName: firstRequest.toolName,
           toolCallId: firstRequest.toolCallId,
         });
-        const answeredApprovals = Object.fromEntries(context.resolvedApprovals ?? []);
+        const pendingTurnAnswers = Object.fromEntries(context.resolvedApprovals ?? []);
         return new RunParkRequested({
           pending: { kind: "tool-approval", request: firstRequest },
-          ...(Object.keys(answeredApprovals).length > 0 ? { answeredApprovals } : {}),
+          ...(Object.keys(pendingTurnAnswers).length > 0 ? { pendingTurnAnswers } : {}),
         });
       });
 

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -412,7 +412,7 @@ describe("a batch of gated calls, with nobody in the room to answer", () => {
     const first = (await Effect.runPromise(store.list()))[0];
     if (first?.state.kind !== "input-required") throw new Error("expected a parked run");
     // The first park has nothing to remember yet.
-    expect(first.state.snapshot.answeredApprovals).toBeUndefined();
+    expect(first.state.snapshot.pendingTurnAnswers).toBeUndefined();
 
     await Effect.runPromiseExit(
       resumeRun({
@@ -424,7 +424,7 @@ describe("a batch of gated calls, with nobody in the room to answer", () => {
     const second = (await Effect.runPromise(store.list()))[0];
     if (second?.state.kind !== "input-required") throw new Error("expected a second park");
     // The second one is where it matters: without this the next resume forgets round one.
-    expect(Object.keys(second.state.snapshot.answeredApprovals ?? {})).toEqual([TOOL_CALL.id]);
+    expect(Object.keys(second.state.snapshot.pendingTurnAnswers ?? {})).toEqual([TOOL_CALL.id]);
   });
 });
 

--- a/packages/core/src/agent/run/park-signal.ts
+++ b/packages/core/src/agent/run/park-signal.ts
@@ -21,12 +21,12 @@ import type { PendingInput } from "./run-state";
 export class RunParkRequested extends Data.TaggedError("RunParkRequested")<{
   readonly pending: PendingInput;
   /**
-   * Approvals already given for this turn, raised with the signal so they survive the park.
+   * This turn's answers so far, raised with the signal so they survive the park.
    *
    * Every reconstruction of this signal must carry it — see `withTranscript`, which builds
-   * a new one from a handful of fields and would otherwise drop this silently.
+   * a new one from a handful of named fields and would otherwise drop this silently.
    */
-  readonly answeredApprovals?: Readonly<Record<string, ApprovalOutcome>>;
+  readonly pendingTurnAnswers?: Readonly<Record<string, ApprovalOutcome>>;
   /** Attached by the agent loop on the way out; absent while the signal is still inside the executor. */
   readonly messages?: readonly ChatMessage[];
   readonly iteration?: number;
@@ -68,8 +68,8 @@ export function withTranscript(
   if (signal.messages !== undefined) return signal;
   return new RunParkRequested({
     pending: signal.pending,
-    ...(signal.answeredApprovals !== undefined
-      ? { answeredApprovals: signal.answeredApprovals }
+    ...(signal.pendingTurnAnswers !== undefined
+      ? { pendingTurnAnswers: signal.pendingTurnAnswers }
       : {}),
     messages,
     iteration,

--- a/packages/core/src/agent/run/resume.ts
+++ b/packages/core/src/agent/run/resume.ts
@@ -123,11 +123,11 @@ export function resumeRun(options: ResumeRunOptions) {
       );
     }
 
-    // Every approval this turn has already collected, plus the one just given. Building the
-    // map from the new answer alone was the bug: a turn needing two approvals would stop on
-    // the first, then on the second, then on the first again, because each resume had
+    // Everything this turn has already been answered, plus the answer just given. Building
+    // the map from the new answer alone was the bug: a turn needing two approvals would stop
+    // on the first, then on the second, then on the first again, because each resume had
     // forgotten the round before it.
-    const alreadyAnswered = Object.entries(snapshot.answeredApprovals ?? {});
+    const alreadyAnswered = Object.entries(snapshot.pendingTurnAnswers ?? {});
     const resolved =
       options.outcome.kind === "approval" && pending.kind === "tool-approval"
         ? {

--- a/packages/core/src/agent/run/run-recorder.ts
+++ b/packages/core/src/agent/run/run-recorder.ts
@@ -34,8 +34,8 @@ function parkedState(signal: RunParkRequested, expiresAt: string): RunState {
     snapshot: {
       messages: signal.messages ?? [],
       iteration: signal.iteration ?? 0,
-      ...(signal.answeredApprovals !== undefined
-        ? { answeredApprovals: signal.answeredApprovals }
+      ...(signal.pendingTurnAnswers !== undefined
+        ? { pendingTurnAnswers: signal.pendingTurnAnswers }
         : {}),
     },
     expiresAt,
@@ -127,8 +127,8 @@ export function withRunRecording<E, R>(
             Effect.fail(
               new RunParkRequested({
                 pending: error.pending,
-                ...(error.answeredApprovals !== undefined
-                  ? { answeredApprovals: error.answeredApprovals }
+                ...(error.pendingTurnAnswers !== undefined
+                  ? { pendingTurnAnswers: error.pendingTurnAnswers }
                   : {}),
                 ...(error.messages !== undefined ? { messages: error.messages } : {}),
                 ...(error.iteration !== undefined ? { iteration: error.iteration } : {}),

--- a/packages/core/src/agent/run/run-state.ts
+++ b/packages/core/src/agent/run/run-state.ts
@@ -75,17 +75,25 @@ export interface ParkedRunSnapshot {
   readonly messages: readonly ChatMessage[];
   readonly iteration: number;
   /**
-   * Approvals a person has already given for this turn, by tool call id.
+   * Answers given for *this turn's* tool calls so far, by tool call id.
    *
-   * A turn can need more than one, and they arrive one at a time. Without carrying the
-   * earlier ones forward, resuming rebuilt its answers from the single outcome it was
-   * handed — so answering the first would stop on the second, and answering that would
-   * stop on the first again, forever.
+   * Scratch, not policy. It notes that call `x` was answered yes or no while the turn is
+   * mid-flight, and it is gone when the turn ends. It never widens what an agent may do,
+   * and it is nothing to do with "always approve this tool" — that is a standing permission
+   * somebody opts into deliberately, keyed by tool or command rather than by call, and
+   * deriving one from an ordinary yes would grant something nobody asked for.
+   *
+   * Needed because a turn can want several approvals and they arrive one at a time. The
+   * transcript cannot stand in for it: between two parks nothing has executed, so there are
+   * no tool results, and "answered but not yet run" is a state messages cannot express.
+   * Without carrying it, each resume rebuilt its answers from the single outcome it was
+   * handed — answering the first stopped on the second, and answering that stopped on the
+   * first again, round and round.
    *
    * A plain object rather than a `Map` because a run record is stored as JSON, and a `Map`
    * does not survive the round trip.
    */
-  readonly answeredApprovals?: Readonly<Record<string, ApprovalOutcome>>;
+  readonly pendingTurnAnswers?: Readonly<Record<string, ApprovalOutcome>>;
 }
 
 export type RunState =


### PR DESCRIPTION
## What & why

`answeredApprovals` read like a record of permissions granted, and prompted the reasonable question: why keep one when "always approve" already exists?

It isn't that. It notes which of *this turn's* tool calls have been answered yes or no while the turn is mid-flight, and it's discarded when the turn ends. It never widens what an agent may do.

"Always approve" is the opposite on both counts — a standing permission somebody opts into deliberately, keyed by tool or command rather than by call. Deriving one from an ordinary yes would grant something nobody asked for, and approving one command in a batch would approve its sibling.

Renamed to `pendingTurnAnswers`, and the comments now say the same thing.

## How to verify

- Rename only — no behaviour change. `bun test`, `typecheck`, `test:typecheck`, `lint`.
- `git grep answeredApprovals` should find nothing outside `dist/`.
