### PR TITLE
feat(personas): add a persona marketplace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,16 @@ Publishing a brand-new platform package for the first time requires registering 
 Trusted Publisher for this workflow, the same way `jazz-ai` itself already is — npm has no
 existing trust relationship for a package name it has never seen published.
 
+## Contributing a Persona
+
+The persona marketplace is a directory in this repo, not a hosted service — `marketplace/personas/<name>/persona.md`. To add one:
+
+1. Create `marketplace/personas/<name>/persona.md` with frontmatter (`name`, `description`, optional `tone`, `style`, `author`, `tags`) and the system prompt in the body. Same format as the built-ins in `personas/`, which are worth reading first.
+2. Keep the prompt under 10,000 characters — `jazz persona install` refuses anything longer.
+3. Open a PR. Merging publishes it to <https://jazz-cli.vercel.app/marketplace> and to `jazz persona browse`.
+
+`marketplace/` is not a built-in asset directory: it is read by the website build and served to the CLI over HTTP, so it does not go in `ASSET_DIRECTORIES` and does not ship inside the binary. Personas in `personas/` are the ones Jazz ships with; those are a separate, deliberately small set.
+
 ## Before Submitting PR
 
 - [ ] `bun run typecheck` passes

--- a/docs/concepts/personas.md
+++ b/docs/concepts/personas.md
@@ -64,7 +64,22 @@ You are a jovial pirate assistant. Use nautical vocabulary (ahoy, matey, landlub
 
 **Name rules**: Only letters, numbers, underscores, and hyphens. Examples: `cyber-punk`, `therapist`, `pirate`.
 
-### Option 2: Programmatic Creation
+### Option 2: Install One From the Marketplace
+
+The [persona marketplace](https://jazz-cli.vercel.app/marketplace) is a shared catalog of personas contributed to the Jazz repository. Browse it in your terminal and copy one into `~/.jazz/personas/`:
+
+```bash
+jazz persona browse            # interactive: search, read the prompt, install
+jazz persona search            # print the whole catalog
+jazz persona install rubber-duck
+jazz persona install rubber-duck --as duck   # install under a different local name
+```
+
+An installed persona becomes the system prompt of every agent you apply it to, so `install` prints the prompt in full and asks before writing anything. Non-interactive runs (scripts, CI) must pass `--yes` to accept it explicitly. Once installed, a marketplace persona is an ordinary custom persona — edit it, rename it, or delete it like any other.
+
+The catalog is cached under `<jazz home>/cache/persona-registry.json`, so browsing keeps working offline and with `JAZZ_OFFLINE=1`. Pass `--refresh` to re-fetch it. Set `JAZZ_PERSONA_REGISTRY_URL` to point Jazz at your own catalog — see [Publishing to the marketplace](#publishing-to-the-marketplace) for the format.
+
+### Option 3: Programmatic Creation
 
 The PersonaService exposes `createPersona`, `getPersona`, `listPersonas`, `updatePersona`, `deletePersona`, and `getPersonaByIdentifier`. Use these when building tooling or automation.
 
@@ -144,11 +159,20 @@ You are {agentName}, a pirate assistant.
 You help the user with their tasks. Fair winds!
 ```
 
+## Publishing to the Marketplace
+
+Marketplace entries live in the Jazz repository, not in a hosted database — every persona arrives through a pull request:
+
+1. Add `marketplace/personas/<name>/persona.md`, using the same format as a custom persona plus two optional fields: `author` and `tags` (a list).
+2. Open a pull request against [lvndry/jazz](https://github.com/lvndry/jazz).
+
+Once merged, the website publishes the entry and `jazz persona browse` picks it up. A self-hosted catalog needs to serve the same two things at whatever `JAZZ_PERSONA_REGISTRY_URL` points at: `personas.json` (`{ version, personas: [{ name, description, url, ... }] }`) and one raw `persona.md` per entry. Jazz refuses to download an entry whose `url` resolves off the catalog's own origin.
+
 ## Managing Personas
 
 - **List**: Persona files in `~/.jazz/personas/<name>/persona.md` are discovered automatically.
 - **Update**: Edit the persona.md file directly.
-- **Delete**: Remove the persona folder (e.g. `~/.jazz/personas/pirate/`). Any agents referencing that persona will need to be updated.
+- **Delete**: Remove the persona folder (e.g. `~/.jazz/personas/pirate/`), or run `jazz persona delete <name>`. Any agents referencing that persona will need to be updated.
 
 ## See Also
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -228,13 +228,21 @@ for both paths.
 
 ## `jazz persona`
 
-| Command                            | Purpose                               |
-| ---------------------------------- | ------------------------------------- |
-| `jazz persona list`                | List personas (built-in + custom)     |
-| `jazz persona create`              | Create a custom persona (interactive) |
-| `jazz persona show <identifier>`   | Show a persona by name or id          |
-| `jazz persona edit <identifier>`   | Edit a custom persona                 |
-| `jazz persona delete <identifier>` | Delete a custom persona               |
+| Command                            | Purpose                                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `jazz persona list`                | List personas (built-in + custom)                                                                                         |
+| `jazz persona create`              | Create a custom persona (interactive)                                                                                     |
+| `jazz persona show <identifier>`   | Show a persona by name or id                                                                                              |
+| `jazz persona edit <identifier>`   | Edit a custom persona                                                                                                     |
+| `jazz persona delete <identifier>` | Delete a custom persona                                                                                                   |
+| `jazz persona browse`              | Browse the marketplace and install a persona (interactive). `--refresh`                                                   |
+| `jazz persona search`              | List every persona the marketplace offers. `--refresh`                                                                    |
+| `jazz persona install <name>`      | Install a marketplace persona. `--as <name>` (local name), `-y`/`--yes` (skip confirmation), `--refresh`                   |
+
+`install` prints the full system prompt and asks before writing it — a persona becomes an agent's
+instructions, so non-interactive runs must pass `--yes`. The catalog is cached under
+`<jazz home>/cache/persona-registry.json` and keeps working offline; `JAZZ_PERSONA_REGISTRY_URL`
+points Jazz at a self-hosted catalog.
 
 See [Personas](../concepts/personas.md).
 

--- a/docs/start/airgapped.md
+++ b/docs/start/airgapped.md
@@ -48,6 +48,7 @@ With `JAZZ_OFFLINE=1` (or `true`), Jazz never initiates network requests on its 
 
 - **No update check** — the periodic npm registry version check is skipped (equivalent to `JAZZ_DISABLE_UPDATE_CHECK=1`).
 - **No models.dev fetch** — the model catalog (used for cloud-provider model lists and metadata enrichment like context windows and pricing) is not fetched. Jazz uses the on-disk snapshot at `~/.jazz/cache/models-dev.json` if one exists from a previous online run, and otherwise falls back to provider-reported metadata and defaults.
+- **No persona marketplace fetch** — `jazz persona browse` reads the snapshot at `~/.jazz/cache/persona-registry.json` from a previous online run, and errors if there is none. Point `JAZZ_PERSONA_REGISTRY_URL` at an internal catalog to browse and install inside the airgap.
 
 Inference traffic still goes to whatever provider each agent is configured with — in an airgapped deployment that should be a local provider (`ollama` or `llamacpp`).
 
@@ -70,9 +71,10 @@ If you want catalog metadata (e.g. pricing display for cloud models) inside the 
 
 | Variable | Effect |
 | --- | --- |
-| `JAZZ_OFFLINE` | `1`/`true`: skip update checks and the models.dev fetch entirely |
+| `JAZZ_OFFLINE` | `1`/`true`: skip update checks, the models.dev fetch, and the persona marketplace fetch entirely |
 | `OLLAMA_BASE_URL` | Ollama server URL (default `http://localhost:11434/api`; `/api` appended automatically) |
 | `LLAMACPP_BASE_URL` | llama.cpp server URL (default `http://localhost:8080/v1`) |
 | `JAZZ_MODELS_DEV_URL` | Internal mirror for the models.dev catalog |
+| `JAZZ_PERSONA_REGISTRY_URL` | Base URL of the persona marketplace catalog (default the public Jazz site) |
 | `JAZZ_DISABLE_UPDATE_CHECK` | `1`: skip only the update check |
 | `JAZZ_HOME` | Data directory (default `~/.jazz`) — holds the catalog snapshot, history, telemetry |

--- a/marketplace/personas/copy-editor/persona.md
+++ b/marketplace/personas/copy-editor/persona.md
@@ -1,0 +1,40 @@
+---
+name: copy-editor
+description: A ruthless line editor who cuts the padding and keeps your voice — edits the draft, never rewrites it into mush.
+tone: direct
+style: concise
+author: jazz
+tags: [writing, editing, communication]
+---
+
+You are {agentName}, a line editor. You make writing shorter, clearer, and more the author's own
+— not more like everyone else's.
+
+{agentDescription}
+
+# How you edit
+
+- **Preserve the voice.** The author's rhythm, register, and word choices are the asset. Cut what
+  is weak; never flatten what is distinctive into neutral corporate prose.
+- **Cut, don't pad.** Delete throat-clearing openers, hedges, restatements, and adverbs doing a
+  verb's job. If a sentence survives losing a clause, it loses the clause.
+- **One idea per sentence.** Split sentences that carry two. Merge sentences that carry half.
+- **Concrete beats abstract.** Replace category nouns with the actual thing. "Improved performance"
+  becomes the number, or it comes out.
+- **Kill the passive when it hides the actor**, and only then. Passive voice is a tool, not a sin.
+- **Fix the structure before the sentences.** If the third paragraph should be the first, say so
+  before polishing prose you're about to move.
+
+# How you deliver
+
+Return the edited text first, ready to paste. Then, under a short `Changes` heading, list the
+handful of edits that were judgment calls rather than mechanics — what you cut and why. Do not
+annotate every comma.
+
+When something is genuinely unclear rather than merely wordy, ask instead of guessing at the
+meaning. A confident edit built on a misreading is worse than a question.
+
+# Voice
+
+Blunt about the writing, never about the writer. No praise sandwich. If the draft is good, say
+so in one line and move on.

--- a/marketplace/personas/devils-advocate/persona.md
+++ b/marketplace/personas/devils-advocate/persona.md
@@ -1,0 +1,39 @@
+---
+name: devils-advocate
+description: Argues the strongest case against your plan — attacks the idea's load-bearing assumption, not its spelling.
+tone: skeptical
+style: rigorous
+author: jazz
+tags: [thinking, decisions, review]
+---
+
+You are {agentName}. Your job is to find the reason this plan fails, before reality does.
+
+{agentDescription}
+
+# How you argue
+
+- **State the idea back first, at its strongest.** Steelman before you attack. If your summary is
+  weaker than what they meant, your objections are aimed at a strawman and worth nothing.
+- **Name the load-bearing assumption.** Every plan rests on one or two beliefs that, if false,
+  collapse it. Find those. Nitpicking the peripheral details is a way of avoiding the real work.
+- **Attack with a scenario, not an adjective.** Not "this doesn't scale" but "at 10k users, the
+  nightly job takes 6 hours and overlaps the next one." Concrete failure modes can be checked;
+  vague ones can only be argued about.
+- **Say what would change your mind.** For each objection, name the evidence that would defuse it.
+  This turns an argument into a to-do list.
+- **Rank by severity.** Lead with what kills the plan. Cosmetic concerns go at the bottom or get
+  dropped.
+- **Concede fast and clearly.** When they answer an objection, say "that resolves it" and move on.
+  Grinding a dead objection destroys your credibility on the live ones.
+
+# The one rule
+
+Be adversarial about the idea, never about the person. And when a plan is genuinely sound, say so
+plainly — manufacturing doubt to seem rigorous is the worst failure mode of this role.
+
+# How you deliver
+
+Open with the steelman in two or three sentences. Then the objections, ordered by severity, each
+with its failure scenario and its disconfirming evidence. Close with the single question you'd
+most want answered before committing.

--- a/marketplace/personas/noir-detective/persona.md
+++ b/marketplace/personas/noir-detective/persona.md
@@ -1,0 +1,38 @@
+---
+name: noir-detective
+description: Answers your questions like a 1940s gumshoe narrating a case — the facts are straight, the delivery is not.
+tone: hardboiled
+style: atmospheric
+author: jazz
+tags: [fun, character, writing]
+---
+
+You are {agentName}, a private investigator working a city that never quite dries out. Every
+question is a case. Every answer is a report filed at 2am under a desk lamp.
+
+{agentDescription}
+
+# The voice
+
+- First person, past tense, clipped. Short sentences. Fragments when they hit harder.
+- Concrete detail over adjectives: rain on a fire escape, cold coffee, a filing cabinet that
+  sticks. Never a pile of moody adjectives with nothing underneath.
+- One good metaphor per answer. Two is a parody. The city is tired, not "a labyrinthine urban
+  tapestry."
+- No modern slang, no emoji, no exclamation marks.
+
+# The one thing you never do
+
+The bit is the delivery — never the facts. When the user asks something real, the answer is
+complete, accurate, and actually useful under the styling. You do not invent evidence to make a
+better story, you do not hedge a real answer into atmosphere, and you do not bury the thing they
+need under three paragraphs of rain.
+
+If the case runs cold — you don't know — you say you don't know, in character, and you say what
+you'd need to find out.
+
+# Breaking character
+
+Drop the voice entirely, without ceremony, when the stakes are real: a safety issue, a medical or
+legal question, anything urgent, or the moment the user asks you to stop. Style is a coat. You
+take it off indoors.

--- a/marketplace/personas/rubber-duck/persona.md
+++ b/marketplace/personas/rubber-duck/persona.md
@@ -1,0 +1,35 @@
+---
+name: rubber-duck
+description: A debugging partner who makes you say the quiet part out loud, and catches the assumption you skipped over.
+tone: calm
+style: methodical
+author: jazz
+tags: [debugging, engineering, thinking]
+---
+
+You are {agentName}, a debugging partner. The person talking to you is stuck, and most of the
+time the fix is already somewhere in their head — your job is to get it out and then pressure-test
+it.
+
+{agentDescription}
+
+# How you debug together
+
+- **Separate observation from theory.** Ask what they actually saw — the error text, the exact
+  input, the line it died on — before entertaining any explanation of why. Most stuck debugging
+  is a theory that outran the evidence.
+- **Hunt the skipped assumption.** For every "it should be…", ask how they know. The bug lives in
+  the step everyone agrees is obviously fine.
+- **Narrow before you go deep.** Ask what the smallest reproduction is, what changed most recently,
+  and what the last known-good state was. Bisect the problem space before theorizing about internals.
+- **Make the theory falsifiable.** When a theory appears, ask: what would we see if this were true,
+  and what would we see if it weren't? Then propose the cheapest check that distinguishes them.
+- **Say when you don't know.** Guessing confidently at someone's codebase wastes their afternoon.
+  "I don't know — what does the log say between those two lines?" is a real contribution.
+- **Close the loop.** When the bug is found, ask what the root cause was and whether anything else
+  in the codebase shares it.
+
+# Voice
+
+Calm and unhurried, even when they're frustrated. Never lecture; ask. Short turns — one question
+or one observation, then let them talk. No reassurance theater ("great question!"); just help.

--- a/marketplace/personas/socratic-tutor/persona.md
+++ b/marketplace/personas/socratic-tutor/persona.md
@@ -1,0 +1,43 @@
+---
+name: socratic-tutor
+description: Teaches by asking, not telling — draws the answer out of you, then checks that it actually landed.
+tone: patient
+style: probing
+author: jazz
+tags: [learning, teaching, thinking]
+---
+
+You are {agentName}, a Socratic tutor. Your job is not to hand over answers — it is to
+build the learner's ability to reach them without you.
+
+{agentDescription}
+
+# How you teach
+
+- **Find the edge of what they know first.** Before explaining anything, ask one question that
+  reveals where their understanding actually stops. Teach from that edge, not from the top of
+  the subject.
+- **Ask before you tell.** When you can pose a question that makes the next step obvious, pose
+  it. One question at a time — a stack of three is an interrogation, not a lesson.
+- **Never use a term you haven't already introduced.** If a concept needs vocabulary the learner
+  doesn't have, define the vocabulary first, plainly, then use it.
+- **Let them be wrong out loud.** A wrong answer is information. Don't correct it immediately —
+  ask what would happen if it were true, and let the contradiction do the work.
+- **Anchor abstractions in something concrete.** A worked example, a physical analogy, a number
+  they can hold. Abstraction after the example, never before.
+- **Check that it landed.** End a thread by asking them to explain it back, apply it to a
+  slightly different case, or predict what happens when one variable changes.
+
+# When to just answer
+
+Socratic method is a teaching tool, not a hazing ritual. Drop it and answer directly when:
+
+- The learner is blocked on a fact, not a concept ("what's the flag for X?").
+- They say they're in a hurry, or ask you plainly to stop asking questions.
+- They've missed the same step twice — the third time, show them, then have them redo it.
+
+# Voice
+
+Warm and unhurried, never condescending. Short paragraphs. No praise inflation — "yes, exactly"
+when it's exactly right, "close, but watch the second step" when it isn't. Never pretend a
+confused answer was good.

--- a/marketplace/personas/trip-planner/persona.md
+++ b/marketplace/personas/trip-planner/persona.md
@@ -1,0 +1,47 @@
+---
+name: trip-planner
+description: Plans real trips with real constraints — opening hours, transit time, and how tired you'll be by 4pm.
+tone: practical
+style: organized
+author: jazz
+tags: [travel, planning, everyday]
+---
+
+You are {agentName}, a travel planner. You build itineraries that survive contact with a real
+day: jet lag, closing times, and the walk between two things being longer than the map suggests.
+
+{agentDescription}
+
+# What you establish first
+
+Before proposing anything, get the constraints that actually shape a trip — ask only for what
+you're missing, in one short batch, never one question at a time:
+
+- Dates and how many days are truly free (arrival and departure days rarely are).
+- Who's going, and the pace they want: dense, or two things a day and a long lunch.
+- Budget band and where it should go — the room, the food, or the flights.
+- What they can't do: mobility limits, dietary needs, an early flight home.
+- What would make the trip worth it to them. One answer here beats ten preferences.
+
+# How you plan
+
+- **Geography before wishlist.** Group each day by neighborhood so the day isn't spent in transit.
+  Name the transit mode and realistic door-to-door time between stops.
+- **Respect opening hours and closing days.** Many museums shut one weekday; many kitchens close
+  between services. Say when you're unsure and flag it as "verify before you go."
+- **Leave slack.** Two anchors a day plus optional extras. An itinerary with no gaps is a schedule
+  someone will abandon by day two.
+- **Book-ahead items get called out separately**, with how far ahead they typically sell out.
+- **Give a wet-weather alternative** for anything outdoors.
+- **Be honest about tourist traps** and about when the famous thing is genuinely worth it anyway.
+
+# What you don't do
+
+Never invent an address, a price, or an opening time. If you're not confident in a specific fact,
+say so and mark it for the traveler to confirm. A plausible-sounding wrong address costs someone
+an hour of their holiday.
+
+# How you deliver
+
+A day-by-day plan: morning / afternoon / evening, with the anchor for each block, transit notes
+between them, and a short "book ahead" and "verify these" list at the end.

--- a/packages/adapters/src/persona-registry-service.test.ts
+++ b/packages/adapters/src/persona-registry-service.test.ts
@@ -1,0 +1,248 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Cause, Effect, Exit, Option } from "effect";
+import { PersonaRegistryServiceImpl } from "./persona-registry-service";
+
+const BASE_URL = "https://registry.test/marketplace";
+
+const INDEX = {
+  version: 1,
+  personas: [
+    {
+      name: "zebra",
+      description: "Last alphabetically",
+      url: "/marketplace/personas/zebra.md",
+    },
+    {
+      name: "rubber-duck",
+      description: "A debugging partner",
+      tone: "calm",
+      style: "methodical",
+      author: "jazz",
+      tags: ["debugging"],
+      url: "/marketplace/personas/rubber-duck.md",
+    },
+    { name: "no-url", description: "Missing its url" },
+    { name: "bad name", description: "Invalid slug", url: "/marketplace/personas/bad.md" },
+  ],
+};
+
+const PERSONA_MD = `---
+name: rubber-duck
+description: A debugging partner
+tone: calm
+style: methodical
+---
+
+You are {agentName}, a debugging partner.
+`;
+
+const originalFetch = global.fetch;
+const originalOffline = process.env["JAZZ_OFFLINE"];
+
+let cacheDir: string;
+
+function service(): PersonaRegistryServiceImpl {
+  return new PersonaRegistryServiceImpl({ baseUrl: BASE_URL, cacheDir });
+}
+
+/** Serve the index and each persona markdown from an in-memory routing table. */
+function mockFetch(routes: Record<string, string>): ReturnType<typeof mock> {
+  const fetchMock = mock((input: string | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = routes[url];
+    if (body === undefined) {
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }
+    return Promise.resolve(new Response(body, { status: 200 }));
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function defaultRoutes(): Record<string, string> {
+  return {
+    [`${BASE_URL}/personas.json`]: JSON.stringify(INDEX),
+    [`${BASE_URL}/personas/rubber-duck.md`]: PERSONA_MD,
+  };
+}
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect);
+
+/** Run an effect and return the error it failed with, or null if it succeeded. */
+async function runFailure<A, E>(effect: Effect.Effect<A, E>): Promise<E | null> {
+  const exit = await Effect.runPromise(Effect.exit(effect));
+  if (Exit.isSuccess(exit)) return null;
+  return Option.getOrNull(Cause.failureOption(exit.cause));
+}
+
+beforeEach(() => {
+  cacheDir = mkdtempSync(join(tmpdir(), "jazz-persona-registry-test-"));
+  delete process.env["JAZZ_OFFLINE"];
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  if (originalOffline === undefined) delete process.env["JAZZ_OFFLINE"];
+  else process.env["JAZZ_OFFLINE"] = originalOffline;
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+describe("PersonaRegistryService", () => {
+  describe("listEntries", () => {
+    it("returns valid entries sorted by name and drops malformed ones", async () => {
+      mockFetch(defaultRoutes());
+
+      const entries = await run(service().listEntries());
+
+      expect(entries.map((entry) => entry.name)).toEqual(["rubber-duck", "zebra"]);
+      expect(entries[0]?.tags).toEqual(["debugging"]);
+      expect(entries[0]?.author).toBe("jazz");
+    });
+
+    it("serves a second call from the disk snapshot without re-fetching", async () => {
+      const fetchMock = mockFetch(defaultRoutes());
+
+      await run(service().listEntries());
+      await run(service().listEntries());
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches when refresh is requested", async () => {
+      const fetchMock = mockFetch(defaultRoutes());
+
+      await run(service().listEntries());
+      await run(service().listEntries({ refresh: true }));
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to the cached snapshot when the registry is unreachable", async () => {
+      mockFetch(defaultRoutes());
+      await run(service().listEntries());
+
+      global.fetch = mock(() =>
+        Promise.reject(new Error("network down")),
+      ) as unknown as typeof fetch;
+      const entries = await run(service().listEntries({ refresh: true }));
+
+      expect(entries.map((entry) => entry.name)).toEqual(["rubber-duck", "zebra"]);
+    });
+
+    it("uses the cached snapshot offline instead of hitting the network", async () => {
+      mockFetch(defaultRoutes());
+      await run(service().listEntries());
+
+      process.env["JAZZ_OFFLINE"] = "1";
+      const fetchMock = mockFetch(defaultRoutes());
+      const entries = await run(service().listEntries({ refresh: true }));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(entries).toHaveLength(2);
+    });
+
+    it("fails with a NetworkError when offline with nothing cached", async () => {
+      process.env["JAZZ_OFFLINE"] = "1";
+      mockFetch(defaultRoutes());
+
+      const error = await runFailure(service().listEntries());
+
+      expect(error?._tag).toBe("NetworkError");
+    });
+
+    it("fails when the registry is unreachable and nothing is cached", async () => {
+      global.fetch = mock(() =>
+        Promise.reject(new Error("network down")),
+      ) as unknown as typeof fetch;
+
+      const error = await runFailure(service().listEntries());
+
+      expect(error?._tag).toBe("NetworkError");
+    });
+  });
+
+  describe("fetchPersona", () => {
+    it("downloads the definition and splits frontmatter from the prompt", async () => {
+      mockFetch(defaultRoutes());
+
+      const download = await run(service().fetchPersona("rubber-duck"));
+
+      expect(download.entry.name).toBe("rubber-duck");
+      expect(download.sourceUrl).toBe(`${BASE_URL}/personas/rubber-duck.md`);
+      expect(download.tone).toBe("calm");
+      expect(download.style).toBe("methodical");
+      expect(download.systemPrompt).toBe("You are {agentName}, a debugging partner.");
+    });
+
+    it("matches the catalog name case-insensitively", async () => {
+      mockFetch(defaultRoutes());
+
+      const download = await run(service().fetchPersona("RUBBER-DUCK"));
+
+      expect(download.entry.name).toBe("rubber-duck");
+    });
+
+    it("fails when the persona is not in the catalog", async () => {
+      mockFetch(defaultRoutes());
+
+      const error = await runFailure(service().fetchPersona("missing"));
+
+      expect(error?._tag).toBe("ValidationError");
+    });
+
+    it("refuses an entry whose url points off the registry origin", async () => {
+      const hostileIndex = {
+        version: 1,
+        personas: [
+          {
+            name: "hostile",
+            description: "Points elsewhere",
+            url: "https://evil.example/prompt.md",
+          },
+        ],
+      };
+      mockFetch({
+        [`${BASE_URL}/personas.json`]: JSON.stringify(hostileIndex),
+        "https://evil.example/prompt.md": "---\nname: hostile\n---\nowned",
+      });
+
+      const error = await runFailure(service().fetchPersona("hostile"));
+
+      expect(error?._tag).toBe("ValidationError");
+      expect(String((error as { message?: string })?.message)).toContain("outside the registry");
+    });
+
+    it("refuses a definition with an empty prompt body", async () => {
+      mockFetch({
+        ...defaultRoutes(),
+        [`${BASE_URL}/personas/rubber-duck.md`]: "---\nname: rubber-duck\n---\n\n",
+      });
+
+      const error = await runFailure(service().fetchPersona("rubber-duck"));
+
+      expect(String((error as { message?: string })?.message)).toContain("empty system prompt");
+    });
+
+    it("refuses a prompt over the 10,000-character limit", async () => {
+      mockFetch({
+        ...defaultRoutes(),
+        [`${BASE_URL}/personas/rubber-duck.md`]: `---\nname: rubber-duck\n---\n\n${"a".repeat(10_001)}`,
+      });
+
+      const error = await runFailure(service().fetchPersona("rubber-duck"));
+
+      expect(String((error as { message?: string })?.message)).toContain("character prompt limit");
+    });
+
+    it("surfaces a NetworkError when the definition cannot be downloaded", async () => {
+      mockFetch({ [`${BASE_URL}/personas.json`]: JSON.stringify(INDEX) });
+
+      const error = await runFailure(service().fetchPersona("rubber-duck"));
+
+      expect(error?._tag).toBe("NetworkError");
+    });
+  });
+});

--- a/packages/adapters/src/persona-registry-service.ts
+++ b/packages/adapters/src/persona-registry-service.ts
@@ -1,0 +1,357 @@
+/**
+ * Implements `PersonaRegistryService`: reads the persona marketplace, a static
+ * catalog published alongside the Jazz website from `marketplace/personas/` in
+ * the repository.
+ *
+ * The index is mirrored to `<jazz home>/cache/persona-registry.json` so browsing
+ * keeps working offline, and every URL the index points at is checked against the
+ * registry's own origin before it is fetched — a catalog is remote data, and it
+ * must not be able to redirect an install at an arbitrary host.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import {
+  PersonaRegistryServiceTag,
+  type PersonaRegistryService,
+} from "@jazz/core/interfaces/persona-registry";
+import { NetworkError, ValidationError } from "@jazz/core/types/errors";
+import type {
+  PersonaRegistryIndex,
+  RegistryPersonaDownload,
+  RegistryPersonaEntry,
+} from "@jazz/core/types/persona-registry";
+import { getUserDataDirectory } from "@jazz/core/utils/paths";
+import { isOfflineMode } from "@jazz/core/utils/runtime";
+import { Effect, Layer, Option } from "effect";
+import matter from "gray-matter";
+
+/** Where the marketplace is published. Overridable for staging and for tests. */
+const DEFAULT_REGISTRY_BASE_URL = "https://jazz-cli.vercel.app/marketplace";
+const INDEX_PATH = "personas.json";
+const DISK_CACHE_FILE = "persona-registry.json";
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** Bounds on a downloaded definition, matching what `createPersona` will accept. */
+const MAX_DESCRIPTION_LENGTH = 500;
+const MAX_SYSTEM_PROMPT_LENGTH = 10_000;
+const VALID_NAME = /^[a-zA-Z0-9_-]+$/;
+
+export interface PersonaRegistryServiceImplOptions {
+  /** Override the registry base URL. Default: JAZZ_PERSONA_REGISTRY_URL, else the public site. */
+  readonly baseUrl?: string;
+  /** Override the directory the index snapshot is mirrored to. Default: `<jazz home>/cache`. */
+  readonly cacheDir?: string;
+}
+
+/** Shape of the snapshot written to disk: the index plus when it was fetched. */
+interface CachedIndex {
+  readonly fetchedAt: number;
+  readonly index: PersonaRegistryIndex;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseEntry(raw: unknown): RegistryPersonaEntry | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+
+  const name = optionalString(record["name"]);
+  const description = optionalString(record["description"]);
+  const url = optionalString(record["url"]);
+  if (name === undefined || description === undefined || url === undefined) return null;
+  if (!VALID_NAME.test(name)) return null;
+
+  const tone = optionalString(record["tone"]);
+  const style = optionalString(record["style"]);
+  const author = optionalString(record["author"]);
+  const rawTags = record["tags"];
+  const tags = Array.isArray(rawTags)
+    ? rawTags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0)
+    : [];
+
+  return {
+    name,
+    description,
+    url,
+    ...(tone !== undefined && { tone }),
+    ...(style !== undefined && { style }),
+    ...(author !== undefined && { author }),
+    ...(tags.length > 0 && { tags }),
+  };
+}
+
+/** Parse an index document, treating both malformed JSON and a bad shape as "no catalog". */
+function parseIndexJson(raw: string): PersonaRegistryIndex | null {
+  try {
+    return parseIndex(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function parseIndex(raw: unknown): PersonaRegistryIndex | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const personas = record["personas"];
+  if (!Array.isArray(personas)) return null;
+
+  const parsed = personas
+    .map(parseEntry)
+    .filter((entry): entry is RegistryPersonaEntry => entry !== null);
+
+  const version = typeof record["version"] === "number" ? record["version"] : 1;
+  return { version, personas: parsed };
+}
+
+export class PersonaRegistryServiceImpl implements PersonaRegistryService {
+  private readonly baseUrlOverride: string | undefined;
+  private readonly cacheDirOverride: string | undefined;
+
+  constructor(options?: PersonaRegistryServiceImplOptions) {
+    this.baseUrlOverride = options?.baseUrl;
+    this.cacheDirOverride = options?.cacheDir;
+  }
+
+  private baseUrl(): string {
+    const fromEnv = process.env["JAZZ_PERSONA_REGISTRY_URL"];
+    const raw =
+      this.baseUrlOverride ??
+      (fromEnv !== undefined && fromEnv.length > 0 ? fromEnv : DEFAULT_REGISTRY_BASE_URL);
+    return raw.endsWith("/") ? raw : `${raw}/`;
+  }
+
+  private cachePath(): string {
+    return join(this.cacheDirOverride ?? join(getUserDataDirectory(), "cache"), DISK_CACHE_FILE);
+  }
+
+  /**
+   * Resolve an entry URL against the registry base, refusing anything that leaves
+   * the registry's origin. Without this, one bad index entry could point an install
+   * at an attacker-controlled prompt on an unrelated host.
+   */
+  private resolveEntryUrl(url: string): string | null {
+    const base = this.baseUrl();
+    try {
+      const resolved = new URL(url, base);
+      const baseUrl = new URL(base);
+      if (resolved.origin !== baseUrl.origin) return null;
+      if (resolved.protocol !== "https:" && resolved.protocol !== "http:") return null;
+      return resolved.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private async readDiskCache(): Promise<CachedIndex | null> {
+    try {
+      const raw = await readFile(this.cachePath(), "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const index = parseIndex(parsed["index"]);
+      if (index === null) return null;
+      const fetchedAt = typeof parsed["fetchedAt"] === "number" ? parsed["fetchedAt"] : 0;
+      return { fetchedAt, index };
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeDiskCache(index: PersonaRegistryIndex): Promise<void> {
+    const path = this.cachePath();
+    await mkdir(dirname(path), { recursive: true });
+    const snapshot: CachedIndex = { fetchedAt: Date.now(), index };
+    await writeFile(path, JSON.stringify(snapshot), "utf8");
+  }
+
+  private async fetchText(url: string): Promise<string> {
+    const response = await fetch(url, {
+      headers: { Accept: "text/plain, application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return response.text();
+  }
+
+  listEntries(options?: {
+    readonly refresh?: boolean;
+  }): Effect.Effect<readonly RegistryPersonaEntry[], NetworkError> {
+    return Effect.gen(
+      function* (this: PersonaRegistryServiceImpl) {
+        const indexUrl = new URL(INDEX_PATH, this.baseUrl()).toString();
+        const refresh = options?.refresh === true;
+
+        const cached = yield* Effect.promise(() => this.readDiskCache());
+        const cacheIsFresh =
+          cached !== null && !refresh && Date.now() - cached.fetchedAt < CACHE_TTL_MS;
+        if (cacheIsFresh) {
+          return sortEntries(cached.index.personas);
+        }
+
+        if (isOfflineMode()) {
+          if (cached !== null) return sortEntries(cached.index.personas);
+          return yield* Effect.fail(
+            new NetworkError({
+              url: indexUrl,
+              reason: "Jazz is running offline and no marketplace snapshot has been cached yet",
+              suggestion:
+                "Unset JAZZ_OFFLINE and run 'jazz persona browse' once to cache the catalog.",
+            }),
+          );
+        }
+
+        const fetched = yield* Effect.tryPromise({
+          try: () => this.fetchText(indexUrl),
+          catch: (error) => error,
+        }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+        if (fetched === null) {
+          if (cached !== null) {
+            const logger = yield* Effect.serviceOption(LoggerServiceTag);
+            if (Option.isSome(logger)) {
+              yield* logger.value.warn(
+                `Persona marketplace unreachable at ${indexUrl}; using the cached catalog.`,
+              );
+            }
+            return sortEntries(cached.index.personas);
+          }
+          return yield* Effect.fail(
+            new NetworkError({
+              url: indexUrl,
+              reason: "Could not reach the persona marketplace",
+              suggestion:
+                "Check your connection, or set JAZZ_PERSONA_REGISTRY_URL if you host your own catalog.",
+            }),
+          );
+        }
+
+        const index = parseIndexJson(fetched);
+
+        if (index === null) {
+          if (cached !== null) return sortEntries(cached.index.personas);
+          return yield* Effect.fail(
+            new NetworkError({
+              url: indexUrl,
+              reason: "The persona marketplace returned a catalog Jazz could not read",
+              suggestion: "This is likely a temporary publishing problem — try again shortly.",
+            }),
+          );
+        }
+
+        const resolved = index;
+        yield* Effect.tryPromise({
+          try: () => this.writeDiskCache(resolved),
+          catch: (error) => error,
+        }).pipe(Effect.ignore);
+
+        return sortEntries(resolved.personas);
+      }.bind(this),
+    );
+  }
+
+  fetchPersona(
+    name: string,
+  ): Effect.Effect<RegistryPersonaDownload, NetworkError | ValidationError> {
+    return Effect.gen(
+      function* (this: PersonaRegistryServiceImpl) {
+        const entries = yield* this.listEntries();
+        const entry = entries.find(
+          (candidate) => candidate.name.toLowerCase() === name.toLowerCase(),
+        );
+
+        if (entry === undefined) {
+          return yield* Effect.fail(
+            new ValidationError({
+              field: "name",
+              message: `No marketplace persona named "${name}"`,
+              value: name,
+              suggestion: "Run 'jazz persona browse' to see what the marketplace offers.",
+            }),
+          );
+        }
+
+        const sourceUrl = this.resolveEntryUrl(entry.url);
+        if (sourceUrl === null) {
+          return yield* Effect.fail(
+            new ValidationError({
+              field: "url",
+              message: `Marketplace entry "${entry.name}" points outside the registry`,
+              value: entry.url,
+              suggestion:
+                "Jazz refuses to install a persona hosted off the registry's own origin. Report this catalog entry.",
+            }),
+          );
+        }
+
+        const markdown = yield* Effect.tryPromise({
+          try: () => this.fetchText(sourceUrl),
+          catch: (error) =>
+            new NetworkError({
+              url: sourceUrl,
+              reason: `Could not download persona "${entry.name}": ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              suggestion: "Check your connection and try again.",
+            }),
+        });
+
+        const parsed = matter(markdown);
+        const data = parsed.data as Record<string, unknown>;
+        const systemPrompt = parsed.content.trim();
+
+        if (systemPrompt.length === 0) {
+          return yield* Effect.fail(
+            new ValidationError({
+              field: "systemPrompt",
+              message: `Marketplace persona "${entry.name}" has an empty system prompt`,
+              value: sourceUrl,
+              suggestion: "Report this catalog entry — it was published without a prompt body.",
+            }),
+          );
+        }
+
+        if (systemPrompt.length > MAX_SYSTEM_PROMPT_LENGTH) {
+          return yield* Effect.fail(
+            new ValidationError({
+              field: "systemPrompt",
+              message: `Marketplace persona "${entry.name}" exceeds the ${MAX_SYSTEM_PROMPT_LENGTH}-character prompt limit`,
+              value: `(${systemPrompt.length} chars)`,
+              suggestion: "Report this catalog entry — Jazz will not install a prompt this large.",
+            }),
+          );
+        }
+
+        const description = (optionalString(data["description"]) ?? entry.description).slice(
+          0,
+          MAX_DESCRIPTION_LENGTH,
+        );
+        const tone = optionalString(data["tone"]) ?? entry.tone;
+        const style = optionalString(data["style"]) ?? entry.style;
+
+        return {
+          entry,
+          sourceUrl,
+          description,
+          systemPrompt,
+          ...(tone !== undefined && { tone }),
+          ...(style !== undefined && { style }),
+        };
+      }.bind(this),
+    );
+  }
+}
+
+function sortEntries(entries: readonly RegistryPersonaEntry[]): readonly RegistryPersonaEntry[] {
+  return [...entries].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+// ─── Layer ───────────────────────────────────────────────────────────────────
+
+export function createPersonaRegistryServiceLayer(): Layer.Layer<PersonaRegistryService> {
+  return Layer.succeed(PersonaRegistryServiceTag, new PersonaRegistryServiceImpl());
+}

--- a/packages/cli/src/commands/persona-marketplace.ts
+++ b/packages/cli/src/commands/persona-marketplace.ts
@@ -1,0 +1,231 @@
+import { isBuiltinPersona } from "@jazz/adapters/persona-service";
+import {
+  PersonaRegistryServiceTag,
+  type PersonaRegistryService,
+} from "@jazz/core/interfaces/persona-registry";
+import { PersonaServiceTag, type PersonaService } from "@jazz/core/interfaces/persona-service";
+import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
+import {
+  NetworkError,
+  PersonaAlreadyExistsError,
+  StorageError,
+  ValidationError,
+} from "@jazz/core/types/errors";
+import type {
+  RegistryPersonaDownload,
+  RegistryPersonaEntry,
+} from "@jazz/core/types/persona-registry";
+import chalk from "chalk";
+import { Effect } from "effect";
+
+/**
+ * CLI commands for the persona marketplace — a shared catalog of personas that
+ * users can browse and copy into their own `~/.jazz/personas/`.
+ *
+ * An installed persona becomes the system prompt of whichever agent uses it, so
+ * every install shows the prompt in full and asks before writing it to disk.
+ * Non-interactive runs must pass `--yes` to accept that explicitly.
+ */
+
+/** How much of a prompt is shown before the preview is truncated. */
+const PROMPT_PREVIEW_LINES = 40;
+
+export interface InstallPersonaOptions {
+  /** Install under a different local name (avoids clashing with an existing persona). */
+  readonly as?: string;
+  /** Skip the confirmation prompt. Required for non-interactive installs. */
+  readonly yes?: boolean;
+  /** Re-fetch the catalog instead of using the cached snapshot. */
+  readonly refresh?: boolean;
+}
+
+function formatMeta(entry: RegistryPersonaEntry): string {
+  const parts = [
+    entry.tone ? `tone: ${entry.tone}` : "",
+    entry.style ? `style: ${entry.style}` : "",
+    entry.author ? `by ${entry.author}` : "",
+    entry.tags && entry.tags.length > 0 ? entry.tags.join(", ") : "",
+  ].filter((part) => part.length > 0);
+  return parts.join("  ·  ");
+}
+
+/**
+ * Print the full definition the user is about to trust, then ask.
+ * Returns false when the user declines or when a non-interactive run omitted `--yes`.
+ */
+function confirmInstall(
+  download: RegistryPersonaDownload,
+  localName: string,
+  options: InstallPersonaOptions,
+): Effect.Effect<boolean, never, TerminalService> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+
+    yield* terminal.heading(`Marketplace persona: ${download.entry.name}`);
+    yield* terminal.log(download.entry.description);
+    const meta = formatMeta(download.entry);
+    if (meta.length > 0) yield* terminal.log(chalk.dim(meta));
+    yield* terminal.log(chalk.dim(`source: ${download.sourceUrl}`));
+    yield* terminal.log("");
+    yield* terminal.log(chalk.bold("System prompt"));
+    yield* terminal.log(
+      chalk.dim("This text becomes the instructions of any agent you apply the persona to."),
+    );
+    yield* terminal.log("");
+
+    const lines = download.systemPrompt.split("\n");
+    for (const line of lines.slice(0, PROMPT_PREVIEW_LINES)) {
+      yield* terminal.log(`  ${chalk.dim(line)}`);
+    }
+    if (lines.length > PROMPT_PREVIEW_LINES) {
+      yield* terminal.log(
+        chalk.dim(`  … ${lines.length - PROMPT_PREVIEW_LINES} more lines at ${download.sourceUrl}`),
+      );
+    }
+    yield* terminal.log("");
+
+    if (options.yes === true) return true;
+
+    if (!terminal.isInteractive) {
+      yield* terminal.error(
+        `Refusing to install "${localName}" without confirmation. Re-run with --yes to accept this prompt.`,
+      );
+      return false;
+    }
+
+    return yield* terminal.confirm(`Install this persona as "${localName}"?`, false);
+  });
+}
+
+/**
+ * Download one marketplace persona into ~/.jazz/personas/.
+ */
+export function installPersonaCommand(
+  name: string,
+  options: InstallPersonaOptions = {},
+): Effect.Effect<
+  void,
+  NetworkError | StorageError | PersonaAlreadyExistsError | ValidationError,
+  PersonaService | PersonaRegistryService | TerminalService
+> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const registry = yield* PersonaRegistryServiceTag;
+    const personaService = yield* PersonaServiceTag;
+
+    const localName = (options.as ?? name).trim();
+
+    if (isBuiltinPersona(localName)) {
+      return yield* Effect.fail(
+        new PersonaAlreadyExistsError({
+          personaName: localName,
+          suggestion: `"${localName}" is a built-in persona name. Install it under another name with --as <name>.`,
+        }),
+      );
+    }
+
+    const existing = yield* personaService.listPersonas();
+    if (existing.some((persona) => persona.name.toLowerCase() === localName.toLowerCase())) {
+      return yield* Effect.fail(
+        new PersonaAlreadyExistsError({
+          personaName: localName,
+          suggestion: `You already have a persona named "${localName}". Install under a different name with --as <name>, or delete the existing one first.`,
+        }),
+      );
+    }
+
+    const download = yield* registry.fetchPersona(name);
+    const accepted = yield* confirmInstall(download, localName, options);
+    if (!accepted) {
+      yield* terminal.info("Install cancelled.");
+      return;
+    }
+
+    const persona = yield* personaService.createPersona({
+      name: localName,
+      description: download.description,
+      systemPrompt: download.systemPrompt,
+      ...(download.tone !== undefined && { tone: download.tone }),
+      ...(download.style !== undefined && { style: download.style }),
+    });
+
+    yield* terminal.success(`Installed persona "${persona.name}".`);
+    yield* terminal.log(`   Edit it:  jazz persona edit ${persona.name}`);
+    yield* terminal.log(`   Apply it: jazz agent create  (then select "${persona.name}")`);
+  });
+}
+
+/**
+ * List everything the marketplace offers, without installing.
+ */
+export function listMarketplacePersonasCommand(options?: {
+  readonly refresh?: boolean;
+}): Effect.Effect<void, NetworkError, PersonaRegistryService | TerminalService> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const registry = yield* PersonaRegistryServiceTag;
+
+    const entries = yield* registry.listEntries({ refresh: options?.refresh === true });
+
+    if (entries.length === 0) {
+      yield* terminal.info("The persona marketplace is empty right now.");
+      return;
+    }
+
+    yield* terminal.heading(`Marketplace personas (${entries.length})`);
+    yield* terminal.log("");
+
+    for (const entry of entries) {
+      yield* terminal.log(`  ${chalk.bold(entry.name)}`);
+      yield* terminal.log(`    ${chalk.dim(entry.description)}`);
+      const meta = formatMeta(entry);
+      if (meta.length > 0) yield* terminal.log(`    ${chalk.dim(meta)}`);
+      yield* terminal.log("");
+    }
+
+    yield* terminal.info("Install one: jazz persona install <name>");
+  });
+}
+
+/**
+ * Interactive marketplace browser: pick a persona, read its prompt, install it.
+ */
+export function browseMarketplaceCommand(options?: {
+  readonly refresh?: boolean;
+}): Effect.Effect<
+  void,
+  NetworkError | StorageError | PersonaAlreadyExistsError | ValidationError,
+  PersonaService | PersonaRegistryService | TerminalService
+> {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const registry = yield* PersonaRegistryServiceTag;
+
+    if (!terminal.isInteractive) {
+      return yield* listMarketplacePersonasCommand(options);
+    }
+
+    const entries = yield* registry.listEntries({ refresh: options?.refresh === true });
+
+    if (entries.length === 0) {
+      yield* terminal.info("The persona marketplace is empty right now.");
+      return;
+    }
+
+    const selected = yield* terminal.search<string>("Search marketplace personas", {
+      choices: entries.map((entry) => ({
+        name: entry.name,
+        value: entry.name,
+        description: entry.description,
+      })),
+      placeholder: "Type to filter by name or description",
+    });
+
+    if (selected === undefined) {
+      yield* terminal.info("Nothing selected.");
+      return;
+    }
+
+    yield* installPersonaCommand(selected, { refresh: options?.refresh === true });
+  });
+}

--- a/packages/cli/src/commands/persona.ts
+++ b/packages/cli/src/commands/persona.ts
@@ -179,6 +179,7 @@ export function listPersonasCommand(): Effect.Effect<
     }
 
     yield* terminal.info("Create a new persona: jazz persona create");
+    yield* terminal.info("Browse shared personas: jazz persona browse");
   });
 }
 

--- a/packages/core/src/interfaces/persona-registry.ts
+++ b/packages/core/src/interfaces/persona-registry.ts
@@ -1,0 +1,36 @@
+/**
+ * `PersonaRegistryService` interface for reading the persona marketplace — a
+ * remote, git-backed catalog of shareable personas that users can install into
+ * `~/.jazz/personas/`.
+ */
+import { Context, Effect } from "effect";
+import type { NetworkError, ValidationError } from "@/core/types/errors";
+import type { RegistryPersonaDownload, RegistryPersonaEntry } from "@/core/types/persona-registry";
+
+export interface PersonaRegistryService {
+  /**
+   * List every persona advertised by the marketplace.
+   *
+   * Served from a disk snapshot while it is fresh, and falls back to the last
+   * snapshot when the network is unreachable or Jazz is running offline.
+   *
+   * @param options.refresh - Bypass the cached snapshot and re-fetch the index
+   * @returns An Effect resolving to the catalog entries, sorted by name
+   */
+  readonly listEntries: (options?: {
+    readonly refresh?: boolean;
+  }) => Effect.Effect<readonly RegistryPersonaEntry[], NetworkError>;
+
+  /**
+   * Download one persona's full definition, including its system prompt.
+   *
+   * @param name - Catalog name of the persona to download
+   * @returns An Effect resolving to the downloaded persona
+   */
+  readonly fetchPersona: (
+    name: string,
+  ) => Effect.Effect<RegistryPersonaDownload, NetworkError | ValidationError>;
+}
+
+export const PersonaRegistryServiceTag =
+  Context.GenericTag<PersonaRegistryService>("PersonaRegistryService");

--- a/packages/core/src/types/persona-registry.ts
+++ b/packages/core/src/types/persona-registry.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Persona marketplace domain model types
+ *
+ * The marketplace is a git-backed catalog of shareable personas: each entry is a
+ * `persona.md` under `marketplace/personas/<name>/` in the Jazz repository, published
+ * as a static index plus one raw markdown file per persona. Nothing here is
+ * user-generated at runtime — entries land in the catalog through a pull request.
+ */
+
+/** One persona as advertised by the marketplace index (metadata only, no prompt). */
+export interface RegistryPersonaEntry {
+  /** Catalog name, unique within the registry. Also the default install name. */
+  readonly name: string;
+  /** Brief human-readable summary of what this persona does. */
+  readonly description: string;
+  /** Optional tone descriptor (e.g. "patient", "skeptical"). */
+  readonly tone?: string;
+  /** Optional style descriptor (e.g. "concise", "probing"). */
+  readonly style?: string;
+  /** Who contributed the persona. */
+  readonly author?: string;
+  /** Free-form tags used for search and filtering. */
+  readonly tags?: readonly string[];
+  /**
+   * Location of the raw `persona.md`, absolute or relative to the registry base URL.
+   * Resolved against the base and rejected if it escapes that origin.
+   */
+  readonly url: string;
+}
+
+/** The marketplace index document served at `<registry base>/personas.json`. */
+export interface PersonaRegistryIndex {
+  /** Index schema version. Bumped when the entry shape changes incompatibly. */
+  readonly version: number;
+  readonly personas: readonly RegistryPersonaEntry[];
+}
+
+/**
+ * A persona downloaded from the marketplace: the catalog entry it came from, the
+ * fields ready to hand to `PersonaService.createPersona`, and the URL it was read
+ * from so the CLI can show the user exactly what they are about to trust.
+ */
+export interface RegistryPersonaDownload {
+  readonly entry: RegistryPersonaEntry;
+  readonly sourceUrl: string;
+  readonly description: string;
+  readonly systemPrompt: string;
+  readonly tone?: string;
+  readonly style?: string;
+}

--- a/packages/runtime/src/app-layer.ts
+++ b/packages/runtime/src/app-layer.ts
@@ -18,6 +18,7 @@ import { createMemoryServiceLayer } from "@jazz/adapters/memory-service";
 import { NotificationServiceLayer } from "@jazz/adapters/notification";
 import { createPeerLedgerServiceLayer } from "@jazz/adapters/peers/ledger";
 import { createPeerTokenServiceLayer } from "@jazz/adapters/peers/token";
+import { createPersonaRegistryServiceLayer } from "@jazz/adapters/persona-registry-service";
 import { createPersonaServiceLayer } from "@jazz/adapters/persona-service";
 import { createReminderServiceLayer } from "@jazz/adapters/reminder-service";
 import { FileStorageService } from "@jazz/adapters/storage/file";
@@ -207,6 +208,7 @@ export function createAppLayer(
 
   const agentLayer = createAgentServiceLayer().pipe(Layer.provide(storageLayer));
   const personaLayer = createPersonaServiceLayer();
+  const personaRegistryLayer = createPersonaRegistryServiceLayer();
   const memoryServiceLayer = createMemoryServiceLayer();
   const workspaceServiceLayer = createWorkspaceServiceLayer().pipe(Layer.provide(configLayer));
   const reminderServiceLayer = createReminderServiceLayer();
@@ -250,6 +252,7 @@ export function createAppLayer(
     toolRegistrationLayer,
     agentLayer,
     personaLayer,
+    personaRegistryLayer,
     memoryServiceLayer,
     workspaceServiceLayer,
     reminderServiceLayer,

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -747,6 +747,52 @@ function registerPersonaCommands(program: Command): void {
     );
 
   personaCommand
+    .command("browse")
+    .description("Browse the persona marketplace and install a persona (interactive)")
+    .option("--refresh", "Re-fetch the catalog instead of using the cached snapshot")
+    .action((options: { refresh?: boolean }) =>
+      run(
+        () =>
+          import("@jazz/cli/commands/persona-marketplace").then((mod) =>
+            mod.browseMarketplaceCommand({ refresh: options.refresh === true }),
+          ),
+        { session: true },
+      ),
+    );
+
+  personaCommand
+    .command("search")
+    .description("List every persona the marketplace offers")
+    .option("--refresh", "Re-fetch the catalog instead of using the cached snapshot")
+    .action((options: { refresh?: boolean }) =>
+      run(() =>
+        import("@jazz/cli/commands/persona-marketplace").then((mod) =>
+          mod.listMarketplacePersonasCommand({ refresh: options.refresh === true }),
+        ),
+      ),
+    );
+
+  personaCommand
+    .command("install <name>")
+    .description("Install a persona from the marketplace into ~/.jazz/personas/")
+    .option("--as <name>", "Install under a different local name")
+    .option("-y, --yes", "Skip the confirmation prompt (required when non-interactive)")
+    .option("--refresh", "Re-fetch the catalog instead of using the cached snapshot")
+    .action((name: string, options: { as?: string; yes?: boolean; refresh?: boolean }) =>
+      run(
+        () =>
+          import("@jazz/cli/commands/persona-marketplace").then((mod) =>
+            mod.installPersonaCommand(name, {
+              ...(options.as !== undefined ? { as: options.as } : {}),
+              yes: options.yes === true,
+              refresh: options.refresh === true,
+            }),
+          ),
+        { session: true },
+      ),
+    );
+
+  personaCommand
     .command("delete <identifier>")
     .alias("rm")
     .description("Delete a custom persona")

--- a/packages/website/src/content.config.ts
+++ b/packages/website/src/content.config.ts
@@ -12,6 +12,17 @@ export const collections = {
       description: z.string().optional(),
     }),
   }),
+  marketplace: defineCollection({
+    loader: glob({ pattern: "**/persona.md", base: "../../marketplace/personas" }),
+    schema: z.object({
+      name: z.string(),
+      description: z.string(),
+      tone: z.string().optional(),
+      style: z.string().optional(),
+      author: z.string().optional(),
+      tags: z.array(z.string()).default([]),
+    }),
+  }),
   blog: defineCollection({
     loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
     schema: z.object({

--- a/packages/website/src/layouts/Blog.astro
+++ b/packages/website/src/layouts/Blog.astro
@@ -27,6 +27,7 @@ const { title, description, image, jsonLd } = Astro.props;
     <a class="mono" href="/blog">blog</a>
     <div class="grow"></div>
     <a class="mono" href="/docs">docs</a>
+    <a class="mono" href="/marketplace">personas</a>
     <a class="mono" href="https://github.com/lvndry/jazz">github</a>
     <a class="mono" href="/rss.xml">rss</a>
   </header>

--- a/packages/website/src/layouts/Docs.astro
+++ b/packages/website/src/layouts/Docs.astro
@@ -63,6 +63,7 @@ const jsonLd = [
     <a class="brand mono" href="/">▞ jazz</a>
     <a class="mono docs-home" href="/docs">docs</a>
     <a class="mono" href="/blog">blog</a>
+    <a class="mono" href="/marketplace">personas</a>
     <div class="grow"></div>
     {import.meta.env.PROD && <div id="search" class="search"></div>}
     <a class="mono" href="https://github.com/lvndry/jazz">github</a>

--- a/packages/website/src/layouts/Marketplace.astro
+++ b/packages/website/src/layouts/Marketplace.astro
@@ -1,0 +1,55 @@
+---
+import Base from "./Base.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  image?: string | undefined;
+}
+
+const { title, description, image } = Astro.props;
+---
+
+<Base title={title} description={description} image={image}>
+  <header class="top">
+    <a class="brand mono" href="/">▞ jazz</a>
+    <a class="mono" href="/marketplace">personas</a>
+    <div class="grow"></div>
+    <a class="mono" href="/docs">docs</a>
+    <a class="mono" href="/blog">blog</a>
+    <a class="mono" href="https://github.com/lvndry/jazz">github</a>
+  </header>
+  <main>
+    <slot />
+  </main>
+</Base>
+
+<style>
+  .top {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+    padding: 16px 4vw;
+    border-bottom: 1px solid var(--jz-border);
+    font-size: 13px;
+  }
+  .top a {
+    color: var(--jz-secondary);
+    text-decoration: none;
+  }
+  .top a:hover {
+    color: var(--jz-primary);
+  }
+  .top .brand {
+    color: var(--jz-primary);
+    font-size: 14px;
+  }
+  .grow {
+    flex: 1;
+  }
+  main {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 3.5rem 20px 6rem;
+  }
+</style>

--- a/packages/website/src/lib/marketplace.ts
+++ b/packages/website/src/lib/marketplace.ts
@@ -1,0 +1,47 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+export type MarketplaceEntry = CollectionEntry<"marketplace">;
+
+/**
+ * One persona as the CLI's `personas.json` index describes it: metadata plus the
+ * URL of the raw `persona.md`. The prompt body is deliberately not inlined —
+ * browsing a catalog should not download every prompt in it.
+ */
+export interface MarketplaceIndexEntry {
+  name: string;
+  description: string;
+  tone?: string;
+  style?: string;
+  author?: string;
+  tags?: string[];
+  url: string;
+}
+
+/** Path of the raw markdown for a persona, relative to the site root. */
+export function rawPersonaPath(name: string): string {
+  return `/marketplace/personas/${name}.md`;
+}
+
+/** Path of a persona's page on the site. */
+export function personaPath(name: string): string {
+  return `/marketplace/${name}`;
+}
+
+/** Every published persona, sorted by name. */
+export async function getMarketplaceEntries(): Promise<MarketplaceEntry[]> {
+  const entries = await getCollection("marketplace");
+  return entries.sort((left, right) => left.data.name.localeCompare(right.data.name));
+}
+
+export function toIndexEntry(entry: MarketplaceEntry): MarketplaceIndexEntry {
+  const { name, description, tone, style, author, tags } = entry.data;
+  return {
+    name,
+    description,
+    ...(tone ? { tone } : {}),
+    ...(style ? { style } : {}),
+    ...(author ? { author } : {}),
+    ...(tags.length > 0 ? { tags } : {}),
+    url: rawPersonaPath(name),
+  };
+}

--- a/packages/website/src/pages/marketplace/[name].astro
+++ b/packages/website/src/pages/marketplace/[name].astro
@@ -1,0 +1,207 @@
+---
+import Marketplace from "../../layouts/Marketplace.astro";
+import { getMarketplaceEntries, rawPersonaPath, type MarketplaceEntry } from "../../lib/marketplace";
+
+export async function getStaticPaths() {
+  const entries = await getMarketplaceEntries();
+  return entries.map((entry) => ({
+    params: { name: entry.data.name },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: MarketplaceEntry;
+}
+
+const { entry } = Astro.props;
+const { name, description, tone, style, author, tags } = entry.data;
+const prompt = entry.body ?? "";
+const meta = [
+  tone ? `tone: ${tone}` : "",
+  style ? `style: ${style}` : "",
+  author ? `by ${author}` : "",
+].filter(Boolean);
+---
+
+<Marketplace title={`${name} — Jazz persona`} description={description}>
+  <a class="back mono" href="/marketplace">← all personas</a>
+  <h1 class="mono">{name}</h1>
+  <p class="lede">{description}</p>
+  {meta.length > 0 && <p class="meta mono">{meta.join("  ·  ")}</p>}
+  {
+    tags.length > 0 && (
+      <ul class="tags">
+        {tags.map((tag) => (
+          <li class="mono">{tag}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  <div class="install">
+    <code class="mono">jazz persona install {name}</code>
+    <a class="mono raw" href={rawPersonaPath(name)}>raw persona.md</a>
+  </div>
+
+  <section class="prompt">
+    <div class="prompt-head">
+      <h2>System prompt</h2>
+      <button class="copy mono" type="button" data-copy>copy</button>
+    </div>
+    <p class="warn">
+      This text becomes the instructions of any agent you apply the persona to. Read it before you
+      install it.
+    </p>
+    <pre id="prompt-body">{prompt}</pre>
+  </section>
+</Marketplace>
+
+<script>
+  const button = document.querySelector<HTMLButtonElement>("[data-copy]");
+  const body = document.getElementById("prompt-body");
+
+  // The async clipboard API is denied outright in some embedded and locked-down
+  // browsers, so fall back to selecting the text and letting the browser copy it.
+  function copyBySelection(text: string): boolean {
+    const scratch = document.createElement("textarea");
+    scratch.value = text;
+    scratch.setAttribute("readonly", "");
+    scratch.style.position = "fixed";
+    scratch.style.opacity = "0";
+    document.body.appendChild(scratch);
+    scratch.select();
+    let copied = false;
+    try {
+      copied = document.execCommand("copy");
+    } catch {
+      copied = false;
+    }
+    scratch.remove();
+    return copied;
+  }
+
+  button?.addEventListener("click", async () => {
+    if (!body) return;
+    const text = body.textContent ?? "";
+    let copied = false;
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+    } catch {
+      copied = copyBySelection(text);
+    }
+    button.textContent = copied ? "copied" : "copy failed";
+    setTimeout(() => {
+      button.textContent = "copy";
+    }, 2000);
+  });
+</script>
+
+<style>
+  .back {
+    color: var(--jz-muted);
+    font-size: 13px;
+    text-decoration: none;
+  }
+  .back:hover {
+    color: var(--jz-primary);
+  }
+  h1 {
+    margin-top: 18px;
+    font-size: clamp(28px, 4vw, 40px);
+    color: var(--jz-selected);
+  }
+  .lede {
+    margin-top: 12px;
+    color: var(--jz-secondary);
+    max-width: 62ch;
+  }
+  .meta {
+    margin-top: 10px;
+    color: var(--jz-muted);
+    font-size: 13px;
+  }
+  .tags {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 0;
+    list-style: none;
+  }
+  .tags li {
+    font-size: 12px;
+    color: var(--jz-muted);
+    border: 1px solid var(--jz-border);
+    border-radius: 999px;
+    padding: 3px 10px;
+  }
+  .install {
+    margin-top: 26px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .install code {
+    background: var(--jz-surface);
+    border: 1px solid var(--jz-border);
+    border-radius: 6px;
+    padding: 8px 12px;
+    color: var(--jz-selected);
+    font-size: 14px;
+  }
+  .raw {
+    color: var(--jz-link);
+    font-size: 13px;
+  }
+  .prompt {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--jz-border);
+  }
+  .prompt-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  .prompt-head h2 {
+    font-size: 20px;
+    color: var(--jz-selected);
+  }
+  .copy {
+    background: transparent;
+    border: 1px solid var(--jz-border);
+    border-radius: 6px;
+    color: var(--jz-secondary);
+    font-size: 12px;
+    padding: 6px 12px;
+    cursor: pointer;
+  }
+  .copy:hover {
+    border-color: var(--jz-primary);
+    color: var(--jz-primary);
+  }
+  .warn {
+    margin-top: 10px;
+    color: var(--jz-muted);
+    font-size: 13px;
+    max-width: 62ch;
+  }
+  pre {
+    margin-top: 16px;
+    background: var(--jz-surface);
+    border: 1px solid var(--jz-border);
+    border-radius: 6px;
+    padding: 18px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--jz-info);
+  }
+</style>

--- a/packages/website/src/pages/marketplace/index.astro
+++ b/packages/website/src/pages/marketplace/index.astro
@@ -1,0 +1,141 @@
+---
+import Marketplace from "../../layouts/Marketplace.astro";
+import { getMarketplaceEntries, personaPath } from "../../lib/marketplace";
+
+const entries = await getMarketplaceEntries();
+---
+
+<Marketplace
+  title="Persona marketplace — Jazz"
+  description="Browse and copy Jazz personas: reusable system prompts that change how an agent thinks, writes, and pushes back."
+>
+  <p class="eyebrow mono">▞ persona marketplace</p>
+  <h1>Prompts worth stealing.</h1>
+  <p class="lede">
+    A persona is a reusable system prompt — it sets how an agent thinks, writes, and pushes back,
+    independent of the model behind it. Copy one from here, or install it straight from your
+    terminal. Every entry lives in the Jazz repo and arrives through a pull request.
+  </p>
+
+  <div class="install">
+    <code class="mono">jazz persona browse</code>
+    <span class="hint">pick, preview the prompt, install</span>
+  </div>
+
+  <div class="grid">
+    {
+      entries.map((entry) => (
+        <a class="card" href={personaPath(entry.data.name)}>
+          <span class="name mono">{entry.data.name}</span>
+          <span class="desc">{entry.data.description}</span>
+          <span class="meta mono">
+            {[entry.data.tone, entry.data.style].filter(Boolean).join(" · ")}
+          </span>
+        </a>
+      ))
+    }
+  </div>
+
+  <section class="contribute">
+    <h2>Add yours</h2>
+    <p>
+      Drop a <code class="mono">persona.md</code> into <code class="mono">marketplace/personas/&lt;name&gt;/</code>
+      in the <a href="https://github.com/lvndry/jazz">Jazz repository</a> and open a pull request.
+      Same format as the personas Jazz ships with — frontmatter for the metadata, the body is the prompt.
+    </p>
+  </section>
+</Marketplace>
+
+<style>
+  .eyebrow {
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--jz-primary);
+    margin-bottom: 14px;
+  }
+  h1 {
+    font-size: clamp(34px, 5vw, 52px);
+    color: var(--jz-selected);
+  }
+  .lede {
+    margin-top: 16px;
+    color: var(--jz-secondary);
+    max-width: 60ch;
+  }
+  .install {
+    margin-top: 28px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .install code {
+    background: var(--jz-surface);
+    border: 1px solid var(--jz-border);
+    border-radius: 6px;
+    padding: 8px 12px;
+    color: var(--jz-selected);
+    font-size: 14px;
+  }
+  .install .hint {
+    color: var(--jz-muted);
+    font-size: 13px;
+  }
+  .grid {
+    margin-top: 3rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 18px;
+    border: 1px solid var(--jz-border);
+    border-radius: 8px;
+    text-decoration: none;
+    background: var(--jz-surface);
+  }
+  .card:hover {
+    border-color: var(--jz-primary);
+  }
+  .name {
+    color: var(--jz-selected);
+    font-size: 15px;
+  }
+  .card:hover .name {
+    color: var(--jz-primary);
+  }
+  .desc {
+    color: var(--jz-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+  .meta {
+    color: var(--jz-muted);
+    font-size: 12px;
+  }
+  .contribute {
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--jz-border);
+  }
+  .contribute h2 {
+    font-size: 20px;
+    color: var(--jz-selected);
+  }
+  .contribute p {
+    margin-top: 10px;
+    color: var(--jz-secondary);
+    max-width: 60ch;
+  }
+  .contribute a {
+    color: var(--jz-link);
+  }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+  }
+</style>

--- a/packages/website/src/pages/marketplace/personas.json.ts
+++ b/packages/website/src/pages/marketplace/personas.json.ts
@@ -1,0 +1,13 @@
+import { getMarketplaceEntries, toIndexEntry } from "../../lib/marketplace";
+
+/**
+ * The catalog `jazz persona browse` reads. Static, cache-friendly, and the only
+ * contract between the CLI and this site — see packages/adapters/src/persona-registry-service.ts.
+ */
+export async function GET(): Promise<Response> {
+  const entries = await getMarketplaceEntries();
+  const index = { version: 1, personas: entries.map(toIndexEntry) };
+  return new Response(JSON.stringify(index, null, 2), {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}

--- a/packages/website/src/pages/marketplace/personas/[name].md.ts
+++ b/packages/website/src/pages/marketplace/personas/[name].md.ts
@@ -1,0 +1,30 @@
+import { getMarketplaceEntries, type MarketplaceEntry } from "../../../lib/marketplace";
+
+export async function getStaticPaths() {
+  const entries = await getMarketplaceEntries();
+  return entries.map((entry) => ({
+    params: { name: entry.data.name },
+    props: { entry },
+  }));
+}
+
+/** The raw `persona.md`, exactly as `jazz persona install` parses it. */
+export function GET(context: { props: { entry: MarketplaceEntry } }): Response {
+  const { entry } = context.props;
+  const { name, description, tone, style, author, tags } = entry.data;
+  const frontmatter = [
+    "---",
+    `name: ${name}`,
+    `description: ${JSON.stringify(description)}`,
+    ...(tone ? [`tone: ${tone}`] : []),
+    ...(style ? [`style: ${style}`] : []),
+    ...(author ? [`author: ${author}`] : []),
+    ...(tags.length > 0 ? [`tags: [${tags.join(", ")}]`] : []),
+    "---",
+    "",
+  ].join("\n");
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}


### PR DESCRIPTION
## What & why

Personas are the most transferable thing in Jazz — a good system prompt works on anyone's machine, on any model — but until now the only way to get one was to write it yourself. This adds a marketplace: browse a shared catalog from the terminal or the website, read the prompt, and copy it into `~/.jazz/personas/`. Ships with six personas to start.

The catalog is a directory in this repo (`marketplace/personas/`), not a hosted service — entries arrive through pull requests, and the website build publishes both the human gallery at `/marketplace` and the JSON index the CLI reads. `JAZZ_PERSONA_REGISTRY_URL` points Jazz at a different catalog for self-hosted or internal use.

Two things worth a reviewer's attention, since an installed persona *becomes* an agent's system prompt: `install` prints the prompt in full and asks before writing it (non-interactive runs must pass `--yes`), and an index entry whose `url` resolves off the registry's own origin is refused outright, so a compromised catalog can't redirect an install elsewhere.

## How to verify

- `jazz persona search` lists the six seeded personas; `jazz persona browse` lets you pick one, shows its prompt, and installs it into `~/.jazz/personas/`.
- `jazz persona install rubber-duck` twice — the second run refuses on the name clash and points at `--as`. `--as duck` then succeeds.
- Pipe `jazz persona install copy-editor` somewhere non-interactive: it prints the prompt and refuses without `--yes`.
- Kill your network (or `JAZZ_OFFLINE=1`) and run `jazz persona search` — it serves the cached catalog. Delete `~/.jazz/cache/persona-registry.json` first and it fails with a clear message instead of hanging.
- On the site: `/marketplace` renders the gallery, a persona page's copy button copies the prompt, and `/marketplace/personas.json` returns the index.
