### PR TITLE
fix(bots): tighten data written before per-conversation isolation

### DIFF
--- a/packages/discord-bot/src/bridge.ts
+++ b/packages/discord-bot/src/bridge.ts
@@ -1851,9 +1851,10 @@ async function dispatchComponent(
       outstanding.map(([, pending]) => ({ toolCallId: pending.toolCallId, approved })),
     );
     const verdict = approved ? "✅ Approved" : "❌ Rejected";
-    // The clicked message is answered through the interaction; its siblings are
-    // separate messages, so they need their own patch to stop showing buttons
-    // that no longer resolve anything.
+    // Only the clicked message can be answered through the interaction, and the
+    // batch verdict goes there. Its siblings keep the text describing the tool
+    // they were asking about — that is the record of what this click approved —
+    // and lose only their buttons, which no longer resolve anything.
     await interactionCallback(interaction.id, interaction.token, {
       type: CALLBACK_UPDATE_MESSAGE,
       data: { content: `${verdict} — ${outstanding.length} tool calls`, components: [] },
@@ -1861,7 +1862,6 @@ async function dispatchComponent(
     for (const [, pending] of outstanding) {
       if (pending.messageId === messageId) continue;
       await patchMessage(config.botToken, pending.channelId, pending.messageId, {
-        content: `${verdict} as part of a batch`,
         components: [],
       }).catch(() => undefined);
     }

--- a/packages/discord-bot/src/entrypoint.sh
+++ b/packages/discord-bot/src/entrypoint.sh
@@ -31,6 +31,12 @@ if [ "$(id -u)" -ne 0 ] || [ "${JAZZ_BOT_CHAT_ISOLATION:-1}" = "0" ]; then
   # available: nothing outside this user gets in at all.
   chmod 700 "${JAZZ_HOME}"
   mkdir -p "${JAZZ_HOME}/personas"
+
+  # $JAZZ_HOME being 0700 already stops anyone else walking in, but files
+  # written before the switch still carry world-readable modes of their own.
+  # Strip them so the directory mode is not the only thing standing between
+  # another account and this data.
+  chmod -R go-rwx "${JAZZ_HOME}" 2>/dev/null || true
 else
   # Per-conversation sandboxes live at ${JAZZ_HOME}/chats/dc_<channel id>, each
   # owned by its own uid. Those uids are deliberately not in the operator group,
@@ -43,6 +49,17 @@ else
   # Personas are the one thing every conversation is meant to see the same copy
   # of, and only the operator installs them.
   mkdir -p "${JAZZ_HOME}/personas" && chmod 755 "${JAZZ_HOME}/personas"
+
+  # Anything already in the data directory predates isolation and kept whatever
+  # modes a 022 umask gave it. $JAZZ_HOME has to stay traversable for a
+  # conversation to reach its own sandbox, so those leftovers stay reachable
+  # too — a world-readable run log or history file from before the switch is
+  # still readable by every conversation. Personas are shared on purpose;
+  # everything else here belongs to the operator.
+  # `find` rather than a shell glob: caches land at $HOME/.bun and $HOME/.cache,
+  # and "*" does not match a leading dot.
+  find "${JAZZ_HOME}" -mindepth 1 -maxdepth 1 ! -name personas ! -name chats \
+    -exec chmod -R o-rwx {} + 2>/dev/null || true
 fi
 
 # Merge the bridge-managed keys into config.json, leaving anything the operator

--- a/packages/telegram-bot/src/entrypoint.sh
+++ b/packages/telegram-bot/src/entrypoint.sh
@@ -34,6 +34,12 @@ if [ "$(id -u)" -ne 0 ] || [ "${JAZZ_BOT_CHAT_ISOLATION:-1}" = "0" ]; then
   # available: nothing outside this user gets in at all.
   chmod 700 "${JAZZ_HOME}"
   mkdir -p "${JAZZ_HOME}/personas"
+
+  # $JAZZ_HOME being 0700 already stops anyone else walking in, but files
+  # written before the switch still carry world-readable modes of their own.
+  # Strip them so the directory mode is not the only thing standing between
+  # another account and this data.
+  chmod -R go-rwx "${JAZZ_HOME}" 2>/dev/null || true
 else
   # Per-chat sandboxes live at ${JAZZ_HOME}/chats/tg_<chat id>, each owned by
   # its own uid. Those uids are deliberately not in the operator group, so the
@@ -46,6 +52,17 @@ else
   # Personas are the one thing every chat is meant to see the same copy of, and
   # only the operator installs them.
   mkdir -p "${JAZZ_HOME}/personas" && chmod 755 "${JAZZ_HOME}/personas"
+
+  # Anything already in the data directory predates isolation and kept whatever
+  # modes a 022 umask gave it. $JAZZ_HOME has to stay traversable for a
+  # conversation to reach its own sandbox, so those leftovers stay reachable
+  # too — a world-readable run log or history file from before the switch is
+  # still readable by every conversation. Personas are shared on purpose;
+  # everything else here belongs to the operator.
+  # `find` rather than a shell glob: caches land at $HOME/.bun and $HOME/.cache,
+  # and "*" does not match a leading dot.
+  find "${JAZZ_HOME}" -mindepth 1 -maxdepth 1 ! -name personas ! -name chats \
+    -exec chmod -R o-rwx {} + 2>/dev/null || true
 fi
 
 # Directories for the email/calendar skills' XDG-relocated config, data, GPG


### PR DESCRIPTION
## What & why

Follow-up to #538. Data written before per-conversation isolation kept the modes a 022 umask gave it — 0755 directories, 0644 files — and the data directory has to stay traversable for a conversation to reach its own sandbox. On any bridge upgraded from an earlier version that left the leftovers reachable: one conversation's agent could still list and read another's run logs, legacy history and agent files, which is the exposure #538 set out to close.

The entrypoint now strips world access from everything directly under the data directory on each start, sparing only `personas` (shared on purpose) and `chats` (the sandbox root, which needs its traversable mode).

## How to verify

- Seed a data directory with a 0755 directory and a 0644 run log, restart the bridge, and confirm nothing under it is world-readable except `personas`.
- Check the dotfile case specifically: `HOME` points at the data directory, so bun's caches land at `.bun` and `.cache`, which a shell glob misses.
- From one conversation's uid, confirm `ls` on the shared `logs`, `history` and `agents` directories is denied.
- Confirm `personas` is still readable from inside a conversation, or persona switching breaks.
