### PR TITLE
feat(agents): validate every AgentConfig field

### DIFF
--- a/packages/adapters/src/agent-service.test.ts
+++ b/packages/adapters/src/agent-service.test.ts
@@ -646,6 +646,133 @@ describe("AgentService", () => {
     });
   });
 
+  describe("validateAgentConfig required fields", () => {
+    const baseConfig: AgentConfig = {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+    };
+
+    const expectRejected = async (config: AgentConfig) => {
+      const result = await Effect.runPromiseExit(service.validateAgentConfig(config));
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    };
+
+    it("accepts a well-formed config", async () => {
+      await expect(
+        Effect.runPromise(service.validateAgentConfig(baseConfig)),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects a provider that is not in AVAILABLE_PROVIDERS", async () => {
+      // @ts-expect-error - unknown provider
+      await expectRejected({ ...baseConfig, llmProvider: "definitely-not-a-provider" });
+    });
+
+    it("rejects a provider that differs only in case", async () => {
+      // @ts-expect-error - wrong case
+      await expectRejected({ ...baseConfig, llmProvider: "OpenAI" });
+    });
+
+    it("rejects an empty model", async () => {
+      await expectRejected({ ...baseConfig, llmModel: "   " });
+    });
+
+    it("rejects a missing model", async () => {
+      // @ts-expect-error - absent required field
+      await expectRejected({ persona: "default", llmProvider: "openai" });
+    });
+
+    it("rejects an empty persona", async () => {
+      await expectRejected({ ...baseConfig, persona: "" });
+    });
+  });
+
+  describe("validateAgentConfig optional scalars", () => {
+    const baseConfig: AgentConfig = {
+      persona: "default",
+      llmProvider: "openai",
+      llmModel: "gpt-4",
+    };
+
+    const expectRejected = async (config: AgentConfig) => {
+      const result = await Effect.runPromiseExit(service.validateAgentConfig(config));
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
+    };
+
+    const expectAccepted = async (config: AgentConfig) => {
+      await expect(Effect.runPromise(service.validateAgentConfig(config))).resolves.toBeUndefined();
+    };
+
+    it("accepts every reasoning effort level", async () => {
+      for (const effort of ["disable", "low", "medium", "high"] as const) {
+        await expectAccepted({ ...baseConfig, reasoningEffort: effort });
+      }
+    });
+
+    it("rejects an unknown reasoning effort", async () => {
+      // @ts-expect-error - unknown level
+      await expectRejected({ ...baseConfig, reasoningEffort: "maximum" });
+    });
+
+    it("accepts temperature at both ends of the range", async () => {
+      await expectAccepted({ ...baseConfig, temperature: 0 });
+      await expectAccepted({ ...baseConfig, temperature: 2 });
+    });
+
+    it("rejects temperature outside the range", async () => {
+      await expectRejected({ ...baseConfig, temperature: -0.1 });
+      await expectRejected({ ...baseConfig, temperature: 2.1 });
+    });
+
+    it("rejects a temperature that is not a finite number", async () => {
+      await expectRejected({ ...baseConfig, temperature: Number.NaN });
+      await expectRejected({ ...baseConfig, temperature: Number.POSITIVE_INFINITY });
+      // @ts-expect-error - numeric strings are not numbers
+      await expectRejected({ ...baseConfig, temperature: "0.7" });
+    });
+
+    it("accepts positive whole context sizes", async () => {
+      await expectAccepted({ ...baseConfig, numCtx: 8192, maxContextTokens: 32_000 });
+    });
+
+    it("rejects zero, negative, or fractional context sizes", async () => {
+      await expectRejected({ ...baseConfig, numCtx: 0 });
+      await expectRejected({ ...baseConfig, maxContextTokens: -1 });
+      await expectRejected({ ...baseConfig, numCtx: 1024.5 });
+    });
+
+    it("accepts a known web search provider", async () => {
+      await expectAccepted({ ...baseConfig, webSearchProvider: "exa" });
+    });
+
+    it("rejects an unknown web search provider", async () => {
+      // @ts-expect-error - unknown provider
+      await expectRejected({ ...baseConfig, webSearchProvider: "google" });
+    });
+
+    it("accepts named memory scopes", async () => {
+      await expectAccepted({ ...baseConfig, memoryScopes: ["work", "personal"] });
+    });
+
+    it("rejects a non-array memoryScopes value", async () => {
+      // @ts-expect-error - must be an array
+      await expectRejected({ ...baseConfig, memoryScopes: "work" });
+    });
+
+    it("rejects a blank memory scope", async () => {
+      await expectRejected({ ...baseConfig, memoryScopes: ["work", "  "] });
+    });
+  });
+
   describe("deleteAgent", () => {
     it("should delete an agent", async () => {
       // @ts-expect-error - mocking

--- a/packages/adapters/src/agent-service.ts
+++ b/packages/adapters/src/agent-service.ts
@@ -5,9 +5,12 @@
 
 import { validateCustomToolDefinitionShape } from "@jazz/core/agent/tools/custom-tool-validation";
 import { normalizeToolConfig } from "@jazz/core/agent/utils/tool-config";
+import { AVAILABLE_PROVIDERS, isProviderName } from "@jazz/core/constants/models";
 import { AgentServiceTag, type AgentService } from "@jazz/core/interfaces/agent-service";
 import { StorageServiceTag, type StorageService } from "@jazz/core/interfaces/storage";
 import { CommonSuggestions } from "@jazz/core/presentation/error-handler";
+import { isReasoningEffort, REASONING_EFFORTS } from "@jazz/core/types/agent";
+import { isWebSearchProviderName, WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
 import {
   AgentAlreadyExistsError,
   AgentConfigurationError,
@@ -173,6 +176,43 @@ export class AgentServiceImpl implements AgentService {
 
   validateAgentConfig(config: AgentConfig): Effect.Effect<void, AgentConfigurationError> {
     return Effect.gen(function* (this: AgentServiceImpl) {
+      const persona: unknown = config.persona;
+      if (typeof persona !== "string" || persona.trim().length === 0) {
+        return yield* Effect.fail(
+          new AgentConfigurationError({
+            agentId: "unknown",
+            field: "config.persona",
+            message: `Invalid persona ${JSON.stringify(persona)}`,
+            suggestion:
+              'Use a built-in persona ("default", "coder", "researcher") or the name of a persona file in ~/.jazz/personas/.',
+          }),
+        );
+      }
+
+      const llmProvider: unknown = config.llmProvider;
+      if (typeof llmProvider !== "string" || !isProviderName(llmProvider)) {
+        return yield* Effect.fail(
+          new AgentConfigurationError({
+            agentId: "unknown",
+            field: "config.llmProvider",
+            message: `Unknown LLM provider ${JSON.stringify(llmProvider)}`,
+            suggestion: `Use one of: ${AVAILABLE_PROVIDERS.join(", ")}.`,
+          }),
+        );
+      }
+
+      const llmModel: unknown = config.llmModel;
+      if (typeof llmModel !== "string" || llmModel.trim().length === 0) {
+        return yield* Effect.fail(
+          new AgentConfigurationError({
+            agentId: "unknown",
+            field: "config.llmModel",
+            message: `Invalid LLM model ${JSON.stringify(llmModel)}`,
+            suggestion: `Name a model the provider serves, e.g. "gpt-4o" for openai.`,
+          }),
+        );
+      }
+
       if (config.llmApiKeys) {
         for (const [provider, apiKey] of Object.entries(config.llmApiKeys)) {
           if (typeof apiKey !== "string" || apiKey.trim().length === 0) {
@@ -365,6 +405,99 @@ export class AgentServiceImpl implements AgentService {
                 agentId: "unknown",
                 field: "config.tools",
                 message: "Each tool entry must be a non-empty string",
+              }),
+            );
+          }
+        }
+      }
+
+      const reasoningEffort: unknown = config.reasoningEffort;
+      if (reasoningEffort !== undefined && reasoningEffort !== null) {
+        if (typeof reasoningEffort !== "string" || !isReasoningEffort(reasoningEffort)) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.reasoningEffort",
+              message: `Invalid reasoningEffort ${JSON.stringify(reasoningEffort)}`,
+              suggestion: `Use one of: ${REASONING_EFFORTS.join(", ")}.`,
+            }),
+          );
+        }
+      }
+
+      const temperature: unknown = config.temperature;
+      if (temperature !== undefined && temperature !== null) {
+        // The ceiling is the permissive superset across providers (OpenAI allows up to 2,
+        // Anthropic only 1). Per-model limits are enforced at call time via
+        // `supportsTemperature`, so validation only rejects what no provider would accept.
+        if (
+          typeof temperature !== "number" ||
+          !Number.isFinite(temperature) ||
+          temperature < 0 ||
+          temperature > 2
+        ) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.temperature",
+              message: `Invalid temperature ${JSON.stringify(temperature)}`,
+              suggestion:
+                "Use a number between 0 and 2, or remove the field to use the provider default.",
+            }),
+          );
+        }
+      }
+
+      for (const field of ["numCtx", "maxContextTokens"] as const) {
+        const value: unknown = config[field];
+        if (value === undefined || value === null) continue;
+        if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: `config.${field}`,
+              message: `Invalid ${field} ${JSON.stringify(value)}`,
+              suggestion:
+                "Use a positive whole number of tokens, or remove the field to use the default.",
+            }),
+          );
+        }
+      }
+
+      const webSearchProvider: unknown = config.webSearchProvider;
+      if (webSearchProvider !== undefined && webSearchProvider !== null) {
+        if (typeof webSearchProvider !== "string" || !isWebSearchProviderName(webSearchProvider)) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.webSearchProvider",
+              message: `Unknown web search provider ${JSON.stringify(webSearchProvider)}`,
+              suggestion: `Use one of: ${WEB_SEARCH_PROVIDERS.join(", ")}.`,
+            }),
+          );
+        }
+      }
+
+      if (config.memoryScopes !== undefined && config.memoryScopes !== null) {
+        if (!Array.isArray(config.memoryScopes)) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.memoryScopes",
+              message: "memoryScopes must be provided as an array of scope names",
+              suggestion: 'Supply an array of non-empty scope names, e.g. ["work"].',
+            }),
+          );
+        }
+
+        for (const scope of config.memoryScopes as readonly string[]) {
+          if (typeof scope !== "string" || scope.trim().length === 0) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.memoryScopes",
+                message: "Each memoryScopes entry must be a non-empty string",
+                suggestion: "Remove blank entries so every scope has a name.",
               }),
             );
           }

--- a/packages/core/src/constants/models.ts
+++ b/packages/core/src/constants/models.ts
@@ -46,6 +46,10 @@ export const AVAILABLE_PROVIDERS = [
 
 export type ProviderName = (typeof AVAILABLE_PROVIDERS)[number];
 
+export function isProviderName(value: string): value is ProviderName {
+  return (AVAILABLE_PROVIDERS as readonly string[]).includes(value);
+}
+
 /**
  * OpenRouter meta-models that route to some other model rather than being one.
  *

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -30,6 +30,14 @@ export interface Agent {
   readonly updatedAt: Date;
 }
 
+export const REASONING_EFFORTS = ["disable", "low", "medium", "high"] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+export function isReasoningEffort(value: string): value is ReasoningEffort {
+  return (REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
 /**
  * Agent configuration specifying LLM provider, model, and runtime behavior
  *
@@ -60,7 +68,7 @@ export interface AgentConfig {
   readonly summarizerModel?: string;
   /** Optional per-agent API key overrides by provider. Falls back to global config, then env vars. */
   readonly llmApiKeys?: Partial<Record<ProviderName, string>>;
-  readonly reasoningEffort?: "disable" | "low" | "medium" | "high";
+  readonly reasoningEffort?: ReasoningEffort;
   /** Ollama context window (`num_ctx`) in tokens, chosen at agent creation. */
   readonly numCtx?: number;
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -245,8 +245,20 @@ export interface LLMConfig {
   readonly zhipuai?: LLMProviderConfig;
 }
 
-export type WebSearchProviderName =
-  "exa" | "parallel" | "tavily" | "brave" | "perplexity" | "linkup";
+export const WEB_SEARCH_PROVIDERS = [
+  "exa",
+  "parallel",
+  "tavily",
+  "brave",
+  "perplexity",
+  "linkup",
+] as const;
+
+export type WebSearchProviderName = (typeof WEB_SEARCH_PROVIDERS)[number];
+
+export function isWebSearchProviderName(value: string): value is WebSearchProviderName {
+  return (WEB_SEARCH_PROVIDERS as readonly string[]).includes(value);
+}
 
 export interface WebSearchProviderConfig {
   readonly api_key: string;


### PR DESCRIPTION
## What & why

Agent config validation only checked the fields the interactive `jazz agent create`
wizard couldn't constrain — env allowlists, custom tools, companions — and trusted the
rest, because a menu can only produce a valid provider, model or persona. Anything
driving the agent service without that wizard has no menu, so an unknown provider was
written to disk and only surfaced later as a confusing failure at model-resolution time.
The whole config shape is now validated, with errors that name the offending field and
suggest a fix.

This also gives the three closed lists a runtime representation they lacked: providers,
web-search providers and reasoning efforts each now have one array as the single source
of truth, with the type derived from it and a type guard alongside, so the list can no
longer drift from the type.

## Breaking changes / migration

An agent whose stored config is already invalid (only reachable by hand-editing its JSON
under `~/.jazz/agents/`) will now be rejected when saved rather than on next use. Fix the
named field and the edit goes through.

## How to verify

- `jazz agent create` and `jazz agent edit` still complete normally — the wizard's choices
  were always valid, so nothing in the interactive path should change.
- Hand-edit an agent's JSON to `"llmProvider": "gpt"`, then `jazz agent edit` it: the error
  names `config.llmProvider` and lists the accepted providers, instead of failing later at
  model resolution.
- Set `"temperature": 2.5` — rejected; `2` — accepted. The ceiling is the permissive
  superset across providers, since per-model limits are already applied at call time.
- Set `"numCtx": 1024.5` or `0` — rejected as not a positive whole number of tokens.
- Set `"webSearchProvider": "google"` — rejected with the six real options listed.
