### PR TITLE
feat(bots): batch tool approvals, add /mode, and ingest video on Telegram

### DIFF
--- a/docs/use-cases/chat-platforms.md
+++ b/docs/use-cases/chat-platforms.md
@@ -89,6 +89,7 @@ What the Telegram bridge demonstrates — worth reading before you write your ow
 | **Per-chat memory** | `--conversation <chat_id>`. The bridge itself is stateless.                                                                                                                    |
 | **Live progress**   | `--events` NDJSON on stderr drives a status bubble that updates with thinking, tool calls, and sub-agents, then closes with a `✅ Done · 7 tools · 12k tokens · $0.03` summary. |
 | **Cancellation**    | A ⏹ button kills the child process mid-run.                                                                                                                                    |
+| **Approvals**       | Each tool needing a human gets its own accept/reject message. A parallel batch of tool calls grows **⚡ Approve all N** / **🚫 Reject all N** so the whole batch clears in one tap, and `/mode` opts a conversation out of prompting altogether (yolo runs at `high-risk`). Both bridges do this. |
 | **Reminders**       | `/remind 30m …`, persisted to disk so they survive restarts and fire late if the bridge was down.                                                                              |
 | **Spend cap**       | `JAZZ_DAILY_COST_CAP_USD` — known `costUSD` is accumulated per day; after an unpriced run, further requests pause until the next UTC day.                                      |
 | **Local-only mode** | Point `JAZZ_TELEGRAM_PROVIDER=ollama` at a local model: no keys, no cloud, no per-message cost.                                                                                |
@@ -274,6 +275,7 @@ flowchart LR
 
 - **Always use an allowlist.** Both bridges and Jazz have one; use both.
 - **Default to `low-risk`.** At `high-risk`, a message — or a prompt injection inside a web page the agent fetched — can run arbitrary commands on the host. That is the documented behavior of that tier, not a bug.
+- **Know what "yolo" costs.** Both bridges' `/mode yolo` is `high-risk` for that conversation, and it is sticky — it survives `/new` and bridge restarts until someone sets it back to safe. Anyone on the allowlist can set it for their own conversation.
 - **Trim the toolset.** An agent config that doesn't include `execute_command` cannot run shell commands regardless of policy. This is the strongest control available.
 - **Treat the history volume as sensitive.** Transcripts are plaintext JSON under `~/.jazz/history/`.
 - **Cap spend.** Use `costKnown` as well as `costUSD`. The bridges pause subsequent requests after an unpriced run; no dollar cap can guarantee the cost of that first unpriced request.

--- a/packages/bot-shared/src/approval-mode-store.test.ts
+++ b/packages/bot-shared/src/approval-mode-store.test.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  APPROVAL_MODE_LABELS,
+  approvalModeFor,
+  approvalPolicyFor,
+  describeApprovalMode,
+  setApprovalMode,
+} from "./approval-mode-store";
+
+const MODE_FILE = "tg-mode.json";
+const SCOPE = "123456789012345678";
+const OTHER = "223456789012345678";
+
+describe("approval mode store", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-approval-mode-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("defaults to safe before any /mode", () => {
+    expect(approvalModeFor(tmpDir, MODE_FILE, SCOPE)).toBe("safe");
+  });
+
+  it("persists yolo and switches back to safe", () => {
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "yolo");
+    expect(approvalModeFor(tmpDir, MODE_FILE, SCOPE)).toBe("yolo");
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "safe");
+    expect(approvalModeFor(tmpDir, MODE_FILE, SCOPE)).toBe("safe");
+  });
+
+  it("stores nothing for safe so the deployment default keeps applying", () => {
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "yolo");
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "safe");
+    const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, MODE_FILE), "utf8")) as Record<
+      string,
+      string
+    >;
+    expect(stored).toEqual({});
+  });
+
+  it("keeps other conversations isolated", () => {
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "yolo");
+    expect(approvalModeFor(tmpDir, MODE_FILE, OTHER)).toBe("safe");
+  });
+
+  it("preserves a corrupt file instead of clobbering every conversation", () => {
+    const storePath = path.join(tmpDir, MODE_FILE);
+    fs.writeFileSync(storePath, "{not json");
+    setApprovalMode(tmpDir, MODE_FILE, SCOPE, "yolo");
+    expect(fs.existsSync(`${storePath}.corrupt`)).toBe(true);
+    expect(approvalModeFor(tmpDir, MODE_FILE, SCOPE)).toBe("yolo");
+  });
+
+  describe("describeApprovalMode", () => {
+    const html = {
+      bold: (text: string) => `<b>${text}</b>`,
+      code: (text: string) => `<code>${text}</code>`,
+    };
+    const markdown = {
+      bold: (text: string) => `**${text}**`,
+      code: (text: string) => `\`${text}\``,
+    };
+
+    it("names the deployment's configured tier in safe mode", () => {
+      expect(describeApprovalMode("safe", "read-only", html)).toContain("<code>read-only</code>");
+      expect(describeApprovalMode("safe", "low-risk", markdown)).toContain("`low-risk`");
+    });
+
+    it("says yolo never stops, without naming a tier", () => {
+      const described = describeApprovalMode("yolo", "read-only", markdown);
+      expect(described).toContain("**🎲 Yolo**");
+      expect(described).not.toContain("read-only");
+    });
+
+    it("keeps the same wording across both bridges' markup", () => {
+      const withoutHtml = (text: string) => text.replace(/<\/?(?:b|code)>/g, "");
+      const withoutMarkdown = (text: string) => text.replace(/\*\*|`/g, "");
+      for (const mode of ["safe", "yolo"] as const) {
+        expect(withoutHtml(describeApprovalMode(mode, "low-risk", html))).toBe(
+          withoutMarkdown(describeApprovalMode(mode, "low-risk", markdown)),
+        );
+      }
+    });
+
+    it("labels both modes", () => {
+      expect(APPROVAL_MODE_LABELS.safe).toContain("Safe");
+      expect(APPROVAL_MODE_LABELS.yolo).toContain("Yolo");
+    });
+  });
+
+  describe("approvalPolicyFor", () => {
+    it("passes the deployment's configured tier through in safe mode", () => {
+      expect(approvalPolicyFor(tmpDir, MODE_FILE, SCOPE, "read-only")).toBe("read-only");
+      expect(approvalPolicyFor(tmpDir, MODE_FILE, SCOPE, "low-risk")).toBe("low-risk");
+    });
+
+    it("pins yolo to high-risk regardless of the configured tier", () => {
+      setApprovalMode(tmpDir, MODE_FILE, SCOPE, "yolo");
+      expect(approvalPolicyFor(tmpDir, MODE_FILE, SCOPE, "read-only")).toBe("high-risk");
+    });
+  });
+});

--- a/packages/bot-shared/src/approval-mode-store.ts
+++ b/packages/bot-shared/src/approval-mode-store.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-conversation approval mode, shared by the Discord and Telegram bridges.
+ *
+ * Two user-facing modes sit on top of Jazz's three approval-policy tiers:
+ * "safe" keeps whatever tier the deployment was configured with (so an
+ * operator who set `read-only` still gets `read-only`), while "yolo" pins the
+ * run to `high-risk`, which approves everything without prompting. Only "yolo"
+ * is written to disk — an absent entry means safe, so the deployment default
+ * keeps applying to every conversation that never opted out.
+ *
+ * `fileName` is the per-bridge store file (`dc-mode.json` / `tg-mode.json`).
+ */
+
+import {
+  preserveCorruptFile,
+  readRecordStore,
+  recordStorePath,
+  writeRecordStore,
+} from "./scoped-record-store";
+
+export type ApprovalMode = "safe" | "yolo";
+
+export const APPROVAL_MODE_LABELS: Record<ApprovalMode, string> = {
+  safe: "🛡️ Safe",
+  yolo: "🎲 Yolo",
+};
+
+/**
+ * How a bridge emphasises text. Discord speaks Markdown and Telegram speaks
+ * HTML, so the wording below is shared while the markup stays per-platform —
+ * what yolo promises is a product rule and must not drift between the two.
+ */
+export interface ApprovalModeMarkup {
+  bold: (text: string) => string;
+  code: (text: string) => string;
+}
+
+/**
+ * One line describing what a mode does, for the picker and the confirmation.
+ *
+ * Safe names the tier the deployment actually configured, because "safe" is
+ * that tier rather than a fixed one — an operator running `read-only` gets a
+ * different promise from one running `low-risk`.
+ */
+export function describeApprovalMode(
+  mode: ApprovalMode,
+  configuredPolicy: string,
+  markup: ApprovalModeMarkup,
+): string {
+  return mode === "yolo"
+    ? `${markup.bold("🎲 Yolo")} — every tool runs without asking, including shell commands ` +
+        "that write, delete, or reach the network. Nothing will stop and wait for you."
+    : `${markup.bold("🛡️ Safe")} — anything above ${markup.code(configuredPolicy)} ` +
+        "stops and asks you first.";
+}
+
+/** The tier a yolo conversation runs at: every tool auto-approved, nothing prompts. */
+export const YOLO_APPROVAL_POLICY = "high-risk";
+
+export function approvalModeFor(
+  dataDir: string,
+  fileName: string,
+  scopeId: string | number,
+): ApprovalMode {
+  const stored = readRecordStore<ApprovalMode>(recordStorePath(dataDir, fileName))?.[
+    String(scopeId)
+  ];
+  return stored === "yolo" ? "yolo" : "safe";
+}
+
+export function setApprovalMode(
+  dataDir: string,
+  fileName: string,
+  scopeId: string | number,
+  mode: ApprovalMode,
+): void {
+  const path = recordStorePath(dataDir, fileName);
+  const current = readRecordStore<ApprovalMode>(path);
+  if (current === null) {
+    preserveCorruptFile(path);
+  }
+  const next = current ?? {};
+  const key = String(scopeId);
+  if (mode === "yolo") {
+    next[key] = "yolo";
+  } else {
+    delete next[key];
+  }
+  writeRecordStore(path, next);
+}
+
+/**
+ * Resolve the `--approval-policy` value for a conversation, given the tier the
+ * deployment was configured with.
+ */
+export function approvalPolicyFor(
+  dataDir: string,
+  fileName: string,
+  scopeId: string | number,
+  configuredPolicy: string,
+): string {
+  return approvalModeFor(dataDir, fileName, scopeId) === "yolo"
+    ? YOLO_APPROVAL_POLICY
+    : configuredPolicy;
+}

--- a/packages/core/src/presentation/oneshot-presentation-service.test.ts
+++ b/packages/core/src/presentation/oneshot-presentation-service.test.ts
@@ -390,6 +390,40 @@ describe("OneShotPresentationService requestApproval", () => {
     );
     expect(await pendingA).toEqual({ approved: true });
   });
+
+  it("resolves every approval in a batch delivered as one chunk", async () => {
+    // What a chat bridge's "Approve all" does: one write carrying a decision per
+    // outstanding toolCallId, so all of them have to come out of a single chunk.
+    const stdin = new PassThrough();
+    const service = new OneShotPresentationService(
+      DEFAULT_DISPLAY_CONFIG,
+      new Set<StreamEvent["type"]>(["approval_required"]),
+      stdin,
+    );
+
+    const toolCallIds = ["call_1", "call_2", "call_3"];
+    const pending = toolCallIds.map((toolCallId) =>
+      Effect.runPromise(
+        service.requestApproval(makeApprovalRequest({ toolCallId, toolName: "tool" })),
+      ),
+    );
+    await tick();
+
+    stdin.write(
+      toolCallIds
+        .map(
+          (toolCallId) =>
+            `${JSON.stringify({ type: "approval_decision", toolCallId, approved: true })}\n`,
+        )
+        .join(""),
+    );
+
+    expect(await Promise.all(pending)).toEqual([
+      { approved: true },
+      { approved: true },
+      { approved: true },
+    ]);
+  });
 });
 
 describe("OneShotPresentationService.requestUserInput", () => {

--- a/packages/discord-bot/README.md
+++ b/packages/discord-bot/README.md
@@ -19,6 +19,7 @@ Discord  ◀──(Gateway websocket)──▶  bridge  ──jazz run --json─
 - 🎛️ **Per-conversation `/model` and `/persona`** — `/model` picks from a select menu of the current provider's models, or `/model openai/gpt-5.2` (sent as a normal message) switches to any other provider Jazz supports outright; each DM or thread keeps its own choice.
 - 🧵 **Thread binding in servers** — `@mention` in a channel starts a thread; follow-ups in that thread don't need another mention.
 - 🤫 **Mention-gating** — in servers the bot ignores chatter unless mentioned, replied-to, or already in the thread. DMs always respond.
+- 🛡️ **Approvals you can get through fast** — a tool needing a human posts its own accept/reject message; when a model fires several tool calls at once, every outstanding prompt grows **⚡ Approve all N** / **🚫 Reject all N** so one click clears the batch. `/mode mode:yolo` turns approvals off for that conversation entirely; `/mode mode:safe` puts them back.
 - 📡 **Live progress** — a status message updates in real time with thinking, tool calls, sub-agents (🤖), and tools awaiting approval (⛔); it closes with a `✅ Done · tools · tokens · $cost` summary, and the answer lands as a new message.
 - ⏰ **Reminders** — `/remind` or plain language ("remind me in 2 hours …"), scheduled by the agent via a native tool, resolved in your timezone (`/tz`) and delivered even across restarts.
 - 💬 **Per-channel memory**, 🔒 **allowlist-gated**, 🐳 **one-command Docker deploy**.
@@ -126,13 +127,14 @@ allowlisted, or you didn’t @mention it (`DISCORD_REQUIRE_MENTION=1` by default
 | _(DM, or @mention in a server)_ | Answered by your agent                                                                                                                                                                |
 | `/model`                        | Select menu of the current provider's models; send `/model provider/model` (e.g. `anthropic/claude-sonnet-5`) as a normal message to switch this conversation to a different provider outright |
 | `/persona`                      | Select menu of available personas                                                                                                                                                     |
+| `/mode`                         | Show or set this conversation's approval mode. **Safe** (default) keeps `JAZZ_APPROVAL_POLICY`, so risky tools stop and ask. **Yolo** runs every tool without asking. Sticky per conversation — `/new` does not reset it. |
 | `/new`                          | Start a fresh conversation — clears earlier context; keeps your model/persona                                                                                                         |
 | `/incognito`                    | Private conversation (nothing saved to history or memory) until `/new`                                                                                                                |
 | `/remind`                       | Schedule a reminder. `when` = `30m`, `1h30m`, `18:00`, `tomorrow 09:00`, `tue 20:00`, or `2026-08-25 20:00`. Routed through a normal agent turn, which calls the `add_reminder` tool. |
 | _(natural language)_            | Just say it — "remind me to call the dentist in 2 hours". The agent calls `add_reminder` itself.                                                                                      |
 | `/reminders`                    | List your pending reminders (in your timezone); tap one to cancel                                                                                                                     |
 | `/tz`                           | Show or set your timezone (IANA name, e.g. `/tz zone:Europe/Paris`) so reminder times are local                                                                                       |
-| `/status`                       | Current model, your timezone, today's runs/tokens/cost, daily cap, uptime                                                                                                             |
+| `/status`                       | Current model, your timezone, approval mode, today's runs/tokens/cost, daily cap, uptime                                                                                              |
 | `/help`                         | Usage                                                                                                                                                                                 |
 
 While a message is processing, the progress message carries a **⏹ Cancel**
@@ -191,7 +193,7 @@ they only set what a brand-new conversation starts on.
 | `JAZZ_OLLAMA_KEEP_ALIVE`             | —                                       | How long a local Ollama keeps the model loaded (`keep_alive`): `-1` pins it indefinitely, or a duration like `30m`. Unset uses Ollama's 5-minute default, so the first message after a quiet spell pays a full cold model load with no progress shown while it happens. |
 | `JAZZ_REASONING`                     | `medium`                                | `disable`\|`low`\|`medium`\|`high`.                                                                                                                                                                                                                                     |
 | `OLLAMA_BASE_URL`                    | `http://host.docker.internal:11434/api` | Ollama endpoint, used whenever a conversation's provider is `ollama` (default or via `/model`).                                                                                                                                                                                                                |
-| `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`.                                                                                                                                                                                                         |
+| `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`. This is what "safe" means for the deployment; a conversation on `/mode mode:yolo` runs at `high-risk` instead.                                                                                            |
 | `JAZZ_AUTO_APPROVE_TOOLS`            | —                                       | Comma-separated tool names to auto-approve regardless of policy. Tools needing approval that aren't in this list are sent to the channel as an accept/reject prompt instead of being declined.                                                                          |
 | `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                                                                                                                                                                                              |
 | `JAZZ_DAILY_COST_CAP_USD`            | `0`                                     | Daily known-spend ceiling across all conversations; an unpriced run pauses later requests for the UTC day; `0` disables the cap.                                                                                                                                        |
@@ -283,6 +285,9 @@ Set `JAZZ_DEPLOY_BRANCH` to track something other than `main`.
   default `low-risk`, higher-risk actions (shell, delete, push, …) are
   auto-declined; raise it to `high-risk` only if you understand that a prompt
   (or prompt injection) could then run arbitrary commands on the host. Trim the
-  toolset in `agent.discord.json` if you want a smaller blast radius.
+  toolset in `agent.discord.json` if you want a smaller blast radius. Anyone on
+  the allowlist can also put their own conversation on `/mode mode:yolo`, which
+  is `high-risk` for that conversation and survives `/new` and restarts until
+  someone sends `/mode mode:safe`.
 - Agent replies are sent with `allowed_mentions.parse = []` so the model cannot
   ping `@everyone`, `@here`, or arbitrary users.

--- a/packages/discord-bot/src/bridge.ts
+++ b/packages/discord-bot/src/bridge.ts
@@ -13,6 +13,14 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
 import { ReminderServiceImpl } from "@jazz/adapters/reminder-service";
+import {
+  APPROVAL_MODE_LABELS,
+  type ApprovalMode,
+  approvalModeFor,
+  approvalPolicyFor,
+  describeApprovalMode,
+  setApprovalMode,
+} from "@jazz/bot-shared/approval-mode-store";
 import { listPersonaNames } from "@jazz/bot-shared/personas";
 import { listModelsForProvider } from "@jazz/bot-shared/provider-models";
 import { reasoningSnippet, splitReasoning } from "@jazz/bot-shared/reasoning";
@@ -104,6 +112,7 @@ const TZ_FILE = "dc-tz.json";
 const USAGE_FILE = "dc-usage.json";
 const EPOCHS_FILE = "dc-sessions.json";
 const INCOGNITO_FILE = "dc-incognito.json";
+const MODE_FILE = "dc-mode.json";
 
 // The text the progress message is created with. The reporter starts from it so
 // its first render is not sent as an edit to identical content.
@@ -123,10 +132,21 @@ const activeRuns = new Map<
   string,
   { child: Bun.Subprocess<"pipe", "pipe", "pipe">; cancelled: boolean }
 >();
-const pendingApprovals = new Map<
-  string,
-  { toolCallId: string; channelId: string; messageId: string; runToken: string }
->();
+interface PendingApproval {
+  toolCallId: string;
+  channelId: string;
+  messageId: string;
+  runToken: string;
+  /**
+   * The outstanding-approval count this message's buttons currently show.
+   * Approval events arrive concurrently, so a message can be sent with a count
+   * that is already stale by the time it registers; comparing against this is
+   * what tells a refresh which messages genuinely need patching.
+   */
+  shownCount: number;
+}
+
+const pendingApprovals = new Map<string, PendingApproval>();
 const incognitoHistory = new Map<string, unknown[]>();
 
 interface ChannelMeta {
@@ -329,13 +349,97 @@ function cancelComponents(runToken: string): unknown[] {
   return [actionRow([button(`x:${runToken}`, "⏹ Cancel", BUTTON_DANGER)])];
 }
 
-function approvalComponents(token: string): unknown[] {
-  return [
+function approvalComponents(token: string, runToken: string, pendingCount: number): unknown[] {
+  const rows: unknown[] = [
     actionRow([
       button(`a:${token}:1`, "✅ Accept", BUTTON_SUCCESS),
       button(`a:${token}:0`, "❌ Reject", BUTTON_DANGER),
     ]),
   ];
+  // A parallel batch of tool calls asks for approval one message each; clicking
+  // through five of them is the common case, so offer a single click that
+  // clears the whole batch once there is more than one outstanding.
+  if (pendingCount > 1) {
+    rows.push(
+      actionRow([
+        button(`aa:${runToken}:1`, `⚡ Approve all ${pendingCount}`, BUTTON_SUCCESS),
+        button(`aa:${runToken}:0`, `🚫 Reject all ${pendingCount}`, BUTTON_DANGER),
+      ]),
+    );
+  }
+  return rows;
+}
+
+/**
+ * Answer the run's blocked approval prompts over its stdin pipe. Bun's FileSink
+ * buffers writes, so flush() pushes them through now rather than waiting for the
+ * buffer to fill — a batch decision must reach a parked run immediately.
+ */
+async function writeApprovalDecisions(
+  run: { child: Bun.Subprocess<"pipe", "pipe", "pipe"> },
+  decisions: readonly { toolCallId: string; approved: boolean }[],
+): Promise<void> {
+  try {
+    for (const { toolCallId, approved } of decisions) {
+      await run.child.stdin.write(
+        `${JSON.stringify({ type: "approval_decision", toolCallId, approved })}\n`,
+      );
+    }
+    await run.child.stdin.flush();
+  } catch (error) {
+    console.error(`Failed to write approval decision: ${String(error)}`);
+  }
+}
+
+function pendingApprovalsForRun(runToken: string): [string, PendingApproval][] {
+  return [...pendingApprovals].filter(([, pending]) => pending.runToken === runToken);
+}
+
+/**
+ * Rewrite the buttons on a run's outstanding approval messages so their
+ * "Approve all N" count matches reality. Called whenever the outstanding set
+ * changes: a new request arriving makes the count climb, and resolving one
+ * makes it fall — down to a single request, where the batch buttons disappear
+ * again.
+ */
+async function refreshApprovalComponents(config: BridgeConfig, runToken: string): Promise<void> {
+  const outstanding = pendingApprovalsForRun(runToken);
+  for (const [token, pending] of outstanding) {
+    if (pending.shownCount === outstanding.length) continue;
+    pending.shownCount = outstanding.length;
+    await patchMessage(config.botToken, pending.channelId, pending.messageId, {
+      components: approvalComponents(token, runToken, outstanding.length),
+    }).catch(() => undefined);
+  }
+}
+
+function modeComponents(current: ApprovalMode): unknown[] {
+  const modes: ApprovalMode[] = ["safe", "yolo"];
+  return [
+    actionRow(
+      modes.map((mode) =>
+        button(
+          `md:${mode}`,
+          `${mode === current ? "✅ " : ""}${APPROVAL_MODE_LABELS[mode]}`,
+          mode === "yolo" ? BUTTON_DANGER : BUTTON_SUCCESS,
+        ),
+      ),
+    ),
+  ];
+}
+
+function modeExplanation(mode: ApprovalMode, configuredPolicy: string): string {
+  return describeApprovalMode(mode, configuredPolicy, {
+    bold: (text) => `**${text}**`,
+    code: (text) => `\`${text}\``,
+  });
+}
+
+function modeConfirmation(mode: ApprovalMode, configuredPolicy: string): string {
+  return (
+    `✅ Mode → **${APPROVAL_MODE_LABELS[mode]}**\n${modeExplanation(mode, configuredPolicy)}` +
+    (mode === "yolo" ? "\nSend `/mode mode:safe` to turn approvals back on." : "")
+  );
 }
 
 function followupComponents(): unknown[] {
@@ -516,17 +620,22 @@ async function sendApprovalRequest(
     lines.push("```diff", diff, "```");
   }
 
+  // One more than what is already outstanding: this request is about to join
+  // them, and the buttons have to be built before the message is sent.
+  const shownCount = pendingApprovalsForRun(runToken).length + 1;
   const sent = await sendMessage(config.botToken, channelId, lines.join("\n"), {
-    components: approvalComponents(token),
+    components: approvalComponents(token, runToken, shownCount),
   });
-  if (sent !== undefined) {
-    pendingApprovals.set(token, {
-      toolCallId,
-      channelId,
-      messageId: sent.id,
-      runToken,
-    });
-  }
+  if (sent === undefined) return;
+
+  pendingApprovals.set(token, {
+    toolCallId,
+    channelId,
+    messageId: sent.id,
+    runToken,
+    shownCount,
+  });
+  await refreshApprovalComponents(config, runToken);
 }
 
 async function runJazz(
@@ -550,7 +659,7 @@ async function runJazz(
       "--agent",
       agentIdForChannel(channelId),
       "--approval-policy",
-      config.approvalPolicy,
+      approvalPolicyFor(config.jazzHome, MODE_FILE, channelId, config.approvalPolicy),
       ...(config.autoApproveTools.length > 0
         ? ["--auto-approve-tools", config.autoApproveTools.join(",")]
         : []),
@@ -994,6 +1103,7 @@ const HELP_TEXT = [
   "`/model` — pick a model for the current provider, or `/model provider/model` for any other " +
     "provider Jazz supports (e.g. `anthropic/claude-sonnet-5`)",
   "`/persona` — pick my persona / style",
+  "`/mode` — safe (I ask before risky tools) or yolo (I never ask), e.g. `/mode mode:yolo`",
   "`/new` — start a fresh conversation (clears earlier context)",
   "`/incognito` — start a private conversation (nothing saved) until `/new`",
   "`/remind <when> <text>` — e.g. `/remind when:30m text:take pizza out`",
@@ -1016,6 +1126,21 @@ const SLASH_COMMANDS: readonly SlashCommand[] = [
     description: "Pick a model for the current provider (send /model provider/model to switch)",
   },
   { name: "persona", description: "Pick my persona / style" },
+  {
+    name: "mode",
+    description: "Safe (ask before risky tools) or yolo (never ask)",
+    options: [
+      {
+        name: "mode",
+        description: "Leave empty to see the current mode and pick from buttons",
+        type: 3,
+        choices: [
+          { name: "safe", value: "safe" },
+          { name: "yolo", value: "yolo" },
+        ],
+      },
+    ],
+  },
   { name: "reminders", description: "List and cancel your reminders" },
   {
     name: "tz",
@@ -1184,6 +1309,7 @@ async function handleCommand(
         : []),
       `Model: \`${agent.config.llmProvider}/${agent.config.llmModel}\` (reasoning: ${agent.config.reasoningEffort})`,
       `Timezone: \`${tzForChat(config.jazzHome, TZ_FILE, channelId)}\`${hasChatTz(config.jazzHome, TZ_FILE, channelId) ? "" : " (default)"}`,
+      `Mode: ${APPROVAL_MODE_LABELS[approvalModeFor(config.jazzHome, MODE_FILE, channelId)]}`,
       `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}${(day.unpricedRuns ?? 0) > 0 ? ` · ${day.unpricedRuns} unpriced` : ""}`,
       `Daily cap: ${cap > 0 ? `$${cap.toFixed(2)}` : "none"}`,
       `Uptime: ${formatUptime(Date.now() - BRIDGE_STARTED_AT)}`,
@@ -1242,6 +1368,30 @@ async function handleCommand(
     return {
       content: `Pick a ${provider} model, or use /model provider/model to switch provider:`,
       components: [actionRow([stringSelect("m", "Model", options)])],
+    };
+  }
+
+  if (command === "mode") {
+    const requested = args.trim().toLowerCase();
+    if (requested.length > 0) {
+      if (requested !== "safe" && requested !== "yolo") {
+        return {
+          content:
+            "⚠️ Usage: `/mode safe` or `/mode yolo`, or send `/mode` on its own to pick from buttons.",
+        };
+      }
+      setApprovalMode(config.jazzHome, MODE_FILE, channelId, requested);
+      return { content: modeConfirmation(requested, config.approvalPolicy) };
+    }
+    const current = approvalModeFor(config.jazzHome, MODE_FILE, channelId);
+    return {
+      content: [
+        `Current mode: **${APPROVAL_MODE_LABELS[current]}**`,
+        "",
+        modeExplanation("safe", config.approvalPolicy),
+        modeExplanation("yolo", config.approvalPolicy),
+      ].join("\n"),
+      components: modeComponents(current),
     };
   }
 
@@ -1386,6 +1536,7 @@ async function dispatchMessage(
     "incognito",
     "model",
     "persona",
+    "mode",
     "remind",
     "reminders",
     "tz",
@@ -1471,6 +1622,8 @@ async function dispatchSlash(
     args = `${when} ${text}`.trim();
   } else if (name === "tz") {
     args = slashOption(interaction, "zone") ?? "";
+  } else if (name === "mode") {
+    args = slashOption(interaction, "mode") ?? "";
   }
 
   const needsDefer = name === "model" || name === "remind";
@@ -1600,20 +1753,64 @@ async function dispatchComponent(
       return;
     }
     pendingApprovals.delete(token);
-    try {
-      await run.child.stdin.write(
-        `${JSON.stringify({ type: "approval_decision", toolCallId: pending.toolCallId, approved })}\n`,
-      );
-      await run.child.stdin.flush();
-    } catch (error) {
-      console.error(`Failed to write approval decision: ${String(error)}`);
-    }
+    await writeApprovalDecisions(run, [{ toolCallId: pending.toolCallId, approved }]);
     await interactionCallback(interaction.id, interaction.token, {
       type: CALLBACK_UPDATE_MESSAGE,
       data: {
         content: approved ? "✅ Approved" : "❌ Rejected",
         components: [],
       },
+    });
+    // One fewer outstanding: the survivors' "Approve all N" counts are now
+    // stale, and the last one left should lose the batch buttons entirely.
+    await refreshApprovalComponents(config, pending.runToken);
+    return;
+  }
+
+  if (kind === "aa") {
+    const runToken = parts[1] ?? "";
+    const approved = parts[2] === "1";
+    const outstanding = pendingApprovalsForRun(runToken);
+    const run = activeRuns.get(runToken);
+    if (outstanding.length === 0 || !run) {
+      await interactionCallback(interaction.id, interaction.token, {
+        type: CALLBACK_CHANNEL_MESSAGE,
+        data: {
+          content: "Those approvals already expired or the run finished.",
+          flags: FLAG_EPHEMERAL,
+        },
+      });
+      return;
+    }
+    for (const [outstandingToken] of outstanding) pendingApprovals.delete(outstandingToken);
+    await writeApprovalDecisions(
+      run,
+      outstanding.map(([, pending]) => ({ toolCallId: pending.toolCallId, approved })),
+    );
+    const verdict = approved ? "✅ Approved" : "❌ Rejected";
+    // The clicked message is answered through the interaction; its siblings are
+    // separate messages, so they need their own patch to stop showing buttons
+    // that no longer resolve anything.
+    await interactionCallback(interaction.id, interaction.token, {
+      type: CALLBACK_UPDATE_MESSAGE,
+      data: { content: `${verdict} — ${outstanding.length} tool calls`, components: [] },
+    });
+    for (const [, pending] of outstanding) {
+      if (pending.messageId === messageId) continue;
+      await patchMessage(config.botToken, pending.channelId, pending.messageId, {
+        content: `${verdict} as part of a batch`,
+        components: [],
+      }).catch(() => undefined);
+    }
+    return;
+  }
+
+  if (kind === "md") {
+    const mode: ApprovalMode = parts[1] === "yolo" ? "yolo" : "safe";
+    setApprovalMode(config.jazzHome, MODE_FILE, channelId, mode);
+    await interactionCallback(interaction.id, interaction.token, {
+      type: CALLBACK_UPDATE_MESSAGE,
+      data: { content: modeConfirmation(mode, config.approvalPolicy), components: [] },
     });
     return;
   }

--- a/packages/discord-bot/src/discord.ts
+++ b/packages/discord-bot/src/discord.ts
@@ -350,6 +350,8 @@ export interface SlashCommand {
     readonly description: string;
     readonly type: number;
     readonly required?: boolean;
+    /** Fixed values Discord offers as a picklist, for options with a closed set. */
+    readonly choices?: readonly { readonly name: string; readonly value: string }[];
   }[];
 }
 

--- a/packages/telegram-bot/README.md
+++ b/packages/telegram-bot/README.md
@@ -18,11 +18,12 @@ Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --jso
 - 🔌 **Bring your own model** — OpenAI `gpt-5.4` out of the box, or any provider Jazz supports (including local Ollama, no keys/cost).
 - 🎛️ **Per-person `/model` and `/persona`** — `/model` picks from an inline keyboard of the current provider's models, or `/model openai/gpt-5.2` switches to any other provider Jazz supports outright; each user keeps their own choice.
 - ♻️ **Auto reasoning** — switching model reads its advertised capabilities and enables/disables thinking so non-thinking models don't error.
+- 🛡️ **Approvals you can get through fast** — a tool needing a human sends its own accept/reject message; when a model fires several tool calls at once, every outstanding prompt grows **⚡ Approve all N** / **🚫 Reject all N** so one tap clears the batch. `/mode yolo` turns approvals off for that chat entirely; `/mode safe` puts them back.
 - 📡 **Live progress** — a status bubble updates in real time with the agent's thinking, tool calls, sub-agents (🤖), and tools awaiting approval (⛔); it closes with a `✅ Done · tools · tokens · $cost` summary, and the answer lands as a new message (so it notifies).
 - ⏰ **Reminders** — `/remind 30m …` or plain language ("remind me in 2 hours …"), scheduled by the agent itself via a native tool, resolved in your own timezone (`/tz`, or auto-set from a shared location) and delivered even across restarts.
 - 📍 **Location aware** — share a pin to get oriented, find nearby places, and set your timezone automatically.
 - 📊 **On-demand UI** — the agent can write a self-contained webpage (a chart, a form, a small interactive tool) via `create_web_app` and deliver it as either a chat image (no tap) or a tappable Telegram Web App button.
-- 🎙️ **Send voice notes, photos and files** — a voice message is listened to and acted on; a photo or PDF is read. Needs a model with that input modality (Gemini for audio, most models for images), and the bot says so plainly when the current model can't.
+- 🎙️ **Send voice notes, photos, video and files** — a voice message or round video message is listened to and acted on; a photo, sticker, GIF, video or PDF is read. Needs a model with that input modality (Gemini for audio and video, most models for images), and the bot says so plainly when the current model can't.
 - 💬 **Per-chat memory**, ✍️ **Markdown rendering** (with plain-text fallback), 🔒 **allowlist-gated**, 🐳 **one-command Docker deploy**.
 
 ## Requirements
@@ -32,9 +33,9 @@ Telegram  ◀──(getUpdates long-poll)──▶  bridge  ──jazz run --jso
 - A model backend — **either** an API key for a cloud provider (OpenAI by default)
   **or** a local [Ollama](https://ollama.com) with a tool-capable model pulled.
 - Outbound HTTPS to `api.telegram.org`.
-- For voice notes: a model that accepts audio input. In practice that means the
-  Gemini family — Anthropic has no audio models and OpenAI has one. Images and
-  PDFs work on almost anything. The image installs `ffmpeg` so Jazz can measure
+- For voice notes and video: a model that accepts audio or video input. In practice
+  that means the Gemini family — Anthropic has no audio models and OpenAI has one.
+  Images and PDFs work on almost anything, local Ollama vision models included. The image installs `ffmpeg` so Jazz can measure
   how long a clip is and budget context for it accurately.
 
 ## Quick start
@@ -70,12 +71,13 @@ Message your bot: it shows a "typing…" indicator, then the agent's reply.
 | _(any message)_         | Answered by your agent                                                                                                                                                                                                       |
 | `/model`                | Inline keyboard of the current provider's models; `/model provider/model` (e.g. `anthropic/claude-sonnet-5`) switches you to a different provider outright                                                          |
 | `/persona`              | Inline keyboard of available personas                                                                                                                                                                                        |
+| `/mode [safe\|yolo]`     | Show or set this chat's approval mode. **Safe** (default) keeps `JAZZ_APPROVAL_POLICY`, so risky tools stop and ask. **Yolo** runs every tool without asking. Sticky per chat — `/new` does not reset it.                     |
 | `/new` (`/reset`)       | Start a fresh conversation — clears earlier context; keeps your model/persona                                                                                                                                                |
 | `/remind <when> <text>` | Schedule a reminder DM. `<when>` = `30m`, `1h30m`, `90s`, `2d`, `18:00`, `tomorrow 09:00`, `tue 20:00`, or `2026-08-25 20:00`. Routed through a normal agent turn, which calls the `add_reminder` tool.                      |
 | _(natural language)_    | Just say it — "remind me to call the dentist in 2 hours". The agent calls `add_reminder` itself; it understands the same `<when>` formats as `/remind` (durations, clock times, `tomorrow HH:MM`, weekdays, absolute dates). |
 | `/reminders`            | List your pending reminders (in your timezone); tap one to cancel                                                                                                                                                            |
 | `/tz [zone]`            | Show or set your timezone (IANA name, e.g. `/tz Europe/Paris`) so reminder times are local                                                                                                                                   |
-| `/status`               | Current model, your timezone, today's runs/tokens/cost, daily cap, uptime                                                                                                                                                    |
+| `/status`               | Current model, your timezone, approval mode, today's runs/tokens/cost, daily cap, uptime                                                                                                                                     |
 | `/help`                 | Usage                                                                                                                                                                                                                        |
 
 While a message is processing, the progress bubble carries a **⏹ Cancel** button
@@ -258,7 +260,7 @@ Full walkthrough, including the connection-race recovery in more detail, is in t
 | `JAZZ_OLLAMA_KEEP_ALIVE`             | —                                       | How long a local Ollama keeps the model loaded (`keep_alive`): `-1` pins it indefinitely, or a duration like `30m`. Unset uses Ollama's 5-minute default, so the first message after a quiet spell pays a full cold model load with no progress shown while it happens. |
 | `JAZZ_REASONING`                     | `medium`                                | `disable`\|`low`\|`medium`\|`high`.                                                                                                                                                                                                                                     |
 | `OLLAMA_BASE_URL`                    | `http://host.docker.internal:11434/api` | Ollama endpoint, used whenever a conversation's provider is `ollama` (default or via `/model`).                                                                                                                                                                                                                |
-| `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`.                                                                                                                                                                                                         |
+| `JAZZ_APPROVAL_POLICY`               | `low-risk`                              | Auto-approve tools up to: `read-only`\|`low-risk`\|`high-risk`. This is what "safe" means for the deployment; a chat on `/mode yolo` runs at `high-risk` instead.                                                                                                        |
 | `JAZZ_AUTO_APPROVE_TOOLS`            | —                                       | Comma-separated tool names to auto-approve regardless of policy (e.g. `execute_command`) — narrower than raising the whole tier. Tools needing approval that aren't in this list are sent to the chat as an accept/reject prompt instead of being declined.             |
 | `JAZZ_RUN_TIMEOUT_MS`                | `300000`                                | Per-message agent timeout.                                                                                                                                                                                                                                              |
 | `TELEGRAM_MODE`                      | `polling`                               | `polling` or `webhook`.                                                                                                                                                                                                                                                 |

--- a/packages/telegram-bot/src/bridge.ts
+++ b/packages/telegram-bot/src/bridge.ts
@@ -21,6 +21,14 @@ import { join } from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
 import { createConfigLayer } from "@jazz/adapters/config";
 import { ReminderServiceImpl } from "@jazz/adapters/reminder-service";
+import {
+  APPROVAL_MODE_LABELS,
+  type ApprovalMode,
+  approvalModeFor,
+  approvalPolicyFor,
+  describeApprovalMode,
+  setApprovalMode,
+} from "@jazz/bot-shared/approval-mode-store";
 import { listPersonaNames } from "@jazz/bot-shared/personas";
 import { listModelsForProvider } from "@jazz/bot-shared/provider-models";
 import { reasoningSnippet, splitReasoning } from "@jazz/bot-shared/reasoning";
@@ -55,7 +63,13 @@ import {
   syncAgentDisplayName,
   writeAgentFile,
 } from "./agents";
-import { buildMediaPrompt, downloadTelegramFile, type TelegramFileRef } from "./media";
+import {
+  buildMediaPrompt,
+  downloadTelegramFile,
+  type ExtractedMedia,
+  extractMedia,
+  type TelegramMediaFields,
+} from "./media";
 import { withReplyContext } from "./quotes";
 import { startReminderSweep } from "./reminders";
 import { dispatchTelegramRequest, isRenderingRejection } from "./telegram-dispatch";
@@ -70,6 +84,7 @@ const TZ_FILE = "tg-tz.json";
 const USAGE_FILE = "tg-usage.json";
 const EPOCHS_FILE = "tg-sessions.json";
 const INCOGNITO_FILE = "tg-incognito.json";
+const MODE_FILE = "tg-mode.json";
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const GETUPDATES_TIMEOUT_SECONDS = 30;
 const POLL_ERROR_BACKOFF_MS = 5_000;
@@ -112,10 +127,21 @@ const pendingUserInputs = new Map<
   { chatId: number; messageId: number; runToken: string; options: readonly string[] }
 >();
 
-const pendingApprovals = new Map<
-  string,
-  { chatId: number; messageId: number; runToken: string; commandKey?: string }
->();
+interface PendingApproval {
+  chatId: number;
+  messageId: number;
+  runToken: string;
+  commandKey?: string;
+  /**
+   * The outstanding-approval count this message's keyboard currently shows.
+   * Approval events arrive concurrently, so a message can be sent with a count
+   * that is already stale by the time it registers; comparing against this is
+   * what tells a refresh which keyboards genuinely need rewriting.
+   */
+  shownCount: number;
+}
+
+const pendingApprovals = new Map<string, PendingApproval>();
 // Transcript for chats currently in /incognito mode. Lives only in this
 // process's memory — never written to disk — so a bridge restart drops the
 // context rather than ever falling back to a persisted history file. Cleared
@@ -465,7 +491,12 @@ function cancelKeyboard(runToken: string): Record<string, unknown> {
   return { inline_keyboard: [[{ text: "⏹ Cancel", callback_data: `x:${runToken}` }]] };
 }
 
-function approvalKeyboard(toolCallId: string, commandKey?: string): Record<string, unknown> {
+function approvalKeyboard(
+  toolCallId: string,
+  runToken: string,
+  pendingCount: number,
+  commandKey?: string,
+): Record<string, unknown> {
   const rows = [
     [
       { text: "✅ Accept", callback_data: `a:${toolCallId}:1` },
@@ -475,7 +506,61 @@ function approvalKeyboard(toolCallId: string, commandKey?: string): Record<strin
   if (commandKey) {
     rows.push([{ text: `♾️ Always allow "${commandKey}"`, callback_data: `a:${toolCallId}:2` }]);
   }
+  // A parallel batch of tool calls asks for approval one message each; tapping
+  // through five of them is the common case, so offer a single tap that clears
+  // the whole batch once there is more than one outstanding.
+  if (pendingCount > 1) {
+    rows.push([
+      { text: `⚡ Approve all ${pendingCount}`, callback_data: `aa:${runToken}:1` },
+      { text: `🚫 Reject all ${pendingCount}`, callback_data: `aa:${runToken}:0` },
+    ]);
+  }
   return { inline_keyboard: rows };
+}
+
+/**
+ * Answer the run's blocked approval prompts over its stdin pipe. Bun's FileSink
+ * buffers writes, so flush() pushes them through now rather than waiting for the
+ * buffer to fill — a batch decision must reach a parked run immediately.
+ */
+async function writeApprovalDecisions(
+  run: { child: Bun.Subprocess<"pipe", "pipe", "pipe"> },
+  decisions: readonly { toolCallId: string; approved: boolean }[],
+): Promise<void> {
+  try {
+    for (const { toolCallId, approved } of decisions) {
+      await run.child.stdin.write(
+        `${JSON.stringify({ type: "approval_decision", toolCallId, approved })}\n`,
+      );
+    }
+    await run.child.stdin.flush();
+  } catch (error) {
+    console.error(`Failed to write approval decision: ${String(error)}`);
+  }
+}
+
+function pendingApprovalsForRun(runToken: string): [string, PendingApproval][] {
+  return [...pendingApprovals].filter(([, pending]) => pending.runToken === runToken);
+}
+
+/**
+ * Rewrite the keyboards of a run's outstanding approval messages so their
+ * "Approve all N" count matches reality. Called whenever the outstanding set
+ * changes: a new request arriving makes the count climb, and resolving one
+ * makes it fall — down to a single request, where the batch buttons disappear
+ * again.
+ */
+async function refreshApprovalKeyboards(config: BridgeConfig, runToken: string): Promise<void> {
+  const outstanding = pendingApprovalsForRun(runToken);
+  for (const [toolCallId, pending] of outstanding) {
+    if (pending.shownCount === outstanding.length) continue;
+    pending.shownCount = outstanding.length;
+    await callTelegram(config, "editMessageReplyMarkup", {
+      chat_id: pending.chatId,
+      message_id: pending.messageId,
+      reply_markup: approvalKeyboard(toolCallId, runToken, outstanding.length, pending.commandKey),
+    }).catch(() => undefined);
+  }
 }
 
 /** Extract the binary from an execute_command approval's "Command: ..." line, if present. */
@@ -506,6 +591,32 @@ async function addAutoApprovedCommand(jazzHome: string, commandKey: string): Pro
       if (current.includes(commandKey)) return;
       yield* configService.set("autoApprovedCommands", [...current, commandKey]);
     }).pipe(Effect.provide(configLayer), Effect.provide(NodeFileSystem.layer)),
+  );
+}
+
+function modeKeyboard(current: ApprovalMode): Record<string, unknown> {
+  const modes: ApprovalMode[] = ["safe", "yolo"];
+  return {
+    inline_keyboard: [
+      modes.map((mode) => ({
+        text: `${mode === current ? "✅ " : ""}${APPROVAL_MODE_LABELS[mode]}`,
+        callback_data: `md:${mode}`,
+      })),
+    ],
+  };
+}
+
+function modeExplanation(mode: ApprovalMode, configuredPolicy: string): string {
+  return describeApprovalMode(mode, configuredPolicy, {
+    bold: (text) => `<b>${escapeHtml(text)}</b>`,
+    code: (text) => `<code>${escapeHtml(text)}</code>`,
+  });
+}
+
+function modeConfirmation(mode: ApprovalMode, configuredPolicy: string): string {
+  return (
+    `✅ Mode → <b>${APPROVAL_MODE_LABELS[mode]}</b>\n${modeExplanation(mode, configuredPolicy)}` +
+    (mode === "yolo" ? "\nSend <code>/mode safe</code> to turn approvals back on." : "")
   );
 }
 
@@ -760,17 +871,22 @@ async function sendApprovalRequest(
     lines.push(`<pre>${escapeHtml(event.previewDiff)}</pre>`);
   }
 
+  // One more than what is already outstanding: this request is about to join
+  // them, and the keyboard has to be built before the message is sent.
+  const shownCount = pendingApprovalsForRun(runToken).length + 1;
   const messageId = await sendReply(config, chatId, lines.join("\n"), {
-    markup: approvalKeyboard(toolCallId, commandKey),
+    markup: approvalKeyboard(toolCallId, runToken, shownCount, commandKey),
   });
-  if (typeof messageId === "number") {
-    pendingApprovals.set(toolCallId, {
-      chatId,
-      messageId,
-      runToken,
-      ...(commandKey && { commandKey }),
-    });
-  }
+  if (typeof messageId !== "number") return;
+
+  pendingApprovals.set(toolCallId, {
+    chatId,
+    messageId,
+    runToken,
+    shownCount,
+    ...(commandKey && { commandKey }),
+  });
+  await refreshApprovalKeyboards(config, runToken);
 }
 
 /**
@@ -845,7 +961,7 @@ async function runJazz(
       "--agent",
       agentIdForChat(chatId),
       "--approval-policy",
-      config.approvalPolicy,
+      approvalPolicyFor(config.jazzHome, MODE_FILE, chatId, config.approvalPolicy),
       ...(config.autoApproveTools.length > 0
         ? ["--auto-approve-tools", config.autoApproveTools.join(",")]
         : []),
@@ -1340,6 +1456,7 @@ const BOT_COMMANDS: { command: string; description: string }[] = [
     description: "Pick an Ollama model, or set provider/model, e.g. anthropic/claude-sonnet-5",
   },
   { command: "persona", description: "Pick my persona / style" },
+  { command: "mode", description: "Safe (ask before risky tools) or yolo (never ask)" },
   { command: "new", description: "Start a fresh conversation (clears earlier context)" },
   { command: "incognito", description: "Start a private conversation (nothing saved) until /new" },
   { command: "remind", description: "Set a reminder, e.g. /remind 30m take pizza out" },
@@ -1356,6 +1473,7 @@ const HELP_TEXT = [
   "/model — pick an Ollama model, or /model provider/model for any other provider Jazz supports " +
     "(e.g. /model anthropic/claude-sonnet-5)",
   "/persona — pick my persona / style",
+  "/mode — safe (I ask before risky tools) or yolo (I never ask), e.g. /mode yolo",
   "/new — start a fresh conversation (clears earlier context)",
   "/incognito — start a private conversation (nothing saved to history or memory) until /new",
   "/remind <when> <text> — e.g. /remind 30m take pizza out",
@@ -1551,6 +1669,7 @@ async function handleCommand(
         : []),
       `Model: <code>${escapeHtml(agent.config.llmProvider)}/${escapeHtml(agent.config.llmModel)}</code> (reasoning: ${escapeHtml(agent.config.reasoningEffort)})`,
       `Timezone: <code>${escapeHtml(tzForChat(config.jazzHome, TZ_FILE, chatId))}</code>${hasChatTz(config.jazzHome, TZ_FILE, chatId) ? "" : " (default)"}`,
+      `Mode: ${APPROVAL_MODE_LABELS[approvalModeFor(config.jazzHome, MODE_FILE, chatId)]}`,
       `Today: ${day.runs} runs · ${formatTokenCount(day.tokens)} tok · $${day.costUSD.toFixed(4)}${(day.unpricedRuns ?? 0) > 0 ? ` · ${day.unpricedRuns} unpriced` : ""}`,
       `Daily cap: ${cap > 0 ? `$${cap.toFixed(2)}` : "none"}`,
       `Uptime: ${formatUptime(Date.now() - BRIDGE_STARTED_AT)}`,
@@ -1621,6 +1740,37 @@ async function handleCommand(
           "m",
         ),
       },
+    });
+    return;
+  }
+
+  if (command === "mode") {
+    const current = approvalModeFor(config.jazzHome, MODE_FILE, chatId);
+    const requested = args.trim().toLowerCase();
+    if (requested.length > 0) {
+      if (requested !== "safe" && requested !== "yolo") {
+        await sendReply(
+          config,
+          chatId,
+          "⚠️ Usage: <code>/mode safe</code> or <code>/mode yolo</code>, or send " +
+            "<code>/mode</code> on its own to pick from buttons.",
+        );
+        return;
+      }
+      setApprovalMode(config.jazzHome, MODE_FILE, chatId, requested);
+      await sendReply(config, chatId, modeConfirmation(requested, config.approvalPolicy));
+      return;
+    }
+    await callTelegram(config, "sendMessage", {
+      chat_id: chatId,
+      text: [
+        `Current mode: <b>${APPROVAL_MODE_LABELS[current]}</b>`,
+        "",
+        modeExplanation("safe", config.approvalPolicy),
+        modeExplanation("yolo", config.approvalPolicy),
+      ].join("\n"),
+      parse_mode: "HTML",
+      reply_markup: modeKeyboard(current),
     });
     return;
   }
@@ -1759,16 +1909,7 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
       return;
     }
     pendingApprovals.delete(toolCallId);
-    try {
-      // Bun's FileSink buffers writes; flush() pushes it through the pipe now
-      // rather than waiting for the buffer to fill on its own.
-      await run.child.stdin.write(
-        `${JSON.stringify({ type: "approval_decision", toolCallId, approved })}\n`,
-      );
-      await run.child.stdin.flush();
-    } catch (error) {
-      console.error(`Failed to write approval decision: ${String(error)}`);
-    }
+    await writeApprovalDecisions(run, [{ toolCallId, approved }]);
     if (always && pending.commandKey) {
       await addAutoApprovedCommand(config.jazzHome, pending.commandKey).catch((error: unknown) =>
         console.error(`Failed to persist auto-approved command: ${String(error)}`),
@@ -1787,6 +1928,40 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
       message_id: messageId,
       reply_markup: { inline_keyboard: [] },
     });
+    // One fewer outstanding: the survivors' "Approve all N" counts are now
+    // stale, and the last one left should lose the batch buttons entirely.
+    await refreshApprovalKeyboards(config, pending.runToken);
+    return;
+  }
+
+  if (kind === "aa") {
+    const runToken = parts[1] ?? "";
+    const approved = parts[2] === "1";
+    const outstanding = pendingApprovalsForRun(runToken);
+    const run = activeRuns.get(runToken);
+    if (outstanding.length === 0 || !run) {
+      await callTelegram(config, "answerCallbackQuery", {
+        callback_query_id: callback.id,
+        text: "Those approvals already expired or the run finished.",
+      });
+      return;
+    }
+    for (const [toolCallId] of outstanding) pendingApprovals.delete(toolCallId);
+    await writeApprovalDecisions(
+      run,
+      outstanding.map(([toolCallId]) => ({ toolCallId, approved })),
+    );
+    await callTelegram(config, "answerCallbackQuery", {
+      callback_query_id: callback.id,
+      text: `${approved ? "Approved" : "Rejected"} ${outstanding.length} tool calls`,
+    });
+    for (const [, pending] of outstanding) {
+      await callTelegram(config, "editMessageReplyMarkup", {
+        chat_id: pending.chatId,
+        message_id: pending.messageId,
+        reply_markup: { inline_keyboard: [] },
+      }).catch(() => undefined);
+    }
     return;
   }
 
@@ -1819,6 +1994,23 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
     await callTelegram(config, "editMessageReplyMarkup", {
       chat_id: chatId,
       message_id: messageId,
+      reply_markup: { inline_keyboard: [] },
+    });
+    return;
+  }
+
+  if (kind === "md") {
+    const mode = indexRaw === "yolo" ? "yolo" : "safe";
+    setApprovalMode(config.jazzHome, MODE_FILE, chatId, mode);
+    await callTelegram(config, "answerCallbackQuery", {
+      callback_query_id: callback.id,
+      text: `Mode → ${mode}`,
+    });
+    await callTelegram(config, "editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      text: modeConfirmation(mode, config.approvalPolicy),
+      parse_mode: "HTML",
       reply_markup: { inline_keyboard: [] },
     });
     return;
@@ -1875,7 +2067,7 @@ async function handleCallback(config: BridgeConfig, callback: CallbackQuery): Pr
 
 // --- Dispatch -------------------------------------------------------------
 
-interface TelegramMessage {
+interface TelegramMessage extends TelegramMediaFields {
   readonly chat?: { readonly id?: number };
   readonly from?: {
     readonly first_name?: string;
@@ -1890,60 +2082,6 @@ interface TelegramMessage {
   readonly location?: { readonly latitude?: number; readonly longitude?: number };
   /** Caption on a media message — the user's actual request, when they wrote one. */
   readonly caption?: string;
-  /** A voice note, i.e. the record button. Always OGG/Opus, never has a filename. */
-  readonly voice?: TelegramFileRef;
-  /** An audio file sent as music, which Telegram treats separately from a voice note. */
-  readonly audio?: TelegramFileRef;
-  /**
-   * Photos arrive as an array of the same image at several resolutions, smallest first.
-   * The last entry is the largest Telegram kept.
-   */
-  readonly photo?: readonly TelegramFileRef[];
-  /** Any file sent as a document, including images sent with "send as file". */
-  readonly document?: TelegramFileRef;
-}
-
-/**
- * Media on a message, plus what to ask jazz when the user sent no caption.
- *
- * Voice notes get an explicit transcribe-and-act instruction because a bare voice note with no
- * caption is the single most common case, and the model needs to know it should act on what was
- * said rather than just describe the audio.
- */
-function extractMedia(
-  message: TelegramMessage,
-): { file: TelegramFileRef; fallbackInstruction: string } | undefined {
-  if (message.voice !== undefined) {
-    return {
-      file: message.voice,
-      fallbackInstruction:
-        "This is a voice message. Listen to it, then do what it asks — or answer it if it is a question.",
-    };
-  }
-  if (message.audio !== undefined) {
-    return {
-      file: message.audio,
-      fallbackInstruction: "Listen to this audio and tell me what is in it.",
-    };
-  }
-  if (message.photo !== undefined && message.photo.length > 0) {
-    // Largest available resolution: the smaller entries are thumbnails and would waste the
-    // request on an unreadable image.
-    const largest = message.photo[message.photo.length - 1];
-    if (largest !== undefined) {
-      return {
-        file: largest,
-        fallbackInstruction: "Look at this image and tell me what it shows.",
-      };
-    }
-  }
-  if (message.document !== undefined) {
-    return {
-      file: message.document,
-      fallbackInstruction: "Look at this file and tell me what is in it.",
-    };
-  }
-  return undefined;
 }
 
 /**
@@ -1956,7 +2094,7 @@ async function handleMedia(
   config: BridgeConfig,
   chatId: number,
   message: TelegramMessage,
-  media: { file: TelegramFileRef; fallbackInstruction: string },
+  media: ExtractedMedia,
 ): Promise<void> {
   const outcome = await downloadTelegramFile(
     config.botToken,
@@ -2025,7 +2163,7 @@ function dispatchMessage(config: BridgeConfig, message: TelegramMessage | undefi
     }
   }
 
-  // Other message types (stickers, contacts, …) aren't handled yet.
+  // Other message types (contacts, polls, animated .tgs stickers, …) aren't handled yet.
   if (work === undefined) return;
 
   work.catch((error) => {

--- a/packages/telegram-bot/src/media.test.ts
+++ b/packages/telegram-bot/src/media.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildMediaPrompt } from "./media";
+import { buildMediaPrompt, extractMedia } from "./media";
 
 describe("buildMediaPrompt", () => {
   it("puts the path on its own line — mentioning it is what attaches the file", () => {
@@ -28,5 +28,52 @@ describe("buildMediaPrompt", () => {
   it("trims the caption", () => {
     const prompt = buildMediaPrompt("/tmp/a.png", "  what is this?  ", "fallback");
     expect(prompt.startsWith("what is this?")).toBe(true);
+  });
+});
+
+describe("extractMedia", () => {
+  it("picks the largest photo, not a thumbnail", () => {
+    const media = extractMedia({
+      photo: [{ file_id: "thumb" }, { file_id: "medium" }, { file_id: "full" }],
+    });
+    expect(media?.file.file_id).toBe("full");
+  });
+
+  it("prefers the animation over the document copy Telegram sends with a GIF", () => {
+    const media = extractMedia({
+      animation: { file_id: "gif" },
+      document: { file_id: "gif-as-document" },
+    });
+    expect(media?.file.file_id).toBe("gif");
+  });
+
+  it("takes a video", () => {
+    const media = extractMedia({ video: { file_id: "clip" } });
+    expect(media?.file.file_id).toBe("clip");
+  });
+
+  it("asks a round video message to be acted on, like a voice note", () => {
+    const media = extractMedia({ video_note: { file_id: "round" } });
+    expect(media?.file.file_id).toBe("round");
+    expect(media?.fallbackInstruction).toContain("do what it asks");
+  });
+
+  it("takes a static sticker", () => {
+    const media = extractMedia({ sticker: { file_id: "webp-sticker" } });
+    expect(media?.file.file_id).toBe("webp-sticker");
+  });
+
+  it("takes a video sticker", () => {
+    const media = extractMedia({ sticker: { file_id: "webm-sticker", is_video: true } });
+    expect(media?.file.file_id).toBe("webm-sticker");
+  });
+
+  it("skips an animated sticker — .tgs is Lottie JSON, not something a model can look at", () => {
+    const media = extractMedia({ sticker: { file_id: "tgs-sticker", is_animated: true } });
+    expect(media).toBeUndefined();
+  });
+
+  it("returns nothing for a message with no media", () => {
+    expect(extractMedia({})).toBeUndefined();
   });
 });

--- a/packages/telegram-bot/src/media.ts
+++ b/packages/telegram-bot/src/media.ts
@@ -1,5 +1,5 @@
 /**
- * Downloading Telegram media (voice notes, audio, photos, documents) to local files.
+ * Downloading Telegram media (voice notes, audio, photos, video, documents) to local files.
  *
  * The bridge talks to jazz by spawning `jazz run` with a prompt string, so there is no channel
  * for passing bytes. There does not need to be one: jazz ingests attachments by *path*, so a
@@ -43,6 +43,124 @@ export interface TelegramFileRef {
 }
 
 /**
+ * A sticker.
+ *
+ * Static stickers are WebP and video stickers are WebM, both of which a vision model can read.
+ * Animated ones are `.tgs` — gzipped Lottie JSON, which is not an image by the time it reaches
+ * disk — so `is_animated` is the flag that says "skip this one".
+ */
+export interface TelegramStickerRef extends TelegramFileRef {
+  readonly is_animated?: boolean;
+  readonly is_video?: boolean;
+  /** The emoji the sticker stands for, which is what a reply to it quotes. */
+  readonly emoji?: string;
+}
+
+/**
+ * The media-bearing fields of a Telegram message.
+ *
+ * Declared here rather than in the bridge so `extractMedia` can be tested without the bridge:
+ * the bridge's own `TelegramMessage` extends this with the text, chat and reply fields.
+ */
+export interface TelegramMediaFields {
+  /** A voice note, i.e. the record button. Always OGG/Opus, never has a filename. */
+  readonly voice?: TelegramFileRef;
+  /** An audio file sent as music, which Telegram treats separately from a voice note. */
+  readonly audio?: TelegramFileRef;
+  /**
+   * Photos arrive as an array of the same image at several resolutions, smallest first.
+   * The last entry is the largest Telegram kept.
+   */
+  readonly photo?: readonly TelegramFileRef[];
+  /** A GIF. Telegram stores these as soundless MP4. */
+  readonly animation?: TelegramFileRef;
+  /** A video sent from the camera or gallery. */
+  readonly video?: TelegramFileRef;
+  /** A round video message, i.e. holding the camera button. */
+  readonly video_note?: TelegramFileRef;
+  readonly sticker?: TelegramStickerRef;
+  /** Any file sent as a document, including images sent with "send as file". */
+  readonly document?: TelegramFileRef;
+}
+
+export interface ExtractedMedia {
+  readonly file: TelegramFileRef;
+  /** What to ask jazz when the user sent no caption. */
+  readonly fallbackInstruction: string;
+}
+
+/**
+ * Media on a message, plus what to ask jazz when the user sent no caption.
+ *
+ * Voice notes get an explicit transcribe-and-act instruction because a bare voice note with no
+ * caption is the single most common case, and the model needs to know it should act on what was
+ * said rather than just describe the audio. Round video messages are the same gesture with a
+ * camera, so they get the same treatment.
+ *
+ * Order is load-bearing in one place: `animation` is checked before `document`, because Telegram
+ * repeats a GIF in both fields and the document copy would be taken for an opaque file rather
+ * than the video it actually is.
+ */
+export function extractMedia(message: TelegramMediaFields): ExtractedMedia | undefined {
+  if (message.voice !== undefined) {
+    return {
+      file: message.voice,
+      fallbackInstruction:
+        "This is a voice message. Listen to it, then do what it asks — or answer it if it is a question.",
+    };
+  }
+  if (message.audio !== undefined) {
+    return {
+      file: message.audio,
+      fallbackInstruction: "Listen to this audio and tell me what is in it.",
+    };
+  }
+  if (message.photo !== undefined && message.photo.length > 0) {
+    // Largest available resolution: the smaller entries are thumbnails and would waste the
+    // request on an unreadable image.
+    const largest = message.photo[message.photo.length - 1];
+    if (largest !== undefined) {
+      return {
+        file: largest,
+        fallbackInstruction: "Look at this image and tell me what it shows.",
+      };
+    }
+  }
+  if (message.animation !== undefined) {
+    return {
+      file: message.animation,
+      fallbackInstruction: "This is a GIF. Watch it and tell me what happens in it.",
+    };
+  }
+  if (message.video !== undefined) {
+    return {
+      file: message.video,
+      fallbackInstruction: "Watch this video and tell me what is in it.",
+    };
+  }
+  if (message.video_note !== undefined) {
+    return {
+      file: message.video_note,
+      fallbackInstruction:
+        "This is a video message. Watch it, then do what it asks — or answer it if it is a question.",
+    };
+  }
+  if (message.sticker !== undefined && message.sticker.is_animated !== true) {
+    return {
+      file: message.sticker,
+      fallbackInstruction: "Look at this sticker and tell me what it shows.",
+    };
+  }
+  if (message.document !== undefined) {
+    return {
+      file: message.document,
+      fallbackInstruction: "Look at this file and tell me what is in it.",
+    };
+  }
+  return undefined;
+}
+
+/**
  * Extension for a downloaded file.
  *
  * Telegram's own `file_path` is the most reliable source — it reflects what the file actually
@@ -62,17 +180,30 @@ function extensionFor(telegramFilePath: string, mimeType: string | undefined): s
       return "mp3";
     case "audio/mp4":
     case "audio/m4a":
+    case "audio/x-m4a":
       return "m4a";
     case "audio/wav":
       return "wav";
+    case "audio/aac":
+      return "aac";
+    case "audio/flac":
+      return "flac";
     case "image/png":
       return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/gif":
+      return "gif";
     case "image/webp":
       return "webp";
     case "application/pdf":
       return "pdf";
     case "video/mp4":
       return "mp4";
+    case "video/webm":
+      return "webm";
+    case "video/quicktime":
+      return "mov";
     default:
       return "bin";
   }

--- a/packages/telegram-bot/src/quotes.ts
+++ b/packages/telegram-bot/src/quotes.ts
@@ -19,6 +19,9 @@ export interface QuotedMessage {
   readonly voice?: unknown;
   readonly audio?: unknown;
   readonly photo?: readonly unknown[];
+  readonly animation?: unknown;
+  readonly video?: unknown;
+  readonly video_note?: unknown;
   readonly document?: { readonly file_name?: string };
   readonly location?: unknown;
   readonly sticker?: { readonly emoji?: string };
@@ -57,6 +60,9 @@ function mediaLabel(quoted: QuotedMessage): string | undefined {
   if (quoted.voice !== undefined) return "a voice message";
   if (quoted.audio !== undefined) return "an audio file";
   if (quoted.photo !== undefined && quoted.photo.length > 0) return "a photo";
+  if (quoted.animation !== undefined) return "a GIF";
+  if (quoted.video !== undefined) return "a video";
+  if (quoted.video_note !== undefined) return "a video message";
   if (quoted.document !== undefined) {
     const fileName = quoted.document.file_name?.trim();
     return fileName !== undefined && fileName.length > 0 ? `the file ${fileName}` : "a file";


### PR DESCRIPTION
## What & why

Two changes to the chat bridges, both about removing friction from a live conversation.

**Approvals stop being one-at-a-time.** Every tool needing a human still gets its own accept/reject message, but a parallel batch of tool calls now grows an **⚡ Approve all N** / **🚫 Reject all N** button so the whole batch clears in one tap. A chat that doesn't want to be asked at all can send `/mode yolo`; `/mode safe` puts it back. The mode is per-conversation, sticky across `/new` and restarts, and lives in `bot-shared` so Discord and Telegram can't drift on what "yolo" promises.

**Telegram reads video.** Voice notes, photos and documents already worked; this adds video, round video messages, GIFs and stickers. Animated `.tgs` stickers are skipped deliberately — they're Lottie JSON, not something a model can look at. Whether any of it is actually understood still depends on the model's input modalities, and the bot says so plainly when the current one can't.

This also fixes a silent bug: `image/jpeg` was missing from the MIME→extension map, so a photo whose Telegram `file_path` carried no extension was saved as `.bin` and quietly stopped being an attachment — the model got a path it couldn't use and no indication anything was wrong.

## Security note

`/mode yolo` is `high-risk` for that chat: shell commands that write, delete, or reach the network run without stopping. It's sticky, and anyone on the allowlist can set it for their own chat. `docs/use-cases/chat-platforms.md` now says so under the hardening checklist.

## How to verify

- Ask for something that fans out into several tool calls needing approval — confirm the count on the button grows as they arrive, and one tap on **Approve all** clears every outstanding prompt rather than just the newest.
- Reject one prompt individually while others are outstanding; the remaining keyboards should renumber, not go stale.
- Send `/mode yolo`, restart the bridge, confirm the chat still doesn't prompt. `/mode safe` restores the deployment's configured tier — not a hardcoded one.
- Send a video, a GIF and a sticker to a vision model; then send an animated `.tgs` sticker and confirm it's ignored rather than producing a broken attachment.
- Send a photo to a chat running a local Ollama vision model — it should be read, not rejected on size. Local providers are exempt from the hosted 5 MB image cap.
