### PR TITLE
chore(bots): run the bridge auto-update hourly

### DIFF
--- a/docs/start/chat-bots.md
+++ b/docs/start/chat-bots.md
@@ -178,10 +178,10 @@ provider offers. Reasoning effort is set automatically either way.
 
 Both bots ship an `auto-update.sh` that fast-forwards the checkout to `origin/main`,
 rebuilds only if something changed, and rolls back if the new build doesn't come up
-healthy. Install it as a nightly cron job (adjust the path to where you cloned the repo):
+healthy. Install it as an hourly cron job (adjust the path to where you cloned the repo):
 
 ```bash
-(crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "30 * * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
 
 Swap `telegram-bot` for `discord-bot` to update the other one. A sibling executable

--- a/packages/bot-shared/src/auto-update.sh
+++ b/packages/bot-shared/src/auto-update.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Nightly auto-update for a Jazz chat bridge, shared by every bridge.
+# Hourly auto-update for a Jazz chat bridge, shared by every bridge.
 #
 # Fast-forwards the checkout to the latest origin/main, rebuilds only if it
 # actually changed, and rolls back to the previous commit if the new build does
@@ -26,7 +26,7 @@ STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 DEPLOY_BRANCH=${JAZZ_DEPLOY_BRANCH:-main}
 
 # Cron has no reader. Anything a human must act on goes to the bridge itself: in a
-# logfile, a nightly failure is indistinguishable from an update that was not needed.
+# logfile, a failed run is indistinguishable from an update that was not needed.
 notify() {
   echo "$STAMP $1"
   if [ -x "$BRIDGE_DIR/notify.sh" ]; then

--- a/packages/discord-bot/README.md
+++ b/packages/discord-bot/README.md
@@ -237,12 +237,12 @@ cd <repo> && git pull origin main
 cd packages/discord-bot/src && docker compose -p jazz-discord up -d --build
 ```
 
-**Nightly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
+**Hourly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
 rebuilds only if it changed, and rolls back if the new build fails to build or
 isn't healthy. Install it (as the deploy user):
 
 ```sh
-(crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/packages/discord-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "30 * * * * $HOME/jazz/packages/discord-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
 
 **Sending yourself a message:** `notify.sh` posts one message to the first allowed

--- a/packages/discord-bot/src/auto-update.sh
+++ b/packages/discord-bot/src/auto-update.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Nightly auto-update for the Jazz Discord bridge. The logic is shared with the
+# Hourly auto-update for the Jazz Discord bridge. The logic is shared with the
 # other bridges; this only names which one. Install (as the deploy user):
 #
-#   (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/packages/discord-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+#   (crontab -l 2>/dev/null; echo "30 * * * * $HOME/jazz/packages/discord-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 #
 set -eu
 DIR=$(cd -- "$(dirname -- "$0")" && pwd)

--- a/packages/telegram-bot/README.md
+++ b/packages/telegram-bot/README.md
@@ -335,12 +335,12 @@ cd <repo> && git pull origin main
 cd packages/telegram-bot/src && docker compose -p jazz-telegram up -d --build
 ```
 
-**Nightly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
+**Hourly auto-update:** `auto-update.sh` fast-forwards to the latest `origin/main`,
 rebuilds only if it changed, and rolls back if the new build fails to build or
 isn't healthy. Install it (as the deploy user):
 
 ```sh
-(crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "30 * * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 ```
 
 **Sending yourself a message:** `notify.sh` posts one message to the first allowed
@@ -364,7 +364,7 @@ per stream with a character count and duration, and the last line is the outcome
 with the number of model rounds. The newest 200 runs per bridge are kept.
 
 Anything needing a human is also sent to the bridge's own chat via `notify.sh`,
-because a nightly cron failure that only appends to a logfile is invisible: a
+because a cron failure that only appends to a logfile is invisible: a
 checkout left on a feature branch silently skipped every update for over two
 weeks before anyone noticed. If the checkout isn't on `main`, the script parks it
 back there — stashing tracked edits (untracked files such as a local

--- a/packages/telegram-bot/src/auto-update.sh
+++ b/packages/telegram-bot/src/auto-update.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Nightly auto-update for the Jazz Telegram bridge. The logic is shared with the
+# Hourly auto-update for the Jazz Telegram bridge. The logic is shared with the
 # other bridges; this only names which one. Install (as the deploy user):
 #
-#   (crontab -l 2>/dev/null; echo "30 4 * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
+#   (crontab -l 2>/dev/null; echo "30 * * * * $HOME/jazz/packages/telegram-bot/src/auto-update.sh >> $HOME/jazz-autoupdate.log 2>&1") | crontab -
 #
 # Paths are derived from the script's own location, so it works wherever the
 # repo lives.


### PR DESCRIPTION
## What & why

Moves the bridge auto-update from a nightly cron to an hourly one, so a fix reaches a deployed bot within the hour instead of the next morning. The script already rebuilds only when `origin/main` actually moved and rolls back a build that comes up unhealthy, so the extra runs cost a `git fetch` on the quiet passes.

## Breaking changes / migration

Re-run the install snippet from either bridge README to replace the crontab line. Existing deployments stay nightly until you do.

## How to verify

- Re-run the install snippet and confirm `crontab -l` shows `30 * * * *`.
- With the checkout already at `origin/main`, run the script and confirm it exits without rebuilding.
- Move the checkout one commit behind, run it, and confirm it rebuilds and the bridge comes back healthy.
