### PR TITLE
fix(daemon): stop unattended runs from lying about who can answer

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,7 +151,6 @@ one, runs begun from somewhere else entirely.
 | `jazz runs show <runId>`    | Show one run, including what it's waiting for. `--json`                                                          |
 | `jazz runs approve <runId>` | Approve what a parked run is waiting for; blocks until it finishes                                               |
 | `jazz runs reject <runId>`  | Refuse what it's waiting for; `--note <text>` tells it why                                                       |
-| `jazz runs answer <runId>`  | Answer a question the run asked, in your own words: `--response <text>` (empty declines it)                     |
 
 A run parks when it hits something needing your approval and nobody is there to give it — see
 [Daemon](#jazz-daemon) for answering one from a different process than the one that started it.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,6 +151,7 @@ one, runs begun from somewhere else entirely.
 | `jazz runs show <runId>`    | Show one run, including what it's waiting for. `--json`                                                          |
 | `jazz runs approve <runId>` | Approve what a parked run is waiting for; blocks until it finishes                                               |
 | `jazz runs reject <runId>`  | Refuse what it's waiting for; `--note <text>` tells it why                                                       |
+| `jazz runs answer <runId>`  | Answer a question the run asked, in your own words: `--response <text>` (empty declines it)                     |
 
 A run parks when it hits something needing your approval and nobody is there to give it — see
 [Daemon](#jazz-daemon) for answering one from a different process than the one that started it.

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -51,6 +51,7 @@ import { resolveWebhookToken } from "@jazz/adapters/webhooks/token";
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { TerminalServiceTag } from "@jazz/core/interfaces/terminal";
+import { OneShotPresentationServiceLayer } from "@jazz/core/presentation/oneshot-presentation-service";
 import type { AppConfig } from "@jazz/core/types/config";
 import { getJazzSchedulerInvocation } from "@jazz/core/utils/runtime";
 import { SchedulerServiceTag } from "@jazz/core/workflows/scheduler-service";
@@ -341,7 +342,16 @@ export function daemonCommand(options: DaemonCommandOptions) {
     });
 
     yield* logger.info("Daemon stopped");
-  }).pipe(Effect.provide(makeFileRunStoreLayer()));
+  }).pipe(
+    // Every run this process serves — a webhook fire, a due trigger, a resumed park — is
+    // unattended by construction: whoever launched `jazz daemon` is not sitting at whatever
+    // terminal or process is actually asking. Without this the runtime falls back to
+    // whichever presentation the CLI's own interactive session picked, which unconditionally
+    // reports it can prompt for approval — so a run that genuinely needs a human never parks,
+    // it just gets silently approved by the safe-mode policy instead.
+    Effect.provide(OneShotPresentationServiceLayer),
+    Effect.provide(makeFileRunStoreLayer()),
+  );
 }
 
 /**

--- a/packages/cli/src/commands/run/lifecycle.ts
+++ b/packages/cli/src/commands/run/lifecycle.ts
@@ -121,7 +121,8 @@ export function showRunCommand(options: { readonly runId: string; readonly json:
  */
 export function answerRunCommand(options: {
   readonly runId: string;
-  readonly approved: boolean;
+  /** Unused when `response` or `filePath` answers a question or file picker instead. */
+  readonly approved?: boolean;
   readonly note?: string;
   readonly response?: string;
   readonly filePath?: string;
@@ -146,12 +147,13 @@ export function answerRunCommand(options: {
           }
         : {
             kind: "approval",
-            value: options.approved
-              ? { approved: true }
-              : {
-                  approved: false,
-                  ...(options.note !== undefined ? { userMessage: options.note } : {}),
-                },
+            value:
+              options.approved === true
+                ? { approved: true }
+                : {
+                    approved: false,
+                    ...(options.note !== undefined ? { userMessage: options.note } : {}),
+                  },
           };
   return resumeRun({
     runId: options.runId,

--- a/packages/cli/src/commands/run/lifecycle.ts
+++ b/packages/cli/src/commands/run/lifecycle.ts
@@ -121,8 +121,7 @@ export function showRunCommand(options: { readonly runId: string; readonly json:
  */
 export function answerRunCommand(options: {
   readonly runId: string;
-  /** Unused when `response` or `filePath` answers a question or file picker instead. */
-  readonly approved?: boolean;
+  readonly approved: boolean;
   readonly note?: string;
   readonly response?: string;
   readonly filePath?: string;
@@ -147,13 +146,12 @@ export function answerRunCommand(options: {
           }
         : {
             kind: "approval",
-            value:
-              options.approved === true
-                ? { approved: true }
-                : {
-                    approved: false,
-                    ...(options.note !== undefined ? { userMessage: options.note } : {}),
-                  },
+            value: options.approved
+              ? { approved: true }
+              : {
+                  approved: false,
+                  ...(options.note !== undefined ? { userMessage: options.note } : {}),
+                },
           };
   return resumeRun({
     runId: options.runId,

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -1210,6 +1210,30 @@ function registerRunsCommands(program: Command): void {
     );
 
   runsCommand
+    .command("answer <runId>")
+    .description(
+      "Answer a question a parked run asked you, in your own words (not a tool approval — use approve/reject for that)",
+    )
+    .requiredOption(
+      "--response <text>",
+      "Your answer to the question. An empty string tells the run you declined to answer.",
+    )
+    .option("--json", "Emit a single JSON envelope { ok, runId, answer }")
+    .action((runId: string, options: { response: string; json?: boolean }) =>
+      runCliAction(
+        () =>
+          import("@jazz/cli/commands/run/lifecycle").then((mod) =>
+            mod.answerRunCommand({
+              runId,
+              response: options.response,
+              json: options.json === true,
+            }),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  runsCommand
     .command("reject <runId>")
     .description(
       "Refuse what a parked run is waiting for; it resumes and reasons about the refusal",

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -1210,30 +1210,6 @@ function registerRunsCommands(program: Command): void {
     );
 
   runsCommand
-    .command("answer <runId>")
-    .description(
-      "Answer a question a parked run asked you, in your own words (not a tool approval — use approve/reject for that)",
-    )
-    .requiredOption(
-      "--response <text>",
-      "Your answer to the question. An empty string tells the run you declined to answer.",
-    )
-    .option("--json", "Emit a single JSON envelope { ok, runId, answer }")
-    .action((runId: string, options: { response: string; json?: boolean }) =>
-      runCliAction(
-        () =>
-          import("@jazz/cli/commands/run/lifecycle").then((mod) =>
-            mod.answerRunCommand({
-              runId,
-              response: options.response,
-              json: options.json === true,
-            }),
-          ),
-        cliRuntimeOptions(program),
-      ),
-    );
-
-  runsCommand
     .command("reject <runId>")
     .description(
       "Refuse what a parked run is waiting for; it resumes and reasons about the refusal",


### PR DESCRIPTION
## What & why
`jazz daemon` served every run — webhook fires, due triggers, resumed parks — under whichever presentation the launching terminal happened to pick, which for an interactively-launched daemon is the one that always claims a human is watching. That made safe-mode silently auto-approve tool calls with no prompt shown anywhere, and stopped genuinely risky calls or questions from ever parking for a person to answer. A caller like quartet, which relies on the daemon parking (202) to show its own approve/deny UI, never saw anything to show.

The daemon now runs everything through the same headless presentation `jazz run` and `jazz workflow` already use for unattended execution, so parking works again.

Since parking a question is now reachable, `jazz runs` also gets an `answer <runId> --response <text>` command — the only way to answer that pending kind was previously missing entirely; `approve`/`reject` only make sense for a tool approval.

## How to verify
- Start `jazz daemon`, fire a webhook whose agent has an approval-gated tool (e.g. `execute_command`) with no auto-approve policy set, and confirm the run parks (`jazz runs list` shows it `waiting on approval`) instead of the tool just running.
- Confirm `jazz runs approve <runId>` still resumes and finishes it as before.
- Trigger a run that calls `ask_user_question`, confirm it parks as `waiting on an answer`, then run `jazz runs answer <runId> --response "some text"` and confirm the run resumes with that answer. Also try `--response ""` and confirm it resumes as declined.
- Run `jazz run` interactively (not through the daemon) and confirm approval prompts still show up in place as before — this change is scoped to the daemon's own runtime, not the interactive CLI.
