### PR TITLE
Say what a tool call returned, not just that it finished

### DIFF
--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -154,7 +154,7 @@ Every event is a `POST` of one JSON object to that URL.
 | `kind` | Sent when | Also carries |
 |---|---|---|
 | `tool-started` | a tool call begins | — |
-| `tool-finished` | that call returns | `ok` |
+| `tool-finished` | that call returns | `ok`, `summary` |
 | `approval-required` | the run has stopped and needs a person | — |
 
 Every event carries `kind`, `toolName`, and `toolCallId`. The id is the model's own id for
@@ -168,11 +168,23 @@ A tool beginning:
 ```
 
 The same call returning. `ok` is `false` whenever the call did not succeed — an error, a
-timeout, or an approval that was declined:
+timeout, or an approval that was declined. `summary` is what the call returned, folded onto
+one line and clipped to 200 characters, so a listener can show `read_file — 412 lines`
+rather than a bare "finished". It is absent when the call returned nothing:
 
 ```json
-{ "kind": "tool-finished", "toolName": "read_file", "toolCallId": "call_zx1", "ok": true }
+{
+  "kind": "tool-finished",
+  "toolName": "read_file",
+  "toolCallId": "call_zx1",
+  "ok": true,
+  "summary": "# Thursday - 09:00 standup - 14:00 review with @sam…"
+}
 ```
+
+The summary is a tool result, and it only ever goes to the loopback URL the caller supplied
+on this machine. A listener that relays progress somewhere else — another person's screen,
+a chat room — should relay `toolName` and leave `summary` where it was produced.
 
 And a run that has stopped for a person:
 

--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -154,7 +154,7 @@ Every event is a `POST` of one JSON object to that URL.
 | `kind` | Sent when | Also carries |
 |---|---|---|
 | `tool-started` | a tool call begins | — |
-| `tool-finished` | that call returns | `ok`, `summary` |
+| `tool-finished` | that call returns | `ok`, `result` |
 | `approval-required` | the run has stopped and needs a person | — |
 
 Every event carries `kind`, `toolName`, and `toolCallId`. The id is the model's own id for
@@ -168,9 +168,8 @@ A tool beginning:
 ```
 
 The same call returning. `ok` is `false` whenever the call did not succeed — an error, a
-timeout, or an approval that was declined. `summary` is what the call returned, folded onto
-one line and clipped to 200 characters, so a listener can show `read_file — 412 lines`
-rather than a bare "finished". It is absent when the call returned nothing:
+timeout, or an approval that was declined. `result` is what the call returned, unformatted
+and uncut, so a listener can show `read_file — 412 lines` or the whole thing, as it likes:
 
 ```json
 {
@@ -178,13 +177,20 @@ rather than a bare "finished". It is absent when the call returned nothing:
   "toolName": "read_file",
   "toolCallId": "call_zx1",
   "ok": true,
-  "summary": "# Thursday - 09:00 standup - 14:00 review with @sam…"
+  "result": "# Thursday\n- 09:00 standup\n- 14:00 review with @sam"
 }
 ```
 
-The summary is a tool result, and it only ever goes to the loopback URL the caller supplied
+How much of a result to show is the listener's decision, not the daemon's — a status line
+wants a clause and a log pane wants the lot, so jazz clips neither. The one exception is a
+transport ceiling of 8,000 characters, because a tool that returns an entire PDF should not
+push it through a fire-and-forget status `POST` on every call. A result over that line
+arrives cut, with `"resultTruncated": true` beside it, and the run's real answer still
+carries the whole thing.
+
+The result is a tool result, and it only ever goes to the loopback URL the caller supplied
 on this machine. A listener that relays progress somewhere else — another person's screen,
-a chat room — should relay `toolName` and leave `summary` where it was produced.
+a chat room — should relay `toolName` and leave `result` where it was produced.
 
 And a run that has stopped for a person:
 

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -25,6 +25,7 @@ import type { DisplayConfig } from "@/core/types/output";
 import {
   isApprovalRequiredResult,
   shouldAutoApprove,
+  summarizeToolResult,
   type ToolCall,
   type ToolExecutionContext,
   type ToolExecutionResult,
@@ -829,11 +830,13 @@ export class ToolExecutor {
             ).pipe(
               Effect.tap((outcome) =>
                 Effect.sync(() => {
+                  const summary = summarizeToolResult(outcome.result);
                   context.onToolEvent?.({
                     kind: "tool-finished",
                     toolName: outcome.name,
                     toolCallId: outcome.toolCallId,
                     ok: outcome.success,
+                    ...(summary !== undefined ? { summary } : {}),
                   });
                 }),
               ),

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -25,7 +25,6 @@ import type { DisplayConfig } from "@/core/types/output";
 import {
   isApprovalRequiredResult,
   shouldAutoApprove,
-  summarizeToolResult,
   type ToolCall,
   type ToolExecutionContext,
   type ToolExecutionResult,
@@ -33,6 +32,7 @@ import {
 } from "@/core/types/tools";
 import { extractCommandApprovalKey } from "@/core/utils/shell";
 import { formatToolArguments } from "@/core/utils/tool-formatter";
+import { toolResultForProgress } from "@/core/utils/tool-result-formatter";
 import {
   emitToolInvocation,
   recordToolError,
@@ -830,13 +830,18 @@ export class ToolExecutor {
             ).pipe(
               Effect.tap((outcome) =>
                 Effect.sync(() => {
-                  const summary = summarizeToolResult(outcome.result);
+                  const returned = toolResultForProgress(outcome.result);
                   context.onToolEvent?.({
                     kind: "tool-finished",
                     toolName: outcome.name,
                     toolCallId: outcome.toolCallId,
                     ok: outcome.success,
-                    ...(summary !== undefined ? { summary } : {}),
+                    ...(returned !== undefined
+                      ? {
+                          result: returned.text,
+                          ...(returned.truncated ? { resultTruncated: true } : {}),
+                        }
+                      : {}),
                   });
                 }),
               ),

--- a/packages/core/src/types/tools.test.ts
+++ b/packages/core/src/types/tools.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-  MAX_TOOL_PROGRESS_SUMMARY,
-  shouldAutoApprove,
-  summarizeToolResult,
-  type AutoApprovePolicy,
-  type ToolRiskLevel,
-} from "./tools";
+import { shouldAutoApprove, type AutoApprovePolicy, type ToolRiskLevel } from "./tools";
 
 describe("shouldAutoApprove", () => {
   describe("no policy (undefined)", () => {
@@ -95,38 +89,5 @@ describe("shouldAutoApprove", () => {
         }
       }
     });
-  });
-});
-
-describe("summarizeToolResult", () => {
-  it("keeps a short string result as it is", () => {
-    expect(summarizeToolResult("8 results")).toBe("8 results");
-  });
-
-  it("folds a multi-line result onto one line", () => {
-    expect(summarizeToolResult("first\n  second\n\nthird")).toBe("first second third");
-  });
-
-  it("clips a long result to the cap, ellipsis included", () => {
-    const summary = summarizeToolResult("x".repeat(MAX_TOOL_PROGRESS_SUMMARY * 3));
-    expect(summary).toHaveLength(MAX_TOOL_PROGRESS_SUMMARY);
-    expect(summary?.endsWith("\u2026")).toBe(true);
-  });
-
-  it("renders a structured result as JSON", () => {
-    expect(summarizeToolResult({ matches: 3 })).toBe('{"matches":3}');
-  });
-
-  it("says nothing rather than something empty", () => {
-    expect(summarizeToolResult(undefined)).toBeUndefined();
-    expect(summarizeToolResult(null)).toBeUndefined();
-    expect(summarizeToolResult("   \n  ")).toBeUndefined();
-  });
-
-  it("survives a result that cannot be serialized", () => {
-    const cyclic: Record<string, unknown> = {};
-    cyclic["self"] = cyclic;
-    expect(summarizeToolResult(cyclic)).toBeUndefined();
-    expect(summarizeToolResult({ big: 1n })).toBeUndefined();
   });
 });

--- a/packages/core/src/types/tools.test.ts
+++ b/packages/core/src/types/tools.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { shouldAutoApprove, type AutoApprovePolicy, type ToolRiskLevel } from "./tools";
+import {
+  MAX_TOOL_PROGRESS_SUMMARY,
+  shouldAutoApprove,
+  summarizeToolResult,
+  type AutoApprovePolicy,
+  type ToolRiskLevel,
+} from "./tools";
 
 describe("shouldAutoApprove", () => {
   describe("no policy (undefined)", () => {
@@ -89,5 +95,38 @@ describe("shouldAutoApprove", () => {
         }
       }
     });
+  });
+});
+
+describe("summarizeToolResult", () => {
+  it("keeps a short string result as it is", () => {
+    expect(summarizeToolResult("8 results")).toBe("8 results");
+  });
+
+  it("folds a multi-line result onto one line", () => {
+    expect(summarizeToolResult("first\n  second\n\nthird")).toBe("first second third");
+  });
+
+  it("clips a long result to the cap, ellipsis included", () => {
+    const summary = summarizeToolResult("x".repeat(MAX_TOOL_PROGRESS_SUMMARY * 3));
+    expect(summary).toHaveLength(MAX_TOOL_PROGRESS_SUMMARY);
+    expect(summary?.endsWith("\u2026")).toBe(true);
+  });
+
+  it("renders a structured result as JSON", () => {
+    expect(summarizeToolResult({ matches: 3 })).toBe('{"matches":3}');
+  });
+
+  it("says nothing rather than something empty", () => {
+    expect(summarizeToolResult(undefined)).toBeUndefined();
+    expect(summarizeToolResult(null)).toBeUndefined();
+    expect(summarizeToolResult("   \n  ")).toBeUndefined();
+  });
+
+  it("survives a result that cannot be serialized", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    expect(summarizeToolResult(cyclic)).toBeUndefined();
+    expect(summarizeToolResult({ big: 1n })).toBeUndefined();
   });
 });

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -38,6 +38,15 @@ export type AutoApprovePolicy = boolean | "read-only" | "low-risk" | "high-risk"
  * prompt is only a kindness where a prompt was the alternative. Callers that
  * cannot answer the question leave it out and get the conservative reading.
  */
+/**
+ * Longest result summary a progress event carries.
+ *
+ * A progress event is a status line, not a transcript: the caller already gets the full
+ * answer when the run finishes, and a run that greps a repo would otherwise post megabytes
+ * to a listener that has room for one line.
+ */
+export const MAX_TOOL_PROGRESS_SUMMARY = 200;
+
 /** What a run reports about itself while it is still going. */
 export interface ToolProgressEvent {
   readonly kind: "tool-started" | "tool-finished" | "approval-required";
@@ -45,6 +54,43 @@ export interface ToolProgressEvent {
   readonly toolCallId?: string;
   /** Set on "tool-finished": whether the call succeeded. */
   readonly ok?: boolean;
+  /**
+   * Set on "tool-finished": the first line of what the call returned, clipped to
+   * `MAX_TOOL_PROGRESS_SUMMARY`.
+   *
+   * `ok` alone says a tool ran without saying what it found, which is the difference
+   * between "search_web finished" and "search_web — 8 results". Only ever sent to the
+   * loopback progress URL the caller supplied, so this does not widen where a tool result
+   * can travel: it stays on the machine that produced it.
+   */
+  readonly summary?: string;
+}
+
+/**
+ * One line of a tool result, for `ToolProgressEvent.summary`.
+ *
+ * Undefined rather than an empty string when there is nothing to say, so a listener can
+ * tell "returned nothing" from "did not report".
+ */
+export function summarizeToolResult(result: unknown): string | undefined {
+  const body = typeof result === "string" ? result : safeStringify(result);
+  if (body === undefined) return undefined;
+  const line = body.replaceAll(/\s+/gu, " ").trim();
+  if (line.length === 0) return undefined;
+  return line.length > MAX_TOOL_PROGRESS_SUMMARY
+    ? `${line.slice(0, MAX_TOOL_PROGRESS_SUMMARY - 1)}\u2026`
+    : line;
+}
+
+function safeStringify(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    // A result holding a cycle or a BigInt is still a finished tool call; the event should
+    // say so rather than throw inside a fire-and-forget status report.
+    return undefined;
+  }
 }
 
 export function shouldAutoApprove(

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -39,13 +39,16 @@ export type AutoApprovePolicy = boolean | "read-only" | "low-risk" | "high-risk"
  * cannot answer the question leave it out and get the conservative reading.
  */
 /**
- * Longest result summary a progress event carries.
+ * Most of a tool result a progress event will carry.
  *
- * A progress event is a status line, not a transcript: the caller already gets the full
- * answer when the run finishes, and a run that greps a repo would otherwise post megabytes
- * to a listener that has room for one line.
+ * Not a formatting decision — how much of a result to *show* belongs to the listener, and
+ * everything under this ceiling arrives whole. This is the transport saying that a tool
+ * which returns an entire PDF should not push it through a fire-and-forget status POST on
+ * every call. A result over the line is cut here and flagged `resultTruncated`, so a
+ * listener that wants the rest knows to wait for the run's real answer rather than treating
+ * a clipped document as the whole one.
  */
-export const MAX_TOOL_PROGRESS_SUMMARY = 200;
+export const MAX_PROGRESS_RESULT_CHARS = 8_000;
 
 /** What a run reports about itself while it is still going. */
 export interface ToolProgressEvent {
@@ -55,42 +58,21 @@ export interface ToolProgressEvent {
   /** Set on "tool-finished": whether the call succeeded. */
   readonly ok?: boolean;
   /**
-   * Set on "tool-finished": the first line of what the call returned, clipped to
-   * `MAX_TOOL_PROGRESS_SUMMARY`.
+   * Set on "tool-finished": what the call returned.
    *
    * `ok` alone says a tool ran without saying what it found, which is the difference
-   * between "search_web finished" and "search_web — 8 results". Only ever sent to the
-   * loopback progress URL the caller supplied, so this does not widen where a tool result
-   * can travel: it stays on the machine that produced it.
+   * between "search_web finished" and "search_web — 8 results". Sent unformatted and
+   * uncut up to `MAX_PROGRESS_RESULT_CHARS`, because how much of a result to show is the
+   * listener's question, not the daemon's: a status line wants a clause, a log pane wants
+   * the lot, and a daemon that clipped to one of those would have destroyed the other's
+   * answer before it was asked.
+   *
+   * Only ever sent to the loopback progress URL the caller supplied, so this does not widen
+   * where a tool result can travel: it stays on the machine that produced it.
    */
-  readonly summary?: string;
-}
-
-/**
- * One line of a tool result, for `ToolProgressEvent.summary`.
- *
- * Undefined rather than an empty string when there is nothing to say, so a listener can
- * tell "returned nothing" from "did not report".
- */
-export function summarizeToolResult(result: unknown): string | undefined {
-  const body = typeof result === "string" ? result : safeStringify(result);
-  if (body === undefined) return undefined;
-  const line = body.replaceAll(/\s+/gu, " ").trim();
-  if (line.length === 0) return undefined;
-  return line.length > MAX_TOOL_PROGRESS_SUMMARY
-    ? `${line.slice(0, MAX_TOOL_PROGRESS_SUMMARY - 1)}\u2026`
-    : line;
-}
-
-function safeStringify(value: unknown): string | undefined {
-  if (value === undefined || value === null) return undefined;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    // A result holding a cycle or a BigInt is still a finished tool call; the event should
-    // say so rather than throw inside a fire-and-forget status report.
-    return undefined;
-  }
+  readonly result?: string;
+  /** Set on "tool-finished" when `result` hit the ceiling and is not the whole thing. */
+  readonly resultTruncated?: boolean;
 }
 
 export function shouldAutoApprove(

--- a/packages/core/src/utils/tool-result-formatter.test.ts
+++ b/packages/core/src/utils/tool-result-formatter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_PROGRESS_RESULT_CHARS } from "@/core/types/tools";
+import { toolResultForProgress } from "./tool-result-formatter";
+
+describe("toolResultForProgress", () => {
+  it("passes a result through as it is, newlines and all", () => {
+    // Formatting is the listener's business: a status line and a log pane want different
+    // things from the same result, and folding it here would decide for both.
+    expect(toolResultForProgress("first\n  second")).toEqual({
+      text: "first\n  second",
+      truncated: false,
+    });
+  });
+
+  it("renders a structured result as JSON", () => {
+    expect(toolResultForProgress({ matches: 3 })).toEqual({
+      text: '{"matches":3}',
+      truncated: false,
+    });
+  });
+
+  it("cuts a result at the transport ceiling and says that it did", () => {
+    const returned = toolResultForProgress("x".repeat(MAX_PROGRESS_RESULT_CHARS * 2));
+    expect(returned?.text).toHaveLength(MAX_PROGRESS_RESULT_CHARS);
+    expect(returned?.truncated).toBe(true);
+  });
+
+  it("leaves a result exactly at the ceiling whole", () => {
+    const returned = toolResultForProgress("x".repeat(MAX_PROGRESS_RESULT_CHARS));
+    expect(returned?.truncated).toBe(false);
+  });
+
+  it("says nothing rather than something empty", () => {
+    expect(toolResultForProgress(undefined)).toBeUndefined();
+    expect(toolResultForProgress(null)).toBeUndefined();
+    expect(toolResultForProgress("")).toBeUndefined();
+  });
+
+  it("reports a result it could not serialize rather than going quiet", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    expect(toolResultForProgress(cyclic)?.text).toContain("Failed to serialize");
+  });
+});

--- a/packages/core/src/utils/tool-result-formatter.ts
+++ b/packages/core/src/utils/tool-result-formatter.ts
@@ -16,6 +16,8 @@
  *   - Skills (load_skill, load_skill_section) always pass through in full.
  */
 
+import { MAX_PROGRESS_RESULT_CHARS } from "@/core/types/tools";
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -410,4 +412,29 @@ export function formatToolResultForContext(toolName: string, result: unknown): s
   }
 
   return truncateResult(stripped, serialized, maxChars);
+}
+
+/**
+ * A tool result as text for a progress event, and whether it had to be cut.
+ *
+ * Distinct from `formatToolResultForContext`, which shapes a result for a model reading it
+ * as conversation. A listener on the progress URL is not a model: it wants what the call
+ * returned, unstripped and unreformatted, and decides for itself how much of it to show.
+ * The only thing done to it here is the transport ceiling — see `MAX_PROGRESS_RESULT_CHARS`.
+ *
+ * Undefined when there is nothing to report, so a listener can tell "returned nothing" from
+ * "did not say".
+ */
+export function toolResultForProgress(
+  result: unknown,
+): { readonly text: string; readonly truncated: boolean } | undefined {
+  const body = typeof result === "string" ? result : resultOrNothing(result);
+  if (body === undefined || body.length === 0) return undefined;
+  return body.length > MAX_PROGRESS_RESULT_CHARS
+    ? { text: body.slice(0, MAX_PROGRESS_RESULT_CHARS), truncated: true }
+    : { text: body, truncated: false };
+}
+
+function resultOrNothing(value: unknown): string | undefined {
+  return value === undefined || value === null ? undefined : safeStringify(value);
 }


### PR DESCRIPTION
## What changes

A caller watching a long run over the webhook progress URL used to learn that `read_file` finished, and nothing else. `tool-finished` carried `ok` and stopped there, so the useful half of a tool call — what it actually returned — never left the daemon.

`tool-finished` now also carries `result`: what the call returned, unformatted and uncut. A listener can render `search_web — 8 results`, or the whole thing, as it likes.

## Why the daemon does not trim it

How much of a result to show is the listener's question. A status line wants a clause; a log pane wants the lot. A daemon that folded and clipped to fit one of those would have destroyed the other's answer before it was asked, so jazz does neither.

The one cut is a transport ceiling of 8,000 characters, and it is not a format: a tool that returns an entire PDF should not push it through a fire-and-forget status `POST` on every call. A result past the line arrives cut with `"resultTruncated": true` beside it, so a clipped document is never mistaken for a whole one — and the run's real answer still carries all of it.

## Where it can travel

The result is a tool result, and progress URLs are loopback-only, so it never leaves the machine that produced it. That is not a new boundary, but it is now load-bearing, so `docs/concepts/webhooks.md` says it outright: a listener relaying progress onward — to another person's screen, to a chat room — should relay `toolName` and leave `result` where it was produced.

## How to verify

Fire a webhook with a progress URL and watch the events:

```bash
curl -X POST localhost:4747/webhooks/<name> \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-Jazz-Progress-Url: http://127.0.0.1:9999/progress" \
  -d 'read the README and tell me what this is'
```

Each `tool-finished` now carries `result` alongside `ok`, absent when the call returned nothing.

`bun run typecheck`, `bun run lint`, and `bun test packages/core/src/types packages/core/src/utils/tool-result-formatter.test.ts packages/core/src/agent/execution packages/adapters/src/daemon/server.test.ts` all pass. `toolResultForProgress` lives in `utils/tool-result-formatter.ts` beside the existing result-to-text function, and has coverage for pass-through, structured results, the ceiling, the exact-ceiling boundary, empty results, and results that cannot be serialized.