### PR TITLE
fix(daemon): unblock unattended runs and surface job output

### DIFF
--- a/docs/internals/tools-and-approval.md
+++ b/docs/internals/tools-and-approval.md
@@ -133,14 +133,14 @@ flowchart LR
 
     subgraph policies["--approval-policy"]
         direction TB
-        P0["<i>unset / false</i><br/>interactive: read-only + low-risk<br/>unattended: nothing"]
+        P0["<i>unset / false</i><br/>read-only + low-risk"]
         P1["read-only"]
         P2["low-risk"]
         P3["high-risk"]
     end
 
-    P0 -.->|"approves (interactive only)"| RO
-    P0 -.->|"approves (interactive only)"| LR
+    P0 -.->|approves| RO
+    P0 -.->|approves| LR
     P1 -.->|approves| RO
     P2 -.->|approves| RO
     P2 -.->|approves| LR
@@ -176,10 +176,9 @@ the verdict as it would to any declared level. So `--approval-policy read-only` 
 prompt for a listing but still asks about a push.
 
 The classifier is skipped when it cannot change anything: yolo approves either way, the
-command is already allowlisted, or the level was never `unknown`. It is also skipped in
-**safe mode** (policy unset or `false`) on any surface that cannot prompt — headless, cron,
-quiet. There the absent policy approves nothing at all, so a verdict could only widen what
-runs unsupervised, never save a keystroke.
+command is already allowlisted, or the level was never `unknown`. Everywhere else it runs,
+including on surfaces that cannot prompt — an unclassified command stays `unknown`, which
+approves nowhere, so skipping it there would park a run on `git status`.
 
 While it runs, the live zone shows `classifying` on that command (the round-trip can take a
 few seconds). The verdict then lands on the settled receipt — `read-only`, `low-risk`, or

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -214,12 +214,17 @@ succeeds and the ticker is the safety net.
 Opt-in per agent. Runs several independent shell commands in the background with a concurrency
 cap and per-job retry/backoff, without blocking the agent's turn. Completion (fan-in) resumes the
 conversation the same way a wake trigger fires, once every job in the batch reaches a final
-state.
+state, and the agent is told each job's status **and what it printed** — a batch exists to find
+something out, so an exit code on its own would tell it nothing.
+
+If that resumed turn needs an approval nobody is there to give, the run parks instead of dying:
+you get a desktop notification naming it, and `jazz runs resume <id>` finishes it. See
+[tools and approval](../internals/tools-and-approval.md).
 
 | Tool            | Risk        | Approval pair            | What it does                                                                                                   |
 | --------------- | ----------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | `enqueue_batch` | `unknown`   | `execute_enqueue_batch`  | Run several independent shell commands in the background with a concurrency cap and per-job retry/backoff. |
-| `list_jobs`     | `read-only` | —                        | List this agent's background job batches and every job's status.                                              |
+| `list_jobs`     | `read-only` | —                        | List this agent's background job batches, every job's status, and what each one printed.                     |
 | `cancel_batch`  | `low-risk`  | —                        | Cancel a job batch's pending jobs by id (jobs already running finish naturally).                               |
 
 ### Context

--- a/packages/adapters/src/daemon/job-worker.test.ts
+++ b/packages/adapters/src/daemon/job-worker.test.ts
@@ -1,0 +1,119 @@
+import { JOB_OUTPUT_TAIL_CHARS } from "@jazz/core/constants/job-queue";
+import type { JobBatchRecord, JobRecord } from "@jazz/core/interfaces/job-queue-service";
+import { describe, expect, it } from "bun:test";
+import { summarizeBatch } from "./job-worker";
+
+function job(overrides: Partial<JobRecord> & Pick<JobRecord, "id" | "command">): JobRecord {
+  return {
+    status: "succeeded",
+    attempt: 1,
+    maxAttempts: 1,
+    nextAttemptAt: 0,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    result: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function batch(jobs: readonly JobRecord[]): JobBatchRecord {
+  return {
+    id: "b1",
+    agentId: "a1",
+    conversationId: "c1",
+    workingDir: "/repo",
+    concurrencyCap: 1,
+    backoff: { initialMs: 1000, maxMs: 1000 },
+    reason: "watch the worktree",
+    createdAt: 0,
+    completedAt: 1,
+    jobs,
+  };
+}
+
+describe("summarizeBatch", () => {
+  /**
+   * The regression: a batch of four `git status` snapshots reported "4/4 succeeded" and not
+   * one line of what they saw, so polling a worktree could never tell the agent anything.
+   */
+  it("quotes what a succeeded job printed", () => {
+    const summary = summarizeBatch(
+      batch([
+        job({
+          id: "j1",
+          command: "git status --short",
+          result: { stdout: " M packages/protocol/src/index.ts\n", stderr: "", exitCode: 0 },
+        }),
+      ]),
+    );
+
+    expect(summary).toContain("M packages/protocol/src/index.ts");
+    expect(summary).toContain("1/1 succeeded");
+  });
+
+  it("says so when a succeeded job printed nothing", () => {
+    const summary = summarizeBatch(
+      batch([job({ id: "j1", command: "true", result: { stdout: "", stderr: "", exitCode: 0 } })]),
+    );
+
+    expect(summary).toContain("succeeded with no output");
+  });
+
+  it("quotes stderr for a failed job", () => {
+    const summary = summarizeBatch(
+      batch([
+        job({
+          id: "j1",
+          command: "bun test",
+          status: "failed",
+          attempt: 2,
+          result: { stdout: "", stderr: "1 test failed", exitCode: 1 },
+        }),
+      ]),
+    );
+
+    expect(summary).toContain("failed after 2 attempt(s)");
+    expect(summary).toContain("1 test failed");
+  });
+
+  it("falls back to stdout for a failed job that diagnosed itself there", () => {
+    const summary = summarizeBatch(
+      batch([
+        job({
+          id: "j1",
+          command: "make",
+          status: "failed",
+          result: { stdout: "undefined reference to `main'", stderr: "", exitCode: 1 },
+        }),
+      ]),
+    );
+
+    expect(summary).toContain("undefined reference");
+    expect(summary).not.toContain("no output captured");
+  });
+
+  it("keeps the tail of a long output, and marks that it cut", () => {
+    const long = `${"x".repeat(JOB_OUTPUT_TAIL_CHARS * 2)}THE-VERDICT`;
+    const summary = summarizeBatch(
+      batch([
+        job({ id: "j1", command: "build", result: { stdout: long, stderr: "", exitCode: 0 } }),
+      ]),
+    );
+
+    expect(summary).toContain("THE-VERDICT");
+    expect(summary).toContain("earlier output trimmed");
+    expect(summary.length).toBeLessThan(long.length);
+  });
+
+  it("reports a cancelled job without pretending it ran", () => {
+    const summary = summarizeBatch(
+      batch([job({ id: "j1", command: "git fetch", status: "cancelled" })]),
+    );
+
+    expect(summary).toContain("cancelled before it ran");
+    expect(summary).toContain("0/1 succeeded");
+  });
+});

--- a/packages/adapters/src/daemon/job-worker.ts
+++ b/packages/adapters/src/daemon/job-worker.ts
@@ -5,20 +5,22 @@
  * triggers and workflow catch-up.
  *
  * A batch's completion (fan-in) reuses the exact resume mechanism wake triggers already use —
- * `AgentRunner.run` with `parkWhenUnattended: true` against the batch's `conversationId` — the
- * only difference is what causes the resume: a job finishing rather than a clock firing.
+ * `runUnattendedTurn` against the batch's `conversationId` — the only difference is what causes
+ * the resume: a job finishing rather than a clock firing.
  */
 
 import * as os from "node:os";
-import { AgentRunner } from "@jazz/core/agent/agent-runner";
-import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
 import { runShellCommand } from "@jazz/core/agent/tools/shell-tools";
-import { DEFAULT_JOB_TIMEOUT_MS, WORKER_POOL_SIZE } from "@jazz/core/constants/job-queue";
+import {
+  DEFAULT_JOB_TIMEOUT_MS,
+  JOB_OUTPUT_TAIL_CHARS,
+  WORKER_POOL_SIZE,
+} from "@jazz/core/constants/job-queue";
 import type { JobBatchRecord, JobRecord } from "@jazz/core/interfaces/job-queue-service";
-import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { createSanitizedEnv } from "@jazz/core/utils/env";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { Effect } from "effect";
+import { runUnattendedTurn } from "@/adapters/daemon/unattended-resume";
 import {
   claimDueJobs,
   completeJob,
@@ -26,29 +28,37 @@ import {
   reclaimExpiredLeases,
   type ClaimedJob,
 } from "@/adapters/job-queue-service";
-import {
-  loadConversation,
-  saveConversation,
-} from "@jazz/adapters/history/conversation-history-service";
 
 function jobBatchDirectory(): string {
   return `${getJazzHomeDirectory()}/job-batches`;
 }
 
+function tail(output: string): string {
+  if (output.length <= JOB_OUTPUT_TAIL_CHARS) return output;
+  return `…(earlier output trimmed)…\n${output.slice(-JOB_OUTPUT_TAIL_CHARS)}`;
+}
+
+/** Quotes what a job printed: an exit code alone tells a polling agent nothing it can act on. */
 function formatJobLine(job: JobRecord): string {
-  if (job.status === "succeeded") {
-    return `- \`${job.command}\`: succeeded${job.attempt > 1 ? ` (attempt ${job.attempt})` : ""}.`;
-  }
   if (job.status === "cancelled") {
     return `- \`${job.command}\`: cancelled before it ran.`;
   }
-  const stderrTail = job.result?.stderr
-    ? job.result.stderr.slice(-500)
-    : (job.lastError ?? "no output captured");
-  return `- \`${job.command}\`: failed after ${job.attempt} attempt(s) — ${stderrTail}`;
+  if (job.status === "succeeded") {
+    const attempts = job.attempt > 1 ? ` (attempt ${job.attempt})` : "";
+    const stdout = job.result?.stdout?.trim();
+    return stdout
+      ? `- \`${job.command}\`: succeeded${attempts}, and printed:\n\`\`\`\n${tail(stdout)}\n\`\`\``
+      : `- \`${job.command}\`: succeeded${attempts} with no output.`;
+  }
+  const diagnostics = job.result?.stderr?.trim() || job.result?.stdout?.trim();
+  const why = diagnostics
+    ? `\n\`\`\`\n${tail(diagnostics)}\n\`\`\``
+    : ` — ${job.lastError ?? "no output captured"}`;
+  return `- \`${job.command}\`: failed after ${job.attempt} attempt(s)${why}`;
 }
 
-function summarizeBatch(batch: JobBatchRecord): string {
+/** Exported for test: this string is the entire report a woken agent gets about its batch. */
+export function summarizeBatch(batch: JobBatchRecord): string {
   const succeeded = batch.jobs.filter((job) => job.status === "succeeded").length;
   const lines = batch.jobs.map(formatJobLine);
   return (
@@ -58,65 +68,15 @@ function summarizeBatch(batch: JobBatchRecord): string {
   );
 }
 
-/**
- * Resume the batch's owning conversation with a synthesized summary of every job's outcome.
- * Mirrors `fireWakeTrigger` in `trigger-runner.ts` exactly — same load/run/save shape — because a
- * finished batch is just a different reason to fire the same kind of unattended resume.
- */
+/** A finished batch is one more reason to fire an unattended turn; the rest is shared. */
 function fireBatchResume(agentId: string, batch: JobBatchRecord) {
-  return Effect.gen(function* () {
-    const logger = yield* LoggerServiceTag;
-    const agentResult = yield* getAgentByIdentifier(agentId).pipe(Effect.either);
-    if (agentResult._tag === "Left") {
-      yield* logger.warn("Job batch resume skipped: agent not found", {
-        agentId,
-        batchId: batch.id,
-      });
-      return;
-    }
-    const agent = agentResult.right;
-
-    const priorRecord = yield* loadConversation(agentId, batch.conversationId).pipe(
-      Effect.catchAll(() => Effect.succeed(null)),
-    );
-
-    const response = yield* AgentRunner.run({
-      agent,
-      userInput: summarizeBatch(batch),
-      conversationId: batch.conversationId,
-      parkWhenUnattended: true,
-      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
-    }).pipe(
-      Effect.catchAll((error) =>
-        Effect.gen(function* () {
-          yield* logger.warn("Job batch resume run failed", {
-            agentId,
-            batchId: batch.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return undefined;
-        }),
-      ),
-    );
-    if (response === undefined) return;
-
-    const now = new Date().toISOString();
-    yield* saveConversation({
-      agentId,
-      conversationId: batch.conversationId,
-      title: priorRecord?.title ?? batch.reason.slice(0, 80),
-      startedAt: priorRecord?.startedAt ?? now,
-      endedAt: now,
-      messages: response.messages ?? priorRecord?.messages ?? [],
-    }).pipe(
-      Effect.catchAll((error) =>
-        logger.warn("Job batch resume conversation save failed", {
-          agentId,
-          batchId: batch.id,
-          error: error instanceof Error ? error.message : String(error),
-        }),
-      ),
-    );
+  return runUnattendedTurn({
+    agentId,
+    conversationId: batch.conversationId,
+    prompt: summarizeBatch(batch),
+    fallbackTitle: batch.reason,
+    source: "job batch",
+    sourceId: batch.id,
   });
 }
 

--- a/packages/adapters/src/daemon/job-worker.ts
+++ b/packages/adapters/src/daemon/job-worker.ts
@@ -38,7 +38,6 @@ function tail(output: string): string {
   return `…(earlier output trimmed)…\n${output.slice(-JOB_OUTPUT_TAIL_CHARS)}`;
 }
 
-/** Quotes what a job printed: an exit code alone tells a polling agent nothing it can act on. */
 function formatJobLine(job: JobRecord): string {
   if (job.status === "cancelled") {
     return `- \`${job.command}\`: cancelled before it ran.`;
@@ -57,7 +56,7 @@ function formatJobLine(job: JobRecord): string {
   return `- \`${job.command}\`: failed after ${job.attempt} attempt(s)${why}`;
 }
 
-/** Exported for test: this string is the entire report a woken agent gets about its batch. */
+/** Exported for test: the entire report a woken agent gets about its batch. */
 export function summarizeBatch(batch: JobBatchRecord): string {
   const succeeded = batch.jobs.filter((job) => job.status === "succeeded").length;
   const lines = batch.jobs.map(formatJobLine);
@@ -68,7 +67,6 @@ export function summarizeBatch(batch: JobBatchRecord): string {
   );
 }
 
-/** A finished batch is one more reason to fire an unattended turn; the rest is shared. */
 function fireBatchResume(agentId: string, batch: JobBatchRecord) {
   return runUnattendedTurn({
     agentId,

--- a/packages/adapters/src/daemon/trigger-runner.ts
+++ b/packages/adapters/src/daemon/trigger-runner.ts
@@ -10,20 +10,14 @@
  * checked with a plain `<=` comparison — no cron math involved.
  */
 
-import { AgentRunner } from "@jazz/core/agent/agent-runner";
-import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
-import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
 import { sendDesktopNotification } from "@jazz/core/utils/desktop-notify";
 import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
 import { runInProcessScheduledWorkflows } from "@jazz/core/workflows/catch-up";
 import { Effect } from "effect";
 import { runDueJobs } from "@/adapters/daemon/job-worker";
+import { runUnattendedTurn } from "@/adapters/daemon/unattended-resume";
 import { sweepDueReminders } from "@/adapters/reminder-service";
 import { sweepDueWakeTriggers } from "@/adapters/wake-trigger-service";
-import {
-  loadConversation,
-  saveConversation,
-} from "@jazz/adapters/history/conversation-history-service";
 
 function wakeTriggerDirectory(): string {
   return `${getJazzHomeDirectory()}/wake-triggers`;
@@ -44,71 +38,18 @@ function isBotHostedAgentId(agentId: string): boolean {
   return agentId.startsWith("tg_") || agentId.startsWith("dc_");
 }
 
-/**
- * Resume the conversation a wake trigger belongs to and run its prompt as the next turn.
- *
- * Mirrors the CLI's own resume path (`packages/cli/src/commands/run/execute.ts`): load prior
- * history if any, pass it to `AgentRunner.run` explicitly (the runner never loads history on
- * its own), then persist the updated transcript. A trigger whose agent no longer exists is
- * logged and dropped rather than retried — there's nothing to resume it into.
- */
+/** A due trigger is one more reason to fire an unattended turn; the rest is shared. */
 export function fireWakeTrigger(
   agentId: string,
   trigger: { id: string; conversationId: string; prompt: string },
 ) {
-  return Effect.gen(function* () {
-    const logger = yield* LoggerServiceTag;
-    const agentResult = yield* getAgentByIdentifier(agentId).pipe(Effect.either);
-    if (agentResult._tag === "Left") {
-      yield* logger.warn("Wake trigger skipped: agent not found", {
-        agentId,
-        triggerId: trigger.id,
-      });
-      return;
-    }
-    const agent = agentResult.right;
-
-    const priorRecord = yield* loadConversation(agentId, trigger.conversationId).pipe(
-      Effect.catchAll(() => Effect.succeed(null)),
-    );
-
-    const response = yield* AgentRunner.run({
-      agent,
-      userInput: trigger.prompt,
-      conversationId: trigger.conversationId,
-      parkWhenUnattended: true,
-      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
-    }).pipe(
-      Effect.catchAll((error) =>
-        Effect.gen(function* () {
-          yield* logger.warn("Wake trigger run failed", {
-            agentId,
-            triggerId: trigger.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return undefined;
-        }),
-      ),
-    );
-    if (response === undefined) return;
-
-    const now = new Date().toISOString();
-    yield* saveConversation({
-      agentId,
-      conversationId: trigger.conversationId,
-      title: priorRecord?.title ?? trigger.prompt.slice(0, 80),
-      startedAt: priorRecord?.startedAt ?? now,
-      endedAt: now,
-      messages: response.messages ?? priorRecord?.messages ?? [],
-    }).pipe(
-      Effect.catchAll((error) =>
-        logger.warn("Wake trigger conversation save failed", {
-          agentId,
-          triggerId: trigger.id,
-          error: error instanceof Error ? error.message : String(error),
-        }),
-      ),
-    );
+  return runUnattendedTurn({
+    agentId,
+    conversationId: trigger.conversationId,
+    prompt: trigger.prompt,
+    fallbackTitle: trigger.prompt,
+    source: "wake trigger",
+    sourceId: trigger.id,
   });
 }
 

--- a/packages/adapters/src/daemon/trigger-runner.ts
+++ b/packages/adapters/src/daemon/trigger-runner.ts
@@ -38,7 +38,6 @@ function isBotHostedAgentId(agentId: string): boolean {
   return agentId.startsWith("tg_") || agentId.startsWith("dc_");
 }
 
-/** A due trigger is one more reason to fire an unattended turn; the rest is shared. */
 export function fireWakeTrigger(
   agentId: string,
   trigger: { id: string; conversationId: string; prompt: string },

--- a/packages/adapters/src/daemon/unattended-resume.test.ts
+++ b/packages/adapters/src/daemon/unattended-resume.test.ts
@@ -1,0 +1,93 @@
+import { RunParkRequested } from "@jazz/core/agent/run/park-signal";
+import type { ChatMessage } from "@jazz/core/types/message";
+import { describe, expect, it } from "bun:test";
+import { approvalNotification, classifyTurnOutcome } from "./unattended-resume";
+
+const TRANSCRIPT: ChatMessage[] = [
+  { role: "user", content: "batch finished" },
+  { role: "assistant", content: "looking" },
+];
+
+function park(overrides: Record<string, unknown> = {}): RunParkRequested {
+  return new RunParkRequested({
+    pending: {
+      kind: "tool-approval",
+      request: {
+        toolCallId: "call_1",
+        toolName: "execute_command",
+        message: "Command: git status",
+        executeToolName: "execute_execute_command",
+        executeArgs: {},
+      },
+    },
+    messages: TRANSCRIPT,
+    runId: "run-1",
+    expiresAt: "2026-01-02T00:00:00Z",
+    ...overrides,
+  } as ConstructorParameters<typeof RunParkRequested>[0]);
+}
+
+describe("classifyTurnOutcome", () => {
+  /**
+   * The regression: a park leaves the runner as a failure, and reading it as one logged an
+   * empty message, skipped the save so the turn was lost, and told nobody a run was waiting.
+   */
+  it("reads a park as parked, not as a failure", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: park() });
+
+    expect(outcome.kind).toBe("parked");
+  });
+
+  it("carries the transcript the parked turn produced, so it can still be saved", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: park() });
+
+    if (outcome.kind !== "parked") throw new Error("expected a park");
+    expect(outcome.messages).toEqual(TRANSCRIPT);
+  });
+
+  it("names the run to resume and what it stopped on", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: park() });
+
+    if (outcome.kind !== "parked") throw new Error("expected a park");
+    expect(outcome.runId).toBe("run-1");
+    expect(outcome.waitingOn).toBe("execute_command");
+    expect(outcome.expiresAt).toBe("2026-01-02T00:00:00Z");
+  });
+
+  it("calls a park with no run id unresumable rather than pointing at nothing", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: park({ runId: undefined }) });
+
+    expect(outcome.kind).toBe("unresumable");
+  });
+
+  it("still reads a genuine error as a failure, with its message intact", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: new Error("provider exploded") });
+
+    expect(outcome).toEqual({ kind: "failed", error: "provider exploded" });
+  });
+
+  it("reads a completed run as finished, with its messages", () => {
+    const outcome = classifyTurnOutcome({ ok: true, messages: TRANSCRIPT });
+
+    expect(outcome).toEqual({ kind: "finished", messages: TRANSCRIPT });
+  });
+
+  it("tolerates a completed run that carried no messages", () => {
+    const outcome = classifyTurnOutcome({ ok: true });
+
+    expect(outcome).toEqual({ kind: "finished", messages: [] });
+  });
+});
+
+describe("approvalNotification", () => {
+  it("tells the reader which run to answer and how", () => {
+    const outcome = classifyTurnOutcome({ ok: false, error: park() });
+    if (outcome.kind !== "parked") throw new Error("expected a park");
+
+    const notification = approvalNotification({ source: "job batch", sourceId: "b1" }, outcome);
+
+    expect(notification.body).toContain("jazz runs resume run-1");
+    expect(notification.body).toContain("execute_command");
+    expect(notification.body).toContain("b1");
+  });
+});

--- a/packages/adapters/src/daemon/unattended-resume.ts
+++ b/packages/adapters/src/daemon/unattended-resume.ts
@@ -23,20 +23,16 @@ import {
 export interface UnattendedTurn {
   readonly agentId: string;
   readonly conversationId: string;
-  /** The turn's user input — the summary or prompt that explains why the agent was woken. */
   readonly prompt: string;
-  /** Title for a conversation that does not have one yet. */
   readonly fallbackTitle: string;
-  /** What woke the agent, for log lines and the notification: `"job batch"`, `"wake trigger"`. */
+  /** Human-readable, for logs and the notification: `"job batch"`, `"wake trigger"`. */
   readonly source: string;
-  /** The batch or trigger id, carried into every log line so one can be traced. */
   readonly sourceId: string;
 }
 
 /**
- * Persist the transcript a turn ended on, whether it finished or parked. A parked run has
- * produced real messages up to the approval; dropping them leaves the next turn with no memory
- * of having been woken.
+ * A parked turn produced real messages up to the approval; dropping them leaves the next turn
+ * with no memory of having been woken.
  */
 function persist(
   turn: UnattendedTurn,
@@ -66,11 +62,8 @@ function persist(
 }
 
 /**
- * What a finished `AgentRunner.run` means, decided apart from the IO that acts on it.
- *
- * A park arrives as a *failure*, and telling it apart from a real one is the whole reason
- * this is its own function: reading `parked` as `failed` is what lost the transcript and
- * left a waiting run invisible.
+ * A park arrives as a *failure*. Telling it apart from a real one is why this is its own
+ * function: reading `parked` as `failed` is what lost the transcript and hid the waiting run.
  */
 export type TurnOutcome =
   | { readonly kind: "finished"; readonly messages: readonly ChatMessage[] }

--- a/packages/adapters/src/daemon/unattended-resume.ts
+++ b/packages/adapters/src/daemon/unattended-resume.ts
@@ -1,0 +1,200 @@
+/**
+ * @fileoverview One turn on an existing conversation with nobody at the keyboard — the daemon's
+ * two reasons to start one being a job batch finishing and a wake trigger firing.
+ *
+ * `AgentRunner.run` signals a park by *failing* with `RunParkRequested`, which is not an error:
+ * the run stopped on an approval, was persisted, and finishes later via `jazz runs resume <id>`.
+ * Both callers used to catch it as a failure, which logged an empty message, skipped the save so
+ * the transcript was lost, and told nobody a run was waiting. A park is its own outcome here.
+ */
+
+import { AgentRunner } from "@jazz/core/agent/agent-runner";
+import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
+import { isRunParkRequested } from "@jazz/core/agent/run/park-signal";
+import { LoggerServiceTag } from "@jazz/core/interfaces/logger";
+import type { ChatMessage } from "@jazz/core/types/message";
+import { sendDesktopNotification } from "@jazz/core/utils/desktop-notify";
+import { Effect } from "effect";
+import {
+  loadConversation,
+  saveConversation,
+} from "@jazz/adapters/history/conversation-history-service";
+
+export interface UnattendedTurn {
+  readonly agentId: string;
+  readonly conversationId: string;
+  /** The turn's user input — the summary or prompt that explains why the agent was woken. */
+  readonly prompt: string;
+  /** Title for a conversation that does not have one yet. */
+  readonly fallbackTitle: string;
+  /** What woke the agent, for log lines and the notification: `"job batch"`, `"wake trigger"`. */
+  readonly source: string;
+  /** The batch or trigger id, carried into every log line so one can be traced. */
+  readonly sourceId: string;
+}
+
+/**
+ * Persist the transcript a turn ended on, whether it finished or parked. A parked run has
+ * produced real messages up to the approval; dropping them leaves the next turn with no memory
+ * of having been woken.
+ */
+function persist(
+  turn: UnattendedTurn,
+  startedAt: string | undefined,
+  messages: readonly ChatMessage[],
+) {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+    const now = new Date().toISOString();
+    yield* saveConversation({
+      agentId: turn.agentId,
+      conversationId: turn.conversationId,
+      title: turn.fallbackTitle.slice(0, 80),
+      startedAt: startedAt ?? now,
+      endedAt: now,
+      messages: [...messages],
+    }).pipe(
+      Effect.catchAll((error) =>
+        logger.warn(`Unattended ${turn.source} conversation save failed`, {
+          agentId: turn.agentId,
+          sourceId: turn.sourceId,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      ),
+    );
+  });
+}
+
+/**
+ * What a finished `AgentRunner.run` means, decided apart from the IO that acts on it.
+ *
+ * A park arrives as a *failure*, and telling it apart from a real one is the whole reason
+ * this is its own function: reading `parked` as `failed` is what lost the transcript and
+ * left a waiting run invisible.
+ */
+export type TurnOutcome =
+  | { readonly kind: "finished"; readonly messages: readonly ChatMessage[] }
+  | {
+      readonly kind: "parked";
+      readonly runId: string;
+      readonly waitingOn: string;
+      readonly expiresAt: string | undefined;
+      readonly messages: readonly ChatMessage[] | undefined;
+    }
+  /** Parked, but never persisted, so there is no run to point anybody at. */
+  | { readonly kind: "unresumable" }
+  | { readonly kind: "failed"; readonly error: string };
+
+export function classifyTurnOutcome(
+  result:
+    | { readonly ok: true; readonly messages?: readonly ChatMessage[] }
+    | { readonly ok: false; readonly error: unknown },
+): TurnOutcome {
+  if (result.ok) return { kind: "finished", messages: result.messages ?? [] };
+  if (!isRunParkRequested(result.error)) {
+    return {
+      kind: "failed",
+      error: result.error instanceof Error ? result.error.message : String(result.error),
+    };
+  }
+  const park = result.error;
+  if (park.runId === undefined) return { kind: "unresumable" };
+  return {
+    kind: "parked",
+    runId: park.runId,
+    waitingOn:
+      park.pending.kind === "tool-approval" ? park.pending.request.toolName : park.pending.kind,
+    expiresAt: park.expiresAt,
+    messages: park.messages,
+  };
+}
+
+export function approvalNotification(
+  turn: Pick<UnattendedTurn, "source" | "sourceId">,
+  parked: Extract<TurnOutcome, { kind: "parked" }>,
+): { readonly title: string; readonly body: string } {
+  return {
+    title: "Jazz needs your approval",
+    body: `${turn.source} "${turn.sourceId}" stopped on ${parked.waitingOn}. Run: jazz runs resume ${parked.runId}`,
+  };
+}
+
+/** A missing agent is logged and dropped rather than retried — there is nothing to resume into. */
+export function runUnattendedTurn(turn: UnattendedTurn) {
+  return Effect.gen(function* () {
+    const logger = yield* LoggerServiceTag;
+    const agentResult = yield* getAgentByIdentifier(turn.agentId).pipe(Effect.either);
+    if (agentResult._tag === "Left") {
+      yield* logger.warn(`Unattended ${turn.source} skipped: agent not found`, {
+        agentId: turn.agentId,
+        sourceId: turn.sourceId,
+      });
+      return;
+    }
+    const agent = agentResult.right;
+
+    const priorRecord = yield* loadConversation(turn.agentId, turn.conversationId).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
+    const named = { ...turn, fallbackTitle: priorRecord?.title ?? turn.fallbackTitle };
+    const startedAt = priorRecord?.startedAt;
+
+    const outcome = yield* AgentRunner.run({
+      agent,
+      userInput: turn.prompt,
+      conversationId: turn.conversationId,
+      parkWhenUnattended: true,
+      ...(priorRecord !== null ? { conversationHistory: priorRecord.messages } : {}),
+    }).pipe(
+      Effect.map((response) =>
+        classifyTurnOutcome({
+          ok: true,
+          ...(response.messages ? { messages: response.messages } : {}),
+        }),
+      ),
+      Effect.catchAll((error) => Effect.succeed(classifyTurnOutcome({ ok: false, error }))),
+    );
+
+    switch (outcome.kind) {
+      case "failed":
+        yield* logger.warn(`Unattended ${turn.source} run failed`, {
+          agentId: turn.agentId,
+          sourceId: turn.sourceId,
+          error: outcome.error,
+        });
+        return;
+
+      case "unresumable":
+        yield* logger.warn(`Unattended ${turn.source} needed approval it could not save`, {
+          agentId: turn.agentId,
+          sourceId: turn.sourceId,
+        });
+        return;
+
+      case "parked": {
+        yield* logger.info(`Unattended ${turn.source} parked waiting for approval`, {
+          agentId: turn.agentId,
+          sourceId: turn.sourceId,
+          runId: outcome.runId,
+          waitingOn: outcome.waitingOn,
+          expiresAt: outcome.expiresAt,
+          resumeWith: `jazz runs resume ${outcome.runId}`,
+        });
+        if (outcome.messages !== undefined) {
+          yield* persist(named, startedAt, outcome.messages);
+        }
+        const notification = approvalNotification(turn, outcome);
+        yield* sendDesktopNotification(notification.title, notification.body);
+        return;
+      }
+
+      case "finished":
+        yield* persist(
+          named,
+          startedAt,
+          outcome.messages.length > 0 ? outcome.messages : (priorRecord?.messages ?? []),
+        );
+        return;
+    }
+  });
+}

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -247,8 +247,7 @@ export class ToolExecutor {
             isToolNameAutoApproved(name, context.autoApprovedTools) ||
             isCommandAutoApproved(name, approvalResult.executeArgs, context.autoApprovedCommands);
 
-          // Decides prompt-or-park for the calls that do not auto-approve; it does not
-          // change which ones do.
+          // Decides prompt-or-park; it does not change which calls auto-approve.
           const canPrompt = presentationService.canPromptForApproval?.() === true;
 
           const commandArg = approvalResult.executeArgs["command"];
@@ -782,9 +781,7 @@ export class ToolExecutor {
             context.parentAgent &&
             command !== undefined
           ) {
-            // Nobody can be prompted on this path, so the command stands on its own —
-            // conversation context is only evidence when the person the approval protects
-            // is the one who wrote it.
+            // Nobody can be prompted here, so the command stands on its own.
             riskLevel = yield* classifyCommandRisk(
               command,
               context.parentAgent,

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -138,6 +138,8 @@ export class ToolExecutor {
     conversationId: string,
     toolsRequiringApproval: ReadonlySet<string>,
     parkable = false,
+    /** Command-risk verdicts the batch's pre-park pass already paid for, by tool call id. */
+    preclassifiedRisk?: ReadonlyMap<string, ToolRiskLevel>,
   ): Effect.Effect<
     { toolCallId: string; result: unknown; success: boolean; name: string },
     Error,
@@ -245,16 +247,19 @@ export class ToolExecutor {
             isToolNameAutoApproved(name, context.autoApprovedTools) ||
             isCommandAutoApproved(name, approvalResult.executeArgs, context.autoApprovedCommands);
 
-          // Whether this surface can actually put the decision in front of a
-          // person. Safe mode means "skip the prompts that are not worth
-          // asking"; where there is no prompt to skip it has to mean nothing.
+          // Decides prompt-or-park for the calls that do not auto-approve; it does not
+          // change which ones do.
           const canPrompt = presentationService.canPromptForApproval?.() === true;
 
           const commandArg = approvalResult.executeArgs["command"];
           const command = typeof commandArg === "string" ? commandArg : undefined;
 
-          if (
-            shouldClassifyExecuteCommand(riskLevel, autoApprovePolicy, allowlisted, canPrompt) &&
+          const alreadyClassified = preclassifiedRisk?.get(toolCall.id);
+          if (alreadyClassified !== undefined) {
+            classifiedRisk = alreadyClassified;
+            riskLevel = alreadyClassified;
+          } else if (
+            shouldClassifyExecuteCommand(riskLevel, autoApprovePolicy, allowlisted) &&
             context.parentAgent &&
             command !== undefined
           ) {
@@ -286,7 +291,7 @@ export class ToolExecutor {
           // Check if auto-approve policy allows this tool, per-tool session allowlist,
           // or per-command prefix allowlist matches
           const checkAutoApproved = () =>
-            shouldAutoApprove(riskLevel, getCurrentPolicy(), { canPrompt }) ||
+            shouldAutoApprove(riskLevel, getCurrentPolicy()) ||
             isToolNameAutoApproved(name, context.autoApprovedTools) ||
             isCommandAutoApproved(name, approvalResult.executeArgs, context.autoApprovedCommands);
 
@@ -725,7 +730,11 @@ export class ToolExecutor {
        * So parking is safe as long as it happens before anything executes, which is what
        * deciding here rather than inside each fiber buys. Every round either parks having
        * run nothing, or has every approval in hand and runs the batch once.
+       *
+       * Verdicts reached here are handed to the per-call path via `preclassifiedRisk`, which
+       * would otherwise classify the same command a second time inside its own fiber.
        */
+      const preclassifiedRisk = new Map<string, ToolRiskLevel>();
       const parkTheBatch = Effect.gen(function* () {
         if (context.parkWhenUnattended !== true) return undefined;
         if (presentationService.canPromptForApproval?.() === true) return undefined;
@@ -758,13 +767,34 @@ export class ToolExecutor {
           const toolInfo = yield* registry
             .getTool(name)
             .pipe(Effect.catchAll(() => Effect.succeed({ riskLevel: "high-risk" as const })));
-          const autoApproved =
-            shouldAutoApprove(toolInfo.riskLevel, context.getAutoApprovePolicy?.(), {
-              canPrompt: false,
-            }) ||
+          const policy = context.getAutoApprovePolicy?.();
+          const allowlisted =
             isToolNameAutoApproved(name, context.autoApprovedTools) ||
             isCommandAutoApproved(name, request.executeArgs, context.autoApprovedCommands);
-          if (autoApproved) continue;
+
+          // Without classifying, `execute_command` stays `unknown` and parks even `git
+          // status` — while the per-call path, which does classify, would let it through.
+          let riskLevel = toolInfo.riskLevel;
+          const commandArg = request.executeArgs["command"];
+          const command = typeof commandArg === "string" ? commandArg : undefined;
+          if (
+            shouldClassifyExecuteCommand(riskLevel, policy, allowlisted) &&
+            context.parentAgent &&
+            command !== undefined
+          ) {
+            // Nobody can be prompted on this path, so the command stands on its own —
+            // conversation context is only evidence when the person the approval protects
+            // is the one who wrote it.
+            riskLevel = yield* classifyCommandRisk(
+              command,
+              context.parentAgent,
+              undefined,
+              runMetrics,
+            );
+            preclassifiedRisk.set(toolCall.id, riskLevel);
+          }
+
+          if (shouldAutoApprove(riskLevel, policy) || allowlisted) continue;
 
           needsAnswering.push(toolCall);
           if (needsAnswering.length === 1) {
@@ -827,6 +857,8 @@ export class ToolExecutor {
               agentId,
               conversationId,
               approvalSet,
+              false,
+              preclassifiedRisk,
             ).pipe(
               Effect.tap((outcome) =>
                 Effect.sync(() => {

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -82,7 +82,11 @@ const SECOND_SAFE_TOOL_CALL = {
   function: { name: "harmless", arguments: JSON.stringify({}) },
 };
 
-function makeLayers(store: InMemoryRunStore, firstTurnCalls = [TOOL_CALL]) {
+function makeLayers(
+  store: InMemoryRunStore,
+  firstTurnCalls = [TOOL_CALL],
+  gatedRiskLevel: "high-risk" | "low-risk" | "read-only" = "high-risk",
+) {
   // First completion asks for the gated tool; every later one answers in text. A resumed
   // run must therefore reach the *second* response, which it can only do once the parked
   // tool call has a result.
@@ -127,7 +131,7 @@ function makeLayers(store: InMemoryRunStore, firstTurnCalls = [TOOL_CALL]) {
   const dangerTool = {
     name: "danger",
     description: "Does something gated",
-    riskLevel: "high-risk" as const,
+    riskLevel: gatedRiskLevel,
     approvalExecuteToolName: "danger_execute",
     hidden: false,
     longRunning: false,
@@ -309,6 +313,76 @@ describe("park and resume, through the real loop", () => {
     expect(executions).toEqual([]);
     if (exit._tag === "Failure") return;
     expect(isRunParkRequested(exit.value)).toBe(false);
+  });
+});
+
+describe("what an unattended run may do without being asked", () => {
+  /**
+   * The regression: with nobody reachable, `shouldAutoApprove` used to clear nothing at all,
+   * so a run woken by a finished job batch parked on its first `git status` and the work
+   * never happened. Being unattended decides prompt-or-park, not what needs approving.
+   */
+  it("runs a read-only gated tool rather than parking on it", async () => {
+    executions = [];
+    const store = new InMemoryRunStore();
+
+    const exit = await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "look at the worktree",
+        conversationId: "conv-read-only",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(makeLayers(store, [TOOL_CALL], "read-only"))) as Effect.Effect<
+        unknown,
+        unknown
+      >,
+    );
+
+    expect(exit._tag).toBe("Success");
+    expect(executions).toEqual(["danger_execute"]);
+    expect(await Effect.runPromise(store.list())).toHaveLength(0);
+  });
+
+  it("runs a whole batch of them, so the pre-park pass agrees with the per-call one", async () => {
+    executions = [];
+    executedTargets = [];
+    const store = new InMemoryRunStore();
+
+    const exit = await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "look at the worktree twice",
+        conversationId: "conv-read-only-batch",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(
+        Effect.provide(makeLayers(store, [TOOL_CALL, SECOND_TOOL_CALL], "read-only")),
+      ) as Effect.Effect<unknown, unknown>,
+    );
+
+    expect(exit._tag).toBe("Success");
+    expect(executedTargets.sort()).toEqual(["/tmp/x", "/tmp/y"]);
+    expect(await Effect.runPromise(store.list())).toHaveLength(0);
+  });
+
+  it("still parks a high-risk one", async () => {
+    executions = [];
+    const store = new InMemoryRunStore();
+
+    const exit = await Effect.runPromiseExit(
+      AgentRunner.run({
+        agent: AGENT,
+        userInput: "do the gated thing",
+        conversationId: "conv-high-risk",
+        stream: false,
+        parkWhenUnattended: true,
+      }).pipe(Effect.provide(makeLayers(store))) as Effect.Effect<unknown, unknown>,
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(executions).toEqual([]);
+    expect(await Effect.runPromise(store.list())).toHaveLength(1);
   });
 });
 

--- a/packages/core/src/agent/tools/base-tool.ts
+++ b/packages/core/src/agent/tools/base-tool.ts
@@ -31,6 +31,13 @@ export interface BaseToolConfig<R, Args extends Record<string, unknown>> {
    */
   readonly description: string;
   /**
+   * One-line summary for a `deferred`-tier tool, falling back to a truncated `description`.
+   *
+   * This is the only text `search_tools` matches, and matching is literal token overlap, so it
+   * has to carry the words a request would use rather than the ones the implementation uses.
+   */
+  readonly summary?: string;
+  /**
    * Optional array of tags for categorizing and organizing tools.
    */
   readonly tags?: readonly string[];
@@ -108,6 +115,7 @@ export function defineTool<R, Args extends Record<string, unknown>>(
   return {
     name: config.name,
     description: config.description,
+    ...(config.summary !== undefined ? { summary: config.summary } : {}),
     tags: config.tags ?? [],
     ...(config.aliases ? { aliases: config.aliases } : {}),
     parameters: config.parameters,
@@ -171,6 +179,8 @@ export interface ApprovalToolConfig<R, Args extends Record<string, unknown>> {
   readonly name: string;
   /** Description of what the tool does (will be prefixed with approval marker) */
   readonly description: string;
+  /** One-line summary `search_tools` matches. See {@link BaseToolConfig.summary}. */
+  readonly summary?: string;
   /** Optional tags for categorization */
   readonly tags?: readonly string[];
   /** Zod schema for parameters */
@@ -255,6 +265,7 @@ export function defineApprovalTool<R, Args extends Record<string, unknown>>(
   const approvalTool = defineTool<R, Args>({
     name: config.name,
     description: config.description,
+    ...(config.summary !== undefined ? { summary: config.summary } : {}),
     ...(config.tags ? { tags: config.tags } : {}),
     parameters: config.parameters,
     riskLevel,

--- a/packages/core/src/agent/tools/command-risk.test.ts
+++ b/packages/core/src/agent/tools/command-risk.test.ts
@@ -18,8 +18,8 @@ describe("shouldClassifyExecuteCommand", () => {
   it("runs for an unknown risk under the tiers a verdict could change", () => {
     expect(shouldClassifyExecuteCommand("unknown", "read-only", false)).toBe(true);
     expect(shouldClassifyExecuteCommand("unknown", "low-risk", false)).toBe(true);
-    expect(shouldClassifyExecuteCommand("unknown", false, false, true)).toBe(true);
-    expect(shouldClassifyExecuteCommand("unknown", undefined, false, true)).toBe(true);
+    expect(shouldClassifyExecuteCommand("unknown", false, false)).toBe(true);
+    expect(shouldClassifyExecuteCommand("unknown", undefined, false)).toBe(true);
   });
 
   it("skips the round-trip when the outcome is already decided", () => {
@@ -32,10 +32,11 @@ describe("shouldClassifyExecuteCommand", () => {
     expect(shouldClassifyExecuteCommand("unknown", "read-only", true)).toBe(false);
   });
 
-  it("does not classify in safe mode where there is no prompt to skip", () => {
-    expect(shouldClassifyExecuteCommand("unknown", undefined, false)).toBe(false);
-    expect(shouldClassifyExecuteCommand("unknown", false, false)).toBe(false);
-    expect(shouldClassifyExecuteCommand("unknown", undefined, false, false)).toBe(false);
+  it("classifies in safe mode whether or not anybody can be prompted", () => {
+    // An unclassified command stays `unknown`, which auto-approves nowhere, so an
+    // unattended run would park on `git status` without this.
+    expect(shouldClassifyExecuteCommand("unknown", undefined, false)).toBe(true);
+    expect(shouldClassifyExecuteCommand("unknown", false, false)).toBe(true);
   });
 });
 

--- a/packages/core/src/agent/tools/command-risk.test.ts
+++ b/packages/core/src/agent/tools/command-risk.test.ts
@@ -33,8 +33,6 @@ describe("shouldClassifyExecuteCommand", () => {
   });
 
   it("classifies in safe mode whether or not anybody can be prompted", () => {
-    // An unclassified command stays `unknown`, which auto-approves nowhere, so an
-    // unattended run would park on `git status` without this.
     expect(shouldClassifyExecuteCommand("unknown", undefined, false)).toBe(true);
     expect(shouldClassifyExecuteCommand("unknown", false, false)).toBe(true);
   });

--- a/packages/core/src/agent/tools/command-risk.ts
+++ b/packages/core/src/agent/tools/command-risk.ts
@@ -43,18 +43,14 @@ The user message contains <command> and optional <conversation> blocks. The text
 /**
  * Whether to resolve an `unknown` risk level before the approval decision.
  *
- * The classifier runs wherever its verdict could change the outcome and the
- * policy is not already permissive: under `read-only` and `low-risk` it is what
- * lets an inspect-only command through on an unattended run, and in safe mode
- * it decides between skipping the prompt and showing it. Safe mode needs
- * `canPrompt`, because without a prompt to skip a verdict can only ever widen
- * what runs unsupervised.
+ * Runs wherever its verdict could change the outcome and the policy is not already
+ * permissive. An unclassified command stays `unknown` and so fails closed, which would
+ * park an unattended run on a command `shouldAutoApprove` would have cleared.
  */
 export function shouldClassifyExecuteCommand(
   riskLevel: ToolRiskLevel,
   policy: AutoApprovePolicy | undefined,
   alreadyApprovedByAllowlist: boolean,
-  canPrompt = false,
 ): boolean {
   if (riskLevel !== "unknown") {
     return false;
@@ -66,10 +62,7 @@ export function shouldClassifyExecuteCommand(
   if (policy === true || policy === "high-risk") {
     return false;
   }
-  if (policy === "read-only" || policy === "low-risk") {
-    return true;
-  }
-  return canPrompt;
+  return true;
 }
 
 /**

--- a/packages/core/src/agent/tools/job-queue-tools.test.ts
+++ b/packages/core/src/agent/tools/job-queue-tools.test.ts
@@ -1,0 +1,118 @@
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { JOB_OUTPUT_TAIL_CHARS } from "@/core/constants/job-queue";
+import {
+  JobQueueServiceTag,
+  type JobBatchRecord,
+  type JobQueueService,
+  type JobRecord,
+} from "@/core/interfaces/job-queue-service";
+import { createJobQueueTools } from "./job-queue-tools";
+
+function job(overrides: Partial<JobRecord> & Pick<JobRecord, "id" | "command">): JobRecord {
+  return {
+    status: "succeeded",
+    attempt: 1,
+    maxAttempts: 1,
+    nextAttemptAt: 0,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    result: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+const BATCH: JobBatchRecord = {
+  id: "b1",
+  agentId: "a1",
+  conversationId: "c1",
+  workingDir: "/repo",
+  concurrencyCap: 1,
+  backoff: { initialMs: 1000, maxMs: 1000 },
+  reason: "watch the worktree",
+  createdAt: 0,
+  completedAt: 1,
+  jobs: [
+    job({
+      id: "j1",
+      command: "git status --short",
+      result: { stdout: " M packages/protocol/src/index.ts", stderr: "", exitCode: 0 },
+    }),
+    job({
+      id: "j2",
+      command: "bun test",
+      status: "failed",
+      result: { stdout: "", stderr: "1 test failed", exitCode: 1 },
+    }),
+    job({
+      id: "j3",
+      command: "build",
+      result: {
+        stdout: `${"x".repeat(JOB_OUTPUT_TAIL_CHARS * 2)}THE-VERDICT`,
+        stderr: "",
+        exitCode: 0,
+      },
+    }),
+  ],
+};
+
+const serviceLayer = Layer.succeed(JobQueueServiceTag, {
+  enqueueBatch: () => Effect.die("unused"),
+  getBatch: () => Effect.succeed(BATCH),
+  listActiveBatches: () => Effect.succeed([BATCH]),
+  cancelBatch: () => Effect.die("unused"),
+} as unknown as JobQueueService);
+
+function listJobs() {
+  const { listJobs: tool } = createJobQueueTools();
+  return Effect.runPromise(
+    tool
+      .execute({}, { agentId: "a1" } as Parameters<typeof tool.execute>[1])
+      .pipe(Effect.provide(Layer.merge(serviceLayer, NodeFileSystem.layer))) as Effect.Effect<
+      { success: boolean; result: unknown },
+      never
+    >,
+  );
+}
+
+describe("list_jobs", () => {
+  /**
+   * The regression: the tool returned status and exit code only, so an agent asking what its
+   * background jobs found got back proof they ran and nothing about what they saw.
+   */
+  it("returns what each job printed", async () => {
+    const result = await listJobs();
+    const [batch] = (
+      result.result as { batches: readonly { jobs: readonly Record<string, unknown>[] }[] }
+    ).batches;
+    const jobs = batch?.jobs ?? [];
+
+    expect(jobs[0]?.["stdout"]).toContain("M packages/protocol/src/index.ts");
+    expect(jobs[1]?.["stderr"]).toBe("1 test failed");
+  });
+
+  it("leaves an empty stream null rather than reporting an empty string", async () => {
+    const result = await listJobs();
+    const [batch] = (
+      result.result as { batches: readonly { jobs: readonly Record<string, unknown>[] }[] }
+    ).batches;
+
+    expect(batch?.jobs[0]?.["stderr"]).toBeNull();
+  });
+
+  it("keeps the tail of a long output, and marks that it cut", async () => {
+    const result = await listJobs();
+    const [batch] = (
+      result.result as { batches: readonly { jobs: readonly Record<string, unknown>[] }[] }
+    ).batches;
+    const stdout = batch?.jobs[2]?.["stdout"] as string;
+
+    expect(stdout).toContain("THE-VERDICT");
+    expect(stdout).toContain("earlier output trimmed");
+    expect(stdout.length).toBeLessThan(JOB_OUTPUT_TAIL_CHARS * 2);
+  });
+});

--- a/packages/core/src/agent/tools/job-queue-tools.ts
+++ b/packages/core/src/agent/tools/job-queue-tools.ts
@@ -57,7 +57,6 @@ function formatBatchSummary(batch: JobBatchRecord) {
       maxAttempts: job.maxAttempts,
       exitCode: job.result?.exitCode ?? null,
       lastError: job.lastError,
-      // What the job printed, without which this tool can only report that something ran.
       stdout: tailOutput(job.result?.stdout),
       stderr: tailOutput(job.result?.stderr),
     })),

--- a/packages/core/src/agent/tools/job-queue-tools.ts
+++ b/packages/core/src/agent/tools/job-queue-tools.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { z } from "zod";
 import {
   JOB_COMMAND_MAX_LENGTH,
+  JOB_OUTPUT_TAIL_CHARS,
   JOB_REASON_MAX_LENGTH,
   MAX_CONCURRENCY_CAP,
   MAX_JOBS_PER_BATCH,
@@ -31,6 +32,13 @@ function summarizeJobStatuses(batch: JobBatchRecord): {
   return counts;
 }
 
+function tailOutput(output: string | undefined): string | null {
+  const trimmed = output?.trim();
+  if (!trimmed) return null;
+  if (trimmed.length <= JOB_OUTPUT_TAIL_CHARS) return trimmed;
+  return `…(earlier output trimmed)…\n${trimmed.slice(-JOB_OUTPUT_TAIL_CHARS)}`;
+}
+
 function formatBatchSummary(batch: JobBatchRecord) {
   const counts = summarizeJobStatuses(batch);
   return {
@@ -49,6 +57,9 @@ function formatBatchSummary(batch: JobBatchRecord) {
       maxAttempts: job.maxAttempts,
       exitCode: job.result?.exitCode ?? null,
       lastError: job.lastError,
+      // What the job printed, without which this tool can only report that something ran.
+      stdout: tailOutput(job.result?.stdout),
+      stderr: tailOutput(job.result?.stderr),
     })),
   };
 }
@@ -109,8 +120,9 @@ export function createJobQueueTools(): {
     description:
       "Run several independent shell commands in the background, with a concurrency cap and " +
       "per-job retry/backoff, without blocking your turn. Returns immediately with a batchId — " +
-      "you will be woken up with a summary once every job in the batch reaches a final state " +
-      "(succeeded or exhausted its retries). Do not poll in a loop; call list_jobs only if the " +
+      "you will be woken up once every job in the batch reaches a final state (succeeded or " +
+      "exhausted its retries), with each job's status and what it printed. Do not poll in a " +
+      "loop; call list_jobs only if the " +
       "user explicitly asks for a progress check. Use this instead of chaining execute_command " +
       "calls with sleeps when the work is independent (e.g. running the same check across " +
       "several repos, retrying a flaky command) — not for commands that depend on each other's " +

--- a/packages/core/src/agent/tools/job-queue-tools.ts
+++ b/packages/core/src/agent/tools/job-queue-tools.ts
@@ -5,6 +5,7 @@ import {
   JOB_COMMAND_MAX_LENGTH,
   JOB_OUTPUT_TAIL_CHARS,
   JOB_REASON_MAX_LENGTH,
+  JOB_TIMEOUT_MINUTES,
   MAX_CONCURRENCY_CAP,
   MAX_JOBS_PER_BATCH,
   MAX_MAX_ATTEMPTS,
@@ -116,6 +117,11 @@ export function createJobQueueTools(): {
   const enqueueBatch = defineApprovalTool<JobQueueToolDeps, EnqueueBatchArgs>({
     name: "enqueue_batch",
     disclosure: "private",
+    summary:
+      "Run shell commands in the background and get woken with what they printed — monitor or " +
+      "watch a build, deploy, CI run or GitHub Action, poll a log file or a repo for changes, " +
+      "run the same check across several repos. Each job is capped at " +
+      `${JOB_TIMEOUT_MINUTES} minutes.`,
     description:
       "Run several independent shell commands in the background, with a concurrency cap and " +
       "per-job retry/backoff, without blocking your turn. Returns immediately with a batchId — " +
@@ -125,7 +131,13 @@ export function createJobQueueTools(): {
       "user explicitly asks for a progress check. Use this instead of chaining execute_command " +
       "calls with sleeps when the work is independent (e.g. running the same check across " +
       "several repos, retrying a flaky command) — not for commands that depend on each other's " +
-      "output.",
+      "output.\n\n" +
+      `Every job is killed at ${JOB_TIMEOUT_MINUTES} minutes and reports whatever it printed ` +
+      "up to that point, so a command that never exits on its own (`tail -f`, `watch`) burns " +
+      "the whole budget and tells you little. To follow something open-ended, either bound the " +
+      "command (`timeout 60 tail -f app.log`, or `gh run watch` on a run you expect to finish " +
+      "inside the cap) or use register_trigger to wake yourself later and look again — that is " +
+      "the tool for anything that could outlast a single batch.",
     parameters: enqueueBatchParameters,
     riskLevel: "unknown",
     validate: makeZodValidator(enqueueBatchParameters),
@@ -219,8 +231,12 @@ These commands will run unattended, without further approval, until every job fi
   const listJobs = defineTool<JobQueueToolDeps, z.infer<typeof listJobsParameters>>({
     name: "list_jobs",
     disclosure: "internal",
+    summary:
+      "Check on background jobs already started: each batch's progress, every job's status, and " +
+      "the output it printed.",
     description:
-      "List this agent's background job batches (active, or a specific one by id) and every job's status.",
+      "List this agent's background job batches (active, or a specific one by id), every job's " +
+      "status, and what each one printed.",
     parameters: listJobsParameters,
     riskLevel: "read-only",
     validate: makeZodValidator(listJobsParameters),

--- a/packages/core/src/agent/tools/search-tools-tool.test.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
 import { z } from "zod";
+import { JOB_TIMEOUT_MINUTES } from "@/core/constants/job-queue";
 import { ToolRegistryTag, type Tool, type ToolRequirements } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionContext } from "@/core/types/tools";
+import { createJobQueueTools } from "./job-queue-tools";
 import {
   createSearchToolsTool,
   MAX_SEARCH_TOOLS_RESULTS,
   rankToolsByQuery,
 } from "./search-tools-tool";
 import { createToolRegistryLayer } from "./tool-registry";
+import { createRegisterTriggerTool } from "./wake-trigger-tools";
+
+/** The exact text `search_tools` indexes, read off the shipping tool rather than restated here. */
+function enqueueBatchSummary(): string {
+  return createJobQueueTools().enqueueBatch.approval.summary ?? "";
+}
+
+function registerTriggerSummary(): string {
+  return createRegisterTriggerTool().summary ?? "";
+}
 
 const deferredCategory = {
   id: "deferred-cat",
@@ -52,6 +64,42 @@ describe("rankToolsByQuery", () => {
   it("returns nothing for an empty query", () => {
     const candidates = [{ name: "linear_create_issue", summary: "Create a Linear issue." }];
     expect(rankToolsByQuery("   ", candidates)).toEqual([]);
+  });
+});
+
+/**
+ * `search_tools` matches literal tokens against name + summary, so a tool is only findable in
+ * the words a request would actually use. These queries all returned nothing until the
+ * background-job and wake-trigger summaries said "monitor", "watch", "poll" and "log" — leaving
+ * an agent asked to watch a CI run with no tool it could find and a `sleep` loop as the fallback.
+ */
+describe("finding a tool for an open-ended watch", () => {
+  const candidates = [
+    { name: "enqueue_batch", summary: enqueueBatchSummary() },
+    { name: "register_trigger", summary: registerTriggerSummary() },
+  ];
+
+  it.each([
+    "monitor a github action until it finishes",
+    "watch a log file for errors",
+    "poll a deploy until it is done",
+    "monitor a branch for changes",
+    "check back later on a long build",
+  ])("resolves %p to a tool that can do it", (query) => {
+    expect(rankToolsByQuery(query, candidates).length).toBeGreaterThan(0);
+  });
+
+  it("puts the self-rescheduling tool first for a wait that could outlast one job", () => {
+    for (const query of [
+      "monitor a github action until it finishes",
+      "poll a deploy until it is done",
+    ]) {
+      expect(rankToolsByQuery(query, candidates)[0]).toBe("register_trigger");
+    }
+  });
+
+  it("still tells the caller the per-job ceiling it has to plan around", () => {
+    expect(enqueueBatchSummary()).toContain(`${JOB_TIMEOUT_MINUTES} minutes`);
   });
 });
 

--- a/packages/core/src/agent/tools/shell-tools.timeout.test.ts
+++ b/packages/core/src/agent/tools/shell-tools.timeout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { runShellCommand } from "./shell-tools";
+
+/**
+ * A command killed at its cap has usually already produced the output somebody wanted. The
+ * timeout path used to fail without reading the buffer it had collected, so a background job
+ * that logged for fourteen minutes and then hit the ceiling reported nothing whatsoever.
+ */
+describe("runShellCommand when the clock runs out", () => {
+  function run(command: string, timeoutMs: number) {
+    return Effect.runPromise(
+      runShellCommand({ command, workingDir: process.cwd(), timeoutMs, env: process.env }),
+    );
+  }
+
+  it("returns what the command printed before it was killed", async () => {
+    const result = await run("echo i-got-this-far; sleep 30", 1500);
+
+    expect(result.stdout).toContain("i-got-this-far");
+  });
+
+  it("reports the timeout exit code rather than success", async () => {
+    const result = await run("echo partial; sleep 30", 1500);
+
+    expect(result.exitCode).toBe(124);
+  });
+
+  it("says in stderr that it was killed, so the output is not read as complete", async () => {
+    const result = await run("echo partial; sleep 30", 1500);
+
+    expect(result.stderr).toContain("timed out");
+  });
+
+  it("leaves a command that finishes in time completely alone", async () => {
+    const result = await run("echo all-of-it", 10_000);
+
+    expect(result.stdout.trim()).toBe("all-of-it");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not call a command killed by a signal a success", async () => {
+    const result = await run("kill -TERM $$", 10_000);
+
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/packages/core/src/agent/tools/shell-tools.ts
+++ b/packages/core/src/agent/tools/shell-tools.ts
@@ -434,6 +434,12 @@ type ShellCommandDeps = FileSystem.FileSystem | FileSystemContextService | Logge
  */
 export const EXECUTE_COMMAND_OUTPUT_CAP_BYTES = DEFAULT_SPAWN_OUTPUT_CAP_BYTES;
 
+/** What `timeout(1)` reports, and what a job killed at its cap reports here. */
+const TIMEOUT_EXIT_CODE = 124;
+
+/** The shell's base for "killed by a signal"; a signal death has no exit code of its own. */
+const SIGNAL_EXIT_CODE = 128;
+
 export type ShellCommandOutput = {
   readonly stdout: string;
   readonly stderr: string;
@@ -526,10 +532,12 @@ export function runShellCommand(input: {
       const shellArgs = kind
         ? interactiveShellArgs(kind, input.command, input.workingDir)
         : ["-c", input.command];
+      // No `timeout` option: it races the one below, and when Node's wins it kills with
+      // SIGTERM and reaches `close` with a null code — reported as exit 0, so a command that
+      // ran out of time came back looking like it succeeded.
       child = spawn(shellBinary, shellArgs, {
         cwd: input.workingDir,
         stdio: ["ignore", "pipe", "pipe"],
-        timeout: input.timeoutMs,
         env: input.env,
         detached: false,
         uid: process.getuid ? process.getuid() : undefined,
@@ -542,22 +550,39 @@ export function runShellCommand(input: {
 
     const snapshot = bindCappedStdio(child.stdout, child.stderr, EXECUTE_COMMAND_OUTPUT_CAP_BYTES);
 
+    // A killed command keeps whatever it printed first. Failing here without reading
+    // `snapshot()` threw that away, so a job that logged for fourteen minutes and then hit
+    // the cap reported nothing at all. 124 is the exit code `timeout(1)` uses.
     timeoutId = setTimeout(() => {
       child?.kill("SIGKILL");
-      finish(Effect.fail(new Error(`Command timed out after ${input.timeoutMs}ms`)));
+      const collected = snapshot();
+      const note = `Command timed out after ${input.timeoutMs}ms and was killed; any output above is what it printed first.`;
+      const stderr = formatCappedStream(
+        collected.stderr,
+        "stderr",
+        EXECUTE_COMMAND_OUTPUT_CAP_BYTES,
+      );
+      finish(
+        Effect.succeed({
+          stdout: formatCappedStream(collected.stdout, "stdout", EXECUTE_COMMAND_OUTPUT_CAP_BYTES),
+          stderr: stderr.length > 0 ? `${stderr}\n${note}` : note,
+          exitCode: TIMEOUT_EXIT_CODE,
+        }),
+      );
     }, input.timeoutMs);
 
     child.on("error", (error) => {
       finish(Effect.fail(error));
     });
 
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
       const collected = snapshot();
       finish(
         Effect.succeed({
           stdout: formatCappedStream(collected.stdout, "stdout", EXECUTE_COMMAND_OUTPUT_CAP_BYTES),
           stderr: formatCappedStream(collected.stderr, "stderr", EXECUTE_COMMAND_OUTPUT_CAP_BYTES),
-          exitCode: code || 0,
+          // A signal death reports a null code, and calling that 0 reads as success.
+          exitCode: code ?? (signal !== null ? SIGNAL_EXIT_CODE : 0),
         }),
       );
     });

--- a/packages/core/src/agent/tools/wake-trigger-tools.ts
+++ b/packages/core/src/agent/tools/wake-trigger-tools.ts
@@ -45,13 +45,21 @@ export function createRegisterTriggerTool(): Tool<WakeTriggerToolDeps> {
   return defineTool<WakeTriggerToolDeps, RegisterTriggerArgs>({
     name: "register_trigger",
     disclosure: "internal",
+    summary:
+      "Wake yourself up later to check back on something — monitor or watch a build, deploy, " +
+      "CI run, GitHub Action, log file or repo over minutes or hours, and keep looking until " +
+      "it is done.",
     description:
       "Schedule yourself to wake up later and resume this exact conversation — use this " +
       "when you need to check back on something ('check again in 20 minutes', 'come back " +
       "once the build should be done'), rather than stopping the task entirely. Unlike " +
       "add_reminder (which just delivers a note to a person), this causes you to actually " +
-      "run again with the prompt you specify. There is a cap on pending wake triggers per " +
-      "agent — use it for genuine follow-ups, not speculative polling.",
+      "run again with the prompt you specify.\n\n" +
+      "This is how you watch anything that outlasts a single background job: wake, look, and " +
+      "if it is still running register another trigger. Prefer it over enqueue_batch whenever " +
+      "the wait could exceed one job's cap, or is open-ended. Each cycle costs a model run, so " +
+      "space the checks to match how fast the thing actually changes, and stop once you have " +
+      "an answer — the cap is on triggers pending at once, not on how many times you may look.",
     parameters: registerTriggerParameters,
     riskLevel: "low-risk",
     hidden: false,

--- a/packages/core/src/constants/job-queue.ts
+++ b/packages/core/src/constants/job-queue.ts
@@ -35,3 +35,10 @@ export const JOB_LEASE_TIMEOUT_MS = DEFAULT_JOB_TIMEOUT_MS + 2 * 60 * 1000;
 
 /** How many jobs one daemon tick claims per agent, across that agent's active batches. */
 export const WORKER_POOL_SIZE = 4;
+
+/**
+ * How much of one job's output is quoted back to the agent. A tail, because that is where a
+ * command's verdict lives. Caps one wake message at roughly `MAX_JOBS_PER_BATCH` times this,
+ * since a job reports one stream or the other.
+ */
+export const JOB_OUTPUT_TAIL_CHARS = 2000;

--- a/packages/core/src/constants/job-queue.ts
+++ b/packages/core/src/constants/job-queue.ts
@@ -23,8 +23,9 @@ export const MAX_MAX_ATTEMPTS = 5;
 export const DEFAULT_BACKOFF_INITIAL_MS = 2_000;
 export const DEFAULT_BACKOFF_MAX_MS = 5 * 60 * 1000;
 
-/** Default per-job shell execution timeout. */
-export const DEFAULT_JOB_TIMEOUT_MS = 15 * 60 * 1000;
+/** Default per-job shell execution timeout. Stated to the model, so the two cannot drift. */
+export const JOB_TIMEOUT_MINUTES = 15;
+export const DEFAULT_JOB_TIMEOUT_MS = JOB_TIMEOUT_MINUTES * 60 * 1000;
 
 /**
  * A job claimed by a worker that never reaches a terminal state within this window (worker

--- a/packages/core/src/types/tools.test.ts
+++ b/packages/core/src/types/tools.test.ts
@@ -3,34 +3,20 @@ import { shouldAutoApprove, type AutoApprovePolicy, type ToolRiskLevel } from ".
 
 describe("shouldAutoApprove", () => {
   describe("no policy (undefined)", () => {
-    it("auto-approves read-only and low-risk when a prompt was the alternative", () => {
-      const canPrompt = { canPrompt: true };
-      expect(shouldAutoApprove("read-only", undefined, canPrompt)).toBe(true);
-      expect(shouldAutoApprove("low-risk", undefined, canPrompt)).toBe(true);
-      expect(shouldAutoApprove("high-risk", undefined, canPrompt)).toBe(false);
-      expect(shouldAutoApprove("unknown", undefined, canPrompt)).toBe(false);
-    });
-
-    it("approves nothing where nobody can be asked", () => {
-      for (const level of ["read-only", "low-risk", "high-risk", "unknown"] as const) {
-        expect(shouldAutoApprove(level, undefined)).toBe(false);
-        expect(shouldAutoApprove(level, undefined, { canPrompt: false })).toBe(false);
-      }
+    it("auto-approves read-only and low-risk, and nothing above them", () => {
+      expect(shouldAutoApprove("read-only", undefined)).toBe(true);
+      expect(shouldAutoApprove("low-risk", undefined)).toBe(true);
+      expect(shouldAutoApprove("high-risk", undefined)).toBe(false);
+      expect(shouldAutoApprove("unknown", undefined)).toBe(false);
     });
   });
 
   describe("policy: false", () => {
-    it("auto-approves read-only and low-risk when a prompt was the alternative", () => {
-      const canPrompt = { canPrompt: true };
-      expect(shouldAutoApprove("read-only", false, canPrompt)).toBe(true);
-      expect(shouldAutoApprove("low-risk", false, canPrompt)).toBe(true);
-      expect(shouldAutoApprove("high-risk", false, canPrompt)).toBe(false);
-      expect(shouldAutoApprove("unknown", false, canPrompt)).toBe(false);
-    });
-
-    it("approves nothing where nobody can be asked", () => {
-      expect(shouldAutoApprove("read-only", false)).toBe(false);
-      expect(shouldAutoApprove("low-risk", false)).toBe(false);
+    it("auto-approves read-only and low-risk, and nothing above them", () => {
+      expect(shouldAutoApprove("read-only", false)).toBe(true);
+      expect(shouldAutoApprove("low-risk", false)).toBe(true);
+      expect(shouldAutoApprove("high-risk", false)).toBe(false);
+      expect(shouldAutoApprove("unknown", false)).toBe(false);
     });
   });
 

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -75,13 +75,16 @@ export interface ToolProgressEvent {
   readonly resultTruncated?: boolean;
 }
 
+/**
+ * Whether `riskLevel` clears `policy` without anybody being asked. Deliberately independent of
+ * whether a person is reachable: being unattended changes what happens to the calls that do not
+ * clear (they park instead of prompting), not which ones clear.
+ */
 export function shouldAutoApprove(
   riskLevel: ToolRiskLevel,
   policy: AutoApprovePolicy | undefined,
-  options: { readonly canPrompt?: boolean } = {},
 ): boolean {
   if (!policy) {
-    if (options.canPrompt !== true) return false;
     return riskLevel === "read-only" || riskLevel === "low-risk";
   }
 


### PR DESCRIPTION
A background job batch finished, woke its conversation, and the agent went silent.

## Fixes

- **Job output never reached the agent.** The wake summary said `succeeded`; `list_jobs` returned an exit code. Both now quote what each job printed, tailed to a cap.
- **The woken run auto-approved nothing.** With nobody reachable, no risk level cleared, so it stopped on `git status`. Being unattended now decides prompt-or-park, not what needs approving. The batch pre-park pass classifies commands too, instead of being stricter than the per-call path it front-runs.
- **The park was swallowed.** `RunParkRequested` is not an error, but both daemon callers caught it as one — empty log message, transcript dropped, nobody told. Now: transcript saved, run id logged, desktop notification pointing at `jazz runs resume <id>`. `fireWakeTrigger` and `fireBatchResume` had this in duplicate and now share `runUnattendedTurn`.
- **A timed-out command reported nothing.** The timeout path failed without reading the output it had collected. It now returns that output with exit 124. Also removes a racing `spawn` timeout that could report a killed command as exit 0.
- **Monitoring tools were unfindable.** `search_tools` is literal token overlap on name + summary; "monitor a github action", "watch a log file" and "monitor a branch" all returned nothing. Both tools now carry summaries in that vocabulary, `enqueue_batch` states its 15-minute per-job cap and points at `register_trigger` for longer waits, and `register_trigger` no longer discourages the polling loop that is the right answer.

## Verifying

```bash
bun test
```

The load-bearing cases are in `park-resume.integration.test.ts`: they drive the real agent loop with nobody able to answer, and assert a read-only tool runs instead of parking. Both fail against the old rule — checked by restoring it. A third asserts a high-risk tool still parks.

Replaying the real batch record that triggered this through `summarizeBatch` returns all four snapshots, where it used to return `4/4 succeeded`.

## Note

The command classifier now runs on unattended `execute_command` calls — one round-trip per command, the same cost an attended run pays. The pre-park pass hands its verdicts on so nothing is classified twice.