### PR TITLE
docs(bots): document the OpenAI-compatible provider for the bridges

### DIFF
--- a/packages/discord-bot/src/.env.example
+++ b/packages/discord-bot/src/.env.example
@@ -75,6 +75,22 @@ JAZZ_REASONING=medium
 # JAZZ_DISCORD_MODEL=qwen3.6:27b
 OLLAMA_BASE_URL=http://host.docker.internal:11434/api
 
+# --- Local models via an OpenAI-compatible server (vLLM, llama.cpp, a proxy) ---
+# Use the `llamacpp` provider for ANY server that speaks OpenAI's /v1 — there is
+# no separate `vllm` provider, and none is needed: `llamacpp` is Jazz's generic
+# OpenAI-compatible client.
+#   JAZZ_DISCORD_PROVIDER=llamacpp
+#   JAZZ_DISCORD_MODEL=<the server's --served-model-name>
+#
+# IMPORTANT: the model name must be one the models.dev catalog recognises. Jazz
+# resolves a model's tool and reasoning capability from that catalog by bare
+# model id, and vLLM implements none of llama.cpp's /props, so a name the
+# catalog does not know resolves to supportsTools=false — at which point every
+# tool is silently dropped from the request and the bot answers without ever
+# reading a file. There is no error; it just gets quietly worse.
+# LLAMACPP_BASE_URL=http://host.docker.internal:8000/v1
+# LLAMACPP_API_KEY=
+
 # Auto-approve tools up to this risk level: read-only | low-risk | high-risk.
 JAZZ_APPROVAL_POLICY=low-risk
 

--- a/packages/telegram-bot/src/.env.example
+++ b/packages/telegram-bot/src/.env.example
@@ -82,6 +82,22 @@ JAZZ_REASONING=medium
 # published 11434). A missing Ollama model surfaces as "Not Found".
 OLLAMA_BASE_URL=http://host.docker.internal:11434/api
 
+# --- Local models via an OpenAI-compatible server (vLLM, llama.cpp, a proxy) ---
+# Use the `llamacpp` provider for ANY server that speaks OpenAI's /v1 — there is
+# no separate `vllm` provider, and none is needed: `llamacpp` is Jazz's generic
+# OpenAI-compatible client.
+#   JAZZ_TELEGRAM_PROVIDER=llamacpp
+#   JAZZ_TELEGRAM_MODEL=<the server's --served-model-name>
+#
+# IMPORTANT: the model name must be one the models.dev catalog recognises. Jazz
+# resolves a model's tool and reasoning capability from that catalog by bare
+# model id, and vLLM implements none of llama.cpp's /props, so a name the
+# catalog does not know resolves to supportsTools=false — at which point every
+# tool is silently dropped from the request and the bot answers without ever
+# reading a file. There is no error; it just gets quietly worse.
+# LLAMACPP_BASE_URL=http://host.docker.internal:8000/v1
+# LLAMACPP_API_KEY=
+
 # Auto-approve tools up to this risk level: read-only | low-risk | high-risk.
 JAZZ_APPROVAL_POLICY=low-risk
 


### PR DESCRIPTION
## What & why

Both bridge `.env.example` files explain how to reach a local model via Ollama but
not via an OpenAI-compatible server — the other local option, and the one a vLLM
deployment needs.

Worth spelling out because the provider name is counter-intuitive: there is no
`vllm` provider and none is needed, since `llamacpp` is already the generic
`createOpenAICompatible` client. Anyone looking for "vllm" in
`AVAILABLE_PROVIDERS` concludes it is unsupported and stops.

The note about the model name is the part that actually costs debugging time.
Capability resolution falls back to the models.dev catalog by bare model id when
llama.cpp's `/props` is absent — which it always is on vLLM — so a name the catalog
does not know yields `supportsTools: false`, and `buildToolConfig` then drops every
tool from the request. Nothing errors; the bot just answers without reading
anything.

Docs only, no code change.

## How to verify

- Read `packages/telegram-bot/src/.env.example` and
  `packages/discord-bot/src/.env.example` — each now documents
  `JAZZ_<BOT>_PROVIDER=llamacpp` alongside the existing Ollama block.
- Follow the new block against any OpenAI-compatible server and confirm a bridge
  starts and answers.
- The edge case the note warns about: set `JAZZ_<BOT>_MODEL` to a name models.dev
  does not know and confirm the bot still replies but silently never calls a tool.
  That is the failure the comment exists to prevent.
