### PR TITLE
refactor(agents): drop the pre-role companion keys

### DIFF
--- a/packages/adapters/src/agent-service.test.ts
+++ b/packages/adapters/src/agent-service.test.ts
@@ -625,12 +625,20 @@ describe("AgentService", () => {
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();
     });
 
-    it("still accepts pre-role companion keys from stored configs", async () => {
+    it("refuses a companion key that is not a role", async () => {
+      // `vision` was the key before roles existed. Accepting it stored a binding that
+      // `perception-tools` — which looks a companion up by role directly — would never
+      // find, so the agent read as configured and behaved as unconfigured.
       const program = service.validateAgentConfig({
         ...baseConfig,
         companions: { vision: "anthropic/claude-sonnet-4-5" } as never,
       });
-      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
+      const result = await Effect.runPromiseExit(program);
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        // @ts-expect-error - accessing error
+        expect(result.cause.error).toBeInstanceOf(AgentConfigurationError);
+      }
     });
 
     it("accepts config with no companions", async () => {

--- a/packages/adapters/src/agent-service.ts
+++ b/packages/adapters/src/agent-service.ts
@@ -19,7 +19,7 @@ import {
   ValidationError,
 } from "@jazz/core/types/errors";
 import { type Agent, type AgentConfig, type CustomToolDefinition } from "@jazz/core/types/index";
-import { COMPANION_ROLES, normalizeCompanionRole } from "@jazz/core/types/llm";
+import { COMPANION_ROLES, isCompanionRole } from "@jazz/core/types/llm";
 import { parseProviderModel } from "@jazz/core/utils/provider-model";
 import { Effect, Layer } from "effect";
 import shortuuid from "short-uuid";
@@ -257,7 +257,7 @@ export class AgentServiceImpl implements AgentService {
           );
         }
         for (const [key, companion] of Object.entries(companions as Record<string, unknown>)) {
-          if (normalizeCompanionRole(key) === undefined) {
+          if (!isCompanionRole(key)) {
             return yield* Effect.fail(
               new AgentConfigurationError({
                 agentId: "unknown",

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -101,23 +101,6 @@ export function parseCompanionRole(role: CompanionRole): {
 }
 
 /**
- * Companion keys as written before roles existed: bare `"vision" | "audio" | "video"`,
- * all of them analysis. Kept so stored agent configs keep working.
- */
-const LEGACY_COMPANION_KEYS: Readonly<Record<string, CompanionRole>> = {
-  vision: "analyze:image",
-  image: "analyze:image",
-  audio: "analyze:audio",
-  video: "analyze:video",
-};
-
-/** The role a stored companion key means, or `undefined` when it means nothing. */
-export function normalizeCompanionRole(key: string): CompanionRole | undefined {
-  if (isCompanionRole(key)) return key;
-  return LEGACY_COMPANION_KEYS[key];
-}
-
-/**
  * Service contract for an LLM provider
  *
  * An LLM provider represents a configured connection to an LLM service (OpenAI,

--- a/packages/core/src/utils/model-capabilities.test.ts
+++ b/packages/core/src/utils/model-capabilities.test.ts
@@ -10,7 +10,6 @@ import {
   isCompanionRole,
   isMediaModality,
   modelSupportsRole,
-  normalizeCompanionRole,
 } from "./model-capabilities";
 
 function model(overrides: Partial<ModelInfo> & { id: string }): ModelInfo {
@@ -111,12 +110,13 @@ describe("role vocabulary", () => {
     expect(describeRole("generate:audio")).toBe("audio generation");
   });
 
-  it("reads pre-role companion keys as analysis bindings", () => {
-    expect(normalizeCompanionRole("vision")).toBe("analyze:image");
-    expect(normalizeCompanionRole("audio")).toBe("analyze:audio");
-    expect(normalizeCompanionRole("video")).toBe("analyze:video");
-    expect(normalizeCompanionRole("generate:image")).toBe("generate:image");
-    expect(normalizeCompanionRole("smell")).toBeUndefined();
+  it("recognises a role only under its canonical key", () => {
+    // The one form a binding can take. `perception-tools` looks a companion up by role
+    // directly, so a key in any other shape would be stored and then never found.
+    expect(isCompanionRole("analyze:image")).toBe(true);
+    expect(isCompanionRole("generate:image")).toBe(true);
+    expect(isCompanionRole("vision")).toBe(false);
+    expect(isCompanionRole("smell")).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/model-capabilities.ts
+++ b/packages/core/src/utils/model-capabilities.ts
@@ -26,7 +26,6 @@ export {
   companionRole,
   isCompanionRole,
   isMediaModality,
-  normalizeCompanionRole,
   parseCompanionRole,
   type CompanionRole,
   type MediaAction,


### PR DESCRIPTION
## What & why

Companion bindings could be keyed the pre-role way — bare `vision`/`audio`/`video` — and
`normalizeCompanionRole` read those as `analyze:*` so older configs kept working. No release
has shipped roles, so there are no older configs, and the support was half wired anyway:
validation accepted the old key and stored it, while `perception-tools` looks a binding up as
`config.companions[role]` directly and never found it. An agent read as having a vision
companion and behaved as having none.

That is precisely the failure a bound companion prevents — an unattended run has nobody to
ask — so it is worth being unable to express rather than expressible and inert.

## Breaking changes / migration

A hand-written `vision`/`audio`/`video` companion key is now refused on save instead of
accepted and ignored. Rewrite it as `analyze:image` / `analyze:audio` / `analyze:video`; the
binding was doing nothing before the change.

## How to verify

- Put `"companions": { "vision": "anthropic/claude-haiku-4-5" }` in an agent's JSON and edit
  the agent: refused, naming `config.companions.vision`. Before, it saved and the agent still
  had no vision companion.
- `"analyze:image"` with the same value saves, and `analyze_media` on an image routes there
  without prompting — including under `jazz daemon`, where nothing can prompt.
- `"generate:image"` still validates and binds; nothing consumes it yet.
