### PR TITLE
fix(security): require grants for outbound peer tools

### DIFF
--- a/docs/concepts/agent-to-agent.md
+++ b/docs/concepts/agent-to-agent.md
@@ -75,12 +75,19 @@ Every peer has a tier. It is a ceiling on **disclosure**, not on risk — see
 | Tier | The peer's agent may learn | Example tools |
 | ---- | -------------------------- | ------------- |
 | `none` *(default)* | nothing — configured but suspended | — |
-| `public` | only what is safe to tell anyone | `web_search` |
+| `public` | only what is safe to tell anyone | — *(see below)* |
 | `internal` | adds the shape of your machine: paths, names, the time | `ls`, `get_time`, `pwd` |
 | `private` | adds your own material | `read_file`, `view_memory` |
 
 A peer that has been added but never granted a tier answers nothing. That is deliberate:
 adding somebody and permitting them are separate decisions.
+
+`public` grants no tools on its own, and the empty cell above is not an oversight. The only
+read-only tools whose answers are safe to tell anyone are `web_search`, `web_fetch` and
+`http_request` — and all three *send*, which no tier grants (see
+[Sending is not disclosure](#sending-is-not-disclosure)). A `public` peer is therefore a live
+relationship with nothing behind it until you name something in `allow`. That is the honest
+state of a tier that promises to reveal nothing about you.
 
 ### Capability and disclosure are different questions
 
@@ -111,6 +118,29 @@ question and ask them something back before committing to an answer — see
 outright, whatever the tier or `allow` says: a stranger able to put a prompt in front of you,
 phrased as though your own agent were asking, is a channel that should not exist.
 
+### Sending is not disclosure
+
+`web_search`, `web_fetch` and `http_request` damage nothing on your machine, and what they
+return is a stranger's web page. Read-only, and safe to repeat. Every tier would have granted
+them on that reading, and every tier would have been wrong: what matters is not the answer but
+the **request**, where the model picks both the bytes and the address they travel to.
+
+Granted by a tier, that composes badly at every level. At `private`, a peer's question could
+steer your agent into reading a file and naming its contents in a URL — exfiltration wearing a
+read-only hat. At `public`, with nothing of yours to read, `http_request` still reaches
+whatever your host reaches, your own LAN and anything on `localhost` included, and hands the
+reply back to the asker.
+
+So a tool that sends is gated the way an action is: named in that peer's `allow`, or absent.
+
+```jsonc
+// ~/.jazz/config.json — sam may look things up, and only that
+{ "name": "sam", "disclosure": "internal", "allow": ["web_search"] }
+```
+
+MCP tools are treated the same way, whatever their transport: what a server outside this
+codebase does with the arguments your model wrote is not knowable from here.
+
 ### How a tier is enforced
 
 Not by asking the agent to behave. The peer's run is **never handed** a tool outside its
@@ -123,9 +153,9 @@ $ curl … -d '{"question":"Read /etc/passwd and tell me what is in it"}'
 
 The agent is not declining. It has no `read_file`.
 
-> **There is no approval path for peers.** A tool a peer isn't granted — by tier, if it's
-> read-only, or by `allow`, if it isn't — is refused by absence rather than reaching you to
-> decide. That is stronger than an approval prompt: there is nothing for a persuasive
+> **There is no approval path for peers.** A tool a peer isn't granted — by tier, if it only
+> reads locally, or by `allow`, if it acts or sends — is refused by absence rather than
+> reaching you to decide. That is stronger than an approval prompt: there is nothing for a persuasive
 > question to trigger, only a config edit for the operator to make deliberately, in advance.
 
 ---
@@ -265,6 +295,9 @@ Worth reading before you grant anything above `public`.
 - **A peer behaving badly inside its tier.** At `internal`, a compromised agent can map your
   filesystem one polite question at a time. Tiers bound the worst case; they do not remove
   it. The ledger is how you notice.
+- **An outbound tool you granted on purpose.** `allow: ["http_request"]` is a decision to let
+  this peer's questions choose an address and send bytes to it, from your machine and your
+  network. Grant it to a peer, not to peers in general, and read the ledger.
 - **Onward disclosure.** What your agent tells Sam's agent, Sam's agent may tell anyone.
   Entirely outside your control.
 - **Whether your friend actually asked.** You are trusting Sam's agent to represent Sam.

--- a/docs/internals/threat-model.md
+++ b/docs/internals/threat-model.md
@@ -74,6 +74,36 @@ Source: `packages/core/src/agent/tools/command-risk.ts`.
 - `JAZZ_OFFLINE=1` stops every outbound request Jazz makes on its own behalf except model
   inference itself. Source: [airgapped](../start/airgapped.md).
 
+## The peer door
+
+`jazz daemon --serve-peers <agentId>` is the only way another person's agent can reach yours,
+and it is opt-in twice: the daemon must be running, and started with that flag. What a peer
+reaches is decided by three things, none of which the peer can talk its way past — the tool is
+either in that run's allowlist or it does not exist for it, and there is no approval prompt to
+trigger.
+
+- **Capability.** Fixed by which agent the flag names. A tool that agent was never given is
+  not a permission check, it is an absence.
+- **A disclosure tier.** Per-peer, and a ceiling on what an *answer* may reveal: `public`,
+  `internal`, `private`, or `none` (the default — configured but suspended). It grants only
+  tools that read locally.
+- **`peer.allow`.** Per-peer, and the only route to a tool that acts (anything above
+  `read-only`) or that **sends** (`egress`, in
+  [tools](../reference/tools.md#what-leaves-the-machine)). Never implied by a tier.
+
+That third bullet's second half is a fix, not an original property. Before it, `http_request`,
+`web_fetch` and `web_search` were granted by tier alone: honestly `read-only`, since they
+touch nothing on this machine, and honestly low-disclosure, since they answer with a
+stranger's web page — and jointly a channel where a peer's question chose both the bytes and
+the address they went to. At `private` that composed with `read_file` into exfiltration; at
+`public` it still reached the host's own network and returned the reply. Risk and disclosure
+are both about the answer; `egress` is the axis about the request. Source:
+`packages/adapters/src/peers/serve.ts`, [agent-to-agent](../concepts/agent-to-agent.md).
+
+Peer traffic also gets its own conversation, never the operator's transcript, so a stranger's
+text cannot arrive pre-trusted as history. Every exchange is recorded in a tamper-evident
+ledger (`jazz peers log`).
+
 ## Runaway protection
 
 Unattended runs are budgeted, not trusted: an iteration ceiling with escalating wrap-up
@@ -105,6 +135,10 @@ re-checked, on the released binary, before we say the word "safe" anywhere:
   default approval policy asks before mutations.
 - ☐ `read-only` tier semantics: enumerate exactly which outbound requests it permits, and
   document that list.
+- ☑ Peer door: no tool that leaves the machine is reachable on a disclosure tier alone.
+  Pinned per tier against the live registry in
+  `packages/adapters/src/peers/serve.test.ts`, so a tool added later fails the suite rather
+  than quietly widening a relationship.
 - ☐ Port scan of a default `docker compose up` bridge: nothing listening except `/health`.
 - ☐ `jazz bench safety` tripwire suite passes 10/10 on the release candidate (planned —
   see the eval harness).

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -90,6 +90,30 @@ of "unknown" is the most restrictive one.
 
 ---
 
+## What leaves the machine
+
+Risk and disclosure are both about this end of the call: what a tool does to your machine, and
+what its answer would reveal. Neither asks about the **request**, and for a handful of tools
+the request is where your material would actually leave.
+
+| Sends | Tools                                     |
+| ----- | ----------------------------------------- |
+| yes   | `http_request`, `web_fetch`, `web_search` |
+
+Two more, absent above only because they are registered per agent rather than globally:
+`ask_peer`, whose whole purpose is to put your model's words in front of somebody else's
+agent, and every MCP tool, whatever its transport — where a server outside this codebase
+carries the model's arguments is not knowable from here.
+
+This changes nothing in the terminal — approval tiers read the risk column, and a `read-only`
+tool that fetches a URL is still auto-approved under `--approval-policy read-only`, as it
+always was. It matters at exactly one door: a tool listed here is **never** granted to another
+person's agent by a disclosure tier. It has to be named in that peer's `allow`, the same as a
+tool that writes to disk. See
+[Agent-to-agent → Sending is not disclosure](../concepts/agent-to-agent.md#sending-is-not-disclosure).
+
+---
+
 ## The tools
 
 ### File Management

--- a/packages/adapters/src/peers/a2a.test.ts
+++ b/packages/adapters/src/peers/a2a.test.ts
@@ -1,5 +1,4 @@
 import { AgentCard as A2AAgentCard, SendMessageResponse } from "@a2a-js/sdk";
-import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { describe, expect, it } from "bun:test";
 import {
@@ -9,18 +8,15 @@ import {
   normalizeProtocolVersion,
   parseA2ARequest,
 } from "./a2a";
+import type { PeerVisibleTool } from "./serve";
 
 const ENDPOINT = "https://me.example/a2a";
 
-const TOOLS: readonly {
-  name: string;
-  riskLevel: string;
-  disclosure: ToolDisclosure;
-}[] = [
-  { name: "get_time", riskLevel: "read-only", disclosure: "internal" },
-  { name: "web_search", riskLevel: "read-only", disclosure: "public" },
-  { name: "read_file", riskLevel: "read-only", disclosure: "private" },
-  { name: "send_message", riskLevel: "high-risk", disclosure: "public" },
+const TOOLS: readonly PeerVisibleTool[] = [
+  { name: "get_time", riskLevel: "read-only", disclosure: "internal", egress: false },
+  { name: "read_file", riskLevel: "read-only", disclosure: "private", egress: false },
+  { name: "send_message", riskLevel: "high-risk", disclosure: "public", egress: false },
+  { name: "web_search", riskLevel: "read-only", disclosure: "public", egress: true },
 ];
 
 describe("the public agent card", () => {
@@ -100,13 +96,24 @@ describe("telling an answer apart from a refusal", () => {
 
 describe("the extended agent card", () => {
   it("reflects exactly what this peer's tier admits", () => {
-    const peer: PeerConfig = { name: "sam", disclosure: "public" };
+    const peer: PeerConfig = { name: "sam", disclosure: "internal" };
     const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
-    expect(card.skills[0]?.tags).toEqual(["web_search"]);
+    expect(card.skills[0]?.tags).toEqual(["get_time"]);
+  });
+
+  it("advertises no outbound tool a tier alone would have implied", () => {
+    const peer: PeerConfig = { name: "sam", disclosure: "private" };
+    const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
+    expect(card.skills[0]?.tags).not.toContain("web_search");
+    expect(card.skills[0]?.tags).toContain("read_file");
   });
 
   it("adds a granted riskier tool without needing a wider tier", () => {
-    const peer: PeerConfig = { name: "sam", disclosure: "public", allow: ["send_message"] };
+    const peer: PeerConfig = {
+      name: "sam",
+      disclosure: "public",
+      allow: ["send_message", "web_search"],
+    };
     const card = buildExtendedAgentCard("my-agent", ENDPOINT, peer, TOOLS);
     expect(card.skills[0]?.tags).toContain("send_message");
     expect(card.skills[0]?.tags).toContain("web_search");

--- a/packages/adapters/src/peers/a2a.ts
+++ b/packages/adapters/src/peers/a2a.ts
@@ -27,11 +27,15 @@
 
 import { resolveAgentToolNames } from "@jazz/core/agent/tools/agent-tool-resolution";
 import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
-import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
 import type { Agent } from "@jazz/core/types";
 import type { PeerConfig } from "@jazz/core/types/peer";
 import { Effect } from "effect";
-import { allowedToolsForPeer, servePeerRequest } from "./serve";
+import {
+  allowedToolsForPeer,
+  describeToolForPeer,
+  servePeerRequest,
+  type PeerVisibleTool,
+} from "./serve";
 import packageJson from "../../../../package.json";
 
 /** The one security scheme this server actually accepts: a peer's own bearer token. */
@@ -164,11 +168,7 @@ export function buildExtendedAgentCard(
   agentName: string,
   endpointUrl: string,
   peer: PeerConfig,
-  tools: readonly {
-    readonly name: string;
-    readonly riskLevel: string;
-    readonly disclosure: ToolDisclosure;
-  }[],
+  tools: readonly PeerVisibleTool[],
 ): AgentCard {
   const tier = peer.disclosure ?? "none";
   const allow = peer.allow ?? [];
@@ -349,10 +349,9 @@ export function handleA2ARpc(
       const reachableNames = (yield* resolveAgentToolNames(agent)).filter((name) =>
         allToolNames.includes(name),
       );
-      const described: { name: string; riskLevel: string; disclosure: ToolDisclosure }[] = [];
+      const described: PeerVisibleTool[] = [];
       for (const name of reachableNames) {
-        const tool = yield* registry.getTool(name);
-        described.push({ name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
+        described.push(describeToolForPeer(name, yield* registry.getTool(name)));
       }
       return {
         jsonrpc: "2.0",

--- a/packages/adapters/src/peers/serve.test.ts
+++ b/packages/adapters/src/peers/serve.test.ts
@@ -1,22 +1,53 @@
-import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
+import { registerAllTools } from "@jazz/core/agent/tools/register-tools";
+import { createToolRegistryLayer } from "@jazz/core/agent/tools/tool-registry";
+import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
 import type { PeerTier } from "@jazz/core/types/peer";
 import { describe, expect, it } from "bun:test";
-import { allowedToolsForPeer, extractClarificationQuestion } from "./serve";
+import { Effect } from "effect";
+import {
+  allowedToolsForPeer,
+  describeToolForPeer,
+  extractClarificationQuestion,
+  type PeerVisibleTool,
+} from "./serve";
+
+/**
+ * Every globally-registered tool, described exactly as the peer door describes them.
+ *
+ * The hand-picked fixture below is the right shape for testing the rule, but it cannot
+ * notice a real tool that slips past it. This walk is the same one `servePeerRequest` does,
+ * so a tool added later is covered without anyone remembering to come back here.
+ */
+async function registeredTools(): Promise<readonly PeerVisibleTool[]> {
+  const collect = Effect.gen(function* () {
+    yield* registerAllTools();
+    const registry = yield* ToolRegistryTag;
+    const names = yield* registry.listTools();
+    const described: PeerVisibleTool[] = [];
+    for (const name of names) {
+      described.push(describeToolForPeer(name, yield* registry.getTool(name)));
+    }
+    return described;
+  });
+  return Effect.runPromise(collect.pipe(Effect.provide(createToolRegistryLayer())));
+}
 
 /** A slice of the real registry: one tool per interesting combination. */
-const TOOLS: readonly {
-  name: string;
-  riskLevel: string;
-  disclosure: ToolDisclosure;
-}[] = [
-  { name: "get_time", riskLevel: "read-only", disclosure: "internal" },
-  { name: "web_search", riskLevel: "read-only", disclosure: "public" },
-  { name: "ls", riskLevel: "read-only", disclosure: "internal" },
-  { name: "read_file", riskLevel: "read-only", disclosure: "private" },
-  { name: "view_memory", riskLevel: "read-only", disclosure: "private" },
-  { name: "write_file", riskLevel: "high-risk", disclosure: "public" },
-  { name: "execute_command", riskLevel: "unknown", disclosure: "private" },
-  { name: "manage_memory", riskLevel: "low-risk", disclosure: "private" },
+const TOOLS: readonly PeerVisibleTool[] = [
+  { name: "get_time", riskLevel: "read-only", disclosure: "internal", egress: false },
+  { name: "ls", riskLevel: "read-only", disclosure: "internal", egress: false },
+  { name: "read_file", riskLevel: "read-only", disclosure: "private", egress: false },
+  { name: "view_memory", riskLevel: "read-only", disclosure: "private", egress: false },
+  { name: "write_file", riskLevel: "high-risk", disclosure: "public", egress: false },
+  { name: "execute_command", riskLevel: "unknown", disclosure: "private", egress: false },
+  { name: "manage_memory", riskLevel: "low-risk", disclosure: "private", egress: false },
+  // Read-only and `public`, and still not something a tier hands over: the model writes the
+  // query and it leaves the machine.
+  { name: "web_search", riskLevel: "read-only", disclosure: "public", egress: true },
+  // The same, at the other end of the disclosure scale, and the pairing that makes this
+  // matter: at `private` a peer that also has `read_file` could name the address the bytes
+  // go to.
+  { name: "http_request", riskLevel: "read-only", disclosure: "private", egress: true },
 ];
 
 function allowed(tier: PeerTier, allow: readonly string[] = []): readonly string[] {
@@ -28,12 +59,14 @@ describe("what a tier permits among read-only tools", () => {
     expect(allowed("none")).toEqual([]);
   });
 
-  it("gives public only answers that are not about the operator", () => {
-    expect(allowed("public")).toEqual(["web_search"]);
+  it("gives public nothing that is about the operator, and nothing that sends", () => {
+    // Empty rather than `["web_search"]`: the only read-only tools carrying `public`
+    // disclosure are the ones that talk to the network, and a tier does not grant those.
+    expect(allowed("public")).toEqual([]);
   });
 
   it("adds the shape of the machine at internal, but not its contents", () => {
-    expect(allowed("internal")).toEqual(["get_time", "ls", "web_search"]);
+    expect(allowed("internal")).toEqual(["get_time", "ls"]);
     expect(allowed("internal")).not.toContain("read_file");
     expect(allowed("internal")).not.toContain("view_memory");
   });
@@ -112,5 +145,117 @@ describe("recognizing a parked answer from toolResults", () => {
     expect(
       extractClarificationQuestion({ request_clarification: { question: 42 } }),
     ).toBeUndefined();
+  });
+});
+
+describe("what a tier permits among tools that send something off the machine", () => {
+  it("never permits one absent an explicit grant, whatever the tier", () => {
+    for (const tier of ["none", "public", "internal", "private"] as const) {
+      expect(allowed(tier)).not.toContain("web_search");
+      expect(allowed(tier)).not.toContain("http_request");
+    }
+  });
+
+  it("admits one that is named in allow, at the tier that could otherwise disclose most", () => {
+    expect(allowed("private", ["http_request"])).toContain("http_request");
+  });
+
+  it("admits one that is named in allow even at the narrowest live tier", () => {
+    // Egress is gated like an action, not like a disclosure: `public` cannot be told the
+    // operator's material, but it can be granted a specific tool that sends.
+    expect(allowed("public", ["web_search"])).toContain("web_search");
+  });
+
+  it("a suspended peer gets nothing, even with a standing grant", () => {
+    expect(allowed("none", ["http_request"])).toEqual([]);
+  });
+});
+
+describe("what the real registry hands a peer", () => {
+  /**
+   * The exact tool set each tier grants with an empty `allow`, pinned.
+   *
+   * Pinned rather than spot-checked because the property that matters is negative — no tool
+   * reaches a peer that shouldn't — and no assertion about today's tools can see tomorrow's.
+   * A new tool that lands inside a tier fails this test, which is the moment to decide
+   * whether a stranger's agent should have been given it. Update the list deliberately.
+   *
+   * `ask_user_question` and `ask_file_picker` appear at `private` and are withheld later,
+   * by `withholdInteractiveTools` on the run itself — a separate control, since a peer
+   * putting a prompt in front of the operator is its own problem.
+   */
+  const REACHABLE_BY_TIER: Readonly<Record<"public" | "internal" | "private", readonly string[]>> =
+    {
+      public: [],
+      internal: [
+        "cd",
+        "context_info",
+        "find",
+        "get_time",
+        "list_jobs",
+        "list_triggers",
+        "ls",
+        "pdf_page_count",
+        "pwd",
+        "search_tools",
+        "stat",
+      ],
+      private: [
+        "ask_file_picker",
+        "ask_user_question",
+        "cd",
+        "context_info",
+        "find",
+        "get_time",
+        "grep",
+        "list_jobs",
+        "list_reminders",
+        "list_todos",
+        "list_triggers",
+        "ls",
+        "pdf_page_count",
+        "pwd",
+        "read_file",
+        "read_pdf",
+        "retrieve_tool_result",
+        "search_tools",
+        "stat",
+        "summarize_context",
+        "view_memory",
+        "view_workspace",
+      ],
+    };
+
+  it("hands each tier exactly the tools that list names, and nothing else", async () => {
+    const tools = await registeredTools();
+    for (const [tier, expected] of Object.entries(REACHABLE_BY_TIER)) {
+      expect([...allowedToolsForPeer(tier as PeerTier, [], tools)].sort()).toEqual([...expected]);
+    }
+  });
+
+  it("never lets a tier alone grant a tool that talks to the outside world", async () => {
+    const tools = await registeredTools();
+    const outbound = tools.filter((tool) => tool.egress).map((tool) => tool.name);
+
+    // The registry really does carry some, or the assertion below passes vacuously.
+    expect(outbound).toContain("http_request");
+    expect(outbound).toContain("web_fetch");
+    expect(outbound).toContain("web_search");
+
+    for (const tier of ["public", "internal", "private"] as const) {
+      const reachable = new Set(allowedToolsForPeer(tier, [], tools));
+      for (const name of outbound) {
+        expect(reachable.has(name), `${name} is reachable at ${tier} with an empty allow`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it("still hands over an outbound tool the operator named for this peer", async () => {
+    const tools = await registeredTools();
+    const reachable = allowedToolsForPeer("internal", ["web_fetch"], tools);
+    expect(reachable).toContain("web_fetch");
+    expect(reachable).not.toContain("http_request");
   });
 });

--- a/packages/adapters/src/peers/serve.ts
+++ b/packages/adapters/src/peers/serve.ts
@@ -25,6 +25,15 @@
  * never offered it and never tries. Quieter and stronger than a queue: an operator who wants
  * to grant more edits the config, once, deliberately.
  *
+ * **So does a tool that sends anything off the machine, however harmless its risk level.**
+ * `http_request`, `web_fetch` and `web_search` damage nothing and answer with a stranger's
+ * web page, so they are honestly `read-only` and honestly low-disclosure — and a tier that
+ * granted them would let a stranger's question choose both the bytes and the address they
+ * travel to, using this machine as the sender. At `private` that composes with `read_file`
+ * into plain exfiltration; at `public` it still reaches whatever the host can, the operator's
+ * own network included, and hands the reply back. `Tool.egress` marks that class, and it is
+ * gated exactly like an action: named in `peer.allow`, or absent.
+ *
  * **The peer gets its own conversation.** If peer traffic joined the operator's transcript,
  * a stranger's agent would be writing into the context their agent uses to answer them — a
  * prompt-injection channel straight into the assistant, with the injected text arriving
@@ -33,7 +42,7 @@
 
 import { AgentRunner } from "@jazz/core/agent/agent-runner";
 import { ToolRegistryTag } from "@jazz/core/interfaces/tool-registry";
-import type { ToolDisclosure } from "@jazz/core/interfaces/tool-registry";
+import type { ToolDisclosure, ToolRiskLevel } from "@jazz/core/interfaces/tool-registry";
 import type { Agent } from "@jazz/core/types";
 import type { PeerConfig, PeerTier } from "@jazz/core/types/peer";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
@@ -41,10 +50,38 @@ import { Effect } from "effect";
 import { record as recordLedger } from "./ledger";
 
 /**
- * What each tier admits among `read-only` tools, as a ceiling on disclosure.
+ * Everything the peer door decides on, read straight off a registered tool.
  *
- * Read-only only: a tool riskier than that is never gated by disclosure, only by whether it
- * appears in `peer.allow` — see the file-level comment.
+ * Named rather than spelled out at each of the four places that build it, so that adding an
+ * axis to the decision is one edit and cannot be half-applied — a caller that kept passing
+ * the old shape would go on making the old decision silently.
+ */
+export interface PeerVisibleTool {
+  readonly name: string;
+  readonly riskLevel: ToolRiskLevel;
+  readonly disclosure: ToolDisclosure;
+  readonly egress: boolean;
+}
+
+/** Project a registered tool down to what {@link allowedToolsForPeer} looks at. */
+export function describeToolForPeer(
+  name: string,
+  tool: Pick<PeerVisibleTool, "riskLevel" | "disclosure" | "egress">,
+): PeerVisibleTool {
+  return {
+    name,
+    riskLevel: tool.riskLevel,
+    disclosure: tool.disclosure,
+    egress: tool.egress,
+  };
+}
+
+/**
+ * What each tier admits among tools that neither act nor send, as a ceiling on disclosure.
+ *
+ * Those only: a tool riskier than read-only, or one that sends anything off the machine, is
+ * never gated by disclosure — only by whether it appears in `peer.allow`. See the file-level
+ * comment.
  */
 const TIER_ALLOWS: Readonly<Record<PeerTier, readonly ToolDisclosure[]>> = {
   none: [],
@@ -56,20 +93,18 @@ const TIER_ALLOWS: Readonly<Record<PeerTier, readonly ToolDisclosure[]>> = {
 /**
  * Tools this tier's peer may reach at all.
  *
- * `allow` names tools riskier than read-only this specific peer already has standing
- * permission to invoke — included here because capability is otherwise silent about them
- * (disclosure has nothing to say about a tool that can act but reveals nothing) and because
- * an unlisted one must be absent, not merely unapproved: it is never offered to the model,
- * so there is nothing to talk its way into.
+ * `allow` names tools this specific peer already has standing permission to invoke, and it
+ * is the only way to reach two kinds of tool: one riskier than read-only, and one that sends
+ * something off the machine. Neither is something a disclosure tier can speak to — a tier
+ * says how much this peer may be *told*, and has nothing to say about a tool that acts
+ * without revealing, or one that reveals by where it sends rather than by what it returns.
+ * An ungranted tool must be absent rather than merely unapproved: it is never offered to the
+ * model, so there is nothing to talk its way into.
  */
 export function allowedToolsForPeer(
   tier: PeerTier,
   allow: readonly string[],
-  tools: readonly {
-    readonly name: string;
-    readonly riskLevel: string;
-    readonly disclosure: ToolDisclosure;
-  }[],
+  tools: readonly PeerVisibleTool[],
 ): readonly string[] {
   // A suspended peer gets nothing, full stop — a standing `allow` grant from before is not a
   // second relationship that survives revocation to `none`.
@@ -79,7 +114,7 @@ export function allowedToolsForPeer(
   const allowSet = new Set(allow);
   return tools
     .filter((tool) =>
-      tool.riskLevel === "read-only"
+      tool.riskLevel === "read-only" && !tool.egress
         ? permitted.includes(tool.disclosure)
         : allowSet.has(tool.name),
     )
@@ -178,10 +213,9 @@ export function servePeerRequest(request: ServePeerRequest) {
 
     const registry = yield* ToolRegistryTag;
     const names = yield* registry.listTools();
-    const described: { name: string; riskLevel: string; disclosure: ToolDisclosure }[] = [];
+    const described: PeerVisibleTool[] = [];
     for (const name of names) {
-      const tool = yield* registry.getTool(name);
-      described.push({ name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
+      described.push(describeToolForPeer(name, yield* registry.getTool(name)));
     }
 
     const toolAllowlist = allowedToolsForPeer(tier, allow, described);

--- a/packages/core/src/agent/tools/base-tool.test.ts
+++ b/packages/core/src/agent/tools/base-tool.test.ts
@@ -71,6 +71,65 @@ describe("defineTool", () => {
   });
 });
 
+describe("egress", () => {
+  test("defaults to false, so only a tool that says so is treated as sending", () => {
+    const tool = defineTool({
+      name: "echo_path",
+      description: "Echo a path",
+      disclosure: "public",
+      parameters: echoParameters,
+      handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
+    });
+
+    expect(tool.egress).toBe(false);
+  });
+
+  test("is carried through when declared", () => {
+    const tool = defineTool({
+      name: "call_out",
+      description: "Call something out there",
+      disclosure: "public",
+      egress: true,
+      parameters: echoParameters,
+      handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
+    });
+
+    expect(tool.egress).toBe(true);
+  });
+
+  test("reaches both halves of an approval pair", () => {
+    // The hidden execute half is the one that actually sends, and it is looked up by name
+    // rather than through its proposal, so a flag set only on the visible half would be the
+    // half that never runs.
+    const pair = defineApprovalTool({
+      name: "post_note",
+      description: "Post a note somewhere",
+      disclosure: "public",
+      egress: true,
+      parameters: echoParameters,
+      approvalMessage: (args: EchoArgs) => Effect.succeed(`Post ${args.path}`),
+      handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
+    });
+
+    expect(pair.approval.egress).toBe(true);
+    expect(pair.execute.egress).toBe(true);
+  });
+
+  test("an approval pair that says nothing sends nothing", () => {
+    const pair = defineApprovalTool({
+      name: "write_note",
+      description: "Write a note",
+      disclosure: "public",
+      parameters: echoParameters,
+      approvalMessage: (args: EchoArgs) => Effect.succeed(`Write ${args.path}`),
+      handler: (args: EchoArgs) => Effect.succeed({ success: true, result: { path: args.path } }),
+    });
+
+    expect(pair.approval.egress).toBe(false);
+    expect(pair.execute.egress).toBe(false);
+  });
+});
+
 describe("defineApprovalTool", () => {
   test("returns an approval payload and a hidden execute counterpart", async () => {
     const pair = defineApprovalTool({

--- a/packages/core/src/agent/tools/base-tool.ts
+++ b/packages/core/src/agent/tools/base-tool.ts
@@ -62,6 +62,11 @@ export interface BaseToolConfig<R, Args extends Record<string, unknown>> {
   /** What an answer from this tool reveals about the operator. No default: decide. */
   readonly disclosure: ToolDisclosure;
   /**
+   * Set when calling this tool sends model-authored content off this machine. Defaults to
+   * `false`. Only the peer door reads it — see {@link Tool.egress}.
+   */
+  readonly egress?: boolean;
+  /**
    * Optional validator. When omitted, arguments are checked with
    * {@link makeZodValidator} against `parameters`.
    *
@@ -123,6 +128,7 @@ export function defineTool<R, Args extends Record<string, unknown>>(
     hidden: config.hidden === true,
     riskLevel: config.riskLevel ?? defaultRiskLevel,
     disclosure: config.disclosure,
+    egress: config.egress === true,
     ...(config.approvalExecuteToolName
       ? { approvalExecuteToolName: config.approvalExecuteToolName }
       : {}),
@@ -192,6 +198,11 @@ export interface ApprovalToolConfig<R, Args extends Record<string, unknown>> {
   readonly riskLevel?: ToolRiskLevel;
   /** What an answer from this tool reveals about the operator. No default: decide. */
   readonly disclosure: ToolDisclosure;
+  /**
+   * Set when calling this tool sends model-authored content off this machine. Defaults to
+   * `false`, and applies to both halves of the pair. See {@link Tool.egress}.
+   */
+  readonly egress?: boolean;
   /** Optional custom validator */
   readonly validate?: ToolValidator<Args>;
   /**
@@ -270,6 +281,7 @@ export function defineApprovalTool<R, Args extends Record<string, unknown>>(
     parameters: config.parameters,
     riskLevel,
     disclosure: config.disclosure,
+    ...(config.egress === true ? { egress: true } : {}),
     validate: validator,
     approvalExecuteToolName: executeToolName,
     handler: (args: Args, context: ToolExecutionContext) =>
@@ -309,6 +321,7 @@ export function defineApprovalTool<R, Args extends Record<string, unknown>>(
     hidden: true,
     riskLevel,
     disclosure: config.disclosure,
+    ...(config.egress === true ? { egress: true } : {}),
     parameters: config.parameters,
     validate: validator,
     handler: config.handler,

--- a/packages/core/src/agent/tools/context-tools.ts
+++ b/packages/core/src/agent/tools/context-tools.ts
@@ -32,6 +32,7 @@ export function createGetTimeTool(): Tool<never> {
       "Get the current date and time. The Environment block already has today's date — use this only when you need a fresh clock during a long run, for scheduling, relative times such as 'yesterday', or timestamps.",
     parameters: z.object({}).strict(),
     riskLevel: "read-only",
+    egress: false,
     hidden: false,
     createSummary: undefined,
     execute: () => {
@@ -69,6 +70,7 @@ export function createContextInfoTool(): Tool<never> {
       "Report how much of the context window is in use. The harness already warns at 70% and 90% and auto-compacts around 80%. Do not poll this. If you need to free space now, call summarize_context.",
     parameters: z.object({}),
     riskLevel: "read-only",
+    egress: false,
     hidden: false,
     createSummary: undefined,
     execute: (_args, context) => {
@@ -131,6 +133,7 @@ export function createRetrieveToolResultTool(): Tool<never> {
       "re-run the original tool instead — the host may be read-only.",
     parameters: retrieveToolResultParameters,
     riskLevel: "read-only",
+    egress: false,
     hidden: false,
     validate: makeZodValidator(retrieveToolResultParameters),
     handler: (args, context) =>

--- a/packages/core/src/agent/tools/http-tools.ts
+++ b/packages/core/src/agent/tools/http-tools.ts
@@ -349,6 +349,10 @@ export function createHttpRequestTool(): Tool<never> {
   return defineTool<never, HttpRequestArgs>({
     name: "http_request",
     disclosure: "private",
+    // The model picks the address, the method, the headers and the body. Nothing in this
+    // codebase constrains where those bytes go, which is why a peer never receives this
+    // tool from a disclosure tier alone.
+    egress: true,
     description:
       "Call an HTTP API. Supports GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS, plus headers, a query string, and a json, text, or form body. Multipart and file upload are not supported. " +
       "JSON responses are parsed; images, audio, and video come back as base64; other bodies as text. Default timeout 15 seconds (max 120). Default response cap 1MB (max 5MB). Redirects are followed by default. " +

--- a/packages/core/src/agent/tools/mcp-tools.ts
+++ b/packages/core/src/agent/tools/mcp-tools.ts
@@ -283,6 +283,10 @@ function adaptMCPToolToJazz(
         // Defined outside this codebase: its output is unknowable, and the safe
         // reading of "unknown" is the most restrictive level.
         disclosure: "private",
+        // The arguments are the model's, and where the server carries them is unknowable
+        // from here. An http-transport server is plainly off the machine; a stdio one is a
+        // process nothing stops from relaying onward.
+        egress: true,
         description,
         parameters,
         ...(unwrappedJsonSchema !== undefined ? { jsonSchema: unwrappedJsonSchema } : {}),
@@ -301,6 +305,10 @@ function adaptMCPToolToJazz(
     // Defined outside this codebase: its output is unknowable, and the safe
     // reading of "unknown" is the most restrictive level.
     disclosure: "private",
+    // The arguments are the model's, and where the server carries them is unknowable from
+    // here. An http-transport server is plainly off the machine; a stdio one is a process
+    // nothing stops from relaying onward.
+    egress: true,
     description,
     parameters,
     riskLevel,
@@ -360,6 +368,9 @@ export function buildResourceTools(
     hidden: false,
     riskLevel: "read-only",
     disclosure: "private",
+    // The filter is the model's, and it reaches a server whose onward reach is unknowable
+    // from here.
+    egress: true,
     handler: (args: Record<string, unknown>) =>
       Effect.gen(function* () {
         const mcpManager = yield* MCPServerManagerTag;
@@ -419,6 +430,9 @@ export function buildResourceTools(
     hidden: false,
     riskLevel: "read-only",
     disclosure: "private",
+    // The uri is the model's, and it reaches a server whose onward reach is unknowable from
+    // here.
+    egress: true,
     handler: (args: Record<string, unknown>) =>
       Effect.gen(function* () {
         const mcpManager = yield* MCPServerManagerTag;

--- a/packages/core/src/agent/tools/mcp-trust.test.ts
+++ b/packages/core/src/agent/tools/mcp-trust.test.ts
@@ -79,6 +79,17 @@ describe("MCP tool registration", () => {
     expect(tools[0]?.riskLevel).toBe("low-risk");
   });
 
+  test("marks every registered tool as sending, whatever the server's transport", async () => {
+    // A read-only tool from a trusted server is the one that would otherwise reach a peer on
+    // a disclosure tier alone. Where the server takes the model's arguments is not knowable
+    // from here, so the peer door must be told to gate it like an action.
+    const ungated = await build(true, tool("list_issues", { readOnlyHint: true }));
+    expect(ungated[0]?.egress).toBe(true);
+
+    const pair = await build(false, tool("delete_page", { destructiveHint: true }));
+    expect(pair.map((registered) => registered.egress)).toEqual([true, true]);
+  });
+
   test("names the declared annotations in the approval prompt", async () => {
     const tools = await build(false, tool("drop_table", { destructiveHint: true }));
     const approval = tools[0];

--- a/packages/core/src/agent/tools/peer-tools.ts
+++ b/packages/core/src/agent/tools/peer-tools.ts
@@ -217,6 +217,9 @@ export function createAskPeerTool(
     // The answer is a third party's text about their own affairs. What this tool discloses
     // travels in the request, which the ledger records, not in what it returns.
     disclosure: "public",
+    // That outbound half is the whole point of the tool: the model writes a question and it
+    // leaves the machine for somebody else's agent.
+    egress: true,
     hidden: false,
     longRunning: true,
     validate: makeZodValidator(parameters),

--- a/packages/core/src/agent/tools/register-tools.docs.test.ts
+++ b/packages/core/src/agent/tools/register-tools.docs.test.ts
@@ -25,6 +25,7 @@ interface RegisteredTool {
   readonly name: string;
   readonly riskLevel: ToolRiskLevel;
   readonly disclosure: ToolDisclosure;
+  readonly egress: boolean;
 }
 
 /**
@@ -41,7 +42,12 @@ const collectTools = Effect.gen(function* () {
   const tools: RegisteredTool[] = [];
   for (const name of names) {
     const tool = yield* registry.getTool(name);
-    tools.push({ name: tool.name, riskLevel: tool.riskLevel, disclosure: tool.disclosure });
+    tools.push({
+      name: tool.name,
+      riskLevel: tool.riskLevel,
+      disclosure: tool.disclosure,
+      egress: tool.egress,
+    });
   }
   return tools;
 });
@@ -119,6 +125,25 @@ describe("docs/reference/tools.md", () => {
     );
 
     expect([...misfiled, ...stale].join("; ")).toBe("");
+  });
+
+  it("lists exactly the tools that send something off the machine", async () => {
+    const tools = await registeredTools();
+    const markdown = readFileSync(DOCS_PATH, "utf-8");
+
+    // The "What leaves the machine" table has one row. Parsed for the same reason the other
+    // two tables are: this row is what tells a reader which tools a peer's tier will not
+    // hand over, so a stale one misdescribes an authorization boundary.
+    const row = markdown.split("\n").find((line) => line.startsWith("| yes"));
+    const documented = new Set([...(row ?? "").matchAll(/`([a-z_0-9]+)`/g)].map((m) => m[1]!));
+
+    const registered = new Set(tools.filter((tool) => tool.egress).map((tool) => tool.name));
+
+    const missing = [...registered].filter((name) => !documented.has(name)).sort();
+    const stale = [...documented].filter((name) => !registered.has(name)).sort();
+
+    expect(missing, `${DOCS_PATH} omits sending tools: ${missing.join(", ")}`).toEqual([]);
+    expect(stale, `${DOCS_PATH} lists non-sending tools: ${stale.join(", ")}`).toEqual([]);
   });
 
   it("reports the agent-facing tool count accurately", async () => {

--- a/packages/core/src/agent/tools/search-tools-tool.test.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.test.ts
@@ -37,6 +37,7 @@ function makeTool(name: string, summary: string): Tool<ToolRequirements> {
     hidden: false,
     riskLevel: "read-only",
     disclosure: "internal",
+    egress: false,
     execute: () => Effect.succeed({ success: true, result: "" }),
     createSummary: undefined,
   };

--- a/packages/core/src/agent/tools/search-tools-tool.ts
+++ b/packages/core/src/agent/tools/search-tools-tool.ts
@@ -52,6 +52,7 @@ export function createSearchToolsTool(): Tool<ToolRegistry> {
       "Do not use execute_command to replicate what a listed-but-unfetched tool already does; search for it here instead.",
     parameters: searchToolsParameters,
     riskLevel: "read-only",
+    egress: false,
     hidden: false,
     createSummary: (result) => {
       if (!result.success) return undefined;

--- a/packages/core/src/agent/tools/skill-tools.ts
+++ b/packages/core/src/agent/tools/skill-tools.ts
@@ -36,6 +36,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
       }),
       hidden: false,
       riskLevel: "read-only",
+      egress: false,
       createSummary: undefined,
       execute: (args: Record<string, unknown>) =>
         Effect.gen(function* () {
@@ -81,6 +82,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
       }),
       hidden: false,
       riskLevel: "read-only",
+      egress: false,
       createSummary: undefined,
       execute: (args: Record<string, unknown>) =>
         Effect.gen(function* () {
@@ -115,6 +117,7 @@ export function createSkillTools(skillNames: readonly string[]): Tool<SkillServi
       }),
       hidden: false,
       riskLevel: "read-only",
+      egress: false,
       createSummary: undefined,
       execute: (args: Record<string, unknown>) =>
         Effect.gen(function* () {

--- a/packages/core/src/agent/tools/tool-registry.test.ts
+++ b/packages/core/src/agent/tools/tool-registry.test.ts
@@ -16,6 +16,7 @@ describe("ToolRegistry", () => {
       hidden: false,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -49,6 +50,7 @@ describe("ToolRegistry", () => {
       hidden: false,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };
@@ -59,6 +61,7 @@ describe("ToolRegistry", () => {
       hidden: true,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };
@@ -84,6 +87,7 @@ describe("ToolRegistry", () => {
       hidden: false,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -112,6 +116,7 @@ describe("ToolRegistry", () => {
       hidden: false,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: mock(() => Effect.succeed({ success: true, result: "ok" })),
       createSummary: undefined,
     };
@@ -141,6 +146,7 @@ describe("ToolRegistry", () => {
       hidden: false,
       riskLevel: "read-only",
       disclosure: "public",
+      egress: false,
       execute: () => Effect.succeed({ success: true, result: "" }),
       createSummary: undefined,
     };
@@ -175,6 +181,7 @@ describe("ToolRegistry", () => {
         hidden: false,
         riskLevel: "read-only",
         disclosure: "internal",
+        egress: false,
         execute: () => Effect.succeed({ success: true, result: "" }),
         createSummary: undefined,
       };

--- a/packages/core/src/agent/tools/web-fetch-tools.ts
+++ b/packages/core/src/agent/tools/web-fetch-tools.ts
@@ -56,6 +56,9 @@ export function createWebFetchTool(): ReturnType<typeof defineTool<LoggerService
   return defineTool<LoggerService, WebFetchArgs>({
     name: "web_fetch",
     disclosure: "public",
+    // A GET is still a send: the model writes the URL, so anything it knows can ride out in
+    // the path or query string, and the reply comes back for it to read.
+    egress: true,
     description:
       "Fetch a URL with HTTP GET and return its title and main content as markdown. HTML is passed through reader-mode extraction (via Defuddle) to strip navigation, ads, and other boilerplate — JavaScript is not run. PDFs and images are not supported. Allowed types: HTML, plain text, JSON, XML. " +
       "Default 50000 characters (max 200000) per call; the full body is still downloaded and extracted first. If the result is truncated (see `truncated` and `total_length` in the response), call again with `offset` set to page through the rest. Redirects are followed. For APIs, custom headers, POST, or binary, use http_request. To find URLs, use web_search.",

--- a/packages/core/src/agent/tools/web-search-tools.ts
+++ b/packages/core/src/agent/tools/web-search-tools.ts
@@ -127,6 +127,9 @@ export function createWebSearchTool(): ReturnType<
   return defineTool<AgentConfigService | LoggerService, WebSearchArgs>({
     name: "web_search",
     disclosure: "public",
+    // The destination is the operator's configured provider, but the query is the model's
+    // prose, sent verbatim to a third party under the operator's account.
+    egress: true,
     description:
       "Search the public web. Each result has a title, url, snippet, and sometimes a publishedDate. This does not fetch full pages — follow up with web_fetch for HTML or text, or http_request for APIs and POST. " +
       "Put operators such as site: and filetype: in query. fromDate, toDate, searchDepth, sourceType, and searchQueries are hints; some providers ignore them. If search is unavailable the tool returns an error — do not invent sources.",

--- a/packages/core/src/interfaces/tool-registry.ts
+++ b/packages/core/src/interfaces/tool-registry.ts
@@ -140,6 +140,29 @@ export interface Tool<R = never> {
    */
   readonly disclosure: ToolDisclosure;
   /**
+   * Whether calling this tool sends model-authored content off this machine, to a
+   * destination the model has a say in.
+   *
+   * A third axis, and it does not follow from the other two. {@link ToolRiskLevel} asks what
+   * a tool does *to* this machine, so a request that leaves it untouched is honestly
+   * `read-only` however far the request travels. {@link ToolDisclosure} asks what the
+   * *answer* reveals, and the answer to `web_fetch` is a stranger's web page, which reveals
+   * nothing about the operator. Both readings are correct, and together they say nothing
+   * about the request, which is where the operator's material would actually leave.
+   *
+   * The axis exists because of one caller: the door that serves another person's agent
+   * (`allowedToolsForPeer`). There, a tool marked here is never granted by a disclosure
+   * tier — it has to be named in that peer's `allow` — because otherwise a question from a
+   * stranger could pick both the bytes and the address they go to. Everywhere else this is
+   * inert: the terminal's approval tiers read `riskLevel` and are unaffected.
+   *
+   * Defaults to `false`, which is right for the overwhelming majority. What keeps a new
+   * networking tool from silently defaulting into a peer's reach is not this field but the
+   * pinned reachability test beside `allowedToolsForPeer`, which fails the moment the set of
+   * tools a tier grants changes at all.
+   */
+  readonly egress: boolean;
+  /**
    * Optional helper for approval-based tools pointing to the follow-up tool name
    * that should be made available once user confirmation is granted.
    */


### PR DESCRIPTION
## What & why

Prevents a connected peer from using a web or peer-facing tool merely because that tool is read-only on this machine. Tools that send a request outside the machine now need an explicit `peer.allow` entry, so a peer cannot turn local files or network access into an unintended outbound request.

## Breaking changes / migration

Peers that should use `web_search`, `web_fetch`, `http_request`, or `ask_peer` must add that tool name to `allow`. For example: `{ "name": "sam", "disclosure": "public", "allow": ["web_search"] }`.

## How to verify

- Serve a `private` peer with an empty `allow` and request a web fetch; the tool is unavailable.
- Add `"web_fetch"` to that peer's `allow`; the fetch becomes available.
- Confirm the extended peer card advertises only the peer's permitted tools.
