### PR TITLE
fix(cli): interrupt parent runs with active subagents

### DIFF
--- a/packages/cli/src/chat-service.ts
+++ b/packages/cli/src/chat-service.ts
@@ -55,7 +55,12 @@ import { Effect, Layer } from "effect";
 import { hydrateTranscriptFromHistory } from "@/cli/ui/hydrate-transcript";
 import { store } from "@/cli/ui/store";
 import { handleSpecialCommand, parseSpecialCommand, setSkillCommands } from "./chat/commands";
-import type { CommandContext, CommandResult } from "./chat/commands/types";
+import {
+  confirmSessionLimitOverage,
+  estimateSessionCostUSD,
+  findExceededSessionLimits,
+} from "./chat/commands/session-limits";
+import type { CommandContext, CommandResult, SessionLimits } from "./chat/commands/types";
 import { persistConversationIfNeeded } from "./chat/persist-conversation";
 import {
   initializeSession,
@@ -153,6 +158,8 @@ export class ChatServiceImpl implements ChatService {
       }
       let loggedMessageCount = 0;
       let sessionUsage = { promptTokens: 0, completionTokens: 0 };
+      let sessionTurnCount = 0;
+      let sessionLimits: SessionLimits = {};
       let autoApprovePolicy: AutoApprovePolicy | undefined = undefined;
       let autoApprovedCommands: string[] = [];
       const autoApprovedTools: string[] = [];
@@ -328,6 +335,8 @@ export class ChatServiceImpl implements ChatService {
               conversationId,
               conversationHistory,
               sessionUsage,
+              sessionTurnCount,
+              sessionLimits,
               sessionStartedAt,
               lastUsedAgentId,
               ...(autoApprovePolicy !== undefined ? { autoApprovePolicy } : {}),
@@ -362,6 +371,7 @@ export class ChatServiceImpl implements ChatService {
               conversationTitle = null;
               startedAt = new Date().toISOString();
               sessionUsage = { promptTokens: 0, completionTokens: 0 };
+              sessionTurnCount = 0;
               // Initialize the new conversation
               const fileSystemContext = yield* FileSystemContextServiceTag;
               yield* initializeSession(agent, conversationId).pipe(
@@ -417,6 +427,9 @@ export class ChatServiceImpl implements ChatService {
               // Sync mode state with store for Shift+Tab toggle
               store.setModeIsYolo(autoApprovePolicy === true || autoApprovePolicy === "high-risk");
             }
+            if (commandResult.newSessionLimits !== undefined) {
+              sessionLimits = commandResult.newSessionLimits;
+            }
 
             if (commandResult.addAutoApprovedCommand) {
               if (!autoApprovedCommands.includes(commandResult.addAutoApprovedCommand)) {
@@ -452,6 +465,24 @@ export class ChatServiceImpl implements ChatService {
             }
           }
         }
+
+        if (Object.keys(sessionLimits).length > 0) {
+          const costUSD = yield* estimateSessionCostUSD(sessionUsage, agent);
+          const exceeded = findExceededSessionLimits(sessionLimits, {
+            turns: sessionTurnCount,
+            costUSD,
+            tokens: sessionUsage.promptTokens + sessionUsage.completionTokens,
+          });
+          if (exceeded.length > 0) {
+            const proceed = yield* confirmSessionLimitOverage(terminal, exceeded);
+            if (!proceed) {
+              yield* terminal.log("Turn cancelled. Use /limit to raise or clear the cap.");
+              yield* terminal.log("");
+              continue;
+            }
+          }
+        }
+        sessionTurnCount += 1;
 
         yield* Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;

--- a/packages/cli/src/chat/commands/constants.ts
+++ b/packages/cli/src/chat/commands/constants.ts
@@ -29,6 +29,11 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "fork", description: "Fork conversation (new branch from last message)" },
   { name: "help", description: "Show available commands and shortcuts", usage: "[command]" },
   {
+    name: "limit",
+    description: "Set a session turn, cost, or token limit (applied immediately)",
+    usage: "[turns|usd|tokens <value>|clear]",
+  },
+  {
     name: "mcp",
     description: "Manage MCP servers",
     usage: "[reconnect <server>]",

--- a/packages/cli/src/chat/commands/handler.test.ts
+++ b/packages/cli/src/chat/commands/handler.test.ts
@@ -102,6 +102,8 @@ describe("handleSpecialCommand resume", () => {
       conversationHistory: [],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(Date.now() - 1800_000),
     };
 
@@ -145,6 +147,8 @@ describe("handleSpecialCommand resume", () => {
       conversationHistory: [{ role: "user", content: "still on screen" }],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(Date.now() - 1800_000),
     };
 
@@ -191,6 +195,8 @@ describe("handleSpecialCommand shell escape", () => {
           conversationHistory: [],
           conversationId: "test-session",
           sessionUsage: { promptTokens: 0, completionTokens: 0 },
+          sessionTurnCount: 0,
+          sessionLimits: {},
           sessionStartedAt: new Date(),
         },
       ).pipe(Effect.provide(layers)) as Effect.Effect<CommandResult, unknown, never>,
@@ -222,6 +228,8 @@ describe("handleSpecialCommand shell escape", () => {
           conversationHistory: [],
           conversationId: "test-session",
           sessionUsage: { promptTokens: 0, completionTokens: 0 },
+          sessionTurnCount: 0,
+          sessionLimits: {},
           sessionStartedAt: new Date(),
         },
       ).pipe(Effect.provide(layers)) as Effect.Effect<CommandResult, unknown, never>,
@@ -238,6 +246,8 @@ describe("handleSpecialCommand /reasoning", () => {
     conversationHistory: [],
     conversationId: "test-session",
     sessionUsage: { promptTokens: 0, completionTokens: 0 },
+    sessionTurnCount: 0,
+    sessionLimits: {},
     sessionStartedAt: new Date(),
   };
 
@@ -370,6 +380,8 @@ describe("handleSpecialCommand /tools", () => {
       conversationHistory: [],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(),
     };
 
@@ -429,6 +441,8 @@ describe("handleSpecialCommand /agents", () => {
       conversationHistory: [],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(),
       lastUsedAgentId: null,
     };
@@ -475,6 +489,8 @@ describe("handleSpecialCommand /peers", () => {
       conversationHistory: [],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(),
     };
 
@@ -519,6 +535,8 @@ describe("handleSpecialCommand /peers", () => {
       conversationHistory: [],
       conversationId: "test-session",
       sessionUsage: { promptTokens: 0, completionTokens: 0 },
+      sessionTurnCount: 0,
+      sessionLimits: {},
       sessionStartedAt: new Date(),
     };
 

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -59,7 +59,15 @@ import { getGlyphs } from "@/cli/ui/glyphs";
 import { getThemeVariant, setThemeVariant } from "@/cli/ui/theme";
 import * as fmt from "@/cli/utils/list-format";
 import { CHAT_COMMANDS } from "./constants";
-import type { CommandContext, CommandResult, SpecialCommand } from "./types";
+import {
+  confirmSessionLimitOverage,
+  estimateSessionCostUSD,
+  findExceededSessionLimits,
+  formatSessionLimitMetric,
+  SESSION_LIMIT_FIELD,
+  type SessionLimitMetric,
+} from "./session-limits";
+import type { CommandContext, CommandResult, SessionLimits, SpecialCommand } from "./types";
 
 /**
  * Handle special commands from user input.
@@ -101,6 +109,9 @@ export function handleSpecialCommand(
 
       case "help":
         return yield* handleHelpCommand(terminal, command.args);
+
+      case "limit":
+        return yield* handleLimitCommand(terminal, agent, context, command.args);
 
       case "tools":
         return yield* handleToolsCommand(terminal, agent);
@@ -1177,6 +1188,173 @@ function handleReasoningCommand(
     yield* terminal.info(`Levels: ${validLevels.join(", ")}`);
     yield* terminal.log(fmt.blank());
     return { shouldContinue: true };
+  });
+}
+
+/**
+ * Handle /limit command - view or set a session-wide turn/cost/token cap.
+ *
+ * "Session-wide" means the limit stays in effect for the rest of this
+ * conversation (not just the current turn) and is checked before every turn
+ * against this conversation's accumulated usage — the same numbers /cost and
+ * /stats show. With no args in an interactive terminal this opens the picker
+ * (select the metric, then type a value); with no args elsewhere it prints
+ * current usage and limits. A limit that's already exceeded the moment it's
+ * set is reported immediately here — enforcement itself happens on the next
+ * turn attempt in the chat loop.
+ */
+function handleLimitCommand(
+  terminal: TerminalService,
+  agent: CommandContext["agent"],
+  context: CommandContext,
+  args: string[],
+): Effect.Effect<CommandResult, never, never> {
+  const metricAliases: Record<string, SessionLimitMetric> = {
+    turn: "turns",
+    turns: "turns",
+    usd: "usd",
+    cost: "usd",
+    dollar: "usd",
+    dollars: "usd",
+    token: "tokens",
+    tokens: "tokens",
+  };
+
+  const parseValue = (raw: string): number | null | "invalid" => {
+    const lower = raw.toLowerCase();
+    if (lower === "clear" || lower === "none" || lower === "off") return null;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return "invalid";
+    return parsed;
+  };
+
+  const currentUsage = Effect.gen(function* () {
+    const costUSD = yield* estimateSessionCostUSD(context.sessionUsage, agent);
+    return {
+      turns: context.sessionTurnCount,
+      costUSD,
+      tokens: context.sessionUsage.promptTokens + context.sessionUsage.completionTokens,
+    };
+  });
+
+  const applyLimit = (
+    metric: SessionLimitMetric,
+    value: number | null,
+  ): Effect.Effect<CommandResult, never, never> =>
+    Effect.gen(function* () {
+      const field = SESSION_LIMIT_FIELD[metric];
+      const nextLimits: SessionLimits = { ...context.sessionLimits };
+      if (value === null) {
+        delete nextLimits[field];
+        yield* terminal.success(`Cleared the session ${metric} limit.`);
+      } else {
+        nextLimits[field] = value;
+        yield* terminal.success(
+          `Session ${metric} limit set to ${formatSessionLimitMetric(metric, value)} (this session only).`,
+        );
+      }
+      yield* terminal.log(fmt.blank());
+
+      if (value !== null) {
+        const usage = yield* currentUsage;
+        const exceeded = findExceededSessionLimits(nextLimits, usage);
+        if (exceeded.length > 0) {
+          yield* confirmSessionLimitOverage(terminal, exceeded);
+          yield* terminal.log(fmt.blank());
+        }
+      }
+
+      return { shouldContinue: true, newSessionLimits: nextLimits };
+    });
+
+  return Effect.gen(function* () {
+    if (args.length === 1 && args[0]?.toLowerCase() === "clear") {
+      yield* terminal.success("Cleared all session limits.");
+      yield* terminal.log(fmt.blank());
+      return { shouldContinue: true, newSessionLimits: {} };
+    }
+
+    if (args.length > 0) {
+      const metric = metricAliases[(args[0] ?? "").toLowerCase()];
+      if (!metric) {
+        yield* terminal.error(`Unknown limit "${args[0]}". Use: turns, usd, tokens, or clear.`);
+        yield* terminal.log(fmt.blank());
+        return { shouldContinue: true };
+      }
+      const rawValue = args[1];
+      if (rawValue === undefined) {
+        yield* terminal.error(`Usage: /limit ${metric} <value>|clear`);
+        yield* terminal.log(fmt.blank());
+        return { shouldContinue: true };
+      }
+      const value = parseValue(rawValue);
+      if (value === "invalid") {
+        yield* terminal.error(
+          `Invalid value "${rawValue}" — expected a positive number or "clear".`,
+        );
+        yield* terminal.log(fmt.blank());
+        return { shouldContinue: true };
+      }
+      return yield* applyLimit(metric, value);
+    }
+
+    // No args: show current usage and limits.
+    const usage = yield* currentUsage;
+    yield* terminal.log(fmt.heading("Session Limits"));
+    for (const metric of ["turns", "usd", "tokens"] as const) {
+      const limitValue = context.sessionLimits[SESSION_LIMIT_FIELD[metric]];
+      const used =
+        metric === "turns" ? usage.turns : metric === "usd" ? usage.costUSD : usage.tokens;
+      yield* terminal.log(
+        fmt.keyValueCompact(
+          metric,
+          limitValue === undefined
+            ? `${formatSessionLimitMetric(metric, used)} used, no limit set`
+            : `${formatSessionLimitMetric(metric, used)} used / ${formatSessionLimitMetric(metric, limitValue)} limit`,
+        ),
+      );
+    }
+    yield* terminal.log(fmt.blank());
+
+    if (!terminal.isInteractive) {
+      yield* terminal.info('Set one with "/limit turns|usd|tokens <value>", or "/limit clear".');
+      yield* terminal.log(fmt.blank());
+      return { shouldContinue: true };
+    }
+
+    const selectedMetric = yield* terminal.select<SessionLimitMetric>("Set a session limit:", {
+      choices: (["turns", "usd", "tokens"] as const).map((metric) => ({
+        name: metric,
+        value: metric,
+      })),
+    });
+    if (!selectedMetric) {
+      yield* terminal.log(fmt.blank());
+      return { shouldContinue: true };
+    }
+
+    const currentValue = context.sessionLimits[SESSION_LIMIT_FIELD[selectedMetric]];
+    const rawValue = yield* terminal.ask(
+      `New ${selectedMetric} limit (number, or "clear" to remove it):`,
+      {
+        cancellable: true,
+        simple: true,
+        ...(currentValue !== undefined ? { defaultValue: String(currentValue) } : {}),
+        validate: (input) => {
+          const parsed = parseValue(input);
+          return parsed === "invalid" ? 'Enter a positive number, or "clear".' : true;
+        },
+      },
+    );
+    if (rawValue === undefined) {
+      yield* terminal.log(fmt.blank());
+      return { shouldContinue: true };
+    }
+    const value = parseValue(rawValue);
+    if (value === "invalid") {
+      return { shouldContinue: true };
+    }
+    return yield* applyLimit(selectedMetric, value);
   });
 }
 

--- a/packages/cli/src/chat/commands/limit-command.test.ts
+++ b/packages/cli/src/chat/commands/limit-command.test.ts
@@ -1,0 +1,146 @@
+import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
+import type { Agent } from "@jazz/core/types/agent";
+import type { ModelsDevMetadata } from "@jazz/core/utils/models-dev";
+import { describe, expect, it, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import type { CommandContext, CommandResult } from "./types";
+
+mock.module("@jazz/core/utils/models-dev", () => ({
+  getModelsDevMetadata: () =>
+    Promise.resolve({ inputPricePerMillion: 3, outputPricePerMillion: 15 } as ModelsDevMetadata),
+  getModelsDevProviderModels: () => Promise.resolve([]),
+}));
+
+const { handleSpecialCommand } = await import("./handler");
+
+const testAgent = {
+  id: "a",
+  name: "A",
+  config: { persona: "default", llmProvider: "openai", llmModel: "gpt-4", tools: [] },
+} as unknown as Agent;
+
+function baseContext(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    agent: testAgent,
+    conversationHistory: [],
+    conversationId: "c",
+    sessionUsage: { promptTokens: 0, completionTokens: 0 },
+    sessionTurnCount: 0,
+    sessionLimits: {},
+    sessionStartedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function runLimit(
+  args: string[],
+  context: CommandContext,
+  terminal: Partial<TerminalService>,
+): Promise<CommandResult> {
+  const fullTerminal: Partial<TerminalService> = {
+    log: mock(() => Effect.succeed(undefined)),
+    ...terminal,
+  };
+  const terminalLayer = Layer.succeed(
+    TerminalServiceTag,
+    fullTerminal as unknown as TerminalService,
+  );
+  return Effect.runPromise(
+    handleSpecialCommand({ type: "limit", args }, context).pipe(
+      Effect.provide(terminalLayer),
+    ) as Effect.Effect<CommandResult, unknown, never>,
+  );
+}
+
+describe("handleSpecialCommand /limit", () => {
+  it("sets a direct usd limit", async () => {
+    const success = mock(() => Effect.void);
+    const result = await runLimit(["usd", "5"], baseContext(), { success });
+    expect(result.newSessionLimits).toEqual({ maxCostUSD: 5 });
+    expect(success).toHaveBeenCalledWith(expect.stringContaining("Session usd limit set to $5.00"));
+  });
+
+  it("sets a direct turns limit", async () => {
+    const result = await runLimit(["turns", "10"], baseContext(), {
+      success: mock(() => Effect.void),
+    });
+    expect(result.newSessionLimits).toEqual({ maxTurns: 10 });
+  });
+
+  it("accepts metric aliases", async () => {
+    const result = await runLimit(["cost", "2.5"], baseContext(), {
+      success: mock(() => Effect.void),
+    });
+    expect(result.newSessionLimits).toEqual({ maxCostUSD: 2.5 });
+  });
+
+  it("clears one metric, keeping the others", async () => {
+    const result = await runLimit(
+      ["usd", "clear"],
+      baseContext({ sessionLimits: { maxCostUSD: 5, maxTurns: 10 } }),
+      { success: mock(() => Effect.void) },
+    );
+    expect(result.newSessionLimits).toEqual({ maxTurns: 10 });
+  });
+
+  it("clears every limit with /limit clear", async () => {
+    const result = await runLimit(
+      ["clear"],
+      baseContext({ sessionLimits: { maxCostUSD: 5, maxTurns: 10 } }),
+      { success: mock(() => Effect.void) },
+    );
+    expect(result.newSessionLimits).toEqual({});
+  });
+
+  it("rejects an unknown metric without touching sessionLimits", async () => {
+    const error = mock(() => Effect.void);
+    const result = await runLimit(["bogus", "5"], baseContext(), { error });
+    expect(result.newSessionLimits).toBeUndefined();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Unknown limit "bogus"'));
+  });
+
+  it("rejects a non-numeric value", async () => {
+    const error = mock(() => Effect.void);
+    const result = await runLimit(["usd", "abc"], baseContext(), { error });
+    expect(result.newSessionLimits).toBeUndefined();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Invalid value "abc"'));
+  });
+
+  it("warns and asks to continue when the new limit is already exceeded", async () => {
+    const warn = mock(() => Effect.void);
+    const confirm = mock(() => Effect.succeed(false));
+    const result = await runLimit(["turns", "1"], baseContext({ sessionTurnCount: 3 }), {
+      success: mock(() => Effect.void),
+      warn,
+      confirm,
+    });
+    // The limit is applied regardless of the answer — enforcement happens on
+    // the next turn attempt in the chat loop, not inside /limit itself.
+    expect(result.newSessionLimits).toEqual({ maxTurns: 1 });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("turns limit reached"));
+    expect(confirm).toHaveBeenCalled();
+  });
+
+  it("prints status without prompting on a non-interactive terminal", async () => {
+    const info = mock(() => Effect.void);
+    const result = await runLimit([], baseContext({ sessionLimits: { maxTurns: 10 } }), {
+      isInteractive: false,
+      info,
+    });
+    expect(result).toEqual({ shouldContinue: true });
+    expect(info).toHaveBeenCalled();
+  });
+
+  it("opens the picker and applies the selected metric+value on an interactive terminal", async () => {
+    const select = mock(() => Effect.succeed("tokens")) as unknown as TerminalService["select"];
+    const ask = mock(() => Effect.succeed("100000")) as unknown as TerminalService["ask"];
+    const success = mock(() => Effect.void);
+    const result = await runLimit([], baseContext(), {
+      isInteractive: true,
+      select,
+      ask,
+      success,
+    });
+    expect(result.newSessionLimits).toEqual({ maxTokens: 100_000 });
+  });
+});

--- a/packages/cli/src/chat/commands/mcp-prompt-args.test.ts
+++ b/packages/cli/src/chat/commands/mcp-prompt-args.test.ts
@@ -17,6 +17,8 @@ const context: CommandContext = {
   conversationHistory: [],
   conversationId: "c",
   sessionUsage: { promptTokens: 0, completionTokens: 0 },
+  sessionTurnCount: 0,
+  sessionLimits: {},
   sessionStartedAt: new Date(),
 };
 

--- a/packages/cli/src/chat/commands/parser.test.ts
+++ b/packages/cli/src/chat/commands/parser.test.ts
@@ -113,6 +113,12 @@ describe("parseSpecialCommand", () => {
       expect(result.type).toBe("workflows");
       expect(result.args).toEqual(["create", "my-newsletter"]);
     });
+
+    it("should parse /limit usd 5", () => {
+      const result = parseSpecialCommand("/limit usd 5");
+      expect(result.type).toBe("limit");
+      expect(result.args).toEqual(["usd", "5"]);
+    });
   });
 
   describe("case insensitivity", () => {

--- a/packages/cli/src/chat/commands/parser.ts
+++ b/packages/cli/src/chat/commands/parser.ts
@@ -74,6 +74,8 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "export", args };
     case "retry":
       return { type: "retry", args };
+    case "limit":
+      return { type: "limit", args };
     default:
       // A slash command that matches a registered skill runs that skill.
       // args[0] is the skill name (mirrors the "unknown" convention).

--- a/packages/cli/src/chat/commands/session-limits.test.ts
+++ b/packages/cli/src/chat/commands/session-limits.test.ts
@@ -1,0 +1,84 @@
+import type { Agent } from "@jazz/core/types/agent";
+import type { ModelsDevMetadata } from "@jazz/core/utils/models-dev";
+import { describe, expect, it, mock } from "bun:test";
+import { Effect } from "effect";
+
+let metadata: ModelsDevMetadata | undefined;
+
+mock.module("@jazz/core/utils/models-dev", () => ({
+  getModelsDevMetadata: () => Promise.resolve(metadata),
+  getModelsDevProviderModels: () => Promise.resolve([]),
+}));
+
+const { estimateSessionCostUSD, findExceededSessionLimits, formatSessionLimitMetric } =
+  await import("./session-limits");
+
+const testAgent = {
+  id: "a",
+  name: "A",
+  config: { persona: "default", llmProvider: "openai", llmModel: "gpt-4", tools: [] },
+} as unknown as Agent;
+
+describe("findExceededSessionLimits", () => {
+  it("returns nothing when no limits are configured", () => {
+    expect(findExceededSessionLimits({}, { turns: 100, costUSD: 100, tokens: 1_000_000 })).toEqual(
+      [],
+    );
+  });
+
+  it("flags a metric once usage reaches its limit", () => {
+    const exceeded = findExceededSessionLimits(
+      { maxTurns: 5 },
+      { turns: 5, costUSD: 0, tokens: 0 },
+    );
+    expect(exceeded).toEqual([{ metric: "turns", limit: 5, used: 5 }]);
+  });
+
+  it("does not flag a metric below its limit", () => {
+    expect(findExceededSessionLimits({ maxTurns: 5 }, { turns: 4, costUSD: 0, tokens: 0 })).toEqual(
+      [],
+    );
+  });
+
+  it("flags every exceeded metric at once", () => {
+    const exceeded = findExceededSessionLimits(
+      { maxTurns: 5, maxCostUSD: 1, maxTokens: 100 },
+      { turns: 10, costUSD: 2, tokens: 200 },
+    );
+    expect(exceeded.map((overage) => overage.metric).sort()).toEqual(["tokens", "turns", "usd"]);
+  });
+});
+
+describe("formatSessionLimitMetric", () => {
+  it("formats turns with pluralization", () => {
+    expect(formatSessionLimitMetric("turns", 1)).toBe("1 turn");
+    expect(formatSessionLimitMetric("turns", 2)).toBe("2 turns");
+  });
+
+  it("formats usd to 2 decimals", () => {
+    expect(formatSessionLimitMetric("usd", 5)).toBe("$5.00");
+    expect(formatSessionLimitMetric("usd", 1.5)).toBe("$1.50");
+  });
+
+  it("formats tokens with locale separators", () => {
+    expect(formatSessionLimitMetric("tokens", 100_000)).toBe("100,000 tokens");
+  });
+});
+
+describe("estimateSessionCostUSD", () => {
+  it("returns 0 when pricing metadata is unavailable", async () => {
+    metadata = undefined;
+    const cost = await Effect.runPromise(
+      estimateSessionCostUSD({ promptTokens: 1_000_000, completionTokens: 1_000_000 }, testAgent),
+    );
+    expect(cost).toBe(0);
+  });
+
+  it("prices accumulated tokens against input/output rates", async () => {
+    metadata = { inputPricePerMillion: 3, outputPricePerMillion: 15 } as ModelsDevMetadata;
+    const cost = await Effect.runPromise(
+      estimateSessionCostUSD({ promptTokens: 1_000_000, completionTokens: 500_000 }, testAgent),
+    );
+    expect(cost).toBeCloseTo(3 + 7.5);
+  });
+});

--- a/packages/cli/src/chat/commands/session-limits.ts
+++ b/packages/cli/src/chat/commands/session-limits.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared logic for the /limit command: estimating this conversation's spend
+ * against configured turn/USD/token caps, and gating a turn on user
+ * confirmation once a cap is reached. Used both by the /limit handler itself
+ * (to report an already-exceeded cap the moment it's set) and by the chat
+ * loop (to gate every subsequent turn).
+ */
+
+import type { TerminalService } from "@jazz/core/interfaces/terminal";
+import type { Agent } from "@jazz/core/types";
+import { getModelsDevMetadata } from "@jazz/core/utils/models-dev";
+import { Effect } from "effect";
+import type { SessionLimits, SessionUsage } from "./types";
+
+export type SessionLimitMetric = "turns" | "usd" | "tokens";
+
+export const SESSION_LIMIT_FIELD: Record<SessionLimitMetric, keyof SessionLimits> = {
+  turns: "maxTurns",
+  usd: "maxCostUSD",
+  tokens: "maxTokens",
+};
+
+export interface SessionLimitUsage {
+  readonly turns: number;
+  readonly costUSD: number;
+  readonly tokens: number;
+}
+
+export interface SessionLimitOverage {
+  readonly metric: SessionLimitMetric;
+  readonly limit: number;
+  readonly used: number;
+}
+
+/** Estimated USD spent so far, from accumulated tokens and model pricing (same calculation as /cost). */
+export function estimateSessionCostUSD(
+  sessionUsage: SessionUsage,
+  agent: Agent,
+): Effect.Effect<number, never, never> {
+  return Effect.promise(() =>
+    getModelsDevMetadata(agent.config.llmModel, agent.config.llmProvider),
+  ).pipe(
+    Effect.map((meta) => {
+      const inputPricePerMillion = meta?.inputPricePerMillion ?? 0;
+      const outputPricePerMillion = meta?.outputPricePerMillion ?? 0;
+      return (
+        (sessionUsage.promptTokens / 1_000_000) * inputPricePerMillion +
+        (sessionUsage.completionTokens / 1_000_000) * outputPricePerMillion
+      );
+    }),
+  );
+}
+
+export function findExceededSessionLimits(
+  limits: SessionLimits,
+  usage: SessionLimitUsage,
+): SessionLimitOverage[] {
+  const exceeded: SessionLimitOverage[] = [];
+  if (limits.maxTurns !== undefined && usage.turns >= limits.maxTurns) {
+    exceeded.push({ metric: "turns", limit: limits.maxTurns, used: usage.turns });
+  }
+  if (limits.maxCostUSD !== undefined && usage.costUSD >= limits.maxCostUSD) {
+    exceeded.push({ metric: "usd", limit: limits.maxCostUSD, used: usage.costUSD });
+  }
+  if (limits.maxTokens !== undefined && usage.tokens >= limits.maxTokens) {
+    exceeded.push({ metric: "tokens", limit: limits.maxTokens, used: usage.tokens });
+  }
+  return exceeded;
+}
+
+export function formatSessionLimitMetric(metric: SessionLimitMetric, value: number): string {
+  switch (metric) {
+    case "turns":
+      return `${Math.round(value)} turn${Math.round(value) === 1 ? "" : "s"}`;
+    case "usd":
+      return `$${value.toFixed(2)}`;
+    case "tokens":
+      return `${Math.round(value).toLocaleString()} tokens`;
+  }
+}
+
+/**
+ * Warn about every exceeded cap and ask whether to continue. Declining does
+ * not clear the limit — the next turn hits this same gate again — so raising
+ * or clearing it with /limit is the only way past it.
+ */
+export function confirmSessionLimitOverage(
+  terminal: TerminalService,
+  exceeded: readonly SessionLimitOverage[],
+): Effect.Effect<boolean, never, never> {
+  return Effect.gen(function* () {
+    for (const overage of exceeded) {
+      yield* terminal.warn(
+        `Session ${overage.metric} limit reached: ${formatSessionLimitMetric(overage.metric, overage.used)} used, limit ${formatSessionLimitMetric(overage.metric, overage.limit)}.`,
+      );
+    }
+    return yield* terminal.confirm("Continue anyway?", false);
+  });
+}

--- a/packages/cli/src/chat/commands/types.ts
+++ b/packages/cli/src/chat/commands/types.ts
@@ -35,6 +35,7 @@ export type CommandType =
   | "export"
   | "retry"
   | "shell"
+  | "limit"
   | "runSkill"
   | "runMcpPrompt"
   | "unknown";
@@ -73,12 +74,28 @@ export interface CommandResult {
   resendMessage?: string;
   /** Message to send to the agent after a user-side command has completed. */
   messageForAgent?: string;
+  /** New session-wide limits set by /limit (a full replacement, not a patch — an absent field means "no limit"). */
+  newSessionLimits?: SessionLimits;
 }
 
 /** Token usage accumulated for the current conversation (for /cost). */
 export interface SessionUsage {
   promptTokens: number;
   completionTokens: number;
+}
+
+/**
+ * Session-wide caps set by /limit. Checked against this conversation's
+ * accumulated usage (the same numbers /cost and /stats show) before every
+ * turn; an absent field means that metric is uncapped.
+ */
+export interface SessionLimits {
+  /** Max number of turns (user messages sent to the agent) for this conversation. */
+  maxTurns?: number;
+  /** Max cumulative estimated USD spend for this conversation. */
+  maxCostUSD?: number;
+  /** Max cumulative tokens (prompt + completion) for this conversation. */
+  maxTokens?: number;
 }
 
 /**
@@ -90,6 +107,10 @@ export interface CommandContext {
   conversationHistory: ChatMessage[];
   /** Accumulated input/output tokens for this session (reset on /new). */
   sessionUsage: SessionUsage;
+  /** Number of turns sent to the agent this conversation (reset on /new, for /limit). */
+  sessionTurnCount: number;
+  /** Session-wide turn/cost/token caps set by /limit (persists across /new). */
+  sessionLimits: SessionLimits;
   /** Timestamp when the chat session started (for /stats duration). */
   sessionStartedAt: Date;
   /** Current auto-approve policy (for /mode display). */

--- a/packages/cli/src/presentation/ink-presentation-service.test.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.test.ts
@@ -592,6 +592,41 @@ describe("InkStreamingRenderer", () => {
       const last = setActivityCalls[setActivityCalls.length - 1];
       expect(last!.phase).toBe("idle");
     });
+
+    test("complete clears tools that have no matching completion event", async () => {
+      const renderer = createRenderer();
+      emitStreamStart(renderer);
+
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "tool_execution_start",
+          toolName: "retrieve_tool_result",
+          toolCallId: "tc-stale",
+        }),
+      );
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "complete",
+          response: completeResponse("done"),
+          totalDurationMs: 100,
+        }),
+      );
+
+      // A new turn must not inherit the previous turn's tool row.
+      emitStreamStart(renderer);
+      Effect.runSync(
+        renderer.handleEvent({
+          type: "tool_execution_start",
+          toolName: "http",
+          toolCallId: "tc-new",
+        }),
+      );
+      const latest = setActivityCalls.at(-1);
+      expect(latest?.phase).toBe("tool-execution");
+      if (latest?.phase === "tool-execution") {
+        expect(latest.tools.map((tool) => tool.toolCallId)).toEqual(["tc-new"]);
+      }
+    });
   });
 
   describe("sub-agent tool routing", () => {

--- a/packages/cli/src/presentation/ink-presentation-service.ts
+++ b/packages/cli/src/presentation/ink-presentation-service.ts
@@ -703,6 +703,11 @@ export class InkStreamingRenderer implements StreamingRenderer {
     this.flushStreamBuffer();
     this.collapseReasoningRegion();
     store.finalizeStream();
+    // A complete event is the terminal boundary for the renderer, even when
+    // an execution path did not deliver a matching tool completion event.
+    // Clear the accumulator so a tool from this turn cannot reappear when the
+    // renderer is reused for the next turn.
+    this.acc.activeTools.clear();
 
     if (!this.hasStreamedText) {
       this.printFinalResponse(event);

--- a/packages/cli/src/ui/fullscreen/bridge.test.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.test.tsx
@@ -706,6 +706,7 @@ describe("fullscreen bridge", () => {
     await settleKeypress(rendered.flush, 100);
 
     expect(interrupted).toBe(1);
+    expect(store.getOutputSnapshot().entries.at(-1)?.message).toBe("Interrupting…");
     store.setInterruptHandler(null);
     store.setChatBusy(false);
     rendered.renderer.destroy();

--- a/packages/cli/src/ui/fullscreen/bridge.tsx
+++ b/packages/cli/src/ui/fullscreen/bridge.tsx
@@ -2129,7 +2129,15 @@ export function FullscreenBridge(): React.ReactNode {
 
   const onAction = useCallback(
     (action: KeyAction) => {
-      if (action.type === "interrupt") interrupt.current?.();
+      if (action.type === "interrupt") {
+        store.printOutput({
+          type: "warn",
+          message: "Interrupting…",
+          timestamp: new Date(),
+        });
+        store.collapseAllEphemeral();
+        interrupt.current?.();
+      }
       if (action.type === "flush-queue") {
         // Enqueue the current draft alongside anything already queued, then ask
         // the chat loop to drain the lot into the running conversation now.
@@ -2139,6 +2147,12 @@ export function FullscreenBridge(): React.ReactNode {
           commitComposer(EMPTY_COMPOSER);
         }
         store.requestFlushQueue();
+        store.printOutput({
+          type: "warn",
+          message: "Interrupting…",
+          timestamp: new Date(),
+        });
+        store.collapseAllEphemeral();
         interrupt.current?.();
         return;
       }

--- a/packages/cli/src/ui/store.test.ts
+++ b/packages/cli/src/ui/store.test.ts
@@ -312,20 +312,21 @@ describe("UIStore", () => {
   });
 
   describe("interrupt handler stack", () => {
-    test("nested setInterruptHandler restores outer handler when inner pops", () => {
+    test("nested handlers all receive an interrupt, and inner pop restores outer dispatch", () => {
       const s = new UIStore();
-      const seen: Array<(() => void) | null> = [];
-      s.subscribeSession(() => seen.push(s.getSessionSnapshot().interruptHandler));
-
-      const outer = (): void => {};
-      const inner = (): void => {};
+      const calls: string[] = [];
+      const outer = (): void => void calls.push("outer");
+      const inner = (): void => void calls.push("inner");
 
       s.setInterruptHandler(outer);
       s.setInterruptHandler(inner);
-      s.setInterruptHandler(null);
+      s.getSessionSnapshot().interruptHandler?.();
+      expect(calls).toEqual(["inner", "outer"]);
 
-      const top = seen[seen.length - 1];
-      expect(top).toBe(outer);
+      calls.length = 0;
+      s.setInterruptHandler(null);
+      s.getSessionSnapshot().interruptHandler?.();
+      expect(calls).toEqual(["outer"]);
     });
 
     test("popping below empty is a no-op (over-pop tolerated)", () => {
@@ -341,7 +342,7 @@ describe("UIStore", () => {
       s.setInterruptHandler(handler);
       unsubscribe();
 
-      expect(s.getSessionSnapshot().interruptHandler).toBe(handler);
+      expect(s.getSessionSnapshot().interruptHandler).not.toBeNull();
     });
   });
 

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -282,6 +282,10 @@ export class UIStore {
   private inputHistory: string[] = [];
   private ephemeralRegions: Map<EphemeralRegionId, EphemeralRegion> = new Map();
   private ephemeralIdCounter = 0;
+  // A run may synchronously spawn nested runs. Interrupting only the top-most
+  // callback leaves the parent waiting for (and potentially respawning) a child.
+  // Keep the stack for scoped cleanup, but dispatch an interrupt to every active
+  // run so Esc Esc always cancels the complete run tree.
   private interruptHandlerStack: Array<() => void> = [];
   private backgroundHandlerStack: Array<() => void> = [];
   private promptContinuation: ((result: PromptResult) => void) | null = null;
@@ -422,8 +426,20 @@ export class UIStore {
     } else {
       this.interruptHandlerStack.push(handler);
     }
-    const top = this.interruptHandlerStack[this.interruptHandlerStack.length - 1] ?? null;
-    patchSlice(this.session, { interruptHandler: top });
+    const handlers = this.interruptHandlerStack.slice();
+    const interrupt =
+      handlers.length === 0
+        ? null
+        : handlers.length === 1
+          ? handlers[0]!
+          : (): void => {
+              // Run newest first so the currently visible child is stopped
+              // immediately, then propagate to its parent and any ancestors.
+              for (let index = handlers.length - 1; index >= 0; index -= 1) {
+                handlers[index]?.();
+              }
+            };
+    patchSlice(this.session, { interruptHandler: interrupt });
   };
 
   setBackgroundHandler = (handler: (() => void) | null): void => {


### PR DESCRIPTION
## What & why
Esc Esc now cancels the complete active run, including nested subagents, instead of stopping only the most recently spawned child. The fullscreen UI also shows immediate interruption feedback and clears transient subagent panels so operators know the run has stopped.

## How to verify
- Run the CLI with a task that spawns a subagent, then press Esc twice; confirm the parent and child stop together.
- Repeat with multiple active/nested subagents and confirm one Esc Esc cancels the whole run tree.
- Confirm the fullscreen UI displays “Interrupting…” and no stale subagent panels remain.
- Run the focused CLI/UI tests and TypeScript typecheck.