### PR TITLE
refactor(agents): drop the pre-role companion key map

### DIFF
--- a/packages/adapters/src/agent-service.test.ts
+++ b/packages/adapters/src/agent-service.test.ts
@@ -625,14 +625,6 @@ describe("AgentService", () => {
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();
     });
 
-    it("still accepts pre-role companion keys from stored configs", async () => {
-      const program = service.validateAgentConfig({
-        ...baseConfig,
-        companions: { vision: "anthropic/claude-sonnet-4-5" } as never,
-      });
-      await expect(Effect.runPromise(program)).resolves.toBeUndefined();
-    });
-
     it("accepts config with no companions", async () => {
       const program = service.validateAgentConfig(baseConfig);
       await expect(Effect.runPromise(program)).resolves.toBeUndefined();

--- a/packages/adapters/src/agent-service.ts
+++ b/packages/adapters/src/agent-service.ts
@@ -19,7 +19,7 @@ import {
   ValidationError,
 } from "@jazz/core/types/errors";
 import { type Agent, type AgentConfig, type CustomToolDefinition } from "@jazz/core/types/index";
-import { COMPANION_ROLES, normalizeCompanionRole } from "@jazz/core/types/llm";
+import { COMPANION_ROLES, isCompanionRole } from "@jazz/core/types/llm";
 import { parseProviderModel } from "@jazz/core/utils/provider-model";
 import { Effect, Layer } from "effect";
 import shortuuid from "short-uuid";
@@ -257,7 +257,7 @@ export class AgentServiceImpl implements AgentService {
           );
         }
         for (const [key, companion] of Object.entries(companions as Record<string, unknown>)) {
-          if (normalizeCompanionRole(key) === undefined) {
+          if (!isCompanionRole(key)) {
             return yield* Effect.fail(
               new AgentConfigurationError({
                 agentId: "unknown",

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -101,23 +101,6 @@ export function parseCompanionRole(role: CompanionRole): {
 }
 
 /**
- * Companion keys as written before roles existed: bare `"vision" | "audio" | "video"`,
- * all of them analysis. Kept so stored agent configs keep working.
- */
-const LEGACY_COMPANION_KEYS: Readonly<Record<string, CompanionRole>> = {
-  vision: "analyze:image",
-  image: "analyze:image",
-  audio: "analyze:audio",
-  video: "analyze:video",
-};
-
-/** The role a stored companion key means, or `undefined` when it means nothing. */
-export function normalizeCompanionRole(key: string): CompanionRole | undefined {
-  if (isCompanionRole(key)) return key;
-  return LEGACY_COMPANION_KEYS[key];
-}
-
-/**
  * Service contract for an LLM provider
  *
  * An LLM provider represents a configured connection to an LLM service (OpenAI,

--- a/packages/core/src/utils/model-capabilities.test.ts
+++ b/packages/core/src/utils/model-capabilities.test.ts
@@ -10,7 +10,6 @@ import {
   isCompanionRole,
   isMediaModality,
   modelSupportsRole,
-  normalizeCompanionRole,
 } from "./model-capabilities";
 
 function model(overrides: Partial<ModelInfo> & { id: string }): ModelInfo {
@@ -109,14 +108,6 @@ describe("role vocabulary", () => {
   it("says what each role does in words", () => {
     expect(describeRole("analyze:image")).toBe("image understanding");
     expect(describeRole("generate:audio")).toBe("audio generation");
-  });
-
-  it("reads pre-role companion keys as analysis bindings", () => {
-    expect(normalizeCompanionRole("vision")).toBe("analyze:image");
-    expect(normalizeCompanionRole("audio")).toBe("analyze:audio");
-    expect(normalizeCompanionRole("video")).toBe("analyze:video");
-    expect(normalizeCompanionRole("generate:image")).toBe("generate:image");
-    expect(normalizeCompanionRole("smell")).toBeUndefined();
   });
 });
 

--- a/packages/core/src/utils/model-capabilities.ts
+++ b/packages/core/src/utils/model-capabilities.ts
@@ -26,7 +26,6 @@ export {
   companionRole,
   isCompanionRole,
   isMediaModality,
-  normalizeCompanionRole,
   parseCompanionRole,
   type CompanionRole,
   type MediaAction,


### PR DESCRIPTION
## What & why

Removes `LEGACY_COMPANION_KEYS` and `normalizeCompanionRole`. Roles have not shipped, so
nothing keys a companion the old way, and `perception-tools` only ever looked bindings up by
canonical role anyway. `isCompanionRole` is now the single check, like every other closed
list in the config.

## How to verify

- `"companions": { "analyze:image": "anthropic/claude-haiku-4-5" }` saves, and `analyze_media`
  on an image routes there without prompting.
- `"generate:image"` still validates and binds; nothing consumes it yet.
