### PR TITLE
fix(daemon): serve companion bindings under their canonical role

### DIFF
--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -855,6 +855,53 @@ describe("reading one agent over HTTP", () => {
     });
   });
 
+  it("serves a companion written the old way under its role", async () => {
+    // A config from before roles existed keys bindings bare. Served as stored, an editor
+    // would show the role as unset and then write a second key meaning the same thing.
+    const legacy = agentFixture({
+      config: {
+        persona: "default",
+        llmProvider: "anthropic",
+        llmModel: "claude-sonnet-4-6",
+        companions: { vision: "anthropic/claude-haiku-4-5" },
+      },
+    } as Partial<Agent>);
+    const { run } = runnerForWritableAgents([legacy]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/uGS8WAv4cGBiFH1wHB7r4E"));
+    const body = (await response.json()) as { agent: { config: Record<string, unknown> } };
+    expect(body.agent.config["companions"]).toEqual({
+      "analyze:image": "anthropic/claude-haiku-4-5",
+    });
+  });
+
+  it("drops a companion key that names no role rather than echoing it back", async () => {
+    const nonsense = agentFixture({
+      config: {
+        persona: "default",
+        llmProvider: "anthropic",
+        llmModel: "claude-sonnet-4-6",
+        companions: { smell: "anthropic/claude-haiku-4-5" },
+      },
+    } as Partial<Agent>);
+    const { run } = runnerForWritableAgents([nonsense]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/uGS8WAv4cGBiFH1wHB7r4E"));
+    const body = (await response.json()) as { agent: { config: Record<string, unknown> } };
+    expect(body.agent.config["companions"]).toEqual({});
+  });
+
+  it("leaves an agent with no companions without the key", async () => {
+    const { run } = runnerForWritableAgents([agentFixture()]);
+    const handle = makeHandler(LOOPBACK, run);
+
+    const response = await handle(request("GET", "/agents/uGS8WAv4cGBiFH1wHB7r4E"));
+    const body = (await response.json()) as { agent: { config: Record<string, unknown> } };
+    expect(body.agent.config).not.toHaveProperty("companions");
+  });
+
   it("resolves an agent by name as well as by id", async () => {
     const { run } = runnerForWritableAgents([agentFixture()]);
     const handle = makeHandler(LOOPBACK, run);

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -47,7 +47,7 @@ import {
   StorageNotFoundError,
   ValidationError,
 } from "@jazz/core/types/errors";
-import { COMPANION_ROLES, isCompanionRole } from "@jazz/core/types/llm";
+import { COMPANION_ROLES, isCompanionRole, normalizeCompanionRole } from "@jazz/core/types/llm";
 import type { CompanionRole } from "@jazz/core/types/llm";
 import type { ModelInfo } from "@jazz/core/types/llm";
 import type { PeerConfig } from "@jazz/core/types/peer";
@@ -1091,6 +1091,27 @@ function listRuns() {
 }
 
 /**
+ * Companion bindings under their canonical role keys.
+ *
+ * A config written before roles existed keys bindings as bare `vision`/`audio`/`video`, and
+ * jazz resolves those at read time — but it serves the config as stored, so an editor would
+ * show that binding as unset, and saving a fresh one alongside it would leave two keys
+ * meaning the same role with one silently winning. Canonicalising here keeps the one
+ * legacy mapping in `normalizeCompanionRole` rather than copying it into every client.
+ *
+ * A key that means nothing at all is dropped: it cannot be edited under a role, and echoing
+ * it would invite a client to write it back.
+ */
+function canonicalCompanions(companions: Readonly<Record<string, string>>): Record<string, string> {
+  const canonical: Record<string, string> = {};
+  for (const [key, model] of Object.entries(companions)) {
+    const role = normalizeCompanionRole(key);
+    if (role !== undefined) canonical[role] = model;
+  }
+  return canonical;
+}
+
+/**
  * One agent, as much of it as somebody choosing between them needs.
  *
  * Fields are projected one by one rather than returning the stored agent, because
@@ -1122,7 +1143,11 @@ function projectAgentSummary(agent: Agent) {
  * a blank box that means either "unset" or "hidden".
  */
 function projectAgentDetail(agent: Agent) {
-  const { llmApiKeys, ...config } = agent.config;
+  const { llmApiKeys, companions, ...rest } = agent.config;
+  const config = {
+    ...rest,
+    ...(companions !== undefined ? { companions: canonicalCompanions(companions) } : {}),
+  };
   return {
     ...projectAgentSummary(agent),
     config,


### PR DESCRIPTION
## What & why

`GET /agents/:id` served an agent's config as stored, so a companion written before roles
existed went out under its old bare key (`vision`, not `analyze:image`). jazz resolves those
at read time, but a client displaying the config cannot: an editor shows `analyze:image` as
unset, and saving a binding for it leaves two keys meaning the same role with whichever jazz
resolves last silently winning.

The projection now canonicalises through `normalizeCompanionRole`, so the legacy mapping
stays in the one function that owns it rather than being copied into every client that wants
to render a config correctly.

## How to verify

- Hand-write `"companions": { "vision": "anthropic/claude-haiku-4-5" }` into an agent's JSON,
  then `curl localhost:4747/agents/<name>` — it comes back as `"analyze:image"`, and the agent
  still resolves its companion exactly as before.
- Bind `analyze:image` over that agent through `PATCH`, then check the file: one key, not two.
- Put `"companions": { "smell": "..." }` in a config — the key is dropped from the response
  rather than echoed, since nothing could edit it under a role anyway.
- An agent with no companions still comes back with no `companions` key at all.
