### PR TITLE
feat(agents): Denied tools

### DIFF
--- a/packages/adapters/src/agent-service.test.ts
+++ b/packages/adapters/src/agent-service.test.ts
@@ -759,6 +759,19 @@ describe("AgentService", () => {
       await expectRejected({ ...baseConfig, webSearchProvider: "google" });
     });
 
+    it("accepts denied tool names", async () => {
+      await expectAccepted({ ...baseConfig, deniedTools: ["execute_command", "write_file"] });
+    });
+
+    it("rejects a non-array deniedTools value", async () => {
+      // @ts-expect-error - must be an array
+      await expectRejected({ ...baseConfig, deniedTools: "execute_command" });
+    });
+
+    it("rejects a blank denied tool", async () => {
+      await expectRejected({ ...baseConfig, deniedTools: ["execute_command", " "] });
+    });
+
     it("accepts named memory scopes", async () => {
       await expectAccepted({ ...baseConfig, memoryScopes: ["work", "personal"] });
     });

--- a/packages/adapters/src/agent-service.ts
+++ b/packages/adapters/src/agent-service.ts
@@ -478,6 +478,32 @@ export class AgentServiceImpl implements AgentService {
         }
       }
 
+      if (config.deniedTools !== undefined && config.deniedTools !== null) {
+        if (!Array.isArray(config.deniedTools)) {
+          return yield* Effect.fail(
+            new AgentConfigurationError({
+              agentId: "unknown",
+              field: "config.deniedTools",
+              message: "deniedTools must be provided as an array of tool names",
+              suggestion: 'Supply an array of tool names, e.g. ["execute_command"].',
+            }),
+          );
+        }
+
+        for (const tool of config.deniedTools as readonly string[]) {
+          if (typeof tool !== "string" || tool.trim().length === 0) {
+            return yield* Effect.fail(
+              new AgentConfigurationError({
+                agentId: "unknown",
+                field: "config.deniedTools",
+                message: "Each deniedTools entry must be a non-empty string",
+                suggestion: "Remove blank entries so every denial names a tool.",
+              }),
+            );
+          }
+        }
+      }
+
       if (config.memoryScopes !== undefined && config.memoryScopes !== null) {
         if (!Array.isArray(config.memoryScopes)) {
           return yield* Effect.fail(

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -1066,6 +1066,10 @@ describe("the menus an agent editor is built from", () => {
       listTools: () => Effect.succeed(["read_file", "web_search"]),
       listAllTools: () => Effect.succeed(["read_file", "web_search", "ask_user"]),
       listToolsByCategory: () => Effect.succeed({ filesystem: ["read_file"], web: ["web_search"] }),
+      // Every built-in category reports the same tool, so `defaultTools` also has to
+      // dedupe. `web_search` is deliberately in no category here: it stands for a tool an
+      // agent only has because its own config asked for one.
+      getToolsInCategory: () => Effect.succeed(["read_file"]),
     } as unknown as ToolRegistry;
     const handle = makeHandler(LOOPBACK, runnerProviding(ToolRegistryTag, registry));
 
@@ -1074,10 +1078,15 @@ describe("the menus an agent editor is built from", () => {
     const body = (await response.json()) as {
       tools: string[];
       categories: Record<string, string[]>;
+      defaultTools: string[];
     };
     expect(body.tools).toEqual(["read_file", "web_search"]);
     expect(body.tools).not.toContain("ask_user");
     expect(body.categories).toEqual({ filesystem: ["read_file"], web: ["web_search"] });
+    // The distinction a tool picker depends on: `read_file` is on whether or not anyone
+    // asked, so offering a checkbox for it would imply control that `config.tools` does not
+    // have. `web_search` is the kind of row that is genuinely a choice.
+    expect(body.defaultTools).toEqual(["read_file"]);
   });
 
   it("keeps the menus behind the daemon token", async () => {

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -24,6 +24,7 @@ import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
 import { isRunParkRequested } from "@jazz/core/agent/run/park-signal";
 import { resumeRun, type ResumeRunOptions } from "@jazz/core/agent/run/resume";
 import type { PendingInput } from "@jazz/core/agent/run/run-state";
+import { BUILTIN_TOOL_CATEGORIES } from "@jazz/core/agent/tools/tool-categories";
 import { AVAILABLE_PROVIDERS, isProviderName } from "@jazz/core/constants/models";
 import type { ProviderName } from "@jazz/core/constants/models";
 import { AgentConfigServiceTag } from "@jazz/core/interfaces/agent-config";
@@ -1341,7 +1342,18 @@ function listTools() {
     const registry = yield* ToolRegistryTag;
     const tools = yield* registry.listTools();
     const categories = yield* registry.listToolsByCategory();
-    return json({ ok: true, tools, categories });
+
+    // Which of these an agent gets without asking for them.
+    //
+    // Load-bearing for anything with a tool picker: `config.tools` only ever *adds*, so a
+    // checkbox next to a default tool would suggest a permission it does not control. A
+    // caller needs to know which rows are already on before it can honestly offer to turn
+    // one off — which is `deniedTools`, a different field.
+    const defaultTools = (yield* Effect.all(
+      BUILTIN_TOOL_CATEGORIES.map((category) => registry.getToolsInCategory(category.id)),
+    )).flat();
+
+    return json({ ok: true, tools, categories, defaultTools: [...new Set(defaultTools)] });
   });
 }
 

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -46,6 +46,7 @@ import { createAgentRunMetrics, emitAgentRunStarted } from "./metrics/agent-run-
 import { discoverProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
 import { withRunRecording } from "./run/run-recorder";
 import { runSpendUSD } from "./run/run-spend";
+import { withoutDeniedTools } from "./tools/agent-tool-resolution";
 import { registerCustomToolsForAgent } from "./tools/custom-tools";
 import { registerMCPToolsForAgent } from "./tools/register-mcp-tools";
 import { registerPeerTools } from "./tools/register-tools";
@@ -303,10 +304,10 @@ function initializeAgentRun(
     // Combine agent tools with built-in tools, then apply persona deny list.
     let combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
 
-    if (toolProfile?.deny && toolProfile.deny.length > 0) {
-      const denied = new Set(toolProfile.deny);
-      combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
-    }
+    // Both deny lists, in one shared subtraction with the A2A card path.
+    combinedToolNames = [
+      ...withoutDeniedTools(combinedToolNames, toolProfile?.deny, agent.config.deniedTools),
+    ];
 
     // Ephemeral runs (jazz run --ephemeral) withhold the memory-writing tool
     // outright, so the model is never even offered a way to persist anything.

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -46,7 +46,7 @@ import { createAgentRunMetrics, emitAgentRunStarted } from "./metrics/agent-run-
 import { discoverProjectInstructions, type ProjectInstructionFile } from "./project-instructions";
 import { withRunRecording } from "./run/run-recorder";
 import { runSpendUSD } from "./run/run-spend";
-import { withoutDeniedTools } from "./tools/agent-tool-resolution";
+import { toolDenials } from "./tools/agent-tool-resolution";
 import { registerCustomToolsForAgent } from "./tools/custom-tools";
 import { registerMCPToolsForAgent } from "./tools/register-mcp-tools";
 import { registerPeerTools } from "./tools/register-tools";
@@ -304,10 +304,10 @@ function initializeAgentRun(
     // Combine agent tools with built-in tools, then apply persona deny list.
     let combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
 
-    // Both deny lists, in one shared subtraction with the A2A card path.
-    combinedToolNames = [
-      ...withoutDeniedTools(combinedToolNames, toolProfile?.deny, agent.config.deniedTools),
-    ];
+    // Both scopes of denial, after everything that grants. Neither is undoable below: the
+    // allowlist and carve-outs that follow can only narrow further.
+    const denied = toolDenials(agent, toolProfile);
+    combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
 
     // Ephemeral runs (jazz run --ephemeral) withhold the memory-writing tool
     // outright, so the model is never even offered a way to persist anything.

--- a/packages/core/src/agent/tools/agent-tool-resolution.test.ts
+++ b/packages/core/src/agent/tools/agent-tool-resolution.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { withoutDeniedTools } from "./agent-tool-resolution";
+
+describe("subtracting denied tools", () => {
+  const granted = ["read_file", "write_file", "execute_command", "web_search"];
+
+  it("leaves the set alone when nothing is denied", () => {
+    expect(withoutDeniedTools(granted, undefined, undefined)).toEqual(granted);
+    expect(withoutDeniedTools(granted, [], [])).toEqual(granted);
+  });
+
+  it("removes what the agent denies", () => {
+    expect(withoutDeniedTools(granted, undefined, ["execute_command"])).toEqual([
+      "read_file",
+      "write_file",
+      "web_search",
+    ]);
+  });
+
+  it("removes what the persona denies", () => {
+    expect(withoutDeniedTools(granted, ["write_file"], undefined)).toEqual([
+      "read_file",
+      "execute_command",
+      "web_search",
+    ]);
+  });
+
+  it("applies both lists, not whichever is longer", () => {
+    expect(withoutDeniedTools(granted, ["write_file"], ["execute_command"])).toEqual([
+      "read_file",
+      "web_search",
+    ]);
+  });
+
+  it("tolerates a tool denied twice", () => {
+    expect(withoutDeniedTools(granted, ["web_search"], ["web_search"])).toEqual([
+      "read_file",
+      "write_file",
+      "execute_command",
+    ]);
+  });
+
+  it("ignores a denial for a tool that was never granted", () => {
+    // Denying something the agent could not reach anyway is not an error: a tool can be
+    // removed from jazz, or come from an MCP server that is not connected right now, and a
+    // stale entry in the list should not change what happens.
+    expect(withoutDeniedTools(granted, undefined, ["mcp_gone"])).toEqual(granted);
+  });
+
+  it("can deny a tool the agent's own config asked for", () => {
+    // `config.tools` adds and `deniedTools` subtracts, and subtraction runs last, so an
+    // agent that both requests and denies a tool does not get it. Contradictory config,
+    // but it has to resolve one way, and withholding is the safe direction.
+    expect(withoutDeniedTools(["mcp_linear"], undefined, ["mcp_linear"])).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/tools/agent-tool-resolution.test.ts
+++ b/packages/core/src/agent/tools/agent-tool-resolution.test.ts
@@ -1,56 +1,101 @@
 import { describe, expect, it } from "bun:test";
-import { withoutDeniedTools } from "./agent-tool-resolution";
+import { Effect } from "effect";
+import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-registry";
+import type { Agent, AgentConfig } from "@/core/types";
+import { resolveAgentToolNames, toolDenials } from "./agent-tool-resolution";
 
-describe("subtracting denied tools", () => {
-  const granted = ["read_file", "write_file", "execute_command", "web_search"];
+function agentWith(config: Partial<AgentConfig>): Agent {
+  return {
+    id: "agent-1",
+    name: "scratch",
+    config: {
+      persona: "default",
+      llmProvider: "anthropic",
+      llmModel: "claude-sonnet-4-6",
+      ...config,
+    },
+    createdAt: new Date("2026-09-01T00:00:00Z"),
+    updatedAt: new Date("2026-09-01T00:00:00Z"),
+  } as Agent;
+}
 
-  it("leaves the set alone when nothing is denied", () => {
-    expect(withoutDeniedTools(granted, undefined, undefined)).toEqual(granted);
-    expect(withoutDeniedTools(granted, [], [])).toEqual(granted);
+/**
+ * Every built-in category reports the same two tools.
+ *
+ * They stand for the bundle an agent gets without asking, which is the thing the denials
+ * have to be able to reach — narrowing only `config.tools` would never touch them.
+ */
+const registry = {
+  getToolsInCategory: () => Effect.succeed(["read_file", "execute_command"]),
+} as unknown as ToolRegistry;
+
+function resolve(agent: Agent): Promise<readonly string[]> {
+  // PersonaService is deliberately not provided: `resolveAgentToolNames` reads it through
+  // `serviceOption`, so leaving it out is the unrestricted-persona case.
+  return Effect.runPromise(
+    resolveAgentToolNames(agent).pipe(
+      Effect.provideService(ToolRegistryTag, registry),
+    ) as Effect.Effect<readonly string[], never, never>,
+  );
+}
+
+describe("the tools denied to an agent", () => {
+  it("is empty when neither scope denies anything", () => {
+    expect(toolDenials(agentWith({}), undefined).size).toBe(0);
   });
 
-  it("removes what the agent denies", () => {
-    expect(withoutDeniedTools(granted, undefined, ["execute_command"])).toEqual([
-      "read_file",
-      "write_file",
-      "web_search",
+  it("collects the agent's own denials", () => {
+    expect([...toolDenials(agentWith({ deniedTools: ["execute_command"] }), undefined)]).toEqual([
+      "execute_command",
     ]);
   });
 
-  it("removes what the persona denies", () => {
-    expect(withoutDeniedTools(granted, ["write_file"], undefined)).toEqual([
+  it("collects both scopes, since they withhold for different reasons", () => {
+    const denied = toolDenials(agentWith({ deniedTools: ["execute_command"] }), {
+      deny: ["write_file"],
+    });
+    expect([...denied].sort()).toEqual(["execute_command", "write_file"]);
+  });
+
+  it("counts a tool denied by both scopes once", () => {
+    const denied = toolDenials(agentWith({ deniedTools: ["execute_command"] }), {
+      deny: ["execute_command"],
+    });
+    expect(denied.size).toBe(1);
+  });
+});
+
+describe("resolving what an agent can actually reach", () => {
+  it("includes built-in tools the agent never asked for", async () => {
+    // The premise everything else depends on: `config.tools` adds to the bundle rather than
+    // replacing it, so an empty config is not an agent with no tools.
+    expect(await resolve(agentWith({}))).toEqual(["read_file", "execute_command"]);
+  });
+
+  it("withholds a built-in tool the agent denies", async () => {
+    // The whole point of `deniedTools`: before it, nothing an agent could say about itself
+    // could take a bundled tool away.
+    expect(await resolve(agentWith({ deniedTools: ["execute_command"] }))).toEqual(["read_file"]);
+  });
+
+  it("withholds a tool the agent both asks for and denies", async () => {
+    // Contradictory config has to resolve one way. Denial runs last, so it wins — the safe
+    // direction, and the one that makes a denial trustworthy.
+    const agent = agentWith({ tools: ["mcp_linear"], deniedTools: ["mcp_linear"] });
+    expect(await resolve(agent)).not.toContain("mcp_linear");
+  });
+
+  it("still grants a requested tool that nothing denies", async () => {
+    const agent = agentWith({ tools: ["mcp_linear"], deniedTools: ["execute_command"] });
+    expect([...(await resolve(agent))].sort()).toEqual(["mcp_linear", "read_file"]);
+  });
+
+  it("ignores a denial naming a tool the agent never had", async () => {
+    // A tool can be removed from jazz, or come from an MCP server that is not connected
+    // right now. A stale entry should change nothing.
+    expect(await resolve(agentWith({ deniedTools: ["mcp_gone"] }))).toEqual([
       "read_file",
       "execute_command",
-      "web_search",
     ]);
-  });
-
-  it("applies both lists, not whichever is longer", () => {
-    expect(withoutDeniedTools(granted, ["write_file"], ["execute_command"])).toEqual([
-      "read_file",
-      "web_search",
-    ]);
-  });
-
-  it("tolerates a tool denied twice", () => {
-    expect(withoutDeniedTools(granted, ["web_search"], ["web_search"])).toEqual([
-      "read_file",
-      "write_file",
-      "execute_command",
-    ]);
-  });
-
-  it("ignores a denial for a tool that was never granted", () => {
-    // Denying something the agent could not reach anyway is not an error: a tool can be
-    // removed from jazz, or come from an MCP server that is not connected right now, and a
-    // stale entry in the list should not change what happens.
-    expect(withoutDeniedTools(granted, undefined, ["mcp_gone"])).toEqual(granted);
-  });
-
-  it("can deny a tool the agent's own config asked for", () => {
-    // `config.tools` adds and `deniedTools` subtracts, and subtraction runs last, so an
-    // agent that both requests and denies a tool does not get it. Contradictory config,
-    // but it has to resolve one way, and withholding is the safe direction.
-    expect(withoutDeniedTools(["mcp_linear"], undefined, ["mcp_linear"])).toEqual([]);
   });
 });

--- a/packages/core/src/agent/tools/agent-tool-resolution.ts
+++ b/packages/core/src/agent/tools/agent-tool-resolution.ts
@@ -30,6 +30,27 @@ import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-regis
 import type { Agent } from "@/core/types";
 import { BUILTIN_TOOL_CATEGORIES } from "./tool-categories";
 
+/**
+ * Remove every tool the persona or the agent denies.
+ *
+ * Shared by the run path and the A2A card because they resolve tool sets separately, and a
+ * card advertising a tool the run withholds is worse than no card at all. Subtraction lives
+ * here, in one function, so the two cannot drift.
+ *
+ * Applied after everything that *adds* — `config.tools` and the built-in bundle — since both
+ * deny lists are meant to be final: nothing downstream should be able to put a denied tool
+ * back. The two lists differ only in reach: a persona's applies to every agent sharing it,
+ * an agent's to that agent alone.
+ */
+export function withoutDeniedTools(
+  names: readonly string[],
+  personaDeny: readonly string[] | undefined,
+  agentDenied: readonly string[] | undefined,
+): readonly string[] {
+  const denied = new Set([...(personaDeny ?? []), ...(agentDenied ?? [])]);
+  return denied.size === 0 ? names : names.filter((name) => !denied.has(name));
+}
+
 export function resolveAgentToolNames(
   agent: Agent,
 ): Effect.Effect<readonly string[], never, ToolRegistry> {
@@ -62,11 +83,7 @@ export function resolveAgentToolNames(
         .map((id) => toolRegistry.getToolsInCategory(id)),
     )).flat();
 
-    let combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
-    if (toolProfile?.deny && toolProfile.deny.length > 0) {
-      const denied = new Set(toolProfile.deny);
-      combinedToolNames = combinedToolNames.filter((name) => !denied.has(name));
-    }
-    return combinedToolNames;
+    const combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
+    return withoutDeniedTools(combinedToolNames, toolProfile?.deny, agent.config.deniedTools);
   });
 }

--- a/packages/core/src/agent/tools/agent-tool-resolution.ts
+++ b/packages/core/src/agent/tools/agent-tool-resolution.ts
@@ -28,27 +28,28 @@ import { normalizeToolConfig } from "@/core/agent/utils/tool-config";
 import { PersonaServiceTag } from "@/core/interfaces/persona-service";
 import { ToolRegistryTag, type ToolRegistry } from "@/core/interfaces/tool-registry";
 import type { Agent } from "@/core/types";
+import type { PersonaToolProfile } from "@/core/types/persona";
 import { BUILTIN_TOOL_CATEGORIES } from "./tool-categories";
 
 /**
- * Remove every tool the persona or the agent denies.
+ * Every tool withheld from this agent, from either scope that can withhold one.
  *
- * Shared by the run path and the A2A card because they resolve tool sets separately, and a
- * card advertising a tool the run withholds is worse than no card at all. Subtraction lives
- * here, in one function, so the two cannot drift.
+ * The set, not a filter over it. What the run path and the A2A card have to agree on is
+ * *where denials come from* — a caller that forgets `deniedTools` exists is the failure that
+ * matters, and one that writes `.filter` wrong is not a failure anyone has ever had. Adding
+ * a third source later fixes both callers at once; the subtraction itself stays visible at
+ * each call site rather than hidden behind a name.
  *
- * Applied after everything that *adds* — `config.tools` and the built-in bundle — since both
- * deny lists are meant to be final: nothing downstream should be able to put a denied tool
- * back. The two lists differ only in reach: a persona's applies to every agent sharing it,
- * an agent's to that agent alone.
+ * The two scopes differ only in reach: a persona's `deny` applies to every agent sharing
+ * that persona, an agent's `deniedTools` to that agent alone. Neither is meant to be
+ * undoable, so callers subtract this last — after `config.tools` and the built-in bundle,
+ * both of which only ever add.
  */
-export function withoutDeniedTools(
-  names: readonly string[],
-  personaDeny: readonly string[] | undefined,
-  agentDenied: readonly string[] | undefined,
-): readonly string[] {
-  const denied = new Set([...(personaDeny ?? []), ...(agentDenied ?? [])]);
-  return denied.size === 0 ? names : names.filter((name) => !denied.has(name));
+export function toolDenials(
+  agent: Agent,
+  toolProfile: PersonaToolProfile | undefined,
+): ReadonlySet<string> {
+  return new Set([...(toolProfile?.deny ?? []), ...(agent.config.deniedTools ?? [])]);
 }
 
 export function resolveAgentToolNames(
@@ -84,6 +85,7 @@ export function resolveAgentToolNames(
     )).flat();
 
     const combinedToolNames = [...new Set([...agentToolNames, ...builtInToolNames])];
-    return withoutDeniedTools(combinedToolNames, toolProfile?.deny, agent.config.deniedTools);
+    const denied = toolDenials(agent, toolProfile);
+    return combinedToolNames.filter((name) => !denied.has(name));
   });
 }

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -79,7 +79,25 @@ export interface AgentConfig {
    */
   readonly maxContextTokens?: number;
   readonly temperature?: number;
+  /**
+   * Extra tools this agent can call, **on top of** the built-in bundle.
+   *
+   * Additive, not an allowlist: the run set is this unioned with every built-in category the
+   * persona permits. Listing a built-in tool here therefore changes nothing, and leaving one
+   * out does not withhold it — {@link AgentConfig.deniedTools} is how a tool is taken away.
+   */
   readonly tools?: readonly string[];
+  /**
+   * Tools this agent must not be given, whatever else would have granted them.
+   *
+   * The counterpart to `tools`, which can only ever add. Subtracted last, after the persona's
+   * own deny list, so it cannot be undone by a persona or by the built-in bundle — and it is
+   * per agent, where a persona's `toolProfile.deny` applies to everyone sharing that persona.
+   *
+   * Unset means "deny nothing", so every agent that exists today keeps exactly the tools it
+   * has: taking one away is something somebody has to ask for.
+   */
+  readonly deniedTools?: readonly string[];
   readonly webSearchProvider?: WebSearchProviderName;
   /**
    * Env var names exempted from the `execute_command` shell env scrub, even


### PR DESCRIPTION
## What & why

You could not stop one agent from using a tool. `config.tools` only ever *adds* — it is
unioned with every built-in category the persona allows — so leaving a tool out withholds
nothing, and listing a built-in one changes nothing. The only way to take a tool away was a
persona's `toolProfile.deny`, which hits every agent sharing that persona.

`deniedTools` fixes that per agent: subtracted after everything that grants, so neither the
built-in bundle nor a persona can put a denied tool back. Unset means deny nothing, so
nothing changes for any agent that exists today.

`GET /tools` also now reports `defaultTools` — which tools an agent gets whether or not
anyone asked for them. Any UI with a tool picker needs this to tell a row that is genuinely
a choice from one where a checkbox would imply control `config.tools` does not have.

## How to verify

- Add `"deniedTools": ["execute_command"]` to an agent, then ask it to run a shell command:
  it has no such tool, rather than being refused at call time.
- Confirm the persona still works as before — an agent with no `deniedTools` gets exactly
  the tools it got yesterday.
- Put the same tool in both `tools` and `deniedTools`: it is withheld. Contradictory config
  has to resolve one way, and withholding is the safe direction.
- Deny a tool that does not exist, or one from a disconnected MCP server — no error. A stale
  entry should not change what happens.
- `GET /.well-known/agent-card.json` for a peer-serving agent with a denial: the tool is
  absent from the card too. The run path and the card resolve tool sets separately and now
  read one shared `toolDenials` set, so neither can forget a source of denial the other
  honours.
- `curl localhost:4747/tools | jq .defaultTools` — the built-in bundle, deduped across
  categories.
