### PR TITLE
feat(daemon): manage agents over HTTP, and move the doors to Hono

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
       "version": "0.15.6",
       "dependencies": {
         "@jazz/core": "workspace:*",
+        "hono": "^4.13.5",
         "plist": "^5.0.0",
       },
     },
@@ -1321,6 +1322,8 @@
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hono": ["hono@4.13.5", "", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@jazz/core": "workspace:*",
+    "hono": "^4.13.5",
     "plist": "^5.0.0"
   }
 }

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -237,23 +237,22 @@ describe("the daemon's routes", () => {
 
   it("accepts a body the size of an ordinary webhook payload", async () => {
     // The old cap sat under a routine GitHub push event, so the door refused traffic it
-    // exists to receive. Reaching the runner at all is the assertion.
+    // exists to receive. Reaching the runner at all is the assertion — signalled by what the
+    // runner returns rather than by throwing, so this says nothing about how the door treats
+    // an exception.
     const handle = makeWebhookHandler(
       async () => [{ name: "hook", agentId: "default", promptTemplate: "Process {{payload}}" }],
       async () => "webhook-secret",
-      async () => {
-        throw new Error("reached the runner");
-      },
+      async () => new Response("reached the runner", { status: 299 }) as never,
     );
 
-    await expect(
-      handle(
-        request("POST", "/webhooks/hook", {
-          headers: { authorization: "Bearer webhook-secret" },
-          body: "x".repeat(512_000),
-        }),
-      ),
-    ).rejects.toThrow("reached the runner");
+    const response = await handle(
+      request("POST", "/webhooks/hook", {
+        headers: { authorization: "Bearer webhook-secret" },
+        body: "x".repeat(512_000),
+      }),
+    );
+    expect(response.status).toBe(299);
   });
 
   it("returns 404 for malformed webhook URL encoding", async () => {
@@ -944,7 +943,7 @@ describe("deleting an agent over HTTP", () => {
   });
 });
 
-describe("the route table's auth boundary", () => {
+describe("the operator door's auth boundary", () => {
   it("answers a public route without a credential", async () => {
     const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([]));
 
@@ -971,8 +970,12 @@ describe("the route table's auth boundary", () => {
     expect((await handle(request("PUT", "/agents"))).status).toBe(404);
   });
 
-  it("treats an undecodable path segment as no match rather than failing", async () => {
-    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+  it("treats an undecodable path segment as an agent that does not exist", async () => {
+    // A malformed escape is not special-cased: it decodes to something, that something
+    // names no agent, and the answer is the same 404 any unknown name gets. What matters is
+    // that it does not fault.
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
 
     const response = await handle(request("GET", "/agents/%E0%A4%A"));
     expect(response.status).toBe(404);
@@ -1091,5 +1094,22 @@ describe("the menus an agent editor is built from", () => {
     for (const path of ["/catalog", "/models?provider=openai", "/personas", "/tools"]) {
       expect((await handle(request("GET", path))).status).toBe(401);
     }
+  });
+});
+
+describe("a handler that faults", () => {
+  it("answers a JSON 500 rather than letting the fault reach the socket", async () => {
+    // Worth pinning because it changed: a bare async handler let a throw propagate out to
+    // Bun.serve, and the door now catches it. The reply carries no detail — one of these
+    // doors answers callers holding no credential — and the fault goes to stderr.
+    const handle = makeHandler(LOOPBACK, () => {
+      throw new Error("boom");
+    });
+
+    const response = await handle(request("GET", "/agents"));
+    expect(response.status).toBe(500);
+    expect((await response.json()) as { error: string }).toMatchObject({
+      error: "internal error",
+    });
   });
 });

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -17,7 +17,7 @@ import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/web
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
 import { describe, expect, it } from "bun:test";
-import { Effect } from "effect";
+import { Context, Effect } from "effect";
 import { AgentServiceImpl } from "@/adapters/agent-service";
 import { InMemoryRunStore } from "@/adapters/storage/run-store";
 import {
@@ -65,6 +65,14 @@ function agentFixture(overrides: Partial<Agent> = {}): Agent {
     updatedAt: new Date("2026-09-01T00:00:00Z"),
     ...overrides,
   } as Agent;
+}
+
+/** Provides exactly the one service the route under test reaches for. */
+function runnerProviding<S>(tag: Context.Tag<S, S>, service: S) {
+  return <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>): Promise<A> =>
+    Effect.runPromise(
+      effect.pipe(Effect.provideService(tag, service)) as Effect.Effect<A, never, never>,
+    );
 }
 
 /** Only `listAgents` is reachable from the route under test. */
@@ -830,8 +838,8 @@ describe("reading one agent over HTTP", () => {
     const body = (await response.json()) as {
       agent: { config: Record<string, unknown>; apiKeyProviders: string[] };
     };
-    expect(body.agent.config.tools).toEqual(["read_file", "http_request"]);
-    expect(body.agent.config.llmProvider).toBe("anthropic");
+    expect(body.agent.config["tools"]).toEqual(["read_file", "http_request"]);
+    expect(body.agent.config["llmProvider"]).toBe("anthropic");
   });
 
   it("says which providers have a per-agent key without handing the key out", async () => {
@@ -1037,15 +1045,7 @@ describe("the menus an agent editor is built from", () => {
       },
     ];
     const service = { listPersonas: () => Effect.succeed(personas) } as unknown as PersonaService;
-    const handle = makeHandler(LOOPBACK, (effect) =>
-      Effect.runPromise(
-        effect.pipe(Effect.provideService(PersonaServiceTag, service)) as Effect.Effect<
-          unknown,
-          never,
-          never
-        >,
-      ),
-    );
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
 
     const response = await handle(request("GET", "/personas"));
     expect(response.status).toBe(200);
@@ -1067,15 +1067,7 @@ describe("the menus an agent editor is built from", () => {
       listAllTools: () => Effect.succeed(["read_file", "web_search", "ask_user"]),
       listToolsByCategory: () => Effect.succeed({ filesystem: ["read_file"], web: ["web_search"] }),
     } as unknown as ToolRegistry;
-    const handle = makeHandler(LOOPBACK, (effect) =>
-      Effect.runPromise(
-        effect.pipe(Effect.provideService(ToolRegistryTag, registry)) as Effect.Effect<
-          unknown,
-          never,
-          never
-        >,
-      ),
-    );
+    const handle = makeHandler(LOOPBACK, runnerProviding(ToolRegistryTag, registry));
 
     const response = await handle(request("GET", "/tools"));
     expect(response.status).toBe(200);

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -1,10 +1,17 @@
 import path from "node:path";
 import { createRunRecord } from "@jazz/core/agent/run/run-record";
+import { AVAILABLE_PROVIDERS } from "@jazz/core/constants/models";
 import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
+import { PersonaServiceTag } from "@jazz/core/interfaces/persona-service";
+import type { PersonaService } from "@jazz/core/interfaces/persona-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
 import type { StorageService } from "@jazz/core/interfaces/storage";
+import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
+import type { ToolRegistry } from "@jazz/core/interfaces/tool-registry";
+import { REASONING_EFFORTS } from "@jazz/core/types/agent";
 import type { Agent } from "@jazz/core/types/agent";
+import { WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
 import { StorageNotFoundError } from "@jazz/core/types/errors";
 import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
@@ -934,5 +941,155 @@ describe("deleting an agent over HTTP", () => {
     const handle = makeHandler(LOOPBACK, run);
 
     expect((await handle(request("DELETE", "/agents/ghost"))).status).toBe(404);
+  });
+});
+
+describe("the route table's auth boundary", () => {
+  it("answers a public route without a credential", async () => {
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([]));
+
+    expect((await handle(request("GET", "/health"))).status).toBe(200);
+  });
+
+  it("hides whether an unknown path exists from a caller with no token", async () => {
+    // 401 rather than 404 on purpose: if unmatched paths answered 404 while real ones
+    // answered 401, anyone could map the door without holding the token.
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([]));
+
+    expect((await handle(request("GET", "/nothing-here"))).status).toBe(401);
+  });
+
+  it("hides a real path addressed with the wrong method just the same", async () => {
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([]));
+
+    expect((await handle(request("PUT", "/agents"))).status).toBe(401);
+  });
+
+  it("answers 404 for an unsupported method once the caller is authorized", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    expect((await handle(request("PUT", "/agents"))).status).toBe(404);
+  });
+
+  it("treats an undecodable path segment as no match rather than failing", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/agents/%E0%A4%A"));
+    expect(response.status).toBe(404);
+  });
+
+  it("does not let a path param swallow a segment separator", async () => {
+    // `:identifier` matches one segment, so this is a miss rather than an agent named
+    // "a/b" — otherwise a nested route added later would be shadowed by this one.
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    expect((await handle(request("GET", "/agents/a/b"))).status).toBe(404);
+  });
+});
+
+describe("the menus an agent editor is built from", () => {
+  it("serves the same closed lists the validator enforces", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/catalog"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      providers: string[];
+      webSearchProviders: string[];
+      reasoningEfforts: string[];
+    };
+    // Compared against the arrays themselves, so a provider added to jazz without being
+    // served here — which would make the menu narrower than what is accepted — fails.
+    expect(body.providers).toEqual([...AVAILABLE_PROVIDERS]);
+    expect(body.webSearchProviders).toEqual([...WEB_SEARCH_PROVIDERS]);
+    expect(body.reasoningEfforts).toEqual([...REASONING_EFFORTS]);
+  });
+
+  it("refuses to list models for a provider that is not one", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/models?provider=gpt"));
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { field: string; suggestion: string };
+    expect(body.field).toBe("provider");
+    expect(body.suggestion).toContain("anthropic");
+  });
+
+  it("refuses a model listing with no provider at all", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    expect((await handle(request("GET", "/models"))).status).toBe(400);
+  });
+
+  it("lists the personas an agent can be given, without their prompts", async () => {
+    const personas = [
+      {
+        id: "builtin-default",
+        name: "default",
+        description: "the everyday one",
+        systemPrompt: "a long prompt nobody picking a persona needs",
+        tone: "neutral",
+        createdAt: new Date("2026-09-01T00:00:00Z"),
+        updatedAt: new Date("2026-09-01T00:00:00Z"),
+      },
+    ];
+    const service = { listPersonas: () => Effect.succeed(personas) } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, (effect) =>
+      Effect.runPromise(
+        effect.pipe(Effect.provideService(PersonaServiceTag, service)) as Effect.Effect<
+          unknown,
+          never,
+          never
+        >,
+      ),
+    );
+
+    const response = await handle(request("GET", "/personas"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { personas: Record<string, unknown>[] };
+    expect(body.personas[0]).toEqual({
+      id: "builtin-default",
+      name: "default",
+      description: "the everyday one",
+      tone: "neutral",
+    });
+    expect(body.personas[0]).not.toHaveProperty("systemPrompt");
+  });
+
+  it("lists pickable tools with their categories, and leaves hidden ones out", async () => {
+    const registry = {
+      // `listAllTools` is the one that includes hidden tools; using it here would offer a
+      // caller something deliberately not offered, so the route must not reach for it.
+      listTools: () => Effect.succeed(["read_file", "web_search"]),
+      listAllTools: () => Effect.succeed(["read_file", "web_search", "ask_user"]),
+      listToolsByCategory: () => Effect.succeed({ filesystem: ["read_file"], web: ["web_search"] }),
+    } as unknown as ToolRegistry;
+    const handle = makeHandler(LOOPBACK, (effect) =>
+      Effect.runPromise(
+        effect.pipe(Effect.provideService(ToolRegistryTag, registry)) as Effect.Effect<
+          unknown,
+          never,
+          never
+        >,
+      ),
+    );
+
+    const response = await handle(request("GET", "/tools"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      tools: string[];
+      categories: Record<string, string[]>;
+    };
+    expect(body.tools).toEqual(["read_file", "web_search"]);
+    expect(body.tools).not.toContain("ask_user");
+    expect(body.categories).toEqual({ filesystem: ["read_file"], web: ["web_search"] });
+  });
+
+  it("keeps the menus behind the daemon token", async () => {
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, runnerForAgents([]));
+
+    for (const path of ["/catalog", "/models?provider=openai", "/personas", "/tools"]) {
+      expect((await handle(request("GET", path))).status).toBe(401);
+    }
   });
 });

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -3,12 +3,15 @@ import { createRunRecord } from "@jazz/core/agent/run/run-record";
 import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
+import type { StorageService } from "@jazz/core/interfaces/storage";
 import type { Agent } from "@jazz/core/types/agent";
+import { StorageNotFoundError } from "@jazz/core/types/errors";
 import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
+import { AgentServiceImpl } from "@/adapters/agent-service";
 import { InMemoryRunStore } from "@/adapters/storage/run-store";
 import {
   makeA2AHandler,
@@ -629,5 +632,307 @@ describe("choosing which progress events to receive", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("nonsense");
+  });
+});
+
+/**
+ * A real `AgentServiceImpl` over a map, rather than a stubbed service.
+ *
+ * The write routes are thin on purpose — their whole job is to hand a body to the agent
+ * service and turn its refusals into status codes — so a stub that cannot refuse anything
+ * would test nothing. This exercises the validation the endpoints actually rely on.
+ */
+function runnerForWritableAgents(seed: readonly Agent[] = []) {
+  const agents = new Map(seed.map((agent) => [agent.id, agent]));
+  const storage = {
+    listAgents: () => Effect.succeed([...agents.values()]),
+    getAgent: (id: string) => {
+      const found = agents.get(id);
+      return found === undefined
+        ? Effect.fail(new StorageNotFoundError({ path: id }))
+        : Effect.succeed(found);
+    },
+    saveAgent: (agent: Agent) => {
+      agents.set(agent.id, agent);
+      return Effect.void;
+    },
+    deleteAgent: (id: string) => {
+      agents.delete(id);
+      return Effect.void;
+    },
+  } as unknown as StorageService;
+
+  const service = new AgentServiceImpl(storage);
+  const run = <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>): Promise<A> =>
+    Effect.runPromise(
+      effect.pipe(Effect.provideService(AgentServiceTag, service)) as Effect.Effect<
+        A,
+        never,
+        never
+      >,
+    );
+  return { run, agents };
+}
+
+function jsonRequest(method: string, path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("creating an agent over HTTP", () => {
+  it("creates one and answers with its full config", async () => {
+    const { run, agents } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("POST", "/agents", {
+        name: "negotiator",
+        description: "rehearses a hard conversation",
+        config: { persona: "default", llmProvider: "anthropic", llmModel: "claude-sonnet-4-6" },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      ok: boolean;
+      agent: { name: string; provider: string; config: { llmModel: string } };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.agent.name).toBe("negotiator");
+    expect(body.agent.provider).toBe("anthropic");
+    expect(body.agent.config.llmModel).toBe("claude-sonnet-4-6");
+    expect(agents.size).toBe(1);
+  });
+
+  it("names the offending field when the config is invalid, so a form can point at it", async () => {
+    const { run } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("POST", "/agents", {
+        name: "broken",
+        config: { persona: "default", llmProvider: "gpt", llmModel: "gpt-4o" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { field: string; suggestion?: string };
+    expect(body.field).toBe("config.llmProvider");
+    expect(body.suggestion).toContain("anthropic");
+  });
+
+  it("refuses api keys rather than silently dropping them", async () => {
+    const { run, agents } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("POST", "/agents", {
+        name: "leaky",
+        config: {
+          persona: "default",
+          llmProvider: "anthropic",
+          llmModel: "claude-sonnet-4-6",
+          llmApiKeys: { anthropic: "sk-should-not-be-stored" },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("keyring");
+    // The point of refusing over scrubbing: nothing was written, so the caller cannot
+    // believe a key was saved when it was not.
+    expect(agents.size).toBe(0);
+  });
+
+  it("reports a duplicate name as a conflict, not a validation error", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("POST", "/agents", {
+        name: "sonnet",
+        config: { persona: "default", llmProvider: "anthropic", llmModel: "claude-sonnet-4-6" },
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect((await response.json()) as { field: string }).toMatchObject({ field: "name" });
+  });
+
+  it("rejects a name the CLI would also reject", async () => {
+    const { run } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("POST", "/agents", {
+        name: "not a valid name!",
+        config: { persona: "default", llmProvider: "anthropic", llmModel: "claude-sonnet-4-6" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a body that is not a JSON object", async () => {
+    const { run } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    expect((await handle(jsonRequest("POST", "/agents", ["nope"]))).status).toBe(400);
+    expect(
+      (
+        await handle(
+          new Request("http://localhost/agents", { method: "POST", body: "not json at all" }),
+        )
+      ).status,
+    ).toBe(400);
+  });
+
+  it("rejects a body larger than the operator cap before buffering it", async () => {
+    const { run } = runnerForWritableAgents();
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      new Request("http://localhost/agents", {
+        method: "POST",
+        headers: { "content-length": "999999" },
+        body: JSON.stringify({ name: "big" }),
+      }),
+    );
+
+    expect(response.status).toBe(413);
+  });
+
+  it("needs the daemon token, like every other route", async () => {
+    const { run } = runnerForWritableAgents();
+    const handle = makeHandler({ ...LOOPBACK, token: "s3cret" }, run);
+
+    const response = await handle(jsonRequest("POST", "/agents", { name: "nope" }));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("reading one agent over HTTP", () => {
+  it("answers with the whole config an editor needs", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/uGS8WAv4cGBiFH1wHB7r4E"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      agent: { config: Record<string, unknown>; apiKeyProviders: string[] };
+    };
+    expect(body.agent.config.tools).toEqual(["read_file", "http_request"]);
+    expect(body.agent.config.llmProvider).toBe("anthropic");
+  });
+
+  it("says which providers have a per-agent key without handing the key out", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/uGS8WAv4cGBiFH1wHB7r4E"));
+    const text = await response.text();
+    expect(text).not.toContain("sk-must-not-leak");
+    expect(JSON.parse(text) as { agent: { apiKeyProviders: string[] } }).toMatchObject({
+      agent: { apiKeyProviders: ["anthropic"] },
+    });
+  });
+
+  it("resolves an agent by name as well as by id", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/sonnet"));
+    expect(response.status).toBe(200);
+  });
+
+  it("answers 404 for an agent that does not exist", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    expect((await handle(request("GET", "/agents/nobody"))).status).toBe(404);
+  });
+});
+
+describe("updating an agent over HTTP", () => {
+  it("merges the config rather than replacing it", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("PATCH", "/agents/uGS8WAv4cGBiFH1wHB7r4E", {
+        config: { llmModel: "claude-opus-4-6" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      agent: { model: string; config: { tools: string[]; persona: string } };
+    };
+    expect(body.agent.model).toBe("claude-opus-4-6");
+    // Untouched fields survive: this is what makes the route a PATCH.
+    expect(body.agent.config.tools).toEqual(["read_file", "http_request"]);
+    expect(body.agent.config.persona).toBe("default");
+  });
+
+  it("rejects an invalid value without writing anything", async () => {
+    const { run, agents } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("PATCH", "/agents/uGS8WAv4cGBiFH1wHB7r4E", {
+        config: { temperature: 9 },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { field: string }).toMatchObject({
+      field: "config.temperature",
+    });
+    expect(agents.get("uGS8WAv4cGBiFH1wHB7r4E")?.config.temperature).toBeUndefined();
+  });
+
+  it("refuses api keys on update too", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(
+      jsonRequest("PATCH", "/agents/uGS8WAv4cGBiFH1wHB7r4E", {
+        config: { llmApiKeys: { anthropic: "sk-nope" } },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("answers 404 for an agent that does not exist", async () => {
+    const { run } = runnerForWritableAgents([]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(jsonRequest("PATCH", "/agents/ghost", { name: "renamed" }));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("deleting an agent over HTTP", () => {
+  it("removes it and reports the id it removed", async () => {
+    const { run, agents } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("DELETE", "/agents/sonnet"));
+    expect(response.status).toBe(200);
+    expect((await response.json()) as { id: string }).toMatchObject({
+      id: "uGS8WAv4cGBiFH1wHB7r4E",
+    });
+    expect(agents.size).toBe(0);
+  });
+
+  it("answers 404 rather than pretending it deleted something", async () => {
+    const { run } = runnerForWritableAgents([]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    expect((await handle(request("DELETE", "/agents/ghost"))).status).toBe(404);
   });
 });

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -24,13 +24,21 @@ import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
 import { isRunParkRequested } from "@jazz/core/agent/run/park-signal";
 import { resumeRun, type ResumeRunOptions } from "@jazz/core/agent/run/resume";
 import type { PendingInput } from "@jazz/core/agent/run/run-state";
+import { AVAILABLE_PROVIDERS, isProviderName } from "@jazz/core/constants/models";
+import type { ProviderName } from "@jazz/core/constants/models";
+import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
 import type { AgentConfigService } from "@jazz/core/interfaces/agent-config";
 import { AgentServiceTag } from "@jazz/core/interfaces/agent-service";
 import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import { PersonaServiceTag } from "@jazz/core/interfaces/persona-service";
+import type { PersonaService } from "@jazz/core/interfaces/persona-service";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
+import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
 import type { ToolRegistry, ToolRequirements } from "@jazz/core/interfaces/tool-registry";
+import { REASONING_EFFORTS } from "@jazz/core/types/agent";
 import type { Agent, AgentConfig } from "@jazz/core/types/agent";
+import { WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
 import {
   AgentAlreadyExistsError,
   AgentConfigurationError,
@@ -38,6 +46,7 @@ import {
   StorageNotFoundError,
   ValidationError,
 } from "@jazz/core/types/errors";
+import type { ModelInfo } from "@jazz/core/types/llm";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
 import type { ToolProgressEvent } from "@jazz/core/types/tools";
@@ -54,6 +63,7 @@ import {
 } from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
+import { listModelsForProvider } from "@/adapters/llm/model-fetcher";
 import { buildPublicAgentCard, handleA2ARpc, normalizeProtocolVersion } from "@/adapters/peers/a2a";
 import {
   acceptInviteOnInviterSide,
@@ -61,6 +71,7 @@ import {
   type KeyringDependency,
 } from "@/adapters/peers/invites";
 import { servePeerRequest } from "@/adapters/peers/serve";
+import { LLM_PROVIDER_ENV_VARS } from "@/adapters/secrets/registry";
 import {
   loadConversation,
   saveConversation,
@@ -78,6 +89,7 @@ export const DEFAULT_DAEMON_PORT = 4747;
 export type DaemonRequirements =
   | AgentService
   | AgentConfigService
+  | PersonaService
   | RunStoreTag
   | ToolRegistry
   | ToolRequirements
@@ -166,6 +178,100 @@ interface StartRunBody {
   readonly conversationId?: unknown;
 }
 
+/** Path segments captured by a route's `:name` placeholders, already percent-decoded. */
+type RouteParams = Readonly<Record<string, string>>;
+
+/**
+ * One route on a door.
+ *
+ * `auth` is stated per route rather than implied by where the route sits, which is the point
+ * of the table: with an if-chain, whether a route was public depended on whether it appeared
+ * above or below the token check, and adding one in the wrong place published it silently.
+ */
+interface Route {
+  readonly method: string;
+  /** Pattern with `:name` standing for one path segment, e.g. `/agents/:identifier`. */
+  readonly path: string;
+  readonly auth: "token" | "public";
+  readonly handle: (request: Request, params: RouteParams) => Promise<Response>;
+}
+
+interface CompiledRoute extends Route {
+  readonly pattern: RegExp;
+  readonly names: readonly string[];
+}
+
+function compileRoute(route: Route): CompiledRoute {
+  const names: string[] = [];
+  // Literal segments are escaped before the placeholders are substituted, so a path
+  // containing a regex metacharacter matches itself rather than being read as a pattern.
+  // `:` is not a metacharacter, so the placeholders survive escaping intact.
+  const source = route.path
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/:([A-Za-z][A-Za-z0-9]*)/g, (_match, name: string) => {
+      names.push(name);
+      return "([^/]+)";
+    });
+  return { ...route, pattern: new RegExp(`^${source}$`), names };
+}
+
+/**
+ * The route a request addresses, or undefined when nothing matches.
+ *
+ * A path that matches but on the wrong method counts as no match, so an unknown method
+ * answers the same way an unknown path does rather than leaking that the path exists.
+ * An undecodable escape in a captured segment is also no match: it cannot name anything.
+ */
+function matchRoute(
+  routes: readonly CompiledRoute[],
+  method: string,
+  pathname: string,
+): { readonly route: CompiledRoute; readonly params: RouteParams } | undefined {
+  for (const route of routes) {
+    if (route.method !== method) continue;
+    const found = route.pattern.exec(pathname);
+    if (found === null) continue;
+
+    const params: Record<string, string> = {};
+    try {
+      for (const [index, name] of route.names.entries()) {
+        params[name] = decodeURIComponent(found[index + 1] ?? "");
+      }
+    } catch {
+      return undefined;
+    }
+    return { route, params };
+  }
+  return undefined;
+}
+
+/**
+ * Turn a route table into a handler.
+ *
+ * The order of the three checks is deliberate. A public route answers before the token is
+ * looked at; everything else — *including a path that matches nothing* — sits behind it, so
+ * an unauthenticated caller cannot map the door by telling 404s from 401s.
+ */
+function dispatch(
+  routes: readonly CompiledRoute[],
+  options: DaemonOptions,
+): (request: Request) => Promise<Response> {
+  return async function handle(request: Request): Promise<Response> {
+    const matched = matchRoute(routes, request.method, new URL(request.url).pathname);
+
+    if (matched?.route.auth === "public") {
+      return matched.route.handle(request, matched.params);
+    }
+    if (!authorized(request, options.token)) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+    if (matched === undefined) {
+      return json({ ok: false, error: "not found" }, 404);
+    }
+    return matched.route.handle(request, matched.params);
+  };
+}
+
 /**
  * The daemon's request handler, as a plain function of a request.
  *
@@ -176,109 +282,143 @@ export function makeHandler(
   options: DaemonOptions,
   runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
 ): (request: Request) => Promise<Response> {
-  return async function handle(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+  /** A write body, read and screened, or the response that says why it was not. */
+  const agentWriteBody = async (request: Request): Promise<AgentWriteBody | Response> => {
+    const body = await readJsonBody(request);
+    if (body instanceof Response) return body;
+    const problem = configBodyProblem(body.config);
+    return problem === undefined ? body : json({ ok: false, error: problem }, 400);
+  };
 
+  const routes = [
     // Health is unauthenticated on purpose: a supervisor should be able to see that the
     // process is alive without holding a credential that can drive an agent.
-    if (request.method === "GET" && url.pathname === "/health") {
-      return json({ ok: true });
-    }
+    {
+      method: "GET",
+      path: "/health",
+      auth: "public",
+      handle: () => Promise.resolve(json({ ok: true })),
+    },
 
-    if (!authorized(request, options.token)) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
+    {
+      method: "POST",
+      path: "/runs",
+      auth: "token",
+      handle: (request) => startRunRoute(request, runEffect),
+    },
+    { method: "GET", path: "/runs", auth: "token", handle: () => runEffect(listRuns()) },
+    {
+      method: "GET",
+      path: "/runs/:runId",
+      auth: "token",
+      handle: (_request, params) => runEffect(describeRun(params["runId"] ?? "")),
+    },
+    {
+      method: "POST",
+      path: "/runs/:runId/answer",
+      auth: "token",
+      handle: (request, params) => answerRunRoute(request, params["runId"] ?? "", runEffect),
+    },
 
-    if (request.method === "POST" && url.pathname === "/runs") {
-      let body: StartRunBody;
-      try {
-        body = (await request.json()) as StartRunBody;
-      } catch {
-        return json({ ok: false, error: "body must be JSON" }, 400);
-      }
-      const agentIdentifier = typeof body.agent === "string" ? body.agent : undefined;
-      const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
-      if (agentIdentifier === undefined || prompt === undefined) {
-        return json({ ok: false, error: "agent and prompt are required" }, 400);
-      }
-      const conversationId =
-        typeof body.conversationId === "string" && body.conversationId.length > 0
-          ? body.conversationId
-          : generateConversationId("daemon");
+    { method: "GET", path: "/agents", auth: "token", handle: () => runEffect(listAgents()) },
+    {
+      method: "POST",
+      path: "/agents",
+      auth: "token",
+      handle: async (request) => {
+        const body = await agentWriteBody(request);
+        return body instanceof Response ? body : runEffect(createAgent(body));
+      },
+    },
+    {
+      method: "GET",
+      path: "/agents/:identifier",
+      auth: "token",
+      handle: (_request, params) => runEffect(showAgent(params["identifier"] ?? "")),
+    },
+    {
+      method: "PATCH",
+      path: "/agents/:identifier",
+      auth: "token",
+      handle: async (request, params) => {
+        const body = await agentWriteBody(request);
+        return body instanceof Response
+          ? body
+          : runEffect(updateAgent(params["identifier"] ?? "", body));
+      },
+    },
+    {
+      method: "DELETE",
+      path: "/agents/:identifier",
+      auth: "token",
+      handle: (_request, params) => runEffect(deleteAgent(params["identifier"] ?? "")),
+    },
 
-      return runEffect(startRun(agentIdentifier, prompt, conversationId));
-    }
+    // The catalogues behind an agent editor's menus. Served from the daemon rather than
+    // retyped by each client, so a picker cannot offer a value the agent service rejects.
+    {
+      method: "GET",
+      path: "/catalog",
+      auth: "token",
+      handle: () => Promise.resolve(listCatalog()),
+    },
+    {
+      method: "GET",
+      path: "/models",
+      auth: "token",
+      handle: (request) => modelsRoute(request, runEffect),
+    },
+    { method: "GET", path: "/personas", auth: "token", handle: () => runEffect(listPersonas()) },
+    { method: "GET", path: "/tools", auth: "token", handle: () => runEffect(listTools()) },
+  ] satisfies readonly Route[];
 
-    const runMatch = /^\/runs\/([^/]+)$/.exec(url.pathname);
-    if (request.method === "GET" && runMatch?.[1] !== undefined) {
-      return runEffect(describeRun(runMatch[1]));
-    }
+  return dispatch(routes.map(compileRoute), options);
+}
 
-    const answerMatch = /^\/runs\/([^/]+)\/answer$/.exec(url.pathname);
-    if (request.method === "POST" && answerMatch?.[1] !== undefined) {
-      let body: { approved?: unknown; note?: unknown; response?: unknown; filePath?: unknown };
-      try {
-        body = (await request.json()) as {
-          approved?: unknown;
-          note?: unknown;
-          response?: unknown;
-          filePath?: unknown;
-        };
-      } catch {
-        return json({ ok: false, error: "body must be JSON" }, 400);
-      }
-      const approved = body.approved === true;
-      const note = typeof body.note === "string" ? body.note : undefined;
-      const response = typeof body.response === "string" ? body.response.trim() : undefined;
-      const filePath = typeof body.filePath === "string" ? body.filePath.trim() : undefined;
-      return runEffect(answerRun(answerMatch[1], approved, note, response, filePath));
-    }
+async function startRunRoute(
+  request: Request,
+  runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
+): Promise<Response> {
+  let body: StartRunBody;
+  try {
+    body = (await request.json()) as StartRunBody;
+  } catch {
+    return json({ ok: false, error: "body must be JSON" }, 400);
+  }
+  const agentIdentifier = typeof body.agent === "string" ? body.agent : undefined;
+  const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
+  if (agentIdentifier === undefined || prompt === undefined) {
+    return json({ ok: false, error: "agent and prompt are required" }, 400);
+  }
+  const conversationId =
+    typeof body.conversationId === "string" && body.conversationId.length > 0
+      ? body.conversationId
+      : generateConversationId("daemon");
 
-    if (request.method === "GET" && url.pathname === "/runs") {
-      return runEffect(listRuns());
-    }
+  return runEffect(startRun(agentIdentifier, prompt, conversationId));
+}
 
-    if (request.method === "GET" && url.pathname === "/agents") {
-      return runEffect(listAgents());
-    }
-
-    if (request.method === "POST" && url.pathname === "/agents") {
-      const body = await readJsonBody(request);
-      if (body instanceof Response) return body;
-      const problem = configBodyProblem(body.config);
-      if (problem !== undefined) return json({ ok: false, error: problem }, 400);
-      return runEffect(createAgent(body));
-    }
-
-    const agentMatch = /^\/agents\/([^/]+)$/.exec(url.pathname);
-    const agentIdentifier = agentMatch?.[1];
-    if (agentIdentifier !== undefined) {
-      let identifier: string;
-      try {
-        identifier = decodeURIComponent(agentIdentifier);
-      } catch {
-        return json({ ok: false, error: "not found" }, 404);
-      }
-
-      if (request.method === "GET") {
-        return runEffect(showAgent(identifier));
-      }
-
-      if (request.method === "PATCH") {
-        const body = await readJsonBody(request);
-        if (body instanceof Response) return body;
-        const problem = configBodyProblem(body.config);
-        if (problem !== undefined) return json({ ok: false, error: problem }, 400);
-        return runEffect(updateAgent(identifier, body));
-      }
-
-      if (request.method === "DELETE") {
-        return runEffect(deleteAgent(identifier));
-      }
-    }
-
-    return json({ ok: false, error: "not found" }, 404);
-  };
+async function answerRunRoute(
+  request: Request,
+  runId: string,
+  runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
+): Promise<Response> {
+  let body: { approved?: unknown; note?: unknown; response?: unknown; filePath?: unknown };
+  try {
+    body = (await request.json()) as {
+      approved?: unknown;
+      note?: unknown;
+      response?: unknown;
+      filePath?: unknown;
+    };
+  } catch {
+    return json({ ok: false, error: "body must be JSON" }, 400);
+  }
+  const approved = body.approved === true;
+  const note = typeof body.note === "string" ? body.note : undefined;
+  const response = typeof body.response === "string" ? body.response.trim() : undefined;
+  const filePath = typeof body.filePath === "string" ? body.filePath.trim() : undefined;
+  return runEffect(answerRun(runId, approved, note, response, filePath));
 }
 
 /**
@@ -1145,6 +1285,157 @@ function configBodyProblem(config: unknown): string | undefined {
     return "config.llmApiKeys cannot be set over HTTP — use `jazz agent edit` so the key goes to the keyring";
   }
   return undefined;
+}
+
+/**
+ * The fixed vocabularies an agent editor's menus are built from.
+ *
+ * One route because none of them can fail: these are the very arrays
+ * `validateAgentConfig` checks against, so a menu built from this response cannot offer a
+ * value the agent service would reject. The catalogues that do I/O get their own routes, so
+ * a persona directory that will not read cannot take the whole form down with it.
+ */
+function listCatalog(): Response {
+  return json({
+    ok: true,
+    providers: AVAILABLE_PROVIDERS,
+    webSearchProviders: WEB_SEARCH_PROVIDERS,
+    reasoningEfforts: REASONING_EFFORTS,
+  });
+}
+
+/**
+ * How long to wait for a provider's model list.
+ *
+ * Listing models is a live fetch — the models.dev catalogue or the provider's own endpoint —
+ * so it is the one catalogue route that can hang. A caller waiting on a form field needs an
+ * answer or a refusal quickly; ten seconds is long enough for a cold catalogue fetch and
+ * short enough that the field can fall back to a free-text input instead of spinning.
+ */
+const MODEL_LISTING_TIMEOUT = "10 seconds";
+
+/** What a model picker needs: how to name it, and which fields it makes meaningful. */
+function projectModel(model: ModelInfo) {
+  return {
+    id: model.id,
+    ...(model.displayName !== undefined ? { displayName: model.displayName } : {}),
+    supportsTools: model.supportsTools,
+    // Both gate a form field rather than describing the model for its own sake: a
+    // temperature input on a model that ignores temperature, or a reasoning-effort menu on a
+    // model with no reasoning, is a control that silently does nothing.
+    supportsTemperature: model.supportsTemperature !== false,
+    isReasoningModel: model.isReasoningModel === true,
+    ...(model.inputPricePerMillion !== undefined
+      ? { inputPricePerMillion: model.inputPricePerMillion }
+      : {}),
+    ...(model.outputPricePerMillion !== undefined
+      ? { outputPricePerMillion: model.outputPricePerMillion }
+      : {}),
+  };
+}
+
+function listModels(provider: ProviderName) {
+  return Effect.gen(function* () {
+    const configService = yield* AgentConfigServiceTag;
+    const appConfig = yield* configService.appConfig;
+    const llmConfig = appConfig.llm;
+
+    // Same precedence the LLM service itself uses: global config before environment. A
+    // key in the OS keyring is not consulted, because listing models is not worth
+    // unlocking a keyring for — providers that need a key and have none simply list none.
+    const apiKey =
+      llmConfig?.[provider]?.api_key ?? process.env[LLM_PROVIDER_ENV_VARS[provider] ?? ""];
+
+    const models = yield* listModelsForProvider(provider, { apiKey, llmConfig });
+    return json({ ok: true, provider, models: models.map(projectModel) });
+  }).pipe(
+    Effect.timeout(MODEL_LISTING_TIMEOUT),
+    Effect.catchAll((error) =>
+      Effect.succeed(
+        json(
+          {
+            ok: false,
+            error: `Could not list models for ${provider}: ${error instanceof Error ? error.message : String(error)}`,
+            suggestion: "Name the model directly — the catalogue is unavailable, not the model.",
+          },
+          502,
+        ),
+      ),
+    ),
+  );
+}
+
+function modelsRoute(
+  request: Request,
+  runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
+): Promise<Response> {
+  const provider = new URL(request.url).searchParams.get("provider") ?? "";
+  if (!isProviderName(provider)) {
+    return Promise.resolve(
+      json(
+        {
+          ok: false,
+          error: `Unknown provider ${JSON.stringify(provider)}`,
+          field: "provider",
+          suggestion: `Use one of: ${AVAILABLE_PROVIDERS.join(", ")}.`,
+        },
+        400,
+      ),
+    );
+  }
+  return runEffect(listModels(provider));
+}
+
+/**
+ * The personas an agent can be given, built-in and custom alike.
+ *
+ * `systemPrompt` is left out: it is the bulk of a persona and a picker only needs to say
+ * which one this is. Whoever wants the prompt itself is editing the persona, not choosing it.
+ */
+function listPersonas() {
+  return Effect.gen(function* () {
+    const personaService = yield* PersonaServiceTag;
+    const personas = yield* personaService.listPersonas();
+    return json({
+      ok: true,
+      personas: personas.map((persona) => ({
+        id: persona.id,
+        name: persona.name,
+        description: persona.description,
+        ...(persona.tone !== undefined ? { tone: persona.tone } : {}),
+        ...(persona.style !== undefined ? { style: persona.style } : {}),
+      })),
+    });
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.succeed(
+        json(
+          {
+            ok: false,
+            error: `Could not list personas: ${error instanceof Error ? error.message : String(error)}`,
+          },
+          500,
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * The tools an agent's config may name.
+ *
+ * Hidden tools are excluded — `listTools` rather than `listAllTools` — because this answers
+ * "what can somebody pick", and a hidden tool is one that stays callable without being
+ * offered. Categories come along so a picker can group rather than show one flat list of
+ * everything the daemon can do.
+ */
+function listTools() {
+  return Effect.gen(function* () {
+    const registry = yield* ToolRegistryTag;
+    const tools = yield* registry.listTools();
+    const categories = yield* registry.listToolsByCategory();
+    return json({ ok: true, tools, categories });
+  });
 }
 
 /**

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -30,6 +30,14 @@ import type { AgentService } from "@jazz/core/interfaces/agent-service";
 import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { RunStoreTag } from "@jazz/core/interfaces/run-store";
 import type { ToolRegistry, ToolRequirements } from "@jazz/core/interfaces/tool-registry";
+import type { Agent, AgentConfig } from "@jazz/core/types/agent";
+import {
+  AgentAlreadyExistsError,
+  AgentConfigurationError,
+  AgentNotFoundError,
+  StorageNotFoundError,
+  ValidationError,
+} from "@jazz/core/types/errors";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
 import type { ToolProgressEvent } from "@jazz/core/types/tools";
@@ -232,6 +240,41 @@ export function makeHandler(
 
     if (request.method === "GET" && url.pathname === "/agents") {
       return runEffect(listAgents());
+    }
+
+    if (request.method === "POST" && url.pathname === "/agents") {
+      const body = await readJsonBody(request);
+      if (body instanceof Response) return body;
+      const problem = configBodyProblem(body.config);
+      if (problem !== undefined) return json({ ok: false, error: problem }, 400);
+      return runEffect(createAgent(body));
+    }
+
+    const agentMatch = /^\/agents\/([^/]+)$/.exec(url.pathname);
+    const agentIdentifier = agentMatch?.[1];
+    if (agentIdentifier !== undefined) {
+      let identifier: string;
+      try {
+        identifier = decodeURIComponent(agentIdentifier);
+      } catch {
+        return json({ ok: false, error: "not found" }, 404);
+      }
+
+      if (request.method === "GET") {
+        return runEffect(showAgent(identifier));
+      }
+
+      if (request.method === "PATCH") {
+        const body = await readJsonBody(request);
+        if (body instanceof Response) return body;
+        const problem = configBodyProblem(body.config);
+        if (problem !== undefined) return json({ ok: false, error: problem }, 400);
+        return runEffect(updateAgent(identifier, body));
+      }
+
+      if (request.method === "DELETE") {
+        return runEffect(deleteAgent(identifier));
+      }
     }
 
     return json({ ok: false, error: "not found" }, 404);
@@ -519,6 +562,42 @@ const MAX_WEBHOOK_PAYLOAD_LENGTH = 1_048_576;
  * close. It is deliberately not the webhook cap, which a bearer token already gates.
  */
 const MAX_ANONYMOUS_PAYLOAD_LENGTH = 20_000;
+
+/**
+ * Cap on an operator body.
+ *
+ * The largest thing anyone legitimately sends here is an agent config, and the biggest part
+ * of one is `customTools`: 16 entries, each with a description and a JSON Schema. 64 KB
+ * leaves room for that without letting a token holder make the daemon buffer without bound.
+ */
+const MAX_OPERATOR_PAYLOAD_LENGTH = 64_000;
+
+/**
+ * What a create or update body may carry. Every field is `unknown`: the values are checked
+ * where they are used, and the agent service owns the rules for what a valid config is.
+ */
+interface AgentWriteBody {
+  readonly name?: unknown;
+  readonly description?: unknown;
+  readonly config?: unknown;
+}
+
+/** An operator body, parsed, or the response to send instead. */
+async function readJsonBody(request: Request): Promise<AgentWriteBody | Response> {
+  const raw = await readBody(request, MAX_OPERATOR_PAYLOAD_LENGTH);
+  if (raw instanceof Response) return raw;
+
+  let parsed: unknown;
+  try {
+    parsed = raw.length === 0 ? {} : JSON.parse(raw);
+  } catch {
+    return json({ ok: false, error: "body must be JSON" }, 400);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return json({ ok: false, error: "body must be a JSON object" }, 400);
+  }
+  return parsed;
+}
 
 async function readBody(request: Request, limit: number): Promise<string | Response> {
   const declaredLength = request.headers.get("content-length");
@@ -961,28 +1040,170 @@ function listRuns() {
 }
 
 /**
- * The agents this daemon can run, for a caller choosing between them.
+ * One agent, as much of it as somebody choosing between them needs.
  *
  * Fields are projected one by one rather than returning the stored agent, because
  * `AgentConfig` carries `llmApiKeys` and a list endpoint is no place to hand those out.
+ */
+function projectAgentSummary(agent: Agent) {
+  return {
+    id: agent.id,
+    name: agent.name,
+    ...(agent.description !== undefined ? { description: agent.description } : {}),
+    persona: agent.config.persona,
+    provider: agent.config.llmProvider,
+    model: agent.config.llmModel,
+    tools: agent.config.tools ?? [],
+  };
+}
+
+/**
+ * One agent in full, for a caller that has to *edit* it rather than pick it.
+ *
+ * Kept separate from the summary because a list of agents is not the place to send every
+ * agent's custom tools and allowlists — an editor opens one at a time and asks for it here.
+ *
+ * `llmApiKeys` is destructured off rather than omitted field by field, so a secret-bearing
+ * field added to `AgentConfig` later cannot quietly start being served: the rest of the
+ * config passes through, and that one has to be put back deliberately to escape.
+ * `apiKeyProviders` names which providers have a per-agent override without revealing any
+ * of them, which is what an editor needs to show "key set" honestly rather than rendering
+ * a blank box that means either "unset" or "hidden".
+ */
+function projectAgentDetail(agent: Agent) {
+  const { llmApiKeys, ...config } = agent.config;
+  return {
+    ...projectAgentSummary(agent),
+    config,
+    apiKeyProviders: Object.keys(llmApiKeys ?? {}),
+    createdAt: agent.createdAt.toISOString(),
+    updatedAt: agent.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * The status an agent-service failure deserves, and enough of it to fix the request.
+ *
+ * `AgentConfigurationError` carries the offending `field` and a `suggestion`, both of which
+ * are passed through: a caller with a form can put the message on the right input instead of
+ * showing a generic failure, which is the whole reason the error type carries them.
+ */
+function agentErrorResponse(error: unknown): Response {
+  if (error instanceof AgentConfigurationError) {
+    return json(
+      {
+        ok: false,
+        error: error.message,
+        field: error.field,
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      400,
+    );
+  }
+  if (error instanceof ValidationError) {
+    return json(
+      {
+        ok: false,
+        error: error.message,
+        field: error.field,
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      400,
+    );
+  }
+  if (error instanceof AgentAlreadyExistsError) {
+    return json(
+      {
+        ok: false,
+        error: `An agent called "${error.agentId}" already exists`,
+        field: "name",
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      409,
+    );
+  }
+  if (error instanceof StorageNotFoundError || error instanceof AgentNotFoundError) {
+    return json({ ok: false, error: "agent not found" }, 404);
+  }
+  return json({ ok: false, error: error instanceof Error ? error.message : String(error) }, 500);
+}
+
+/**
+ * Why a body cannot become an agent config, if it cannot.
+ *
+ * Only the things `validateAgentConfig` cannot see are checked here: that the config is an
+ * object at all, and that it does not carry `llmApiKeys`. Keys are refused rather than
+ * scrubbed — silently dropping one would look like it had been saved, and this door never
+ * hands them back, so a caller could not tell. They belong in the keyring, via the CLI.
+ */
+function configBodyProblem(config: unknown): string | undefined {
+  if (config === undefined) return undefined;
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return "config must be a JSON object";
+  }
+  if ("llmApiKeys" in config) {
+    return "config.llmApiKeys cannot be set over HTTP — use `jazz agent edit` so the key goes to the keyring";
+  }
+  return undefined;
+}
+
+/**
+ * The agents this daemon can run, for a caller choosing between them.
  */
 function listAgents() {
   return Effect.gen(function* () {
     const agentService = yield* AgentServiceTag;
     const agents = yield* agentService.listAgents();
-    return json({
-      ok: true,
-      agents: agents.map((agent) => ({
-        id: agent.id,
-        name: agent.name,
-        ...(agent.description !== undefined ? { description: agent.description } : {}),
-        persona: agent.config.persona,
-        provider: agent.config.llmProvider,
-        model: agent.config.llmModel,
-        tools: agent.config.tools ?? [],
-      })),
-    });
+    return json({ ok: true, agents: agents.map(projectAgentSummary) });
   });
+}
+
+function showAgent(identifier: string) {
+  return Effect.gen(function* () {
+    const agent = yield* getAgentByIdentifier(identifier);
+    return json({ ok: true, agent: projectAgentDetail(agent) });
+  }).pipe(Effect.catchAll((error) => Effect.succeed(agentErrorResponse(error))));
+}
+
+function createAgent(body: AgentWriteBody) {
+  return Effect.gen(function* () {
+    const agentService = yield* AgentServiceTag;
+    const agent = yield* agentService.createAgent(
+      typeof body.name === "string" ? body.name : "",
+      typeof body.description === "string" ? body.description : undefined,
+      body.config ?? {},
+    );
+    return json({ ok: true, agent: projectAgentDetail(agent) }, 201);
+  }).pipe(Effect.catchAll((error) => Effect.succeed(agentErrorResponse(error))));
+}
+
+/**
+ * Merge a partial config into an agent's own.
+ *
+ * `updateAgent` merges shallowly, which is what makes this a PATCH: fields left out keep
+ * their stored value. The consequence worth knowing is that there is no way to *unset* an
+ * optional field through it — passing `null` sets it to null rather than removing it.
+ */
+function updateAgent(identifier: string, body: AgentWriteBody) {
+  return Effect.gen(function* () {
+    const agentService = yield* AgentServiceTag;
+    const existing = yield* getAgentByIdentifier(identifier);
+    const agent = yield* agentService.updateAgent(existing.id, {
+      ...(typeof body.name === "string" ? { name: body.name } : {}),
+      ...(typeof body.description === "string" ? { description: body.description } : {}),
+      ...(body.config !== undefined ? { config: body.config as AgentConfig } : {}),
+    });
+    return json({ ok: true, agent: projectAgentDetail(agent) });
+  }).pipe(Effect.catchAll((error) => Effect.succeed(agentErrorResponse(error))));
+}
+
+function deleteAgent(identifier: string) {
+  return Effect.gen(function* () {
+    const agentService = yield* AgentServiceTag;
+    const existing = yield* getAgentByIdentifier(identifier);
+    yield* agentService.deleteAgent(existing.id);
+    return json({ ok: true, id: existing.id });
+  }).pipe(Effect.catchAll((error) => Effect.succeed(agentErrorResponse(error))));
 }
 
 /** What a remote client needs to render and answer a parked run, one shape per pending kind. */

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -63,6 +63,7 @@ import {
 } from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { Effect } from "effect";
+import { Hono } from "hono";
 import { listModelsForProvider } from "@/adapters/llm/model-fetcher";
 import { buildPublicAgentCard, handleA2ARpc, normalizeProtocolVersion } from "@/adapters/peers/a2a";
 import {
@@ -178,98 +179,24 @@ interface StartRunBody {
   readonly conversationId?: unknown;
 }
 
-/** Path segments captured by a route's `:name` placeholders, already percent-decoded. */
-type RouteParams = Readonly<Record<string, string>>;
-
 /**
- * One route on a door.
+ * A door, carrying the two answers every door owes a caller whatever its routes are.
  *
- * `auth` is stated per route rather than implied by where the route sits, which is the point
- * of the table: with an if-chain, whether a route was public depended on whether it appeared
- * above or below the token check, and adding one in the wrong place published it silently.
+ * The 500 is worth stating rather than inheriting. A bare async handler let a thrown error
+ * propagate to the socket; Hono catches it and answers instead. That is the better
+ * behaviour — an unhandled effect failure becomes a controlled reply rather than an opaque
+ * socket error — but it is a real change in where faults surface, so it is written down and
+ * the fault is put on stderr, where a daemon's operator is already looking. The reply itself
+ * carries no detail: one of these doors answers a caller who has presented no credential.
  */
-interface Route {
-  readonly method: string;
-  /** Pattern with `:name` standing for one path segment, e.g. `/agents/:identifier`. */
-  readonly path: string;
-  readonly auth: "token" | "public";
-  readonly handle: (request: Request, params: RouteParams) => Promise<Response>;
-}
-
-interface CompiledRoute extends Route {
-  readonly pattern: RegExp;
-  readonly names: readonly string[];
-}
-
-function compileRoute(route: Route): CompiledRoute {
-  const names: string[] = [];
-  // Literal segments are escaped before the placeholders are substituted, so a path
-  // containing a regex metacharacter matches itself rather than being read as a pattern.
-  // `:` is not a metacharacter, so the placeholders survive escaping intact.
-  const source = route.path
-    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    .replace(/:([A-Za-z][A-Za-z0-9]*)/g, (_match, name: string) => {
-      names.push(name);
-      return "([^/]+)";
-    });
-  return { ...route, pattern: new RegExp(`^${source}$`), names };
-}
-
-/**
- * The route a request addresses, or undefined when nothing matches.
- *
- * A path that matches but on the wrong method counts as no match, so an unknown method
- * answers the same way an unknown path does rather than leaking that the path exists.
- * An undecodable escape in a captured segment is also no match: it cannot name anything.
- */
-function matchRoute(
-  routes: readonly CompiledRoute[],
-  method: string,
-  pathname: string,
-): { readonly route: CompiledRoute; readonly params: RouteParams } | undefined {
-  for (const route of routes) {
-    if (route.method !== method) continue;
-    const found = route.pattern.exec(pathname);
-    if (found === null) continue;
-
-    const params: Record<string, string> = {};
-    try {
-      for (const [index, name] of route.names.entries()) {
-        params[name] = decodeURIComponent(found[index + 1] ?? "");
-      }
-    } catch {
-      return undefined;
-    }
-    return { route, params };
-  }
-  return undefined;
-}
-
-/**
- * Turn a route table into a handler.
- *
- * The order of the three checks is deliberate. A public route answers before the token is
- * looked at; everything else — *including a path that matches nothing* — sits behind it, so
- * an unauthenticated caller cannot map the door by telling 404s from 401s.
- */
-function dispatch(
-  routes: readonly CompiledRoute[],
-  options: DaemonOptions,
-): (request: Request) => Promise<Response> {
-  return async function handle(request: Request): Promise<Response> {
-    const matched = matchRoute(routes, request.method, new URL(request.url).pathname);
-
-    if (matched?.route.auth === "public") {
-      return matched.route.handle(request, matched.params);
-    }
-    if (!authorized(request, options.token)) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
-    if (matched === undefined) {
-      return json({ ok: false, error: "not found" }, 404);
-    }
-    return matched.route.handle(request, matched.params);
-  };
+function door(): Hono {
+  const app = new Hono();
+  app.notFound(() => json({ ok: false, error: "not found" }, 404));
+  app.onError((error) => {
+    process.stderr.write(`daemon handler failed: ${String(error)}\n`);
+    return json({ ok: false, error: "internal error" }, 500);
+  });
+  return app;
 }
 
 /**
@@ -277,6 +204,8 @@ function dispatch(
  *
  * Separated from the socket so it can be driven directly in a test without binding a port,
  * and so the runtime that supplies the agent stack is provided once by the caller.
+ * `app.fetch` is exactly that shape, which is why routing can be Hono's problem rather
+ * than this file's.
  */
 export function makeHandler(
   options: DaemonOptions,
@@ -290,89 +219,58 @@ export function makeHandler(
     return problem === undefined ? body : json({ ok: false, error: problem }, 400);
   };
 
-  const routes = [
-    // Health is unauthenticated on purpose: a supervisor should be able to see that the
-    // process is alive without holding a credential that can drive an agent.
-    {
-      method: "GET",
-      path: "/health",
-      auth: "public",
-      handle: () => Promise.resolve(json({ ok: true })),
-    },
+  const app = door();
 
-    {
-      method: "POST",
-      path: "/runs",
-      auth: "token",
-      handle: (request) => startRunRoute(request, runEffect),
-    },
-    { method: "GET", path: "/runs", auth: "token", handle: () => runEffect(listRuns()) },
-    {
-      method: "GET",
-      path: "/runs/:runId",
-      auth: "token",
-      handle: (_request, params) => runEffect(describeRun(params["runId"] ?? "")),
-    },
-    {
-      method: "POST",
-      path: "/runs/:runId/answer",
-      auth: "token",
-      handle: (request, params) => answerRunRoute(request, params["runId"] ?? "", runEffect),
-    },
+  // Health is unauthenticated on purpose: a supervisor should be able to see that the
+  // process is alive without holding a credential that can drive an agent. It is registered
+  // before the token middleware and answers without calling `next`, so the middleware below
+  // never runs for it.
+  app.get("/health", () => json({ ok: true }));
 
-    { method: "GET", path: "/agents", auth: "token", handle: () => runEffect(listAgents()) },
-    {
-      method: "POST",
-      path: "/agents",
-      auth: "token",
-      handle: async (request) => {
-        const body = await agentWriteBody(request);
-        return body instanceof Response ? body : runEffect(createAgent(body));
-      },
-    },
-    {
-      method: "GET",
-      path: "/agents/:identifier",
-      auth: "token",
-      handle: (_request, params) => runEffect(showAgent(params["identifier"] ?? "")),
-    },
-    {
-      method: "PATCH",
-      path: "/agents/:identifier",
-      auth: "token",
-      handle: async (request, params) => {
-        const body = await agentWriteBody(request);
-        return body instanceof Response
-          ? body
-          : runEffect(updateAgent(params["identifier"] ?? "", body));
-      },
-    },
-    {
-      method: "DELETE",
-      path: "/agents/:identifier",
-      auth: "token",
-      handle: (_request, params) => runEffect(deleteAgent(params["identifier"] ?? "")),
-    },
+  // Everything past this point is behind the token, *including a path that matches nothing*:
+  // the wildcard is reached before Hono's 404, so an unauthenticated caller cannot map the
+  // door by telling 404s from 401s.
+  app.use("*", async (context, next) => {
+    if (!authorized(context.req.raw, options.token)) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+    await next();
+    return undefined;
+  });
 
-    // The catalogues behind an agent editor's menus. Served from the daemon rather than
-    // retyped by each client, so a picker cannot offer a value the agent service rejects.
-    {
-      method: "GET",
-      path: "/catalog",
-      auth: "token",
-      handle: () => Promise.resolve(listCatalog()),
-    },
-    {
-      method: "GET",
-      path: "/models",
-      auth: "token",
-      handle: (request) => modelsRoute(request, runEffect),
-    },
-    { method: "GET", path: "/personas", auth: "token", handle: () => runEffect(listPersonas()) },
-    { method: "GET", path: "/tools", auth: "token", handle: () => runEffect(listTools()) },
-  ] satisfies readonly Route[];
+  app.post("/runs", (context) => startRunRoute(context.req.raw, runEffect));
+  app.get("/runs", () => runEffect(listRuns()));
+  app.get("/runs/:runId", (context) => runEffect(describeRun(context.req.param("runId"))));
+  app.post("/runs/:runId/answer", (context) =>
+    answerRunRoute(context.req.raw, context.req.param("runId"), runEffect),
+  );
 
-  return dispatch(routes.map(compileRoute), options);
+  app.get("/agents", () => runEffect(listAgents()));
+  app.post("/agents", async (context) => {
+    const body = await agentWriteBody(context.req.raw);
+    return body instanceof Response ? body : runEffect(createAgent(body));
+  });
+  app.get("/agents/:identifier", (context) =>
+    runEffect(showAgent(context.req.param("identifier"))),
+  );
+  app.patch("/agents/:identifier", async (context) => {
+    const body = await agentWriteBody(context.req.raw);
+    return body instanceof Response
+      ? body
+      : runEffect(updateAgent(context.req.param("identifier"), body));
+  });
+  app.delete("/agents/:identifier", (context) =>
+    runEffect(deleteAgent(context.req.param("identifier"))),
+  );
+
+  // The catalogues behind an agent editor's menus. Served from the daemon rather than
+  // retyped by each client, so a picker cannot offer a value the agent service rejects.
+  app.get("/catalog", () => listCatalog());
+  app.get("/models", (context) => modelsRoute(context.req.raw, runEffect));
+  app.get("/personas", () => runEffect(listPersonas()));
+  app.get("/tools", () => runEffect(listTools()));
+
+  return (request) => Promise.resolve(app.fetch(request));
 }
 
 async function startRunRoute(
@@ -459,28 +357,19 @@ export function makePeerHandler(
   resolveToken: (peerName: string) => Promise<string | undefined>,
   runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
 ): (request: Request) => Promise<Response> {
-  return async function handlePeer(request: Request): Promise<Response> {
-    const url = new URL(request.url);
-    if (request.method !== "POST" || url.pathname !== "/peer/ask") {
-      return json({ ok: false, error: "not found" }, 404);
-    }
+  const app = door();
+
+  app.post("/peer/ask", async (context) => {
     if (options.peerAgent === undefined) {
       return json({ ok: false, error: "not accepting peer questions" }, 404);
     }
 
-    const presented = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");
-    if (presented.length === 0) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
-
-    const caller = await resolveCallerPeer(resolvePeers, resolveToken, presented);
-    if (caller === undefined) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
+    const caller = await callerPeerOrRefusal(context.req.raw, resolvePeers, resolveToken);
+    if (caller instanceof Response) return caller;
 
     let body: { question?: unknown };
     try {
-      body = (await request.json()) as { question?: unknown };
+      body = (await context.req.raw.json()) as { question?: unknown };
     } catch {
       return json({ ok: false, error: "body must be JSON" }, 400);
     }
@@ -490,7 +379,28 @@ export function makePeerHandler(
     }
 
     return runEffect(answerPeer(caller, options.peerAgent, question));
-  };
+  });
+
+  return (request) => Promise.resolve(app.fetch(request));
+}
+
+/**
+ * Which peer is calling, or the refusal to send back.
+ *
+ * Shared by `/peer/ask` and `/a2a` because they are one authorization rule wearing two wire
+ * formats, and two copies of it is two places for it to drift.
+ */
+async function callerPeerOrRefusal(
+  request: Request,
+  resolvePeers: () => Promise<readonly PeerConfig[]>,
+  resolveToken: (peerName: string) => Promise<string | undefined>,
+): Promise<PeerConfig | Response> {
+  const presented = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");
+  if (presented.length === 0) {
+    return json({ ok: false, error: "unauthorized" }, 401);
+  }
+  const caller = await resolveCallerPeer(resolvePeers, resolveToken, presented);
+  return caller ?? json({ ok: false, error: "unauthorized" }, 401);
 }
 
 /** Where a caller announces which A2A protocol version it is speaking. */
@@ -531,35 +441,28 @@ export function makeA2AHandler(
   resolveToken: (peerName: string) => Promise<string | undefined>,
   runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
 ): (request: Request) => Promise<Response> {
-  return async function handleA2A(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+  const app = door();
 
-    if (request.method === "GET" && url.pathname === "/.well-known/agent-card.json") {
-      if (options.peerAgent === undefined) {
-        return json({ ok: false, error: "not accepting peer questions" }, 404);
-      }
-      return json(buildPublicAgentCard(options.peerAgent, a2aEndpointUrl(request)));
+  // The card is deliberately unauthenticated — it is the capability advertisement a stranger
+  // reads before they have any credential — so it sits above nothing and needs no token.
+  app.get("/.well-known/agent-card.json", (context) => {
+    if (options.peerAgent === undefined) {
+      return json({ ok: false, error: "not accepting peer questions" }, 404);
     }
+    return json(buildPublicAgentCard(options.peerAgent, a2aEndpointUrl(context.req.raw)));
+  });
 
-    if (request.method !== "POST" || url.pathname !== "/a2a") {
-      return json({ ok: false, error: "not found" }, 404);
-    }
+  app.post("/a2a", async (context) => {
     if (options.peerAgent === undefined) {
       return json({ ok: false, error: "not accepting peer questions" }, 404);
     }
 
-    const presented = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");
-    if (presented.length === 0) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
-    const caller = await resolveCallerPeer(resolvePeers, resolveToken, presented);
-    if (caller === undefined) {
-      return json({ ok: false, error: "unauthorized" }, 401);
-    }
+    const caller = await callerPeerOrRefusal(context.req.raw, resolvePeers, resolveToken);
+    if (caller instanceof Response) return caller;
 
     let body: unknown;
     try {
-      body = await request.json();
+      body = await context.req.raw.json();
     } catch {
       return json({ ok: false, error: "body must be JSON" }, 400);
     }
@@ -568,12 +471,14 @@ export function makeA2AHandler(
       answerA2A(
         caller,
         options.peerAgent,
-        a2aEndpointUrl(request),
-        normalizeProtocolVersion(request.headers.get(A2A_VERSION_HEADER)),
+        a2aEndpointUrl(context.req.raw),
+        normalizeProtocolVersion(context.req.raw.headers.get(A2A_VERSION_HEADER)),
         body,
       ),
     );
-  };
+  });
+
+  return (request) => Promise.resolve(app.fetch(request));
 }
 
 /**
@@ -594,51 +499,56 @@ export function makePeerInviteHandler(
   keyring?: KeyringDependency,
   peerAgent?: string,
 ): (request: Request) => Promise<Response> {
-  return async function handleInvite(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+  const app = door();
+
+  // The whole door is shut when no peer agent is configured, checked before any route runs:
+  // serving strangers stays opt-in rather than depending on which path one of them guessed.
+  app.use("*", async (_context, next) => {
     if (peerAgent === undefined) {
       return json({ ok: false, error: "not accepting peer invitations" }, 404);
     }
+    await next();
+    return undefined;
+  });
 
-    const previewMatch = /^\/peer-invites\/([^/]+)$/.exec(url.pathname);
-    if (request.method === "GET" && previewMatch?.[1] !== undefined) {
-      const invite = await runEffect(getInvite(previewMatch[1]));
-      if (invite === undefined) {
-        return json({ ok: false, error: "no such invite" }, 404);
-      }
-      // Enough to render a confirmation prompt, not enough to be useful without the secret:
-      // no secret, no hash, and the redeemer's chosen name (if already used) is not exposed.
-      return json({
-        ok: true,
-        inviterDisplayName: invite.inviterDisplayName,
-        inviterAskUrl: invite.inviterAskUrl,
-        proposedTier: invite.proposedTier,
-        expiresAt: invite.expiresAt,
-        status: inviteStatus(invite, new Date()),
-      });
+  app.get("/peer-invites/:id", async (context) => {
+    const invite = await runEffect(getInvite(context.req.param("id")));
+    if (invite === undefined) {
+      return json({ ok: false, error: "no such invite" }, 404);
+    }
+    // Enough to render a confirmation prompt, not enough to be useful without the secret:
+    // no secret, no hash, and the redeemer's chosen name (if already used) is not exposed.
+    return json({
+      ok: true,
+      inviterDisplayName: invite.inviterDisplayName,
+      inviterAskUrl: invite.inviterAskUrl,
+      proposedTier: invite.proposedTier,
+      expiresAt: invite.expiresAt,
+      status: inviteStatus(invite, new Date()),
+    });
+  });
+
+  app.post("/peer-invites/:id/accept", async (context) => {
+    // Capped before parsing, because this is the one route that answers before knowing who
+    // is calling.
+    const raw = await readBody(context.req.raw, MAX_ANONYMOUS_PAYLOAD_LENGTH);
+    if (raw instanceof Response) return raw;
+    let body: { secret?: unknown; as?: unknown };
+    try {
+      body = JSON.parse(raw) as { secret?: unknown; as?: unknown };
+    } catch {
+      return json({ ok: false, error: "body must be JSON" }, 400);
+    }
+    const secret = typeof body.secret === "string" ? body.secret : "";
+    const as = typeof body.as === "string" ? body.as.trim() : "";
+    if (secret.length === 0 || as.length === 0) {
+      return json({ ok: false, error: "secret and as are required" }, 400);
     }
 
-    const acceptMatch = /^\/peer-invites\/([^/]+)\/accept$/.exec(url.pathname);
-    if (request.method === "POST" && acceptMatch?.[1] !== undefined) {
-      const raw = await readBody(request, MAX_ANONYMOUS_PAYLOAD_LENGTH);
-      if (raw instanceof Response) return raw;
-      let body: { secret?: unknown; as?: unknown };
-      try {
-        body = JSON.parse(raw) as { secret?: unknown; as?: unknown };
-      } catch {
-        return json({ ok: false, error: "body must be JSON" }, 400);
-      }
-      const secret = typeof body.secret === "string" ? body.secret : "";
-      const as = typeof body.as === "string" ? body.as.trim() : "";
-      if (secret.length === 0 || as.length === 0) {
-        return json({ ok: false, error: "secret and as are required" }, 400);
-      }
+    return runEffect(acceptInvite(context.req.param("id"), secret, as, keyring));
+  });
 
-      return runEffect(acceptInvite(acceptMatch[1], secret, as, keyring));
-    }
-
-    return json({ ok: false, error: "not found" }, 404);
-  };
+  return (request) => Promise.resolve(app.fetch(request));
 }
 
 function acceptInvite(
@@ -795,25 +705,20 @@ export function makeWebhookHandler(
   resolveToken: (webhookName: string) => Promise<string | undefined>,
   runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
 ): (request: Request) => Promise<Response> {
-  return async function handleWebhook(request: Request): Promise<Response> {
-    const url = new URL(request.url);
-    const match = /^\/webhooks\/([^/]+)$/.exec(url.pathname);
-    const rawName = match?.[1];
-    if (request.method !== "POST" || rawName === undefined) {
-      return json({ ok: false, error: "not found" }, 404);
-    }
-    let webhookName: string;
-    try {
-      webhookName = decodeURIComponent(rawName);
-    } catch {
-      return json({ ok: false, error: "not found" }, 404);
-    }
+  const app = door();
+
+  app.post("/webhooks/:name", async (context) => {
+    const request = context.req.raw;
+    const webhookName = context.req.param("name");
 
     const webhook = (await readWebhooks()).find((candidate) => candidate.name === webhookName);
     if (webhook === undefined) {
       return json({ ok: false, error: "not found" }, 404);
     }
 
+    // Per-webhook rather than one daemon token: each door carries its own credential, and
+    // both the list and the token are read per request so a webhook added a minute ago works
+    // without bouncing the daemon.
     const presented = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");
     const expected = await resolveToken(webhook.name);
     if (
@@ -875,7 +780,9 @@ export function makeWebhookHandler(
         wanted.kinds,
       ),
     );
-  };
+  });
+
+  return (request) => Promise.resolve(app.fetch(request));
 }
 
 /**


### PR DESCRIPTION
## What & why

The daemon could tell a caller which agents exist, but creating or editing one still meant
dropping into the interactive CLI wizard. Anything else driving jazz — a local dashboard, a
script — could read the roster and nothing more. This adds the write half plus the menus an
editor needs, so an agent can be created, retyped or removed without a terminal round trip:

- `POST /agents`, `GET/PATCH/DELETE /agents/:id` — `:id` accepts a name too, as the CLI does
- `GET /catalog`, `GET /models?provider=`, `GET /personas`, `GET /tools` — the vocabularies a
  picker is built from

The catalogue routes serve the same arrays `validateAgentConfig` checks against, so a menu
built from them cannot offer a value the agent service would reject. That is the point of
serving them rather than letting each client retype the list and drift. `/models` carries
per-model `supportsTemperature` and `isReasoningModel`, because a temperature input on a
model that ignores temperature is a control that silently does nothing.

A bad config comes back with the field that was wrong and jazz's own suggestion for fixing
it, so a form can put the message on the offending input. The rules stay in the agent
service — this is another door onto it, not a second rulebook.

Routing moves to Hono along the way, all five doors rather than only the operator's, because
the old if-chain held one invariant by line order alone: whether a route was public depended
on whether it sat above or below the token check, so adding one in the wrong place would
publish it silently. Each door stays its own Hono app, so the credential boundary between an
operator token, per-peer tokens, per-webhook tokens and a one-time invite secret is unchanged.
Hono adds one runtime dependency to `@jazz/adapters`, which had almost none.

## Breaking changes / migration

None. `GET /agents` returns exactly the shape it did; the fuller config an editor needs is
served by the new single-agent route instead, so a list of agents doesn't carry every
agent's custom tools and allowlists.

## How to verify

- `curl -XPOST localhost:4747/agents -d '{"name":"scratch","config":{"persona":"default","llmProvider":"anthropic","llmModel":"claude-sonnet-4-6"}}'`
  then `jazz agent list` — the agent shows up, and the CLI and HTTP views agree.
- `PATCH` just `{"config":{"llmModel":"..."}}` and confirm the agent's tools and persona
  survive: the merge is shallow on purpose, so omitted fields keep their stored value.
- Post a config with `llmApiKeys` set — refused with a 400 pointing at the keyring, and
  nothing is written. Refusing beats scrubbing here: this door never returns keys, so a
  silent drop would be indistinguishable from a successful save.
- `GET /models?provider=gpt` — 400 naming the field; `?provider=anthropic` — a real list.
  Kill your network and retry: 502 with advice to name the model directly, not a hang.
- `GET /tools` — `ask_user` and other hidden tools are absent, since this answers "what can
  somebody pick".
- With `JAZZ_DAEMON_TOKEN` set, request a path that does not exist: 401, not 404. Unmatched
  paths sit behind the token deliberately, so the door cannot be mapped without it. Only
  `/health` answers without one.
- `bun run build:binary`, then run `jazz daemon` from the binary and exercise each door — the
  point being that the new dependency survives `--compile`. Peer, A2A, invite and webhook
  doors all moved, so they are worth a pass too, not just the agent routes.
