### PR TITLE
feat(daemon): list the models that can back a companion, keyed by role

### DIFF
--- a/docs/internals/tools-and-approval.md
+++ b/docs/internals/tools-and-approval.md
@@ -98,7 +98,7 @@ with the interactive one.
 ### Picker-style approvals
 
 Most gates are yes/no. Some decisions are "_which one_" — `analyze_media` asks which
-vision-capable model should do the looking. A proposal may carry `options` alongside its
+image-capable model should do the looking. A proposal may carry `options` alongside its
 message; surfaces then render a picker (same card, rows instead of Yes/No), and the chosen
 row's id returns on the outcome as `selectedOptionId`, merged into the execution tool's
 args under `_selectedOptionId` — a key the model never writes and cannot spoof.
@@ -108,10 +108,12 @@ Two properties are load-bearing:
 - **A request with options is never auto-approved**, under any policy including yolo.
   There is nothing to approve until somebody picked a row. The pre-bound path
   (`config.companions`) skips approval inside the tool itself instead — binding is the
-  consent.
+  consent. Bindings are keyed by companion role — `"<analyze|generate>:<image|audio|video>"` —
+  because reading a modality and producing it are different models: `analyze:image` and
+  `generate:image` bind independently on the same agent.
 - **Unattended runs fail loudly when nothing is bound.** Nobody to ask plus no standing
-  consent means a clear refusal naming what would fix it ("bind a vision companion"),
-  not a silent fallback to whichever model happens to be first.
+  consent means a clear refusal naming what would fix it ("bind an `analyze:image`
+  companion"), not a silent fallback to whichever model happens to be first.
 
 ---
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -249,7 +249,7 @@ Always-on. Lets a text-only agent borrow eyes, ears, or a watch from a model tha
 
 | Tool                        | Risk        | Approval pair          | What it does                                                                                                 |
 | --------------------------- | ----------- | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `analyze_media`             | `high-risk` | `execute_analyze_media` | Delegate image/audio/video analysis to a capable model companion and get the textual answer back. The person at the keyboard picks which model does the looking (picker-style approval, never auto-approved); an agent with a pre-bound `companions` entry for the modality routes there silently instead. |
+| `analyze_media`             | `high-risk` | `execute_analyze_media` | Delegate image/audio/video analysis to a capable model companion and get the textual answer back. The person at the keyboard picks which model does the looking (picker-style approval, never auto-approved); an agent with a pre-bound `companions` entry for the role (`analyze:image`, `analyze:audio`, `analyze:video`) routes there silently instead. |
 
 ### User Interaction
 

--- a/docs/use-cases/headless.md
+++ b/docs/use-cases/headless.md
@@ -102,9 +102,9 @@ interpret that fallback as a free run.
 | `--approval-policy <p>`    | `read-only` \| `low-risk` \| `high-risk`. Tools above the tier are **declined**, not queued.                                                       |
 | `--events <categories>`    | Emit NDJSON progress on stderr: `tools,reasoning,text,usage,approval,subagent,all`.                                                                |
 | `--reasoning <effort>`     | `low` \| `medium` \| `high` \| `disable`. Overrides the agent's config for this run.                                                               |
-| `--with-vision <p/m>`      | Bind the vision companion for this run, e.g. `anthropic/claude-sonnet-4-5`. Overrides the agent's config. Without a bound companion (flag or config), `analyze_media` fails loudly rather than guessing. |
-| `--with-audio <p/m>`       | Same, for the audio companion.                                                                                                                     |
-| `--with-video <p/m>`       | Same, for the video companion.                                                                                                                     |
+| `--with-vision <p/m>`      | Bind the `analyze:image` companion for this run, e.g. `anthropic/claude-sonnet-4-5`. Overrides the agent's config. Without a bound companion (flag or config), `analyze_media` fails loudly rather than guessing. |
+| `--with-audio <p/m>`       | Same, for the `analyze:audio` companion.                                                                                                           |
+| `--with-video <p/m>`       | Same, for the `analyze:video` companion.                                                                                                           |
 | `--timeout <ms>`           | Abort the run after this many milliseconds.                                                                                                        |
 | `--max-iterations <n>`     | Cap the agent's reasoning iterations (default 100).                                                                                                 |
 | `--stream` / `--no-stream` | Force streaming on/off. Streaming auto-disables for non-TTY stdout; `--events reasoning`/`text` re-enable it on their own, since those events exist only on the streaming path. |

--- a/packages/adapters/src/agent-service.test.ts
+++ b/packages/adapters/src/agent-service.test.ts
@@ -606,7 +606,29 @@ describe("AgentService", () => {
     it("accepts a well-formed companions map", async () => {
       const program = service.validateAgentConfig({
         ...baseConfig,
-        companions: { vision: "anthropic/claude-sonnet-4-5", audio: "gemini/gemini-2.0-flash" },
+        companions: {
+          "analyze:image": "anthropic/claude-sonnet-4-5",
+          "analyze:audio": "gemini/gemini-2.0-flash",
+        },
+      });
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("binds the two directions of one modality to different models", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        companions: {
+          "analyze:image": "anthropic/claude-sonnet-4-5",
+          "generate:image": "gemini/gemini-3-pro-image",
+        },
+      });
+      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+    });
+
+    it("still accepts pre-role companion keys from stored configs", async () => {
+      const program = service.validateAgentConfig({
+        ...baseConfig,
+        companions: { vision: "anthropic/claude-sonnet-4-5" } as never,
       });
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();
     });
@@ -616,7 +638,7 @@ describe("AgentService", () => {
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();
     });
 
-    it("rejects an unknown capability key", async () => {
+    it("rejects an unknown role key", async () => {
       const program = service.validateAgentConfig({
         ...baseConfig,
         companions: { smell: "anthropic/claude-sonnet-4-5" } as never,
@@ -634,14 +656,14 @@ describe("AgentService", () => {
       const program = service.validateAgentConfig({
         ...baseConfig,
         // Deliberately malformed — this is what the test is asserting gets rejected.
-        companions: { vision: "just-a-model-name" as `${string}/${string}` },
+        companions: { "analyze:image": "just-a-model-name" as `${string}/${string}` },
       });
       const result = await Effect.runPromiseExit(program);
       expect(result._tag).toBe("Failure");
       if (result._tag === "Failure") {
         // @ts-expect-error - accessing error
         const error = result.cause.error as AgentConfigurationError;
-        expect(error.field).toBe("config.companions.vision");
+        expect(error.field).toBe("config.companions.analyze:image");
       }
     });
   });

--- a/packages/adapters/src/agent-service.ts
+++ b/packages/adapters/src/agent-service.ts
@@ -19,7 +19,7 @@ import {
   ValidationError,
 } from "@jazz/core/types/errors";
 import { type Agent, type AgentConfig, type CustomToolDefinition } from "@jazz/core/types/index";
-import { isPerceptionCapability } from "@jazz/core/types/llm";
+import { COMPANION_ROLES, normalizeCompanionRole } from "@jazz/core/types/llm";
 import { parseProviderModel } from "@jazz/core/utils/provider-model";
 import { Effect, Layer } from "effect";
 import shortuuid from "short-uuid";
@@ -250,22 +250,20 @@ export class AgentServiceImpl implements AgentService {
             new AgentConfigurationError({
               agentId: "unknown",
               field: "config.companions",
-              message: "companions must be an object keyed by perception capability",
+              message: "companions must be an object keyed by companion role",
               suggestion:
-                'Use { "vision": "provider/model", ... } with capabilities vision, audio, video.',
+                'Use { "analyze:image": "provider/model", ... } with roles of the form <analyze|generate>:<image|audio|video>.',
             }),
           );
         }
-        for (const [capability, companion] of Object.entries(
-          companions as Record<string, unknown>,
-        )) {
-          if (!isPerceptionCapability(capability)) {
+        for (const [key, companion] of Object.entries(companions as Record<string, unknown>)) {
+          if (normalizeCompanionRole(key) === undefined) {
             return yield* Effect.fail(
               new AgentConfigurationError({
                 agentId: "unknown",
-                field: `config.companions.${capability}`,
-                message: `Unknown companion capability "${capability}"`,
-                suggestion: "Use one of: vision, audio, video.",
+                field: `config.companions.${key}`,
+                message: `Unknown companion role "${key}"`,
+                suggestion: `Use one of: ${COMPANION_ROLES.join(", ")}.`,
               }),
             );
           }
@@ -273,8 +271,8 @@ export class AgentServiceImpl implements AgentService {
             return yield* Effect.fail(
               new AgentConfigurationError({
                 agentId: "unknown",
-                field: `config.companions.${capability}`,
-                message: `Invalid ${capability} companion ${JSON.stringify(companion)}`,
+                field: `config.companions.${key}`,
+                message: `Invalid ${key} companion ${JSON.stringify(companion)}`,
                 suggestion:
                   'Use "provider/model", e.g. "anthropic/claude-sonnet-4-5", or remove the entry to let interactive sessions ask you to pick.',
               }),

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -13,7 +13,7 @@ import { REASONING_EFFORTS } from "@jazz/core/types/agent";
 import type { Agent } from "@jazz/core/types/agent";
 import { WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
 import { StorageNotFoundError } from "@jazz/core/types/errors";
-import { PERCEPTION_CAPABILITIES } from "@jazz/core/types/llm";
+import { COMPANION_ROLES } from "@jazz/core/types/llm";
 import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
@@ -1017,33 +1017,52 @@ describe("the menus an agent editor is built from", () => {
     expect(body.reasoningEfforts).toEqual([...REASONING_EFFORTS]);
   });
 
-  it("names the modalities a companion can be bound for", async () => {
+  it("names the roles a companion can be bound for", async () => {
     const handle = makeHandler(LOOPBACK, runnerForAgents([]));
 
     const response = await handle(request("GET", "/catalog"));
-    const body = (await response.json()) as { perceptionCapabilities: string[] };
-    // Compared against the array itself, so a modality added to jazz without being served
+    const body = (await response.json()) as { companionRoles: string[] };
+    // Compared against the array itself, so a role added to jazz without being served
     // here — which would leave a companion picker unable to offer it — fails.
-    expect(body.perceptionCapabilities).toEqual([...PERCEPTION_CAPABILITIES]);
+    expect(body.companionRoles).toEqual([...COMPANION_ROLES]);
   });
 
-  it("refuses a capability that is not one, naming the ones that are", async () => {
+  it("serves the two directions of one modality as separate roles", async () => {
+    // The whole point of the role key: a client binding an image companion has to be able
+    // to ask for the model that reads images separately from the one that draws them.
     const handle = makeHandler(LOOPBACK, runnerForAgents([]));
 
-    const response = await handle(request("GET", "/models?provider=openai&capability=smell"));
+    const response = await handle(request("GET", "/catalog"));
+    const body = (await response.json()) as { companionRoles: string[] };
+    expect(body.companionRoles).toContain("analyze:image");
+    expect(body.companionRoles).toContain("generate:image");
+  });
+
+  it("refuses a role that is not one, naming the ones that are", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/models?provider=openai&role=smell"));
     expect(response.status).toBe(400);
     const body = (await response.json()) as { field: string; suggestion: string };
-    expect(body.field).toBe("capability");
-    expect(body.suggestion).toContain("vision");
+    expect(body.field).toBe("role");
+    expect(body.suggestion).toContain("analyze:image");
   });
 
-  it("checks the capability before the provider, so both mistakes are reported", async () => {
-    // A request wrong in two ways should not report only whichever check happens to run
-    // first — the capability is the more specific mistake, so it is the one worth naming.
+  it("refuses a bare modality, which is no longer a role on its own", async () => {
     const handle = makeHandler(LOOPBACK, runnerForAgents([]));
 
-    const response = await handle(request("GET", "/models?provider=gpt&capability=smell"));
-    expect(((await response.json()) as { field: string }).field).toBe("capability");
+    const response = await handle(request("GET", "/models?provider=openai&role=image"));
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { field: string }).field).toBe("role");
+  });
+
+  it("checks the role before the provider, so both mistakes are reported", async () => {
+    // A request wrong in two ways should not report only whichever check happens to run
+    // first — the role is the more specific mistake, so it is the one worth naming.
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/models?provider=gpt&role=smell"));
+    expect(((await response.json()) as { field: string }).field).toBe("role");
   });
 
   it("refuses to list models for a provider that is not one", async () => {

--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -13,6 +13,7 @@ import { REASONING_EFFORTS } from "@jazz/core/types/agent";
 import type { Agent } from "@jazz/core/types/agent";
 import { WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
 import { StorageNotFoundError } from "@jazz/core/types/errors";
+import { PERCEPTION_CAPABILITIES } from "@jazz/core/types/llm";
 import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import { getJazzHomeDirectory, getWorkStateDirectory } from "@jazz/core/utils/paths";
@@ -1014,6 +1015,35 @@ describe("the menus an agent editor is built from", () => {
     expect(body.providers).toEqual([...AVAILABLE_PROVIDERS]);
     expect(body.webSearchProviders).toEqual([...WEB_SEARCH_PROVIDERS]);
     expect(body.reasoningEfforts).toEqual([...REASONING_EFFORTS]);
+  });
+
+  it("names the modalities a companion can be bound for", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/catalog"));
+    const body = (await response.json()) as { perceptionCapabilities: string[] };
+    // Compared against the array itself, so a modality added to jazz without being served
+    // here — which would leave a companion picker unable to offer it — fails.
+    expect(body.perceptionCapabilities).toEqual([...PERCEPTION_CAPABILITIES]);
+  });
+
+  it("refuses a capability that is not one, naming the ones that are", async () => {
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/models?provider=openai&capability=smell"));
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { field: string; suggestion: string };
+    expect(body.field).toBe("capability");
+    expect(body.suggestion).toContain("vision");
+  });
+
+  it("checks the capability before the provider, so both mistakes are reported", async () => {
+    // A request wrong in two ways should not report only whichever check happens to run
+    // first — the capability is the more specific mistake, so it is the one worth naming.
+    const handle = makeHandler(LOOPBACK, runnerForAgents([]));
+
+    const response = await handle(request("GET", "/models?provider=gpt&capability=smell"));
+    expect(((await response.json()) as { field: string }).field).toBe("capability");
   });
 
   it("refuses to list models for a provider that is not one", async () => {

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -47,6 +47,8 @@ import {
   StorageNotFoundError,
   ValidationError,
 } from "@jazz/core/types/errors";
+import { PERCEPTION_CAPABILITIES, isPerceptionCapability } from "@jazz/core/types/llm";
+import type { PerceptionCapability } from "@jazz/core/types/llm";
 import type { ModelInfo } from "@jazz/core/types/llm";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
@@ -63,6 +65,7 @@ import {
   type ToolProgressKind,
 } from "@jazz/core/types/webhook";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
+import { filterCapableModels } from "@jazz/core/utils/model-capabilities";
 import { Effect } from "effect";
 import { Hono } from "hono";
 import { listModelsForProvider } from "@/adapters/llm/model-fetcher";
@@ -1209,6 +1212,9 @@ function listCatalog(): Response {
     providers: AVAILABLE_PROVIDERS,
     webSearchProviders: WEB_SEARCH_PROVIDERS,
     reasoningEfforts: REASONING_EFFORTS,
+    // The modalities an agent can bind a companion for. Served rather than left to each
+    // client to spell out, for the same reason as every other list here.
+    perceptionCapabilities: PERCEPTION_CAPABILITIES,
   });
 }
 
@@ -1242,7 +1248,7 @@ function projectModel(model: ModelInfo) {
   };
 }
 
-function listModels(provider: ProviderName) {
+function listModels(provider: ProviderName, capability?: PerceptionCapability) {
   return Effect.gen(function* () {
     const configService = yield* AgentConfigServiceTag;
     const appConfig = yield* configService.appConfig;
@@ -1255,7 +1261,12 @@ function listModels(provider: ProviderName) {
       llmConfig?.[provider]?.api_key ?? process.env[LLM_PROVIDER_ENV_VARS[provider] ?? ""];
 
     const models = yield* listModelsForProvider(provider, { apiKey, llmConfig });
-    return json({ ok: true, provider, models: models.map(projectModel) });
+    return json({
+      ok: true,
+      provider,
+      ...(capability !== undefined ? { capability } : {}),
+      models: capableFirst(models, capability).map(projectModel),
+    });
   }).pipe(
     Effect.timeout(MODEL_LISTING_TIMEOUT),
     Effect.catchAll((error) =>
@@ -1273,11 +1284,46 @@ function listModels(provider: ProviderName) {
   );
 }
 
+/**
+ * The models that accept `capability`, in jazz's own order, or all of them.
+ *
+ * Filtering and ordering both come from `filterCapableModels` rather than being redone here:
+ * "capable, best first" already means something specific in jazz — priced models before
+ * unpriced, then cheapest input, then id — and a client that re-sorted would quietly disagree
+ * with what the CLI's own picker recommends. The capable ids are mapped back to the full
+ * `ModelInfo` so one response shape serves both the plain list and a companion picker.
+ */
+function capableFirst(
+  models: readonly ModelInfo[],
+  capability: PerceptionCapability | undefined,
+): readonly ModelInfo[] {
+  if (capability === undefined) return models;
+  const byId = new Map(models.map((model) => [model.id, model]));
+  return filterCapableModels(models, capability)
+    .map((capable) => byId.get(capable.modelId))
+    .filter((model): model is ModelInfo => model !== undefined);
+}
+
 function modelsRoute(
   request: Request,
   runEffect: <A>(effect: Effect.Effect<A, unknown, DaemonRequirements>) => Promise<A>,
 ): Promise<Response> {
-  const provider = new URL(request.url).searchParams.get("provider") ?? "";
+  const parameters = new URL(request.url).searchParams;
+  const provider = parameters.get("provider") ?? "";
+  const requested = parameters.get("capability");
+  if (requested !== null && !isPerceptionCapability(requested)) {
+    return Promise.resolve(
+      json(
+        {
+          ok: false,
+          error: `Unknown capability ${JSON.stringify(requested)}`,
+          field: "capability",
+          suggestion: `Use one of: ${PERCEPTION_CAPABILITIES.join(", ")}.`,
+        },
+        400,
+      ),
+    );
+  }
   if (!isProviderName(provider)) {
     return Promise.resolve(
       json(
@@ -1291,7 +1337,7 @@ function modelsRoute(
       ),
     );
   }
-  return runEffect(listModels(provider));
+  return runEffect(requested === null ? listModels(provider) : listModels(provider, requested));
 }
 
 /**

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -47,8 +47,8 @@ import {
   StorageNotFoundError,
   ValidationError,
 } from "@jazz/core/types/errors";
-import { PERCEPTION_CAPABILITIES, isPerceptionCapability } from "@jazz/core/types/llm";
-import type { PerceptionCapability } from "@jazz/core/types/llm";
+import { COMPANION_ROLES, isCompanionRole } from "@jazz/core/types/llm";
+import type { CompanionRole } from "@jazz/core/types/llm";
 import type { ModelInfo } from "@jazz/core/types/llm";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
@@ -1212,9 +1212,11 @@ function listCatalog(): Response {
     providers: AVAILABLE_PROVIDERS,
     webSearchProviders: WEB_SEARCH_PROVIDERS,
     reasoningEfforts: REASONING_EFFORTS,
-    // The modalities an agent can bind a companion for. Served rather than left to each
-    // client to spell out, for the same reason as every other list here.
-    perceptionCapabilities: PERCEPTION_CAPABILITIES,
+    // The roles an agent can bind a companion for, each `"<action>:<modality>"`. Served
+    // rather than left to each client to spell out, for the same reason as every other
+    // list here. Action is part of the key because reading a modality and producing it
+    // are different models: `analyze:image` and `generate:image` bind independently.
+    companionRoles: COMPANION_ROLES,
   });
 }
 
@@ -1248,7 +1250,7 @@ function projectModel(model: ModelInfo) {
   };
 }
 
-function listModels(provider: ProviderName, capability?: PerceptionCapability) {
+function listModels(provider: ProviderName, role?: CompanionRole) {
   return Effect.gen(function* () {
     const configService = yield* AgentConfigServiceTag;
     const appConfig = yield* configService.appConfig;
@@ -1264,8 +1266,8 @@ function listModels(provider: ProviderName, capability?: PerceptionCapability) {
     return json({
       ok: true,
       provider,
-      ...(capability !== undefined ? { capability } : {}),
-      models: capableFirst(models, capability).map(projectModel),
+      ...(role !== undefined ? { role } : {}),
+      models: capableFirst(models, role).map(projectModel),
     });
   }).pipe(
     Effect.timeout(MODEL_LISTING_TIMEOUT),
@@ -1285,7 +1287,7 @@ function listModels(provider: ProviderName, capability?: PerceptionCapability) {
 }
 
 /**
- * The models that accept `capability`, in jazz's own order, or all of them.
+ * The models that can do `role`, in jazz's own order, or all of them.
  *
  * Filtering and ordering both come from `filterCapableModels` rather than being redone here:
  * "capable, best first" already means something specific in jazz — priced models before
@@ -1295,11 +1297,11 @@ function listModels(provider: ProviderName, capability?: PerceptionCapability) {
  */
 function capableFirst(
   models: readonly ModelInfo[],
-  capability: PerceptionCapability | undefined,
+  role: CompanionRole | undefined,
 ): readonly ModelInfo[] {
-  if (capability === undefined) return models;
+  if (role === undefined) return models;
   const byId = new Map(models.map((model) => [model.id, model]));
-  return filterCapableModels(models, capability)
+  return filterCapableModels(models, role)
     .map((capable) => byId.get(capable.modelId))
     .filter((model): model is ModelInfo => model !== undefined);
 }
@@ -1310,15 +1312,15 @@ function modelsRoute(
 ): Promise<Response> {
   const parameters = new URL(request.url).searchParams;
   const provider = parameters.get("provider") ?? "";
-  const requested = parameters.get("capability");
-  if (requested !== null && !isPerceptionCapability(requested)) {
+  const requested = parameters.get("role");
+  if (requested !== null && !isCompanionRole(requested)) {
     return Promise.resolve(
       json(
         {
           ok: false,
-          error: `Unknown capability ${JSON.stringify(requested)}`,
-          field: "capability",
-          suggestion: `Use one of: ${PERCEPTION_CAPABILITIES.join(", ")}.`,
+          error: `Unknown companion role ${JSON.stringify(requested)}`,
+          field: "role",
+          suggestion: `Use one of: ${COMPANION_ROLES.join(", ")}.`,
         },
         400,
       ),

--- a/packages/cli/src/commands/agent-management.ts
+++ b/packages/cli/src/commands/agent-management.ts
@@ -10,6 +10,7 @@ import { JazzStateServiceTag, type JazzStateService } from "@jazz/core/interface
 import { ink, TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
 import type { Agent } from "@jazz/core/types/agent";
 import { CLIError, StorageError, StorageNotFoundError } from "@jazz/core/types/errors";
+import type { MediaModality } from "@jazz/core/types/llm";
 import { agentModelString, formatProviderDisplayName } from "@jazz/core/utils/provider-model";
 import chalk from "chalk";
 import { Effect } from "effect";
@@ -22,11 +23,7 @@ import {
   truncateMiddle,
   wrapCommaList,
 } from "@/cli/utils/string-utils";
-import {
-  findAgentsWithCapability,
-  type MediaCapability,
-  suggestModelsForCapability,
-} from "./media-agents";
+import { findAgentsThatGenerate, suggestModelsForModality } from "./media-agents";
 import { AgentDetailsCard } from "../ui/AgentDetailsCard";
 import { AgentsList } from "../ui/AgentsList";
 
@@ -164,19 +161,19 @@ function formatAgentsListBlock(
  * Jazz cannot generate media on a model that does not do it — there is no tool to fall back on —
  * so "none of your agents can" has to come with the next step attached, or it is a dead end.
  */
-function listAgentsWithCapability(
+function listAgentsThatGenerate(
   agents: readonly Agent[],
-  capability: MediaCapability,
+  modality: MediaModality,
   terminal: TerminalService,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
     const capable = yield* Effect.tryPromise({
-      try: () => findAgentsWithCapability(agents, capability),
+      try: () => findAgentsThatGenerate(agents, modality),
       catch: (error) => error,
     }).pipe(Effect.catchAll(() => Effect.succeed([])));
 
     if (capable.length > 0) {
-      yield* terminal.log(`Agents that can generate ${capability}:\n`);
+      yield* terminal.log(`Agents that can generate ${modality}:\n`);
       for (const { agent, supportsTools } of capable) {
         // Naming the tool gap matters: most media models cannot call tools at all, so an agent
         // that draws may be unable to read a file or search the web.
@@ -187,19 +184,19 @@ function listAgentsWithCapability(
       return;
     }
 
-    yield* terminal.log(`None of your agents can generate ${capability}.\n`);
+    yield* terminal.log(`None of your agents can generate ${modality}.\n`);
 
     const providers = [...new Set(agents.map((agent) => agent.config.llmProvider))].filter(
       (provider) => provider.length > 0,
     );
     const suggestions = yield* Effect.tryPromise({
-      try: () => suggestModelsForCapability(capability, providers),
+      try: () => suggestModelsForModality(modality, providers),
       catch: (error) => error,
     }).pipe(Effect.catchAll(() => Effect.succeed([])));
 
     if (suggestions.length === 0) {
       yield* terminal.log(
-        `No model from your configured providers generates ${capability}. Gemini models are the ` +
+        `No model from your configured providers generates ${modality}. Gemini models are the ` +
           `most common source; add that provider with: jazz config set llm.gemini.api_key <key>`,
       );
       return;
@@ -226,7 +223,7 @@ function listAgentsWithCapability(
  *
  */
 export function listAgentsCommand(
-  options: { readonly can?: MediaCapability } = {},
+  options: { readonly can?: MediaModality } = {},
 ): Effect.Effect<
   void,
   StorageError,
@@ -243,7 +240,7 @@ export function listAgentsCommand(
     }
 
     if (options.can !== undefined) {
-      yield* listAgentsWithCapability(agentsUnsorted, options.can, terminal);
+      yield* listAgentsThatGenerate(agentsUnsorted, options.can, terminal);
       return;
     }
 

--- a/packages/cli/src/commands/media-agents.test.ts
+++ b/packages/cli/src/commands/media-agents.test.ts
@@ -11,8 +11,7 @@ mock.module("@jazz/core/utils/models-dev", () => ({
     Promise.resolve(providerEntries.get(provider) ?? []),
 }));
 
-const { findAgentsWithCapability, isMediaCapability, suggestModelsForCapability } =
-  await import("./media-agents");
+const { findAgentsThatGenerate, suggestModelsForModality } = await import("./media-agents");
 
 function metadata(overrides: Partial<ModelsDevMetadata> = {}): ModelsDevMetadata {
   return {
@@ -42,21 +41,12 @@ function agent(name: string, model: `${string}/${string}`): Agent {
   };
 }
 
-describe("isMediaCapability", () => {
-  it("accepts the three media kinds and nothing else", () => {
-    expect(isMediaCapability("image")).toBe(true);
-    expect(isMediaCapability("audio")).toBe(true);
-    expect(isMediaCapability("video")).toBe(true);
-    expect(isMediaCapability("spreadsheet")).toBe(false);
-  });
-});
-
-describe("findAgentsWithCapability", () => {
+describe("findAgentsThatGenerate", () => {
   it("keeps only agents whose model produces that media", async () => {
     metadataByModel.set("gpt-image-1.5", metadata({ generatesImage: true }));
     metadataByModel.set("claude-sonnet-5", metadata());
 
-    const found = await findAgentsWithCapability(
+    const found = await findAgentsThatGenerate(
       [agent("artist", "openai/gpt-image-1.5"), agent("writer", "anthropic/claude-sonnet-5")],
       "image",
     );
@@ -70,7 +60,7 @@ describe("findAgentsWithCapability", () => {
     metadataByModel.set("draw-only", metadata({ generatesImage: true }));
     metadataByModel.set("draw-and-work", metadata({ generatesImage: true, supportsTools: true }));
 
-    const found = await findAgentsWithCapability(
+    const found = await findAgentsThatGenerate(
       [agent("a", "gemini/draw-only"), agent("b", "gemini/draw-and-work")],
       "image",
     );
@@ -81,26 +71,26 @@ describe("findAgentsWithCapability", () => {
 
   it("does not confuse one modality for another", async () => {
     metadataByModel.set("speaker", metadata({ generatesAudio: true }));
-    expect(await findAgentsWithCapability([agent("s", "gemini/speaker")], "image")).toEqual([]);
-    expect(await findAgentsWithCapability([agent("s", "gemini/speaker")], "audio")).toHaveLength(1);
+    expect(await findAgentsThatGenerate([agent("s", "gemini/speaker")], "image")).toEqual([]);
+    expect(await findAgentsThatGenerate([agent("s", "gemini/speaker")], "audio")).toHaveLength(1);
   });
 
   it("skips agents whose model id cannot be parsed or is unknown", async () => {
     // An unknown model reads the same as "cannot", which is the safe direction: claiming an
     // agent can generate when it cannot sends the user down a dead end.
     expect(
-      await findAgentsWithCapability(
+      await findAgentsThatGenerate(
         [agent("weird", "not-a-model-id" as `${string}/${string}`)],
         "image",
       ),
     ).toEqual([]);
-    expect(
-      await findAgentsWithCapability([agent("x", "openai/never-heard-of-it")], "image"),
-    ).toEqual([]);
+    expect(await findAgentsThatGenerate([agent("x", "openai/never-heard-of-it")], "image")).toEqual(
+      [],
+    );
   });
 });
 
-describe("suggestModelsForCapability", () => {
+describe("suggestModelsForModality", () => {
   function entry(id: string, meta: ModelsDevMetadata) {
     return {
       id,
@@ -118,7 +108,7 @@ describe("suggestModelsForCapability", () => {
       entry("with-tools", metadata({ generatesImage: true, supportsTools: true })),
     ]);
 
-    const suggestions = await suggestModelsForCapability("image", ["openai"]);
+    const suggestions = await suggestModelsForModality("image", ["openai"]);
     expect(suggestions[0]?.id).toBe("with-tools");
   });
 
@@ -128,7 +118,7 @@ describe("suggestModelsForCapability", () => {
       entry("google/gemini-3-pro-image", metadata({ generatesImage: true })),
     ]);
 
-    const ids = (await suggestModelsForCapability("image", ["openrouter"])).map((s) => s.id);
+    const ids = (await suggestModelsForModality("image", ["openrouter"])).map((s) => s.id);
     expect(ids).not.toContain("openrouter/auto");
     expect(ids).toContain("google/gemini-3-pro-image");
   });
@@ -145,11 +135,11 @@ describe("suggestModelsForCapability", () => {
       },
     ]);
 
-    expect(await suggestModelsForCapability("image", ["openai"])).toEqual([]);
+    expect(await suggestModelsForModality("image", ["openai"])).toEqual([]);
   });
 
   it("is empty when a provider has nothing for that capability", async () => {
     providerEntries.set("anthropic", [entry("claude", metadata())]);
-    expect(await suggestModelsForCapability("image", ["anthropic"])).toEqual([]);
+    expect(await suggestModelsForModality("image", ["anthropic"])).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/media-agents.ts
+++ b/packages/cli/src/commands/media-agents.ts
@@ -12,6 +12,8 @@
 
 import { OPENROUTER_GATEWAY_MODELS } from "@jazz/core/constants/models";
 import type { Agent } from "@jazz/core/types/agent";
+import { companionRole, type MediaModality } from "@jazz/core/types/llm";
+import { modelSupportsRole } from "@jazz/core/utils/model-capabilities";
 import {
   getModelsDevMetadata,
   getModelsDevProviderModels,
@@ -19,23 +21,12 @@ import {
   type ModelsDevModelEntry,
 } from "@jazz/core/utils/models-dev";
 
-/** The media an agent can be asked to produce. */
-export type MediaCapability = "image" | "audio" | "video";
-
-export const MEDIA_CAPABILITIES: readonly MediaCapability[] = ["image", "audio", "video"];
-
-export function isMediaCapability(value: string): value is MediaCapability {
-  return (MEDIA_CAPABILITIES as readonly string[]).includes(value);
-}
-
-function metadataHasCapability(
+function metadataGenerates(
   metadata: ModelsDevMetadata | undefined,
-  capability: MediaCapability,
+  modality: MediaModality,
 ): boolean {
   if (metadata === undefined) return false;
-  if (capability === "image") return metadata.generatesImage;
-  if (capability === "audio") return metadata.generatesAudio;
-  return metadata.generatesVideo;
+  return modelSupportsRole(metadata, companionRole("generate", modality));
 }
 
 export interface CapableAgent {
@@ -45,16 +36,16 @@ export interface CapableAgent {
 }
 
 /**
- * The agents whose model produces `capability`.
+ * The agents whose model produces `modality`.
  *
  * `supportsTools` rides along because it is the difference between an agent that can draw *and*
  * work, and one that can only draw — most image models report `tool_call: false`, so an agent on
  * `gemini-3-pro-image` cannot read a file or search the web. Someone choosing between two image
  * agents needs to know that before they pick.
  */
-export async function findAgentsWithCapability(
+export async function findAgentsThatGenerate(
   agents: readonly Agent[],
-  capability: MediaCapability,
+  modality: MediaModality,
 ): Promise<CapableAgent[]> {
   const capable: CapableAgent[] = [];
   for (const agent of agents) {
@@ -66,7 +57,7 @@ export async function findAgentsWithCapability(
       // better to say about this one than "unknown", which reads the same as "no".
       continue;
     }
-    if (metadataHasCapability(metadata, capability)) {
+    if (metadataGenerates(metadata, modality)) {
       capable.push({ agent, supportsTools: metadata?.supportsTools === true });
     }
   }
@@ -74,13 +65,13 @@ export async function findAgentsWithCapability(
 }
 
 /**
- * Models that could back a new agent for this capability, best first.
+ * Models that could back a new agent for this modality, best first.
  *
  * Tool-capable models are ranked first because an agent that can only produce media is a much
  * narrower thing than one that can also do the work around it.
  */
-export async function suggestModelsForCapability(
-  capability: MediaCapability,
+export async function suggestModelsForModality(
+  modality: MediaModality,
   providers: readonly string[],
   limit = 4,
 ): Promise<{ id: string; provider: string; supportsTools: boolean }[]> {
@@ -98,7 +89,7 @@ export async function suggestModelsForCapability(
       // A router advertises what it might reach. Recommending it for image generation would send
       // someone to a model that may or may not be able to do the thing they asked for.
       if (OPENROUTER_GATEWAY_MODELS.has(entry.id)) continue;
-      if (!metadataHasCapability(entry.metadata, capability)) continue;
+      if (!metadataGenerates(entry.metadata, modality)) continue;
       // Only models jazz will let you select: it must hold a conversation.
       if (!entry.inputModalities.includes("text") || !entry.outputModalities.includes("text")) {
         continue;

--- a/packages/cli/src/commands/run/execute.ts
+++ b/packages/cli/src/commands/run/execute.ts
@@ -14,7 +14,7 @@ import {
   makeOneShotPresentationServiceLayer,
 } from "@jazz/core/presentation/oneshot-presentation-service";
 import { AgentNotFoundError } from "@jazz/core/types/errors";
-import type { PerceptionCapability } from "@jazz/core/types/llm";
+import type { CompanionRole } from "@jazz/core/types/llm";
 import type { ChatMessage } from "@jazz/core/types/message";
 import type { StreamEvent } from "@jazz/core/types/streaming";
 import type { AutoApprovePolicy } from "@jazz/core/types/tools";
@@ -120,7 +120,7 @@ export interface RunAgentOnceOptions {
    * A bound companion is what lets an unattended run delegate perception without
    * a human to pick the model.
    */
-  readonly companions?: Partial<Record<PerceptionCapability, `${string}/${string}`>> | undefined;
+  readonly companions?: Partial<Record<CompanionRole, `${string}/${string}`>> | undefined;
   readonly timeoutMs?: number | undefined;
   readonly maxIterations?: number | undefined;
   readonly maxCostUSD?: number | undefined;

--- a/packages/core/src/agent/tools/perception-tools.test.ts
+++ b/packages/core/src/agent/tools/perception-tools.test.ts
@@ -221,7 +221,7 @@ describe("analyze_media empty state", () => {
       proposal
         .execute(
           {
-            capability: "vision",
+            modality: "image",
             task: "what is this?",
             mediaPaths: [join(directory, "shot.png")],
           },
@@ -270,7 +270,7 @@ describe("analyze_media empty state", () => {
       proposal
         .execute(
           {
-            capability: "vision",
+            modality: "image",
             task: "t",
             mediaPaths: [join(directory, "shot.png")],
           },
@@ -287,7 +287,7 @@ describe("analyze_media empty state", () => {
 describe("analyze_media proposal", () => {
   it("fails loudly when a named media file does not resolve", async () => {
     const outcome = await runProposal(
-      { capability: "vision", task: "describe", mediaPaths: ["/definitely/not/here.png"] },
+      { modality: "image", task: "describe", mediaPaths: ["/definitely/not/here.png"] },
       makeContext(),
     );
     expect(outcome.success).toBe(false);
@@ -296,7 +296,7 @@ describe("analyze_media proposal", () => {
 
   it("refuses to delegate audio files to a vision companion", async () => {
     const outcome = await runProposal(
-      { capability: "vision", task: "describe", mediaPaths: ["anything.mp3"] },
+      { modality: "image", task: "describe", mediaPaths: ["anything.mp3"] },
       makeContext(),
     );
     expect(outcome.success).toBe(false);
@@ -306,7 +306,7 @@ describe("analyze_media proposal", () => {
   it("proposes picker-style approval listing only models that can actually see", async () => {
     const outcome = await runProposal(
       {
-        capability: "vision",
+        modality: "image",
         task: "what is in this image?",
         mediaPaths: [join(directory, "shot.png")],
       },

--- a/packages/core/src/agent/tools/perception-tools.ts
+++ b/packages/core/src/agent/tools/perception-tools.ts
@@ -12,7 +12,7 @@
  *   picker-style approval options (`ApprovalRequest.options`); the executor renders
  *   them like any approval card and never auto-approves them — there is nothing to
  *   approve until somebody picked a row.
- * - **A pre-bound companion, unattended.** `config.companions[capability]` names a
+ * - **A pre-bound companion, unattended.** `config.companions["analyze:<modality>"]` names a
  *   `"provider/model"` chosen ahead of time; binding it *is* the consent, so bound runs
  *   skip the prompt entirely — which is what makes cron and bridge runs work where no
  *   one can answer a picker.
@@ -36,12 +36,14 @@ import type { ToolExecutionContext } from "@/core/types/tools";
 import { generateConversationId } from "@/core/utils/conversation-id";
 import { resolveMediaAttachments } from "@/core/utils/media-attachments";
 import {
-  attachmentKindForCapability,
-  describeCapability,
+  companionRole,
+  describeRole,
   filterCapableModels,
   formatModelPriceLine,
+  modelSupportsRole,
   type CapableModel,
-  type PerceptionCapability,
+  type CompanionRole,
+  type MediaModality,
 } from "@/core/utils/model-capabilities";
 import { getModelsDevProviderModels } from "@/core/utils/models-dev";
 import { agentModelString, parseProviderModel } from "@/core/utils/provider-model";
@@ -61,10 +63,10 @@ const COMPANION_MAX_ITERATIONS = 4;
 export const SELECTED_OPTION_KEY = "_selectedOptionId";
 
 const analyzeMediaSchema = z.object({
-  capability: z
-    .enum(["vision", "audio", "video"])
+  modality: z
+    .enum(["image", "audio", "video"])
     .describe(
-      "Which modality to delegate: vision for images, audio for recordings, video for clips.",
+      "Which media kind to delegate: image for pictures, audio for recordings, video for clips.",
     ),
   task: z
     .string()
@@ -81,6 +83,15 @@ const analyzeMediaSchema = z.object({
 });
 
 type AnalyzeMediaArgs = z.infer<typeof analyzeMediaSchema>;
+
+/**
+ * The role these tools delegate. `analyze_media` only ever reads media, so the action
+ * half is fixed here rather than asked of the model — the modality is the only choice
+ * it has to make.
+ */
+function roleFor(modality: MediaModality): CompanionRole {
+  return companionRole("analyze", modality);
+}
 
 type ExecuteArgs = AnalyzeMediaArgs & { readonly [SELECTED_OPTION_KEY]?: string };
 
@@ -118,10 +129,7 @@ interface CandidateList {
   readonly missingKeyProviders: readonly string[];
 }
 
-function listCandidates(
-  capability: PerceptionCapability,
-): Effect.Effect<CandidateList, never, LLMService> {
-  const modality = attachmentKindForCapability(capability);
+function listCandidates(role: CompanionRole): Effect.Effect<CandidateList, never, LLMService> {
   return Effect.gen(function* () {
     const llmService = yield* LLMServiceTag;
     const providerItems = yield* llmService.listProviders();
@@ -131,13 +139,13 @@ function listCandidates(
 
     for (const item of providerItems) {
       if (!item.configured) {
-        const hasCapable = yield* Effect.promise(() => catalogHasCapability(item.name, modality));
+        const hasCapable = yield* Effect.promise(() => catalogHasRole(item.name, role));
         if (hasCapable) missingKeyProviders.push(item.name);
         continue;
       }
       const provider = yield* llmService.getProvider(item.name).pipe(Effect.option);
       if (Option.isNone(provider)) continue;
-      for (const model of filterCapableModels(provider.value.supportedModels, capability)) {
+      for (const model of filterCapableModels(provider.value.supportedModels, role)) {
         available.push({
           id: `${item.name}/${model.modelId}` as `${string}/${string}`,
           provider: item.name,
@@ -149,20 +157,15 @@ function listCandidates(
   });
 }
 
-/** Whether the catalog lists any conversational model with this input modality for a provider. */
-async function catalogHasCapability(
-  providerId: string,
-  modality: "image" | "audio" | "video",
-): Promise<boolean> {
+/** Whether the catalog lists any conversational model that can do this role for a provider. */
+async function catalogHasRole(providerId: string, role: CompanionRole): Promise<boolean> {
   try {
     const entries = await getModelsDevProviderModels(providerId);
     return entries.some((entry) => {
       if (entry.status === "deprecated") return false;
       if (!entry.inputModalities.includes("text")) return false;
       if (!entry.outputModalities.includes("text")) return false;
-      if (modality === "image") return entry.metadata.ingestImage;
-      if (modality === "audio") return entry.metadata.ingestAudio;
-      return entry.metadata.ingestVideo;
+      return modelSupportsRole(entry.metadata, role);
     });
   } catch {
     return false;
@@ -172,7 +175,7 @@ async function catalogHasCapability(
 function buildCompanionAgent(
   parentAgent: Agent,
   selectedId: `${string}/${string}`,
-  capability: PerceptionCapability,
+  role: CompanionRole,
   counter: number,
 ): Agent | null {
   const parsed = parseProviderModel(selectedId);
@@ -180,8 +183,8 @@ function buildCompanionAgent(
   const now = new Date();
   return {
     id: `companion-${counter}-${Date.now()}`,
-    name: `Model Companion (${capability})`,
-    description: `Ephemeral ${describeCapability(capability)} companion delegated by ${parentAgent.name}`,
+    name: `Model Companion (${role})`,
+    description: `Ephemeral ${describeRole(role)} companion delegated by ${parentAgent.name}`,
     config: {
       persona: "default",
       llmProvider: parsed.provider,
@@ -192,10 +195,10 @@ function buildCompanionAgent(
   };
 }
 
-function wrapTask(task: string, capability: PerceptionCapability): string {
+function wrapTask(task: string, role: CompanionRole): string {
   return `[MODEL COMPANION TASK]
 You are a perception specialist. A parent agent delegated media to you because its own model
-cannot perform ${describeCapability(capability)}. This is a ONE-SHOT task.
+cannot perform ${describeRole(role)}. This is a ONE-SHOT task.
 
 Rules:
 - Answer strictly from the attached media and the task below
@@ -232,13 +235,13 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
       yield* logger.info("Running model companion", {
         parentAgentId: parentAgent.id,
         companionModel: agentModelString(companionAgent.config),
-        capability: args.capability,
+        role: roleFor(args.modality),
         attachmentCount: attachments.length,
       });
 
       const response = yield* AgentRunner.runRecursive({
         agent: companionAgent,
-        userInput: wrapTask(args.task, args.capability),
+        userInput: wrapTask(args.task, roleFor(args.modality)),
         conversationId: generateConversationId("companion"),
         maxIterations: COMPANION_MAX_ITERATIONS,
         ephemeralRegionId: regionId,
@@ -322,9 +325,8 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
           };
         }
 
-        const expectedKind = attachmentKindForCapability(args.capability);
         const resolution = yield* Effect.tryPromise({
-          try: () => resolveMediaAttachments(args.mediaPaths, expectedKind),
+          try: () => resolveMediaAttachments(args.mediaPaths, args.modality),
           catch: (error) => new Error(String(error)),
         });
         if (resolution.errors.length > 0 || resolution.attachments.length === 0) {
@@ -340,19 +342,20 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
 
         // Standing consent: a pre-bound companion needs no picker. This is also the
         // only path an unattended run can take, which is why binding matters.
-        const boundCompanion = parentAgent.config.companions?.[args.capability];
+        const role = roleFor(args.modality);
+        const boundCompanion = parentAgent.config.companions?.[role];
         if (boundCompanion) {
           const companionAgent = buildCompanionAgent(
             parentAgent,
             boundCompanion,
-            args.capability,
+            role,
             ++companionCounter,
           );
           if (companionAgent === null) {
             return {
               success: false,
               result: null,
-              error: `Bound ${args.capability} companion "${boundCompanion}" is not a valid provider/model id.`,
+              error: `Bound ${role} companion "${boundCompanion}" is not a valid provider/model id.`,
             };
           }
           const content = yield* runCompanion(
@@ -365,7 +368,7 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
           return { success: true, result: content };
         }
 
-        let candidateList = yield* listCandidates(args.capability);
+        let candidateList = yield* listCandidates(role);
 
         if (candidateList.available.length === 0) {
           const canPrompt = presentation.canPromptForApproval?.() === true;
@@ -377,7 +380,7 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
             if (Option.isSome(terminalOption)) {
               const terminal = terminalOption.value;
               const wantsKey = yield* terminal.confirm(
-                `No ${args.capability}-capable model is reachable yet. Add an API key now?`,
+                `No model that can do ${describeRole(role)} is reachable yet. Add an API key now?`,
                 true,
               );
               if (wantsKey) {
@@ -399,7 +402,7 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
                     const configService = yield* AgentConfigServiceTag;
                     yield* configService.set(`llm.${provider}.api_key`, apiKey.trim());
                     yield* terminal.success("API key saved.");
-                    candidateList = yield* listCandidates(args.capability);
+                    candidateList = yield* listCandidates(role);
                   }
                 }
               }
@@ -411,13 +414,13 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
           const canPrompt = presentation.canPromptForApproval?.() === true;
           const keyHint =
             candidateList.missingKeyProviders.length > 0
-              ? ` No ${args.capability}-capable model is reachable yet: adding an API key for ${candidateList.missingKeyProviders.join(", ")} would fix this.`
-              : ` No provider in the catalog currently offers a conversational model with ${describeCapability(args.capability)}.`;
+              ? ` No model that can do ${describeRole(role)} is reachable yet: adding an API key for ${candidateList.missingKeyProviders.join(", ")} would fix this.`
+              : ` No provider in the catalog currently offers a conversational model with ${describeRole(role)}.`;
           const message = canPrompt
-            ? `Cannot delegate ${args.capability}.${keyHint}`
-            : `Cannot delegate ${args.capability}: nobody can pick a companion in this session.${keyHint} Bind one ahead of time with \`jazz agent edit\` (companions).`;
+            ? `Cannot delegate ${role}.${keyHint}`
+            : `Cannot delegate ${role}: nobody can pick a companion in this session.${keyHint} Bind one ahead of time with \`jazz agent edit\` (companions).`;
           yield* logger.info("analyze_media found no capable models", {
-            capability: args.capability,
+            role,
             missingKeyProviders: candidateList.missingKeyProviders,
           });
           return { success: false, result: null, error: message };
@@ -437,7 +440,7 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
           result: {
             approvalRequired: true,
             message:
-              `Delegate ${args.capability} analysis to a capable model.\n` +
+              `Delegate ${args.modality} analysis to a capable model.\n` +
               `Media: ${described}\nTask: ${args.task}`,
             executeToolName: "execute_analyze_media",
             executeArgs: args as unknown as Record<string, unknown>,
@@ -473,7 +476,7 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
         const companionAgent = buildCompanionAgent(
           parentAgent,
           selectedId as `${string}/${string}`,
-          args.capability,
+          roleFor(args.modality),
           ++companionCounter,
         );
         if (companionAgent === null) {
@@ -483,9 +486,8 @@ export function createPerceptionTools(): Tool<ToolRequirements>[] {
             error: `Picked companion "${selectedId}" is not a valid provider/model id.`,
           };
         }
-        const expectedKind = attachmentKindForCapability(args.capability);
         const resolution = yield* Effect.tryPromise({
-          try: () => resolveMediaAttachments(args.mediaPaths, expectedKind),
+          try: () => resolveMediaAttachments(args.mediaPaths, args.modality),
           catch: (error) => new Error(String(error)),
         });
         if (resolution.attachments.length === 0) {

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -12,7 +12,7 @@
 
 import type { ProviderName } from "@/core/constants/models";
 import type { WebSearchProviderName } from "@/core/types/config";
-import type { PerceptionCapability } from "@/core/types/llm";
+import type { CompanionRole } from "@/core/types/llm";
 
 /**
  * Core Agent entity representing an AI agent configuration
@@ -114,15 +114,19 @@ export interface AgentConfig {
    */
   readonly customTools?: readonly CustomToolDefinition[];
   /**
-   * Pre-bound model companions for delegated perception (`analyze_media`), per
-   * modality, each as `"provider/model"`.
+   * Pre-bound model companions for delegated media work, keyed by
+   * `"<action>:<modality>"` role, each as `"provider/model"`.
+   *
+   * Action and modality are both in the key because they select different models: a
+   * model that reads images usually cannot draw one, so `analyze:image` and
+   * `generate:image` are two independent bindings on the same agent.
    *
    * A bound companion is standing consent: delegation routes there with no prompt,
    * which is the only path an unattended run (cron, bridge) can take. Unbound means
    * interactive sessions ask the human to pick from the capable models, and an
    * unattended session fails loudly instead of guessing.
    */
-  readonly companions?: Partial<Record<PerceptionCapability, `${string}/${string}`>>;
+  readonly companions?: Partial<Record<CompanionRole, `${string}/${string}`>>;
   /** Memory scopes this agent can access. */
   readonly memoryScopes?: readonly string[];
 }

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -52,21 +52,69 @@ export interface ModelInfo {
 }
 
 /**
- * A modality an agent can delegate to a capable model companion (`analyze_media`).
+ * A media kind a model may accept or produce.
  *
- * Mirrors the attachment kinds such delegation can carry, minus `pdf`: every text
- * agent reads PDFs through `read_pdf`, so there is nothing to delegate.
+ * Mirrors the attachment kinds a companion delegation can carry, minus `pdf`: every
+ * text agent reads PDFs through `read_pdf`, so there is nothing to delegate.
  */
-export type PerceptionCapability = "vision" | "audio" | "video";
+export type MediaModality = "image" | "audio" | "video";
 
-export const PERCEPTION_CAPABILITIES: readonly PerceptionCapability[] = [
-  "vision",
-  "audio",
-  "video",
-];
+export const MEDIA_MODALITIES: readonly MediaModality[] = ["image", "audio", "video"];
 
-export function isPerceptionCapability(value: string): value is PerceptionCapability {
-  return (PERCEPTION_CAPABILITIES as readonly string[]).includes(value);
+export function isMediaModality(value: string): value is MediaModality {
+  return (MEDIA_MODALITIES as readonly string[]).includes(value);
+}
+
+/** What a companion does with a modality: read it, or make it. */
+export type MediaAction = "analyze" | "generate";
+
+export const MEDIA_ACTIONS: readonly MediaAction[] = ["analyze", "generate"];
+
+/**
+ * One job an agent can delegate to a model companion, as `"<action>:<modality>"`.
+ *
+ * Action and modality are separate axes because a model rarely does both: most vision
+ * models cannot emit an image, and most image models cannot read one. Keying companion
+ * bindings by the pair is what lets one agent bind `analyze:image` and `generate:image`
+ * to two different models.
+ */
+export type CompanionRole = `${MediaAction}:${MediaModality}`;
+
+export const COMPANION_ROLES: readonly CompanionRole[] = MEDIA_ACTIONS.flatMap((action) =>
+  MEDIA_MODALITIES.map((modality): CompanionRole => `${action}:${modality}`),
+);
+
+export function isCompanionRole(value: string): value is CompanionRole {
+  return (COMPANION_ROLES as readonly string[]).includes(value);
+}
+
+export function companionRole(action: MediaAction, modality: MediaModality): CompanionRole {
+  return `${action}:${modality}`;
+}
+
+export function parseCompanionRole(role: CompanionRole): {
+  readonly action: MediaAction;
+  readonly modality: MediaModality;
+} {
+  const [action, modality] = role.split(":") as [MediaAction, MediaModality];
+  return { action, modality };
+}
+
+/**
+ * Companion keys as written before roles existed: bare `"vision" | "audio" | "video"`,
+ * all of them analysis. Kept so stored agent configs keep working.
+ */
+const LEGACY_COMPANION_KEYS: Readonly<Record<string, CompanionRole>> = {
+  vision: "analyze:image",
+  image: "analyze:image",
+  audio: "analyze:audio",
+  video: "analyze:video",
+};
+
+/** The role a stored companion key means, or `undefined` when it means nothing. */
+export function normalizeCompanionRole(key: string): CompanionRole | undefined {
+  if (isCompanionRole(key)) return key;
+  return LEGACY_COMPANION_KEYS[key];
 }
 
 /**

--- a/packages/core/src/utils/model-capabilities.test.ts
+++ b/packages/core/src/utils/model-capabilities.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import type { ModelInfo } from "@/core/types/llm";
 import {
-  attachmentKindForCapability,
+  companionRole,
+  COMPANION_ROLES,
   describeModelCapabilities,
+  describeRole,
   filterCapableModels,
   formatModelPriceLine,
-  isPerceptionCapability,
-  modelHasCapability,
+  isCompanionRole,
+  isMediaModality,
+  modelSupportsRole,
+  normalizeCompanionRole,
 } from "./model-capabilities";
 
 function model(overrides: Partial<ModelInfo> & { id: string }): ModelInfo {
@@ -14,24 +18,24 @@ function model(overrides: Partial<ModelInfo> & { id: string }): ModelInfo {
 }
 
 describe("filterCapableModels", () => {
-  it("keeps only models whose ingest flags cover the capability", () => {
+  it("keeps only models whose flags cover the role", () => {
     const models = [
       model({ id: "vision-model", ingestImage: true }),
       model({ id: "text-only" }),
       model({ id: "audio-model", ingestAudio: true }),
     ];
 
-    const vision = filterCapableModels(models, "vision");
+    const vision = filterCapableModels(models, "analyze:image");
     expect(vision.map((m) => m.modelId)).toEqual(["vision-model"]);
 
-    const audio = filterCapableModels(models, "audio");
+    const audio = filterCapableModels(models, "analyze:audio");
     expect(audio.map((m) => m.modelId)).toEqual(["audio-model"]);
   });
 
   it("treats an absent flag as no", () => {
-    expect(modelHasCapability(model({ id: "x" }), "video")).toBe(false);
-    expect(modelHasCapability(model({ id: "x", ingestVideo: false }), "video")).toBe(false);
-    expect(modelHasCapability(model({ id: "x", ingestVideo: true }), "video")).toBe(true);
+    expect(modelSupportsRole(model({ id: "x" }), "analyze:video")).toBe(false);
+    expect(modelSupportsRole(model({ id: "x", ingestVideo: false }), "analyze:video")).toBe(false);
+    expect(modelSupportsRole(model({ id: "x", ingestVideo: true }), "analyze:video")).toBe(true);
   });
 
   it("sorts priced before unpriced, then by input price", () => {
@@ -46,7 +50,7 @@ describe("filterCapableModels", () => {
       model({ id: "cheap", ingestImage: true, inputPricePerMillion: 3, outputPricePerMillion: 15 }),
     ];
 
-    expect(filterCapableModels(models, "vision").map((m) => m.modelId)).toEqual([
+    expect(filterCapableModels(models, "analyze:image").map((m) => m.modelId)).toEqual([
       "cheap",
       "expensive",
       "unpriced-vision",
@@ -68,16 +72,51 @@ describe("formatModelPriceLine", () => {
   });
 });
 
-describe("capability vocabulary", () => {
-  it("maps capabilities to the attachment kinds delegation carries", () => {
-    expect(attachmentKindForCapability("vision")).toBe("image");
-    expect(attachmentKindForCapability("audio")).toBe("audio");
-    expect(attachmentKindForCapability("video")).toBe("video");
+describe("role vocabulary", () => {
+  it("reads the two flags of the same modality independently", () => {
+    const ingestOnly = model({ id: "eyes", ingestImage: true });
+    expect(modelSupportsRole(ingestOnly, "analyze:image")).toBe(true);
+    expect(modelSupportsRole(ingestOnly, "generate:image")).toBe(false);
+
+    const generateOnly = model({ id: "brush", generatesImage: true });
+    expect(modelSupportsRole(generateOnly, "analyze:image")).toBe(false);
+    expect(modelSupportsRole(generateOnly, "generate:image")).toBe(true);
   });
 
-  it("rejects non-capabilities like pdf", () => {
-    expect(isPerceptionCapability("pdf")).toBe(false);
-    expect(isPerceptionCapability("vision")).toBe(true);
+  it("covers every action-modality pair exactly once", () => {
+    expect(COMPANION_ROLES).toEqual([
+      "analyze:image",
+      "analyze:audio",
+      "analyze:video",
+      "generate:image",
+      "generate:audio",
+      "generate:video",
+    ]);
+    expect(new Set(COMPANION_ROLES).size).toBe(COMPANION_ROLES.length);
+  });
+
+  it("builds roles from their two axes", () => {
+    expect(companionRole("generate", "video")).toBe("generate:video");
+    expect(isCompanionRole("generate:video")).toBe(true);
+    expect(isCompanionRole("video")).toBe(false);
+  });
+
+  it("rejects non-modalities like pdf", () => {
+    expect(isMediaModality("pdf")).toBe(false);
+    expect(isMediaModality("image")).toBe(true);
+  });
+
+  it("says what each role does in words", () => {
+    expect(describeRole("analyze:image")).toBe("image understanding");
+    expect(describeRole("generate:audio")).toBe("audio generation");
+  });
+
+  it("reads pre-role companion keys as analysis bindings", () => {
+    expect(normalizeCompanionRole("vision")).toBe("analyze:image");
+    expect(normalizeCompanionRole("audio")).toBe("analyze:audio");
+    expect(normalizeCompanionRole("video")).toBe("analyze:video");
+    expect(normalizeCompanionRole("generate:image")).toBe("generate:image");
+    expect(normalizeCompanionRole("smell")).toBeUndefined();
   });
 });
 

--- a/packages/core/src/utils/model-capabilities.ts
+++ b/packages/core/src/utils/model-capabilities.ts
@@ -1,50 +1,74 @@
 /**
- * @fileoverview Perception capabilities: which models can see, hear, and watch.
+ * @fileoverview Media capabilities: which models can see, hear, watch, and make.
  *
  * An agent whose own model is text-only hits a wall the moment the work involves an
- * image, a recording, or a clip. Rather than dead-ending, it delegates perception to
- * a *model companion*: an ephemeral run on any available model that accepts that
- * modality, chosen by the human from a picker (or pre-bound as a standing companion
- * for unattended runs).
+ * image, a recording, or a clip. Rather than dead-ending, it delegates to a *model
+ * companion*: an ephemeral run on any available model that can do the job, chosen by
+ * the human from a picker (or pre-bound as a standing companion for unattended runs).
  *
  * This module is the shared vocabulary for that flow:
- * - {@link PerceptionCapability} — the three modalities worth delegating. PDF is
- *   deliberately absent: every text agent reads PDFs through `read_pdf`, so there is
- *   nothing to delegate.
+ * - {@link MediaModality} — the three media kinds worth delegating. PDF is deliberately
+ *   absent: every text agent reads PDFs through `read_pdf`, so there is nothing to
+ *   delegate.
+ * - {@link modelSupportsRole} — whether a model can do one `<action>:<modality>` job.
  * - {@link filterCapableModels} — narrows a provider's model list to candidates.
  * - {@link formatModelPriceLine} — the per-row price text pickers show, with the
  *   house convention of saying "unknown" rather than inventing $0.
  */
 
-import type { ModelInfo, PerceptionCapability } from "@/core/types/llm";
+import type { CompanionRole, ModelInfo } from "@/core/types/llm";
+import { parseCompanionRole } from "@/core/types/llm";
 
 export {
-  PERCEPTION_CAPABILITIES,
-  isPerceptionCapability,
-  type PerceptionCapability,
+  COMPANION_ROLES,
+  MEDIA_ACTIONS,
+  MEDIA_MODALITIES,
+  companionRole,
+  isCompanionRole,
+  isMediaModality,
+  normalizeCompanionRole,
+  parseCompanionRole,
+  type CompanionRole,
+  type MediaAction,
+  type MediaModality,
 } from "@/core/types/llm";
 
-/** The attachment kind this capability travels as on a message. */
-export function attachmentKindForCapability(
-  capability: PerceptionCapability,
-): "image" | "audio" | "video" {
-  if (capability === "vision") return "image";
-  if (capability === "audio") return "audio";
-  return "video";
+/** Human phrase for a role, used in prompts and picker copy. */
+export function describeRole(role: CompanionRole): string {
+  const { action, modality } = parseCompanionRole(role);
+  return action === "analyze" ? `${modality} understanding` : `${modality} generation`;
 }
 
-/** Human word for the capability, used in prompts and picker copy. */
-export function describeCapability(capability: PerceptionCapability): string {
-  if (capability === "vision") return "image understanding";
-  if (capability === "audio") return "audio understanding";
-  return "video understanding";
-}
+/**
+ * The six capability flags a catalog reports, as the shape every source shares.
+ *
+ * `ModelInfo` and `ModelsDevMetadata` both carry these names — the first optional, the
+ * second required — so one probe reads either without converting between them.
+ */
+export type ModalityFlags = Partial<
+  Pick<
+    ModelInfo,
+    | "ingestImage"
+    | "ingestAudio"
+    | "ingestVideo"
+    | "generatesImage"
+    | "generatesAudio"
+    | "generatesVideo"
+  >
+>;
 
-/** Whether this model itself accepts the modality, per catalog metadata. Absent means no. */
-export function modelHasCapability(model: ModelInfo, capability: PerceptionCapability): boolean {
-  if (capability === "vision") return model.ingestImage === true;
-  if (capability === "audio") return model.ingestAudio === true;
-  return model.ingestVideo === true;
+const ROLE_FLAGS: Readonly<Record<CompanionRole, keyof ModalityFlags>> = {
+  "analyze:image": "ingestImage",
+  "analyze:audio": "ingestAudio",
+  "analyze:video": "ingestVideo",
+  "generate:image": "generatesImage",
+  "generate:audio": "generatesAudio",
+  "generate:video": "generatesVideo",
+};
+
+/** Whether this model can do the role itself, per catalog metadata. Absent means no. */
+export function modelSupportsRole(model: ModalityFlags, role: CompanionRole): boolean {
+  return model[ROLE_FLAGS[role]] === true;
 }
 
 /** One delegatable model: what the picker shows and what the child run runs on. */
@@ -61,7 +85,7 @@ export interface CapableModel {
 }
 
 /**
- * The models in `models` that accept `capability`, best first.
+ * The models in `models` that can do `role`, best first.
  *
  * Unpriced models sort after priced ones at equal footing — not because they are
  * worse, but because when everything else is comparable the one whose cost you can
@@ -70,11 +94,11 @@ export interface CapableModel {
  */
 export function filterCapableModels(
   models: readonly ModelInfo[],
-  capability: PerceptionCapability,
+  role: CompanionRole,
 ): CapableModel[] {
   const capable: (CapableModel & { readonly priced: boolean })[] = [];
   for (const model of models) {
-    if (!modelHasCapability(model, capability)) continue;
+    if (!modelSupportsRole(model, role)) continue;
     const priced =
       model.inputPricePerMillion !== undefined || model.outputPricePerMillion !== undefined;
     capable.push({

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -10,6 +10,12 @@ import {
   parsePositiveFloat,
   parsePositiveInt,
 } from "@jazz/cli/utils/option-parsers";
+import {
+  companionRole,
+  isMediaModality,
+  MEDIA_MODALITIES,
+  type CompanionRole,
+} from "@jazz/core/types/llm";
 import { isPeerTier, PEER_TIERS } from "@jazz/core/types/peer";
 import { setCurrentCommandName } from "@jazz/core/utils/current-command";
 import { parseProviderModel } from "@jazz/core/utils/provider-model";
@@ -47,12 +53,6 @@ interface CliRunOptions {
 
 type AppLayerModule = typeof import("./app-layer");
 type CliCommandEffect = Parameters<AppLayerModule["runCliEffect"]>[0];
-
-const MEDIA_CAPABILITIES = ["image", "audio", "video"] as const;
-
-function isMediaCapability(value: string): value is (typeof MEDIA_CAPABILITIES)[number] {
-  return (MEDIA_CAPABILITIES as readonly string[]).includes(value);
-}
 
 function cliRuntimeOptions(program: Command): CliRuntimeOptions {
   const opts = program.opts<CliOptions>();
@@ -267,14 +267,32 @@ function registerRunCommand(program: Command): void {
           }
         }
 
-        const companionFlags: Record<string, string | undefined> = {
-          vision: options.withVision,
-          audio: options.withAudio,
-          video: options.withVideo,
-        };
-        for (const [capability, companion] of Object.entries(companionFlags)) {
+        // The `--with-*` flags name the modality only; every one of them binds the
+        // analysis side, since there is no generation delegation to bind yet.
+        const companionFlags: readonly {
+          readonly flag: string;
+          readonly role: CompanionRole;
+          readonly value: string | undefined;
+        }[] = [
+          {
+            flag: "--with-vision",
+            role: companionRole("analyze", "image"),
+            value: options.withVision,
+          },
+          {
+            flag: "--with-audio",
+            role: companionRole("analyze", "audio"),
+            value: options.withAudio,
+          },
+          {
+            flag: "--with-video",
+            role: companionRole("analyze", "video"),
+            value: options.withVideo,
+          },
+        ];
+        for (const { flag, value: companion } of companionFlags) {
           if (companion !== undefined && parseProviderModel(companion) === null) {
-            const message = `Invalid --with-${capability} "${companion}". Expected provider/model, e.g. anthropic/claude-sonnet-4-5.`;
+            const message = `Invalid ${flag} "${companion}". Expected provider/model, e.g. anthropic/claude-sonnet-4-5.`;
             if (json) {
               process.stdout.write(
                 `${JSON.stringify({ ok: false, error: message, costUSD: 0 })}\n`,
@@ -330,10 +348,12 @@ function registerRunCommand(program: Command): void {
                 ...(options.ephemeral === true ? { ephemeral: true } : {}),
                 ...(options.historyJson !== undefined ? { historyJson: options.historyJson } : {}),
                 ...(options.park === true ? { park: true } : {}),
-                ...(Object.values(companionFlags).some((value) => value !== undefined)
+                ...(companionFlags.some((entry) => entry.value !== undefined)
                   ? {
                       companions: Object.fromEntries(
-                        Object.entries(companionFlags).filter((entry) => entry[1] !== undefined),
+                        companionFlags
+                          .filter((entry) => entry.value !== undefined)
+                          .map((entry) => [entry.role, entry.value]),
                       ),
                     }
                   : {}),
@@ -362,9 +382,9 @@ function registerAgentCommands(program: Command): void {
     )
     .action((commandOptions: { can?: string }) => {
       const requested = commandOptions.can;
-      if (requested !== undefined && !isMediaCapability(requested)) {
+      if (requested !== undefined && !isMediaModality(requested)) {
         console.error(
-          `Unknown capability "${requested}". Use one of: ${MEDIA_CAPABILITIES.join(", ")}`,
+          `Unknown media kind "${requested}". Use one of: ${MEDIA_MODALITIES.join(", ")}`,
         );
         process.exitCode = 1;
         return;


### PR DESCRIPTION
## What & why

An agent can delegate media work to a bound companion model (`config.companions`), and jazz
already knows which models can do what — plus the order to recommend them in. None of it was
reachable over the daemon, so a client building a companion picker had nothing to ask.

`GET /models?provider=&role=analyze:image` now applies jazz's own `filterCapableModels` rather
than shipping raw flags for callers to re-sort. "Capable, best first" already means something
specific here — priced before unpriced, then cheapest input — and a client re-implementing it
would quietly disagree with what the CLI's picker recommends. `/catalog` also gains
`companionRoles`, so a picker learns the roles the same way it learns the providers.

### Companions are keyed by role now, not by modality

Building the picker surfaced a bug in the config format underneath it. There were two enums for
one vocabulary — `PerceptionCapability` (`vision|audio|video`) and `MediaCapability`
(`image|audio|video`) — with the direction baked into the enum's *name* instead of its values,
which is why `vision` and `image` drifted apart for the same thing.

Because `companions` was keyed by the perception enum, `audio` and `video` could only ever name
a model that *listens*. An agent had no way to bind a model that reads images alongside one that
draws them — and that is the common case, since most vision models cannot emit an image and most
image models cannot read one.

Both enums collapse into `MediaModality`, with `CompanionRole` derived as `"<action>:<modality>"`
over a `MediaAction` axis. So one agent can hold:

```json
"companions": {
  "analyze:image": "anthropic/claude-sonnet-4-5",
  "generate:image": "gemini/gemini-3-pro-image"
}
```

Stored configs keep working — bare `vision`/`audio`/`video` keys normalize to their `analyze:*`
role. `--with-vision`/`--with-audio`/`--with-video` keep their names and bind the analysis side.

`generate:*` roles validate and bind, but nothing consumes them yet: there is no generation
delegation tool, and adding one is a product call, not a type change.

Falling out of it: the 3×2 capability grid was enumerated by hand in two packages
(`modelHasCapability` for ingest in core, `metadataHasCapability` for output in cli). Both become
one `modelSupportsRole` lookup over the six catalog flags `ModelInfo` and `ModelsDevMetadata`
already share, and `attachmentKindForCapability` — which existed only to translate `vision` into
`image` — is gone.

## How to verify

- `curl 'localhost:4747/models?provider=anthropic&role=analyze:image'` — eleven models,
  cheapest priced first.
- Same with `role=analyze:audio` — an empty list. Anthropic has no audio-ingesting model, and
  that is an answer rather than a failure; anything with a picker should say so.
- `role=generate:image` against `provider=gemini` — the image models, and nothing that merely
  reads images.
- `role=image` — 400. A bare modality is no longer a role on its own.
- `role=smell` — 400 naming the field and the six real roles.
- `provider=gpt&role=smell` — reports the role, not the provider. Both are wrong, and the role is
  the more specific mistake.
- `curl localhost:4747/catalog | jq .companionRoles` — the six roles.
- An agent config with a legacy `"vision"` companion key still validates and still delegates.
