### PR TITLE
feat(daemon): POST/PATCH/DELETE /personas, backed by the existing PersonaService

### DIFF
--- a/packages/adapters/src/daemon/server.test.ts
+++ b/packages/adapters/src/daemon/server.test.ts
@@ -12,7 +12,11 @@ import type { ToolRegistry } from "@jazz/core/interfaces/tool-registry";
 import { REASONING_EFFORTS } from "@jazz/core/types/agent";
 import type { Agent } from "@jazz/core/types/agent";
 import { WEB_SEARCH_PROVIDERS } from "@jazz/core/types/config";
-import { StorageNotFoundError } from "@jazz/core/types/errors";
+import {
+  PersonaAlreadyExistsError,
+  PersonaNotFoundError,
+  StorageNotFoundError,
+} from "@jazz/core/types/errors";
 import { COMPANION_ROLES } from "@jazz/core/types/llm";
 import { isLoopbackProgressUrl, parseProgressEvents } from "@jazz/core/types/webhook";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
@@ -48,6 +52,14 @@ function runnerFor(store: InMemoryRunStore) {
 
 function request(method: string, path: string, init?: RequestInit): Request {
   return new Request(`http://localhost${path}`, { method, ...init });
+}
+
+/** A JSON write, since every persona route takes one. */
+function writeRequest(method: string, path: string, body: unknown): Request {
+  return request(method, path, {
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 function agentFixture(overrides: Partial<Agent> = {}): Agent {
@@ -1106,6 +1118,152 @@ describe("the menus an agent editor is built from", () => {
       tone: "neutral",
     });
     expect(body.personas[0]).not.toHaveProperty("systemPrompt");
+  });
+
+  it("writes a persona and answers with the whole thing, prompt included", async () => {
+    const written: unknown[] = [];
+    const service = {
+      createPersona: (input: unknown) => {
+        written.push(input);
+        return Effect.succeed({
+          id: "psn_sceptic",
+          name: "sceptic",
+          description: "Asks what must be true",
+          systemPrompt: "Name the assumption.",
+          tone: "dry",
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        });
+      },
+    } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
+
+    const response = await handle(
+      writeRequest("POST", "/personas", {
+        name: "sceptic",
+        description: "Asks what must be true",
+        systemPrompt: "Name the assumption.",
+        tone: "dry",
+        // Empty is absent, not an empty string written into the file's frontmatter.
+        style: "",
+      }),
+    );
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { persona: Record<string, unknown> };
+    // Unlike the list, which omits it: whoever just wrote a prompt is the one caller who
+    // has a use for reading it back.
+    expect(body.persona["systemPrompt"]).toBe("Name the assumption.");
+    expect(body.persona).not.toHaveProperty("style");
+    expect(written[0]).not.toHaveProperty("style");
+  });
+
+  it("names the field when the service refuses a persona, so a form can mark it", async () => {
+    const service = {
+      createPersona: () => Effect.fail(new PersonaAlreadyExistsError({ personaName: "default" })),
+    } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
+
+    const response = await handle(
+      writeRequest("POST", "/personas", { name: "default", systemPrompt: "…" }),
+    );
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ ok: false, field: "name" });
+  });
+
+  it("takes a persona's name where the CLI would, not only its id", async () => {
+    const asked: string[] = [];
+    const service = {
+      getPersona: (id: string) => {
+        asked.push(id);
+        return Effect.fail(new PersonaNotFoundError({ personaId: id }));
+      },
+      getPersonaByName: (name: string) =>
+        Effect.succeed({
+          id: "psn_sceptic",
+          name,
+          description: "",
+          systemPrompt: "old",
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        }),
+      updatePersona: (id: string, updates: Record<string, unknown>) =>
+        Effect.succeed({
+          id,
+          name: "sceptic",
+          description: "",
+          systemPrompt: String(updates["systemPrompt"]),
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        }),
+    } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
+
+    const response = await handle(
+      writeRequest("PATCH", "/personas/sceptic", { systemPrompt: "new" }),
+    );
+    expect(response.status).toBe(200);
+    expect(asked).toEqual(["sceptic"]);
+    const body = (await response.json()) as { persona: Record<string, unknown> };
+    expect(body.persona["systemPrompt"]).toBe("new");
+  });
+
+  // A patch carrying one field is a change to that field, not an instruction to blank the
+  // rest — the difference between editing a prompt and quietly dropping the tone with it.
+  it("leaves out of a patch the fields the patch left out", async () => {
+    let sent: Record<string, unknown> | undefined;
+    const service = {
+      getPersona: () =>
+        Effect.succeed({
+          id: "psn_sceptic",
+          name: "sceptic",
+          description: "d",
+          systemPrompt: "old",
+          tone: "dry",
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        }),
+      updatePersona: (_id: string, updates: Record<string, unknown>) => {
+        sent = updates;
+        return Effect.succeed({
+          id: "psn_sceptic",
+          name: "sceptic",
+          description: "d",
+          systemPrompt: "new",
+          tone: "dry",
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        });
+      },
+    } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
+
+    await handle(writeRequest("PATCH", "/personas/psn_sceptic", { systemPrompt: "new" }));
+    expect(sent).toEqual({ systemPrompt: "new" });
+  });
+
+  it("deletes a persona and says which one went", async () => {
+    const removed: string[] = [];
+    const service = {
+      getPersona: (id: string) =>
+        Effect.succeed({
+          id,
+          name: "sceptic",
+          description: "",
+          systemPrompt: "…",
+          createdAt: new Date("2026-09-06T00:00:00Z"),
+          updatedAt: new Date("2026-09-06T00:00:00Z"),
+        }),
+      deletePersona: (id: string) => {
+        removed.push(id);
+        return Effect.succeed(undefined);
+      },
+    } as unknown as PersonaService;
+    const handle = makeHandler(LOOPBACK, runnerProviding(PersonaServiceTag, service));
+
+    const response = await handle(request("DELETE", "/personas/psn_sceptic"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, id: "psn_sceptic" });
+    expect(removed).toEqual(["psn_sceptic"]);
   });
 
   it("lists pickable tools with their categories, and leaves hidden ones out", async () => {

--- a/packages/adapters/src/daemon/server.ts
+++ b/packages/adapters/src/daemon/server.ts
@@ -44,6 +44,8 @@ import {
   AgentAlreadyExistsError,
   AgentConfigurationError,
   AgentNotFoundError,
+  PersonaAlreadyExistsError,
+  PersonaNotFoundError,
   StorageNotFoundError,
   ValidationError,
 } from "@jazz/core/types/errors";
@@ -52,6 +54,7 @@ import type { CompanionRole } from "@jazz/core/types/llm";
 import type { ModelInfo } from "@jazz/core/types/llm";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { inviteStatus } from "@jazz/core/types/peer-invite";
+import type { Persona } from "@jazz/core/types/persona";
 import type { ToolProgressEvent } from "@jazz/core/types/tools";
 import type { WebhookConfig } from "@jazz/core/types/webhook";
 import {
@@ -272,6 +275,19 @@ export function makeHandler(
   app.get("/catalog", () => listCatalog());
   app.get("/models", (context) => modelsRoute(context.req.raw, runEffect));
   app.get("/personas", () => runEffect(listPersonas()));
+  app.post("/personas", async (context) => {
+    const body = await readJsonBody(context.req.raw);
+    return body instanceof Response ? body : runEffect(createPersona(body));
+  });
+  app.patch("/personas/:identifier", async (context) => {
+    const body = await readJsonBody(context.req.raw);
+    return body instanceof Response
+      ? body
+      : runEffect(updatePersona(context.req.param("identifier"), body));
+  });
+  app.delete("/personas/:identifier", (context) =>
+    runEffect(deletePersona(context.req.param("identifier"))),
+  );
   app.get("/tools", () => runEffect(listTools()));
 
   return (request) => Promise.resolve(app.fetch(request));
@@ -1348,6 +1364,145 @@ function modelsRoute(
  * `systemPrompt` is left out: it is the bulk of a persona and a picker only needs to say
  * which one this is. Whoever wants the prompt itself is editing the persona, not choosing it.
  */
+/**
+ * What a client is allowed to send when writing a persona.
+ *
+ * Separate from `AgentWriteBody` because the two share only a name: a persona is frontmatter
+ * and a prompt, with no `config` to screen.
+ */
+interface PersonaWriteBody {
+  readonly name?: unknown;
+  readonly description?: unknown;
+  readonly systemPrompt?: unknown;
+  readonly tone?: unknown;
+  readonly style?: unknown;
+}
+
+/** The persona shape every route here answers with, so a client parses one thing. */
+function projectPersona(persona: Persona) {
+  return {
+    id: persona.id,
+    name: persona.name,
+    description: persona.description,
+    systemPrompt: persona.systemPrompt,
+    ...(persona.tone !== undefined ? { tone: persona.tone } : {}),
+    ...(persona.style !== undefined ? { style: persona.style } : {}),
+  };
+}
+
+/**
+ * A persona failure, in terms a form can act on.
+ *
+ * `field` is the point of this: an editor that only has a sentence can show a banner, and one
+ * that knows which input was wrong can put the message where the mistake is. Mirrors
+ * `agentErrorResponse`, which does the same job for the other half of this door.
+ */
+function personaErrorResponse(error: unknown): Response {
+  if (error instanceof PersonaAlreadyExistsError) {
+    return json(
+      {
+        ok: false,
+        error: `A persona called "${error.personaName}" already exists`,
+        field: "name",
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      409,
+    );
+  }
+  if (error instanceof PersonaNotFoundError) {
+    return json(
+      {
+        ok: false,
+        error: `No persona called "${error.personaId}"`,
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      404,
+    );
+  }
+  if (error instanceof StorageNotFoundError) {
+    return json({ ok: false, error: "No such persona", suggestion: error.suggestion }, 404);
+  }
+  if (error instanceof ValidationError) {
+    return json(
+      {
+        ok: false,
+        error: error.message,
+        field: error.field,
+        ...(error.suggestion !== undefined ? { suggestion: error.suggestion } : {}),
+      },
+      400,
+    );
+  }
+  return json(
+    {
+      ok: false,
+      error: `Could not write the persona: ${error instanceof Error ? error.message : String(error)}`,
+    },
+    500,
+  );
+}
+
+function createPersona(body: PersonaWriteBody) {
+  return Effect.gen(function* () {
+    const personaService = yield* PersonaServiceTag;
+    const tone = typeof body.tone === "string" && body.tone.length > 0 ? body.tone : undefined;
+    const style = typeof body.style === "string" && body.style.length > 0 ? body.style : undefined;
+    // Not screened here beyond their types. The service owns what a valid persona is — a name
+    // that collides with a built-in, an empty prompt — and answers naming the field, so a
+    // second copy of those rules on this side could only drift from the first.
+    const persona = yield* personaService.createPersona({
+      name: typeof body.name === "string" ? body.name : "",
+      description: typeof body.description === "string" ? body.description : "",
+      systemPrompt: typeof body.systemPrompt === "string" ? body.systemPrompt : "",
+      ...(tone !== undefined ? { tone } : {}),
+      ...(style !== undefined ? { style } : {}),
+    });
+    return json({ ok: true, persona: projectPersona(persona) }, 201);
+  }).pipe(Effect.catchAll((error) => Effect.succeed(personaErrorResponse(error))));
+}
+
+/**
+ * Change a persona, by name or by id.
+ *
+ * Only the fields present are touched: a client that sends a new prompt is not also silently
+ * clearing the tone it did not mention.
+ */
+function updatePersona(identifier: string, body: PersonaWriteBody) {
+  return Effect.gen(function* () {
+    const personaService = yield* PersonaServiceTag;
+    const existing = yield* findPersona(personaService, identifier);
+    const persona = yield* personaService.updatePersona(existing.id, {
+      ...(typeof body.name === "string" ? { name: body.name } : {}),
+      ...(typeof body.description === "string" ? { description: body.description } : {}),
+      ...(typeof body.systemPrompt === "string" ? { systemPrompt: body.systemPrompt } : {}),
+      ...(typeof body.tone === "string" ? { tone: body.tone } : {}),
+      ...(typeof body.style === "string" ? { style: body.style } : {}),
+    });
+    return json({ ok: true, persona: projectPersona(persona) });
+  }).pipe(Effect.catchAll((error) => Effect.succeed(personaErrorResponse(error))));
+}
+
+function deletePersona(identifier: string) {
+  return Effect.gen(function* () {
+    const personaService = yield* PersonaServiceTag;
+    const existing = yield* findPersona(personaService, identifier);
+    yield* personaService.deletePersona(existing.id);
+    return json({ ok: true, id: existing.id });
+  }).pipe(Effect.catchAll((error) => Effect.succeed(personaErrorResponse(error))));
+}
+
+/**
+ * A persona by whichever of its two names the caller had.
+ *
+ * The CLI takes either, so the door does too — a client holding the name a person typed
+ * should not have to resolve it to an id first.
+ */
+function findPersona(personaService: PersonaService, identifier: string) {
+  return personaService
+    .getPersona(identifier)
+    .pipe(Effect.catchAll(() => personaService.getPersonaByName(identifier)));
+}
+
 function listPersonas() {
   return Effect.gen(function* () {
     const personaService = yield* PersonaServiceTag;


### PR DESCRIPTION
## The asymmetry

`makeHandler` mounted `GET /personas` and nothing else, while `PersonaService` has carried
`createPersona`, `updatePersona` and `deletePersona` since it was written. So a persona could
be read by any client on the door and written only by someone at this machine's terminal —
`packages/cli/src/commands/persona.ts` reaching the service directly, bypassing the daemon.

The immediate caller is quartet's agent editor, whose persona `<select>` is populated from
`GET /personas` and is a dead end when nothing in it fits.

## Mechanisms

Three routes beside the agent ones, same shape, same `readJsonBody` screen:

| | |
|---|---|
| `POST /personas` | `createPersona` → 201 |
| `PATCH /personas/:identifier` | `updatePersona` → 200 |
| `DELETE /personas/:identifier` | `deletePersona` → 200 `{ok, id}` |

**`PersonaWriteBody`** is separate from `AgentWriteBody`: they share only `name`, and a persona
has no `config` to run through `configBodyProblem`.

**`personaErrorResponse`** mirrors `agentErrorResponse` — `PersonaAlreadyExistsError` → 409 with
`field: "name"`, `PersonaNotFoundError` / `StorageNotFoundError` → 404, `ValidationError` → 400
carrying the service's own `field` and `suggestion`. The `field` is the point: a client with only
a sentence shows a banner, one with the field marks the input.

**`findPersona`** tries `getPersona` then falls back to `getPersonaByName`, so `:identifier`
takes either form — the CLI already accepts both, and a client holding the name a person typed
should not have to resolve it first.

**`projectPersona`** includes `systemPrompt`, unlike the list projection which omits it.
Whoever just wrote a prompt is the one caller with a use for reading it back.

A `PATCH` spreads only the keys present in the body, so sending a new `systemPrompt` does not
blank the `tone` it did not mention.

Nothing validates the draft at this layer. The service owns what a valid persona is — a name
colliding with a built-in, an empty prompt — and answers naming the field, so a second copy of
those rules here could only drift from the first.

## Verified

Unit tests cover the write projection, the empty-string-is-absent case, the `field` on a
refusal, name-vs-id resolution, the partial patch, and delete. `bun test` on
`packages/adapters/src/daemon/server.test.ts`: 85 pass. `bun run typecheck` clean.

Also exercised over HTTP against a daemon run from this branch: `POST /personas` writes
`persona.md` with the frontmatter and body, and a colliding name is refused with a 400 from
`ValidationError` before `PersonaAlreadyExistsError` is reached.

## Noticed while testing, not fixed here

`createPersonaServiceLayer()` (persona-service.ts:737) constructs `PersonaServiceImpl` with no
options, so the constructor falls back to `path.join(os.homedir(), ".jazz")` and the service
ignores `JAZZ_HOME` and `--data-dir` — personas are the one thing those do not isolate.
`packages/bot-shared/src/personas.ts:22` already passes `baseDataPath` explicitly, so the fix is
small, but it changes behaviour for anyone relying on personas being machine-global. Left alone
deliberately; worth its own PR.