### PR TITLE
Bound the memory budget, make one lookup enough, and show the operator what is stored

### DIFF
--- a/docs/internals/memory.md
+++ b/docs/internals/memory.md
@@ -54,6 +54,47 @@ file count per scope (`core/constants/memory.ts`). The per-file cap is checked o
 write; the scope-wide byte and file-count caps are checked on every write that grows the
 scope, with an edit charged only its net delta so a shrinking edit always fits.
 
+## Provenance
+
+Every write records who made it, when, and when the file was last read back, in a hidden
+per-scope sidecar (`.provenance.json`). It is a sidecar rather than a header inside the
+memory files because those files are both the artifact a person edits directly and exactly
+what reaches the model — a header would break that equivalence and shift every line number
+`str_replace` and `insert` address. Hidden entries are excluded from listings and from the
+byte and file-count budgets: Jazz's own bookkeeping must not consume the operator's quota.
+
+`lastViewedAt` is recorded but deliberately wired to nothing. Personal memory is not
+re-derivable — delete "allergic to shellfish" and it is gone — so "unused" is a bad proxy
+for "unimportant": an allergy is read once a year. The signal exists for a human reviewing
+memory, not for an automatic deleter.
+
+## Seeing and controlling it
+
+```text
+jazz memory list <agent>            every file the agent can read, with provenance
+jazz memory show <agent> <path>     one file, exactly as the agent reads it
+jazz memory forget <agent> <path>   delete one file permanently
+jazz memory recall [--surface]      how often runs consulted memory before answering
+```
+
+`/memory` does the same inside a chat session (`/memory <path>` to read one, `/memory forget
+<path>` to remove one). Both operate on the real files, so nothing shown is a regenerated
+summary that could differ from what the model actually receives.
+
+## Measuring recall
+
+`view_memory` is tool-call-gated with no preload: nothing injects memory into context, so
+whether a run has continuity depends on the model choosing to spend a call before it
+answers. That is a property of a surface, not something a unit test can settle — a casual
+opener on a chat bridge is both the likeliest miss and the least likely to be noticed.
+
+Each finished run appends one line to `~/.jazz/memory-recall/memory-recall.jsonl` recording
+whether a `view_memory` call landed before the first substantive answer, tagged with the
+surface it came through. Bots shell out to the same `jazz run` a terminal user invokes, so
+each bridge sets `JAZZ_SURFACE`; absent the marker a run is plain CLI. Runs never offered the
+memory tools are recorded too, and excluded from the denominator — they cannot be a miss.
+`jazz memory recall` reports the rate per surface.
+
 ## Path safety
 
 Every action goes through one function, `resolveMemoryPath`, before touching the

--- a/docs/internals/memory.md
+++ b/docs/internals/memory.md
@@ -22,20 +22,37 @@ Anthropic's own memory tool. There is no embedding index or vector search: memor
 full on `view`, which is the right tradeoff at the scale this targets (durable notes about
 the people or projects one agent talks to), not a multi-tenant knowledge base.
 
-Memory is scoped by `Agent.id`, the same identifier that already scopes conversation
-history — so it follows an agent across every surface that invokes it (CLI, a Telegram
-bridge, a Discord bridge), not by session or conversation.
+## Scopes
+
+Memory is partitioned into named **scopes** — `personal`, `finance`, `github-project-a` —
+rather than one silo per agent. A scope is the unit of storage and is independent of agent
+identity, so several agents can share one scope and a single agent can hold several.
+
+An agent's accessible scopes come from `AgentConfig.memoryScopes`. An agent with none
+configured falls back to a single scope named after its own id, which is why memory follows
+an agent across every surface that invokes it (CLI, a Telegram bridge, a Discord bridge)
+rather than being per-session or per-conversation.
+
+Every tool path begins with a scope name (`personal/preferences.md`). Scopes are a strict
+allowlist, not a namespace the agent can address freely: a path naming a scope outside the
+caller's set is reported as not found. Renaming across scopes is refused.
+
+Calling `view_memory` with no path lists every accessible scope **and the files inside them**,
+so one call is enough to see what has been saved. Listing the root never creates a scope
+directory — an unwritten scope shows up as an empty one.
 
 ## On disk
 
 ```text
-~/.jazz/memory/<agentId>/            agent's memory root, created lazily on first write
-~/.jazz/memory/<agentId>.lock/       directory-mutex, same convention as history's lock
+~/.jazz/memory/<scope>/            scope's memory root, created lazily on first write
+~/.jazz/memory/<scope>.lock/       directory-mutex, same convention as history's lock
 ```
 
 Flat UTF-8 files, agent-organized (e.g. `people/alex.md`, `project-context.md`) — no
 enforced schema. Guardrails cap depth, path-segment length, per-file size, total bytes, and
-file count per agent (`core/constants/memory.ts`).
+file count per scope (`core/constants/memory.ts`). The per-file cap is checked on every
+write; the scope-wide byte and file-count caps are checked on every write that grows the
+scope, with an edit charged only its net delta so a shrinking edit always fits.
 
 ## Path safety
 
@@ -46,7 +63,7 @@ same-run "create a file, swap it for a symlink, then read through it" race can't
 one-time check.
 
 Mutating actions (`create`/`str_replace`/`insert`/`delete`/`rename`) share one lock per
-agent — not per file — because the size/count guardrails need a consistent view of the
+scope — not per file — because the size/count guardrails need a consistent view of the
 whole directory tree, and the guardrail check plus the write happen inside the same lock
 acquisition.
 
@@ -58,3 +75,6 @@ durable, potentially sensitive facts about a specific person to disk; forcing it
 everywhere would silently contradict personas (like `researcher`) that promise their tools
 can't write files. Whoever wires up a persistent chat surface (Telegram, Discord) turns memory
 on for that agent specifically.
+
+Ephemeral runs (`jazz run --ephemeral`, `/incognito` in the bots) withhold `manage_memory`
+entirely, so nothing from that conversation reaches long-term memory.

--- a/packages/adapters/src/memory-service.test.ts
+++ b/packages/adapters/src/memory-service.test.ts
@@ -32,6 +32,8 @@ function makeService(): MemoryServiceImpl {
 
 const scopes = ["agent-1"];
 
+const writeContext = { agentId: "agent-1" } as const;
+
 describe("view", () => {
   test("lists the accessible scopes at the root path", async () => {
     const service = makeService();
@@ -53,7 +55,7 @@ describe("view", () => {
 
   test("lists a file after create", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello", writeContext));
     const outcome = await runEffect(service.view(scopes, "agent-1"));
     expect(outcome.kind).toBe("directory");
     if (outcome.kind === "directory") {
@@ -63,7 +65,9 @@ describe("view", () => {
 
   test("reads file content with line numbers via view_range", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "line1\nline2\nline3"));
+    await runEffect(
+      service.create(scopes, "agent-1/notes.txt", "line1\nline2\nline3", writeContext),
+    );
     const outcome = await runEffect(service.view(scopes, "agent-1/notes.txt", [2, 3]));
     expect(outcome.kind).toBe("file");
     if (outcome.kind === "file") {
@@ -90,7 +94,7 @@ describe("create", () => {
   test("creates a file and its parent directories", async () => {
     const service = makeService();
     const outcome = await runEffect(
-      service.create(scopes, "agent-1/people/alex.md", "likes coffee"),
+      service.create(scopes, "agent-1/people/alex.md", "likes coffee", writeContext),
     );
     expect(outcome.success).toBe(true);
     const view = await runEffect(service.view(scopes, "agent-1/people/alex.md"));
@@ -103,7 +107,7 @@ describe("create", () => {
   test("treats a leading slash as relative to the scope root and reports the backing path", async () => {
     const service = makeService();
     const outcome = await runEffect(
-      service.create(scopes, "/agent-1/people/alex.md", "likes coffee"),
+      service.create(scopes, "/agent-1/people/alex.md", "likes coffee", writeContext),
     );
     const expectedPath = path.join(
       fs.realpathSync(path.join(tmpDir, "agent-1")),
@@ -123,8 +127,10 @@ describe("create", () => {
 
   test("errors instead of overwriting an existing file", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "first"));
-    const outcome = await runEffect(service.create(scopes, "agent-1/notes.txt", "second"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "first", writeContext));
+    const outcome = await runEffect(
+      service.create(scopes, "agent-1/notes.txt", "second", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("already exists");
     const view = await runEffect(service.view(scopes, "agent-1/notes.txt"));
@@ -137,29 +143,33 @@ describe("create", () => {
   test("rejects a file exceeding the per-file byte cap", async () => {
     const service = makeService();
     const tooBig = "x".repeat(MAX_MEMORY_FILE_BYTES + 1);
-    const result = await runEither(service.create(scopes, "agent-1/big.txt", tooBig));
+    const result = await runEither(service.create(scopes, "agent-1/big.txt", tooBig, writeContext));
     expect(result._tag).toBe("Left");
   });
 
   test("rejects once the per-scope file count cap is exceeded", async () => {
     const service = makeService();
     for (let i = 0; i < MAX_MEMORY_FILES_PER_SCOPE; i++) {
-      await runEffect(service.create(scopes, `agent-1/file-${i}.txt`, "x"));
+      await runEffect(service.create(scopes, `agent-1/file-${i}.txt`, "x", writeContext));
     }
-    const result = await runEither(service.create(scopes, "agent-1/one-too-many.txt", "x"));
+    const result = await runEither(
+      service.create(scopes, "agent-1/one-too-many.txt", "x", writeContext),
+    );
     expect(result._tag).toBe("Left");
   }, 30_000);
 
   test("fails when the path names no scope", async () => {
     const service = makeService();
-    const outcome = await runEffect(service.create(scopes, "notes.txt", "x"));
+    const outcome = await runEffect(service.create(scopes, "notes.txt", "x", writeContext));
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("Accessible scopes");
   });
 
   test("fails when the path names a scope outside the accessible set", async () => {
     const service = makeService();
-    const outcome = await runEffect(service.create(scopes, "other-scope/notes.txt", "x"));
+    const outcome = await runEffect(
+      service.create(scopes, "other-scope/notes.txt", "x", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("Unknown memory scope");
   });
@@ -168,9 +178,9 @@ describe("create", () => {
 describe("str_replace", () => {
   test("replaces a unique match", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world", writeContext));
     const outcome = await runEffect(
-      service.strReplace(scopes, "agent-1/notes.txt", "world", "there"),
+      service.strReplace(scopes, "agent-1/notes.txt", "world", "there", writeContext),
     );
     expect(outcome.success).toBe(true);
     const view = await runEffect(service.view(scopes, "agent-1/notes.txt"));
@@ -179,17 +189,19 @@ describe("str_replace", () => {
 
   test("deletes in place when new_str is omitted", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world"));
-    await runEffect(service.strReplace(scopes, "agent-1/notes.txt", " world", undefined));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world", writeContext));
+    await runEffect(
+      service.strReplace(scopes, "agent-1/notes.txt", " world", undefined, writeContext),
+    );
     const view = await runEffect(service.view(scopes, "agent-1/notes.txt"));
     if (view.kind === "file") expect(view.content).toBe("hello");
   });
 
   test("fails with no match", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "hello world", writeContext));
     const outcome = await runEffect(
-      service.strReplace(scopes, "agent-1/notes.txt", "goodbye", "hi"),
+      service.strReplace(scopes, "agent-1/notes.txt", "goodbye", "hi", writeContext),
     );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("did not appear verbatim");
@@ -197,8 +209,10 @@ describe("str_replace", () => {
 
   test("fails with multiple matches and reports line numbers", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "dup\nother\ndup"));
-    const outcome = await runEffect(service.strReplace(scopes, "agent-1/notes.txt", "dup", "x"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "dup\nother\ndup", writeContext));
+    const outcome = await runEffect(
+      service.strReplace(scopes, "agent-1/notes.txt", "dup", "x", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("lines: 1, 3");
   });
@@ -207,16 +221,18 @@ describe("str_replace", () => {
 describe("insert", () => {
   test("inserts text at the given line", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "a\nb"));
-    await runEffect(service.insert(scopes, "agent-1/notes.txt", 1, "inserted"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "a\nb", writeContext));
+    await runEffect(service.insert(scopes, "agent-1/notes.txt", 1, "inserted", writeContext));
     const view = await runEffect(service.view(scopes, "agent-1/notes.txt"));
     if (view.kind === "file") expect(view.content).toBe("a\ninserted\nb");
   });
 
   test("rejects an out-of-range insert_line", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "a\nb"));
-    const outcome = await runEffect(service.insert(scopes, "agent-1/notes.txt", 99, "x"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "a\nb", writeContext));
+    const outcome = await runEffect(
+      service.insert(scopes, "agent-1/notes.txt", 99, "x", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("Invalid `insert_line`");
   });
@@ -225,7 +241,7 @@ describe("insert", () => {
 describe("delete", () => {
   test("deletes an existing file", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/notes.txt", "x"));
+    await runEffect(service.create(scopes, "agent-1/notes.txt", "x", writeContext));
     const outcome = await runEffect(service.delete(scopes, "agent-1/notes.txt"));
     expect(outcome.success).toBe(true);
     const view = await runEffect(service.view(scopes, "agent-1/notes.txt"));
@@ -249,8 +265,10 @@ describe("delete", () => {
 describe("rename", () => {
   test("renames an existing file", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/old.txt", "x"));
-    const outcome = await runEffect(service.rename(scopes, "agent-1/old.txt", "agent-1/new.txt"));
+    await runEffect(service.create(scopes, "agent-1/old.txt", "x", writeContext));
+    const outcome = await runEffect(
+      service.rename(scopes, "agent-1/old.txt", "agent-1/new.txt", writeContext),
+    );
     expect(outcome.success).toBe(true);
     expect((await runEffect(service.view(scopes, "agent-1/old.txt"))).kind).toBe("not_found");
     expect((await runEffect(service.view(scopes, "agent-1/new.txt"))).kind).toBe("file");
@@ -258,9 +276,11 @@ describe("rename", () => {
 
   test("fails when the destination already exists", async () => {
     const service = makeService();
-    await runEffect(service.create(scopes, "agent-1/a.txt", "a"));
-    await runEffect(service.create(scopes, "agent-1/b.txt", "b"));
-    const outcome = await runEffect(service.rename(scopes, "agent-1/a.txt", "agent-1/b.txt"));
+    await runEffect(service.create(scopes, "agent-1/a.txt", "a", writeContext));
+    await runEffect(service.create(scopes, "agent-1/b.txt", "b", writeContext));
+    const outcome = await runEffect(
+      service.rename(scopes, "agent-1/a.txt", "agent-1/b.txt", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("already exists");
   });
@@ -268,8 +288,10 @@ describe("rename", () => {
   test("fails renaming across scopes", async () => {
     const multiScopes = ["agent-1", "agent-2"];
     const service = makeService();
-    await runEffect(service.create(multiScopes, "agent-1/a.txt", "a"));
-    const outcome = await runEffect(service.rename(multiScopes, "agent-1/a.txt", "agent-2/a.txt"));
+    await runEffect(service.create(multiScopes, "agent-1/a.txt", "a", writeContext));
+    const outcome = await runEffect(
+      service.rename(multiScopes, "agent-1/a.txt", "agent-2/a.txt", writeContext),
+    );
     expect(outcome.success).toBe(false);
     expect(outcome.message).toContain("across memory scopes");
   });
@@ -278,25 +300,33 @@ describe("rename", () => {
 describe("path safety", () => {
   test("rejects .. traversal", async () => {
     const service = makeService();
-    const result = await runEither(service.create(scopes, "agent-1/../escape.txt", "x"));
+    const result = await runEither(
+      service.create(scopes, "agent-1/../escape.txt", "x", writeContext),
+    );
     expect(result._tag).toBe("Left");
   });
 
   test("rejects a null byte", async () => {
     const service = makeService();
-    const result = await runEither(service.create(scopes, "agent-1/notes\0.txt", "x"));
+    const result = await runEither(
+      service.create(scopes, "agent-1/notes\0.txt", "x", writeContext),
+    );
     expect(result._tag).toBe("Left");
   });
 
   test("rejects paths deeper than the max depth", async () => {
     const service = makeService();
-    const result = await runEither(service.create(scopes, "agent-1/a/b/c/d/e.txt", "x"));
+    const result = await runEither(
+      service.create(scopes, "agent-1/a/b/c/d/e.txt", "x", writeContext),
+    );
     expect(result._tag).toBe("Left");
   });
 
   test("rejects a path segment longer than the max length", async () => {
     const service = makeService();
-    const result = await runEither(service.create(scopes, `agent-1/${"x".repeat(200)}.txt`, "x"));
+    const result = await runEither(
+      service.create(scopes, `agent-1/${"x".repeat(200)}.txt`, "x", writeContext),
+    );
     expect(result._tag).toBe("Left");
   });
 
@@ -327,9 +357,11 @@ describe("root listing", () => {
   test("lists the files inside every accessible scope in one call", async () => {
     const service = new MemoryServiceImpl({ baseMemoryDirectory: tmpDir });
     const twoScopes = ["personal", "work"];
-    await runEffect(service.create(twoScopes, "personal/prefs.md", "bun over npm"));
-    await runEffect(service.create(twoScopes, "personal/people/alex.md", "likes tea"));
-    await runEffect(service.create(twoScopes, "work/status.md", "shipping"));
+    await runEffect(service.create(twoScopes, "personal/prefs.md", "bun over npm", writeContext));
+    await runEffect(
+      service.create(twoScopes, "personal/people/alex.md", "likes tea", writeContext),
+    );
+    await runEffect(service.create(twoScopes, "work/status.md", "shipping", writeContext));
 
     const outcome = await runEffect(service.view(twoScopes, ""));
     expect(outcome.kind).toBe("directory");
@@ -380,8 +412,10 @@ describe("scope byte budget", () => {
 
   test("rejects a create that would exceed the total byte budget", async () => {
     const service = makeBudgetService();
-    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
-    const result = await runEither(service.create(scopes, "agent-1/b.txt", "B".repeat(50)));
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60), writeContext));
+    const result = await runEither(
+      service.create(scopes, "agent-1/b.txt", "B".repeat(50), writeContext),
+    );
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(String(result.left)).toContain("total memory budget");
@@ -390,8 +424,10 @@ describe("scope byte budget", () => {
 
   test("rejects an insert that grows a file past the total byte budget", async () => {
     const service = makeBudgetService();
-    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
-    const result = await runEither(service.insert(scopes, "agent-1/a.txt", 1, "B".repeat(50)));
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60), writeContext));
+    const result = await runEither(
+      service.insert(scopes, "agent-1/a.txt", 1, "B".repeat(50), writeContext),
+    );
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(String(result.left)).toContain("total memory budget");
@@ -400,9 +436,9 @@ describe("scope byte budget", () => {
 
   test("rejects a str_replace that grows a file past the total byte budget", async () => {
     const service = makeBudgetService();
-    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60), writeContext));
     const result = await runEither(
-      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(60), "B".repeat(111)),
+      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(60), "B".repeat(111), writeContext),
     );
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
@@ -412,10 +448,88 @@ describe("scope byte budget", () => {
 
   test("allows a shrinking edit on a scope already at the budget ceiling", async () => {
     const service = makeBudgetService();
-    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(100)));
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(100), writeContext));
     const outcome = await runEffect(
-      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(100), "B".repeat(10)),
+      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(100), "B".repeat(10), writeContext),
     );
     expect(outcome.success).toBe(true);
+  });
+});
+
+describe("provenance", () => {
+  test("records creation, writes, and the writing agent", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/notes.md", "hello", writeContext));
+    const provenance = await runEffect(service.provenance(scopes, "agent-1/notes.md"));
+    expect(provenance?.writeCount).toBe(1);
+    expect(provenance?.writtenBy).toEqual(["agent-1"]);
+    expect(provenance?.createdAt).toBe(provenance?.updatedAt);
+  });
+
+  test("counts each edit and keeps the original creation time", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/notes.md", "hello", writeContext));
+    const created = await runEffect(service.provenance(scopes, "agent-1/notes.md"));
+    await runEffect(service.strReplace(scopes, "agent-1/notes.md", "hello", "bye", writeContext));
+    const edited = await runEffect(service.provenance(scopes, "agent-1/notes.md"));
+    expect(edited?.writeCount).toBe(2);
+    expect(edited?.createdAt).toBe(created?.createdAt);
+  });
+
+  test("records every agent that has written to a shared scope", async () => {
+    const shared = ["team"];
+    const service = makeService();
+    await runEffect(service.create(shared, "team/status.md", "x", { agentId: "a" }));
+    await runEffect(service.insert(shared, "team/status.md", 1, "y", { agentId: "b" }));
+    const provenance = await runEffect(service.provenance(shared, "team/status.md"));
+    expect(provenance?.writtenBy).toEqual(["a", "b"]);
+  });
+
+  test("stamps lastViewedAt when a file is read back", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/notes.md", "hello", writeContext));
+    expect((await runEffect(service.provenance(scopes, "agent-1/notes.md")))?.lastViewedAt).toBe(
+      undefined,
+    );
+    await runEffect(service.view(scopes, "agent-1/notes.md"));
+    expect(
+      (await runEffect(service.provenance(scopes, "agent-1/notes.md")))?.lastViewedAt,
+    ).toBeString();
+  });
+
+  test("forgets provenance when the file is deleted", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/notes.md", "hello", writeContext));
+    await runEffect(service.delete(scopes, "agent-1/notes.md"));
+    expect(await runEffect(service.provenance(scopes, "agent-1/notes.md"))).toBe(undefined);
+  });
+
+  test("carries provenance across a rename", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/old.md", "hello", writeContext));
+    const created = await runEffect(service.provenance(scopes, "agent-1/old.md"));
+    await runEffect(service.rename(scopes, "agent-1/old.md", "agent-1/new.md", writeContext));
+    expect(await runEffect(service.provenance(scopes, "agent-1/old.md"))).toBe(undefined);
+    const moved = await runEffect(service.provenance(scopes, "agent-1/new.md"));
+    expect(moved?.createdAt).toBe(created?.createdAt);
+  });
+
+  test("the sidecar is invisible to listings and free of the file budget", async () => {
+    const service = new MemoryServiceImpl({
+      baseMemoryDirectory: tmpDir,
+      maxFilesPerScope: 1,
+    });
+    await runEffect(service.create(scopes, "agent-1/only.md", "hello", writeContext));
+    const outcome = await runEffect(service.view(scopes, "agent-1"));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries.map((entry) => entry.name)).toEqual(["only.md"]);
+    }
+  });
+
+  test("returns undefined for a scope outside the accessible set", async () => {
+    const service = makeService();
+    await runEffect(service.create(scopes, "agent-1/notes.md", "hello", writeContext));
+    expect(await runEffect(service.provenance(["other"], "agent-1/notes.md"))).toBe(undefined);
   });
 });

--- a/packages/adapters/src/memory-service.test.ts
+++ b/packages/adapters/src/memory-service.test.ts
@@ -322,3 +322,100 @@ describe("path safety", () => {
     }
   });
 });
+
+describe("root listing", () => {
+  test("lists the files inside every accessible scope in one call", async () => {
+    const service = new MemoryServiceImpl({ baseMemoryDirectory: tmpDir });
+    const twoScopes = ["personal", "work"];
+    await runEffect(service.create(twoScopes, "personal/prefs.md", "bun over npm"));
+    await runEffect(service.create(twoScopes, "personal/people/alex.md", "likes tea"));
+    await runEffect(service.create(twoScopes, "work/status.md", "shipping"));
+
+    const outcome = await runEffect(service.view(twoScopes, ""));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries.map((entry) => entry.name)).toEqual([
+        "personal/",
+        "personal/people/",
+        "personal/people/alex.md",
+        "personal/prefs.md",
+        "work/",
+        "work/status.md",
+      ]);
+      const prefs = outcome.entries.find((entry) => entry.name === "personal/prefs.md");
+      expect(prefs?.sizeBytes).toBe("bun over npm".length);
+    }
+  });
+
+  test("does not create a scope directory as a side effect of listing", async () => {
+    const service = new MemoryServiceImpl({ baseMemoryDirectory: tmpDir });
+    const outcome = await runEffect(service.view(["never-written"], ""));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries).toEqual([
+        { name: "never-written/", kind: "directory", sizeBytes: 0 },
+      ]);
+    }
+    expect(fs.existsSync(path.join(tmpDir, "never-written"))).toBe(false);
+  });
+
+  test("still lists a scope whose name is not storage-safe, without walking it", async () => {
+    const service = new MemoryServiceImpl({ baseMemoryDirectory: tmpDir });
+    const outcome = await runEffect(service.view(["../escape"], ""));
+    expect(outcome.kind).toBe("directory");
+    if (outcome.kind === "directory") {
+      expect(outcome.entries).toEqual([{ name: "../escape/", kind: "directory", sizeBytes: 0 }]);
+    }
+  });
+});
+
+describe("scope byte budget", () => {
+  function makeBudgetService(): MemoryServiceImpl {
+    return new MemoryServiceImpl({
+      baseMemoryDirectory: tmpDir,
+      maxTotalBytesPerScope: 100,
+      maxFileBytes: 500,
+    });
+  }
+
+  test("rejects a create that would exceed the total byte budget", async () => {
+    const service = makeBudgetService();
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
+    const result = await runEither(service.create(scopes, "agent-1/b.txt", "B".repeat(50)));
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(String(result.left)).toContain("total memory budget");
+    }
+  });
+
+  test("rejects an insert that grows a file past the total byte budget", async () => {
+    const service = makeBudgetService();
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
+    const result = await runEither(service.insert(scopes, "agent-1/a.txt", 1, "B".repeat(50)));
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(String(result.left)).toContain("total memory budget");
+    }
+  });
+
+  test("rejects a str_replace that grows a file past the total byte budget", async () => {
+    const service = makeBudgetService();
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(60)));
+    const result = await runEither(
+      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(60), "B".repeat(111)),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(String(result.left)).toContain("total memory budget");
+    }
+  });
+
+  test("allows a shrinking edit on a scope already at the budget ceiling", async () => {
+    const service = makeBudgetService();
+    await runEffect(service.create(scopes, "agent-1/a.txt", "A".repeat(100)));
+    const outcome = await runEffect(
+      service.strReplace(scopes, "agent-1/a.txt", "A".repeat(100), "B".repeat(10)),
+    );
+    expect(outcome.success).toBe(true);
+  });
+});

--- a/packages/adapters/src/memory-service.ts
+++ b/packages/adapters/src/memory-service.ts
@@ -18,10 +18,19 @@ import {
   MEMORY_VIEW_TRUNCATE_CHARS,
 } from "@jazz/core/constants/memory";
 import type {
+  MemoryFileProvenance,
+  MemoryScopeProvenance,
+} from "@jazz/core/interfaces/memory-provenance";
+import {
+  EMPTY_MEMORY_SCOPE_PROVENANCE,
+  MEMORY_PROVENANCE_FILENAME,
+} from "@jazz/core/interfaces/memory-provenance";
+import type {
   MemoryDirectoryEntry,
   MemoryMutationOutcome,
   MemoryService,
   MemoryViewOutcome,
+  MemoryWriteContext,
 } from "@jazz/core/interfaces/memory-service";
 import { MemoryServiceTag } from "@jazz/core/interfaces/memory-service";
 import { getMemoryDirectory } from "@jazz/core/utils/paths";
@@ -81,6 +90,10 @@ function walkMemoryTree(
     let totalBytes = 0;
     let fileCount = 0;
     for (const name of names) {
+      // Hidden entries are Jazz's own bookkeeping (the provenance sidecar), not
+      // saved memory, so they must not consume the operator's byte or file
+      // budget — and they are excluded from listings for the same reason.
+      if (name.startsWith(".")) continue;
       const entryPath = path.join(dir, name);
       const info = yield* fs.stat(entryPath).pipe(Effect.catchAll(() => Effect.succeed(null)));
       if (!info) continue;
@@ -127,6 +140,133 @@ function listDirectoryEntries(
       }
     }
     return entries;
+  });
+}
+
+/**
+ * Reads a scope's provenance sidecar. A missing or corrupt file reads as empty
+ * rather than failing: provenance is metadata about memory, and losing it must
+ * never make the memory itself unreadable.
+ */
+function readScopeProvenance(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+): Effect.Effect<MemoryScopeProvenance, never> {
+  return fs.readFileString(path.join(scopeRoot, MEMORY_PROVENANCE_FILENAME)).pipe(
+    Effect.map((raw) => {
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        typeof (parsed as MemoryScopeProvenance).files !== "object"
+      ) {
+        return EMPTY_MEMORY_SCOPE_PROVENANCE;
+      }
+      return parsed as MemoryScopeProvenance;
+    }),
+    Effect.catchAll(() => Effect.succeed(EMPTY_MEMORY_SCOPE_PROVENANCE)),
+  );
+}
+
+function writeScopeProvenance(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+  provenance: MemoryScopeProvenance,
+): Effect.Effect<void, never> {
+  return writeFileStringAtomic(
+    fs,
+    path.join(scopeRoot, MEMORY_PROVENANCE_FILENAME),
+    `${JSON.stringify(provenance, null, 2)}\n`,
+    { tempPrefix: "memory-provenance" },
+  ).pipe(Effect.catchAll(() => Effect.void));
+}
+
+/** Records a write against `relativePath`, creating its entry if it is new. */
+function recordWrite(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+  relativePath: string,
+  writeContext: MemoryWriteContext,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const provenance = yield* readScopeProvenance(fs, scopeRoot);
+    const existing = provenance.files[relativePath];
+    const now = new Date().toISOString();
+    const writtenBy = existing?.writtenBy.includes(writeContext.agentId)
+      ? existing.writtenBy
+      : [...(existing?.writtenBy ?? []), writeContext.agentId];
+
+    const updated: MemoryFileProvenance = {
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      ...(existing?.lastViewedAt !== undefined ? { lastViewedAt: existing.lastViewedAt } : {}),
+      writeCount: (existing?.writeCount ?? 0) + 1,
+      writtenBy,
+    };
+
+    yield* writeScopeProvenance(fs, scopeRoot, {
+      version: 1,
+      files: { ...provenance.files, [relativePath]: updated },
+    });
+  });
+}
+
+function forgetProvenance(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+  relativePath: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const provenance = yield* readScopeProvenance(fs, scopeRoot);
+    if (provenance.files[relativePath] === undefined) return;
+    const files = { ...provenance.files };
+    delete files[relativePath];
+    yield* writeScopeProvenance(fs, scopeRoot, { version: 1, files });
+  });
+}
+
+function moveProvenance(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+  fromPath: string,
+  toPath: string,
+  writeContext: MemoryWriteContext,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const provenance = yield* readScopeProvenance(fs, scopeRoot);
+    const existing = provenance.files[fromPath];
+    const files = { ...provenance.files };
+    delete files[fromPath];
+    const now = new Date().toISOString();
+    files[toPath] = {
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      ...(existing?.lastViewedAt !== undefined ? { lastViewedAt: existing.lastViewedAt } : {}),
+      writeCount: (existing?.writeCount ?? 0) + 1,
+      writtenBy: existing?.writtenBy.includes(writeContext.agentId)
+        ? existing.writtenBy
+        : [...(existing?.writtenBy ?? []), writeContext.agentId],
+    };
+    yield* writeScopeProvenance(fs, scopeRoot, { version: 1, files });
+  });
+}
+
+function touchViewed(
+  fs: FileSystem.FileSystem,
+  scopeRoot: string,
+  relativePath: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const provenance = yield* readScopeProvenance(fs, scopeRoot);
+    const existing = provenance.files[relativePath];
+    if (existing === undefined) return;
+    yield* writeScopeProvenance(fs, scopeRoot, {
+      version: 1,
+      files: {
+        ...provenance.files,
+        [relativePath]: { ...existing, lastViewedAt: new Date().toISOString() },
+      },
+    });
   });
 }
 
@@ -345,6 +485,8 @@ export class MemoryServiceImpl implements MemoryService {
         const truncated = selected.length > MEMORY_VIEW_TRUNCATE_CHARS;
         const displayContent = truncated ? selected.slice(0, MEMORY_VIEW_TRUNCATE_CHARS) : selected;
 
+        yield* touchViewed(fs, root, path.relative(root, target));
+
         return {
           kind: "file",
           path: abbreviateHomePath(target),
@@ -356,7 +498,21 @@ export class MemoryServiceImpl implements MemoryService {
       }.bind(this),
     );
 
-  readonly create: MemoryService["create"] = (scopes, virtualPath, fileText) =>
+  readonly provenance: MemoryService["provenance"] = (scopes, virtualPath) =>
+    Effect.gen(
+      function* (this: MemoryServiceImpl) {
+        const fs = yield* FileSystem.FileSystem;
+        const { scope, rest } = splitScopeAndRest(virtualPath);
+        if (scope === null || !scopes.includes(scope) || !isValidStorageKey(scope)) {
+          return undefined;
+        }
+        const scopeRoot = path.join(this.baseMemoryDirectory, scope);
+        const provenance = yield* readScopeProvenance(fs, scopeRoot);
+        return provenance.files[rest];
+      }.bind(this),
+    );
+
+  readonly create: MemoryService["create"] = (scopes, virtualPath, fileText, writeContext) =>
     Effect.gen(
       function* (this: MemoryServiceImpl) {
         const resolved = this.resolveScope(scopes, virtualPath);
@@ -396,6 +552,7 @@ export class MemoryServiceImpl implements MemoryService {
                 subject: "Creating this file",
               });
               yield* writeFileStringAtomic(fs, target, fileText, { tempPrefix: "memory" });
+              yield* recordWrite(fs, root, path.relative(root, target), writeContext);
 
               return {
                 success: true,
@@ -407,7 +564,13 @@ export class MemoryServiceImpl implements MemoryService {
       }.bind(this),
     );
 
-  readonly strReplace: MemoryService["strReplace"] = (scopes, virtualPath, oldStr, newStr) =>
+  readonly strReplace: MemoryService["strReplace"] = (
+    scopes,
+    virtualPath,
+    oldStr,
+    newStr,
+    writeContext,
+  ) =>
     Effect.gen(
       function* (this: MemoryServiceImpl) {
         const resolved = this.resolveScope(scopes, virtualPath);
@@ -473,6 +636,7 @@ export class MemoryServiceImpl implements MemoryService {
               });
 
               yield* writeFileStringAtomic(fs, target, updatedContent, { tempPrefix: "memory" });
+              yield* recordWrite(fs, root, path.relative(root, target), writeContext);
 
               return {
                 success: true,
@@ -484,7 +648,13 @@ export class MemoryServiceImpl implements MemoryService {
       }.bind(this),
     );
 
-  readonly insert: MemoryService["insert"] = (scopes, virtualPath, insertLine, insertText) =>
+  readonly insert: MemoryService["insert"] = (
+    scopes,
+    virtualPath,
+    insertLine,
+    insertText,
+    writeContext,
+  ) =>
     Effect.gen(
       function* (this: MemoryServiceImpl) {
         const resolved = this.resolveScope(scopes, virtualPath);
@@ -546,6 +716,7 @@ export class MemoryServiceImpl implements MemoryService {
               });
 
               yield* writeFileStringAtomic(fs, target, updatedContent, { tempPrefix: "memory" });
+              yield* recordWrite(fs, root, path.relative(root, target), writeContext);
 
               return {
                 success: true,
@@ -597,6 +768,8 @@ export class MemoryServiceImpl implements MemoryService {
                   ),
                 );
 
+              yield* forgetProvenance(fs, root, path.relative(root, target));
+
               return {
                 success: true,
                 message: `Successfully deleted ${abbreviateHomePath(target)}`,
@@ -607,7 +780,12 @@ export class MemoryServiceImpl implements MemoryService {
       }.bind(this),
     );
 
-  readonly rename: MemoryService["rename"] = (scopes, oldVirtualPath, newVirtualPath) =>
+  readonly rename: MemoryService["rename"] = (
+    scopes,
+    oldVirtualPath,
+    newVirtualPath,
+    writeContext,
+  ) =>
     Effect.gen(
       function* (this: MemoryServiceImpl) {
         const resolvedOld = this.resolveScope(scopes, oldVirtualPath);
@@ -673,6 +851,14 @@ export class MemoryServiceImpl implements MemoryService {
                     Effect.fail(e instanceof Error ? e : new Error(String(e))),
                   ),
                 );
+
+              yield* moveProvenance(
+                fs,
+                root,
+                path.relative(root, source),
+                path.relative(root, destination),
+                writeContext,
+              );
 
               return {
                 success: true,

--- a/packages/adapters/src/memory-service.ts
+++ b/packages/adapters/src/memory-service.ts
@@ -27,6 +27,7 @@ import { MemoryServiceTag } from "@jazz/core/interfaces/memory-service";
 import { getMemoryDirectory } from "@jazz/core/utils/paths";
 import {
   abbreviateHomePath,
+  isValidStorageKey,
   requireValidStorageKey,
   withLock,
   writeFileStringAtomic,
@@ -132,6 +133,12 @@ function listDirectoryEntries(
 export interface MemoryServiceImplOptions {
   /** Override for tests; defaults to ~/.jazz/memory (or $JAZZ_HOME/memory). */
   readonly baseMemoryDirectory?: string;
+  /** Override for tests; defaults to {@link MAX_MEMORY_FILE_BYTES}. */
+  readonly maxFileBytes?: number;
+  /** Override for tests; defaults to {@link MAX_MEMORY_TOTAL_BYTES_PER_SCOPE}. */
+  readonly maxTotalBytesPerScope?: number;
+  /** Override for tests; defaults to {@link MAX_MEMORY_FILES_PER_SCOPE}. */
+  readonly maxFilesPerScope?: number;
 }
 
 /** A path names a scope outside the caller's accessible set, or names no scope at all. */
@@ -141,9 +148,15 @@ type ScopeResolution =
 
 export class MemoryServiceImpl implements MemoryService {
   private readonly baseMemoryDirectory: string;
+  private readonly maxFileBytes: number;
+  private readonly maxTotalBytesPerScope: number;
+  private readonly maxFilesPerScope: number;
 
   constructor(options?: MemoryServiceImplOptions) {
     this.baseMemoryDirectory = options?.baseMemoryDirectory ?? getMemoryDirectory();
+    this.maxFileBytes = options?.maxFileBytes ?? MAX_MEMORY_FILE_BYTES;
+    this.maxTotalBytesPerScope = options?.maxTotalBytesPerScope ?? MAX_MEMORY_TOTAL_BYTES_PER_SCOPE;
+    this.maxFilesPerScope = options?.maxFilesPerScope ?? MAX_MEMORY_FILES_PER_SCOPE;
   }
 
   private memoryLockPath(scope: string): string {
@@ -199,6 +212,43 @@ export class MemoryServiceImpl implements MemoryService {
     return { ok: true, scope, rest };
   }
 
+  /**
+   * Enforces the scope-wide byte and file-count caps for one write.
+   * `addedBytes` is the write's net delta, so an edit is charged only its
+   * growth rather than the whole file, and a shrinking edit always fits.
+   *
+   * Must be called inside the scope lock: it walks the whole tree, and the
+   * result is only sound if no other write lands between the walk and the
+   * write it authorizes.
+   */
+  private requireScopeBudget(
+    fs: FileSystem.FileSystem,
+    root: string,
+    options: { readonly addedBytes: number; readonly addsFile: boolean; readonly subject: string },
+  ): Effect.Effect<void, MemoryGuardrailViolation | Error> {
+    const maxFilesPerScope = this.maxFilesPerScope;
+    const maxTotalBytesPerScope = this.maxTotalBytesPerScope;
+    return Effect.gen(function* () {
+      if (options.addedBytes <= 0 && !options.addsFile) return;
+
+      const stats = yield* walkMemoryTree(fs, root);
+      if (options.addsFile && stats.fileCount + 1 > maxFilesPerScope) {
+        return yield* Effect.fail(
+          new MemoryGuardrailViolation(
+            `${options.subject} would exceed the maximum of ${maxFilesPerScope} files in memory.`,
+          ),
+        );
+      }
+      if (stats.totalBytes + options.addedBytes > maxTotalBytesPerScope) {
+        return yield* Effect.fail(
+          new MemoryGuardrailViolation(
+            `${options.subject} would exceed the total memory budget of ${maxTotalBytesPerScope} bytes.`,
+          ),
+        );
+      }
+    });
+  }
+
   private withValidatedScopeLock<A, E, R>(
     scope: string,
     operation: Effect.Effect<A, E, R>,
@@ -217,12 +267,28 @@ export class MemoryServiceImpl implements MemoryService {
         const { scope, rest } = splitScopeAndRest(virtualPath);
 
         if (scope === null) {
+          const entries: MemoryDirectoryEntry[] = [];
+          for (const name of [...scopes].sort()) {
+            entries.push({ name: `${name}/`, kind: "directory", sizeBytes: 0 });
+
+            // A root listing must not create anything, so an unwritten scope
+            // contributes only its own directory line. Walking an invalid
+            // scope name is skipped rather than failed: it would be rejected
+            // by any real access, and one bad config entry should not blank
+            // out the listing for every other scope.
+            const isValidScope = isValidStorageKey(name);
+            if (!isValidScope) continue;
+
+            const scopeRoot = path.join(this.baseMemoryDirectory, name);
+            const nested = yield* listDirectoryEntries(fs, scopeRoot, 2);
+            for (const child of nested) {
+              entries.push({ ...child, name: `${name}/${child.name}` });
+            }
+          }
           return {
             kind: "directory",
             path: abbreviateHomePath(this.baseMemoryDirectory),
-            entries: [...scopes]
-              .sort()
-              .map((name) => ({ name: `${name}/`, kind: "directory", sizeBytes: 0 }) as const),
+            entries,
           } satisfies MemoryViewOutcome;
         }
 
@@ -306,10 +372,10 @@ export class MemoryServiceImpl implements MemoryService {
               const target = yield* resolveMemoryPath(root, rest);
 
               const fileTextBytes = Buffer.byteLength(fileText, "utf-8");
-              if (fileTextBytes > MAX_MEMORY_FILE_BYTES) {
+              if (fileTextBytes > this.maxFileBytes) {
                 return yield* Effect.fail(
                   new MemoryGuardrailViolation(
-                    `File would be ${fileTextBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+                    `File would be ${fileTextBytes} bytes, exceeding the maximum of ${this.maxFileBytes} bytes.`,
                   ),
                 );
               }
@@ -324,22 +390,11 @@ export class MemoryServiceImpl implements MemoryService {
                 } satisfies MemoryMutationOutcome;
               }
 
-              const stats = yield* walkMemoryTree(fs, root);
-              if (stats.fileCount + 1 > MAX_MEMORY_FILES_PER_SCOPE) {
-                return yield* Effect.fail(
-                  new MemoryGuardrailViolation(
-                    `Creating this file would exceed the maximum of ${MAX_MEMORY_FILES_PER_SCOPE} files in memory.`,
-                  ),
-                );
-              }
-              if (stats.totalBytes + fileTextBytes > MAX_MEMORY_TOTAL_BYTES_PER_SCOPE) {
-                return yield* Effect.fail(
-                  new MemoryGuardrailViolation(
-                    `Creating this file would exceed the total memory budget of ${MAX_MEMORY_TOTAL_BYTES_PER_SCOPE} bytes.`,
-                  ),
-                );
-              }
-
+              yield* this.requireScopeBudget(fs, root, {
+                addedBytes: fileTextBytes,
+                addsFile: true,
+                subject: "Creating this file",
+              });
               yield* writeFileStringAtomic(fs, target, fileText, { tempPrefix: "memory" });
 
               return {
@@ -403,13 +458,19 @@ export class MemoryServiceImpl implements MemoryService {
                 content.slice(0, index) + replacement + content.slice(index + oldStr.length);
 
               const updatedBytes = Buffer.byteLength(updatedContent, "utf-8");
-              if (updatedBytes > MAX_MEMORY_FILE_BYTES) {
+              if (updatedBytes > this.maxFileBytes) {
                 return yield* Effect.fail(
                   new MemoryGuardrailViolation(
-                    `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+                    `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${this.maxFileBytes} bytes.`,
                   ),
                 );
               }
+
+              yield* this.requireScopeBudget(fs, root, {
+                addedBytes: updatedBytes - Buffer.byteLength(content, "utf-8"),
+                addsFile: false,
+                subject: "This edit",
+              });
 
               yield* writeFileStringAtomic(fs, target, updatedContent, { tempPrefix: "memory" });
 
@@ -470,13 +531,19 @@ export class MemoryServiceImpl implements MemoryService {
               const updatedContent = updatedLines.join("\n");
 
               const updatedBytes = Buffer.byteLength(updatedContent, "utf-8");
-              if (updatedBytes > MAX_MEMORY_FILE_BYTES) {
+              if (updatedBytes > this.maxFileBytes) {
                 return yield* Effect.fail(
                   new MemoryGuardrailViolation(
-                    `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${MAX_MEMORY_FILE_BYTES} bytes.`,
+                    `Edit would grow the file to ${updatedBytes} bytes, exceeding the maximum of ${this.maxFileBytes} bytes.`,
                   ),
                 );
               }
+
+              yield* this.requireScopeBudget(fs, root, {
+                addedBytes: updatedBytes - Buffer.byteLength(content, "utf-8"),
+                addsFile: false,
+                subject: "This edit",
+              });
 
               yield* writeFileStringAtomic(fs, target, updatedContent, { tempPrefix: "memory" });
 

--- a/packages/bot-shared/src/chat-sandbox.ts
+++ b/packages/bot-shared/src/chat-sandbox.ts
@@ -439,11 +439,20 @@ export function sandboxCommand(sandbox: ChatSandbox, command: string[]): string[
  * The mail, calendar, GPG and `pass` stores are here for the same reason as
  * Jazz's own state — they are the account credentials of whoever set them up,
  * and a second conversation has no business reading them.
+ *
+ * `surface` names the front door for whatever the spawned process records about
+ * itself. A bot shells out to the same `jazz run` a terminal user invokes, so
+ * without the marker the two are indistinguishable in any per-surface metric.
  */
-export function sandboxEnv(sandbox: ChatSandbox, base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (!sandbox.isolated) return { ...base };
+export function sandboxEnv(
+  sandbox: ChatSandbox,
+  base: NodeJS.ProcessEnv,
+  surface?: string,
+): NodeJS.ProcessEnv {
+  const withSurface = surface === undefined ? { ...base } : { ...base, JAZZ_SURFACE: surface };
+  if (!sandbox.isolated) return withSurface;
   return {
-    ...base,
+    ...withSurface,
     HOME: sandbox.home,
     JAZZ_HOME: sandbox.home,
     XDG_CONFIG_HOME: join(sandbox.home, "xdg-config"),

--- a/packages/cli/src/chat/commands/constants.ts
+++ b/packages/cli/src/chat/commands/constants.ts
@@ -29,6 +29,11 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "fork", description: "Fork conversation (new branch from last message)" },
   { name: "help", description: "Show available commands and shortcuts", usage: "[command]" },
   {
+    name: "memory",
+    description: "Show what this agent has remembered about you, or forget one file",
+    usage: "[forget <path>]",
+  },
+  {
     name: "limit",
     description: "Set a session turn, cost, or token limit (applied immediately)",
     usage: "[turns|usd|tokens <value>|clear]",

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -33,6 +33,7 @@ import {
   type MCPServerConfig,
   type MCPServerManager,
 } from "@jazz/core/interfaces/mcp-server";
+import { MemoryServiceTag, type MemoryService } from "@jazz/core/interfaces/memory-service";
 import { PersonaServiceTag, type PersonaService } from "@jazz/core/interfaces/persona-service";
 import type { PresentationService } from "@jazz/core/interfaces/presentation";
 import { TerminalServiceTag, type TerminalService } from "@jazz/core/interfaces/terminal";
@@ -144,6 +145,9 @@ export function handleSpecialCommand(
 
       case "skills":
         return yield* handleSkillsCommand(terminal);
+
+      case "memory":
+        return yield* handleMemoryCommand(terminal, agent, command.args);
 
       case "context":
         return yield* handleContextCommand(terminal, agent, conversationHistory);
@@ -2666,6 +2670,72 @@ function generateContextGrid(usage: ContextUsageBreakdown): string[] {
   return rows;
 }
 
+/**
+ * `/memory` — what this agent has written down about the person talking to it,
+ * and a way to remove any of it without leaving the conversation.
+ *
+ * Lists the real files and prints their real bytes: what is shown here is
+ * exactly what reaches the model, never a regenerated summary of it.
+ */
+function handleMemoryCommand(
+  terminal: TerminalService,
+  agent: CommandContext["agent"],
+  args: string[],
+): Effect.Effect<CommandResult, Error, MemoryService | FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const memoryService = yield* MemoryServiceTag;
+    const configuredScopes = agent.config.memoryScopes;
+    const scopes =
+      configuredScopes !== undefined && configuredScopes.length > 0 ? configuredScopes : [agent.id];
+
+    if (args[0] === "forget") {
+      const target = args[1];
+      if (target === undefined) {
+        yield* terminal.info("Name the file to forget: /memory forget personal/notes.md");
+        return { shouldContinue: true };
+      }
+      const outcome = yield* memoryService.delete(scopes, target);
+      yield* terminal.log(outcome.success ? fmt.heading("Forgotten") : outcome.message);
+      return { shouldContinue: true };
+    }
+
+    if (args[0] !== undefined) {
+      const outcome = yield* memoryService.view(scopes, args[0]);
+      if (outcome.kind === "file") {
+        const provenance = yield* memoryService
+          .provenance(scopes, args[0])
+          .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+        yield* terminal.log(fmt.heading(outcome.path));
+        if (provenance !== undefined) {
+          yield* terminal.log(
+            `updated ${provenance.updatedAt.slice(0, 10)} · ${provenance.writeCount} write(s)\n`,
+          );
+        }
+        yield* terminal.log(outcome.content);
+        return { shouldContinue: true };
+      }
+      yield* terminal.info(outcome.kind === "directory" ? "That is a directory." : outcome.message);
+      return { shouldContinue: true };
+    }
+
+    const outcome = yield* memoryService.view(scopes, "");
+    const files =
+      outcome.kind === "directory" ? outcome.entries.filter((entry) => entry.kind === "file") : [];
+
+    yield* terminal.log(fmt.heading("Memory"));
+    if (files.length === 0) {
+      yield* terminal.log(`\nNothing saved yet. Scopes: ${scopes.join(", ")}.`);
+      return { shouldContinue: true };
+    }
+
+    yield* terminal.log("");
+    for (const file of files) {
+      yield* terminal.log(`  ${file.name}`);
+    }
+    yield* terminal.log("\n/memory <path> to read one · /memory forget <path> to remove one");
+    return { shouldContinue: true };
+  });
+}
 /**
  * Handle /work command — show or discard the working state kept for this conversation.
  *

--- a/packages/cli/src/chat/commands/types.ts
+++ b/packages/cli/src/chat/commands/types.ts
@@ -10,6 +10,7 @@ import type { AutoApprovePolicy } from "@jazz/core/types/tools";
  * Types of special commands available in the chat interface
  */
 export type CommandType =
+  | "memory"
   | "new"
   | "fork"
   | "help"

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,0 +1,148 @@
+/**
+ * `jazz memory` — see and control what an agent has written down about you.
+ *
+ * Memory is the one store Jazz keeps that is *about a person* and cannot be
+ * re-derived from anything: a preference, an allergy, a relative's name. That
+ * makes an inspection surface a correctness requirement rather than a
+ * convenience — a person cannot consent to what they cannot see, and the
+ * documented failure mode of every auto-writing memory system is that users
+ * are fine with memory right up until they discover what it holds.
+ *
+ * Deliberately operating on the real files: the artifact listed and edited here
+ * is byte-for-byte the one the agent reads back, so nothing shown is a
+ * regenerated summary that might differ from what actually reaches the model.
+ */
+
+import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
+import { readMemoryRecalls, summarizeMemoryRecalls } from "@jazz/core/agent/memory-recall-log";
+import { MemoryServiceTag } from "@jazz/core/interfaces/memory-service";
+import { TerminalServiceTag } from "@jazz/core/interfaces/terminal";
+import { CLIError } from "@jazz/core/types/errors";
+import { Effect } from "effect";
+
+function resolveScopes(agent: {
+  readonly id: string;
+  readonly config: { readonly memoryScopes?: readonly string[] | undefined };
+}): readonly string[] {
+  const configured = agent.config.memoryScopes;
+  return configured !== undefined && configured.length > 0 ? configured : [agent.id];
+}
+
+/** `jazz memory list <agent>` — every file the agent can read, with provenance. */
+export function listMemoryCommand(identifier: string) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const memoryService = yield* MemoryServiceTag;
+    const agent = yield* getAgentByIdentifier(identifier);
+    const scopes = resolveScopes(agent);
+
+    const outcome = yield* memoryService.view(scopes, "");
+    if (outcome.kind !== "directory") {
+      yield* terminal.info("Nothing saved yet.");
+      return;
+    }
+
+    const files = outcome.entries.filter((entry) => entry.kind === "file");
+    if (files.length === 0) {
+      yield* terminal.info(`${agent.name} has saved nothing yet. Scopes: ${scopes.join(", ")}.`);
+      return;
+    }
+
+    yield* terminal.log(`Memory for ${agent.name} (${outcome.path}):\n`);
+    for (const file of files) {
+      const provenance = yield* memoryService
+        .provenance(scopes, file.name)
+        .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+      const written =
+        provenance === undefined
+          ? ""
+          : `  updated ${provenance.updatedAt.slice(0, 10)}, ${provenance.writeCount} write(s)`;
+      yield* terminal.log(`  ${file.name}${written}`);
+    }
+    yield* terminal.log(`\nRead one with: jazz memory show ${identifier} <path>`);
+  });
+}
+
+/** `jazz memory show <agent> <path>` — the exact bytes the agent reads back. */
+export function showMemoryCommand(identifier: string, memoryPath: string) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const memoryService = yield* MemoryServiceTag;
+    const agent = yield* getAgentByIdentifier(identifier);
+    const scopes = resolveScopes(agent);
+
+    const outcome = yield* memoryService.view(scopes, memoryPath);
+    if (outcome.kind === "not_found" || outcome.kind === "too_large") {
+      return yield* Effect.fail(new CLIError({ command: "memory", message: outcome.message }));
+    }
+    if (outcome.kind === "directory") {
+      for (const entry of outcome.entries) {
+        yield* terminal.log(`  ${entry.name}`);
+      }
+      return;
+    }
+
+    const provenance = yield* memoryService
+      .provenance(scopes, memoryPath)
+      .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+    if (provenance !== undefined) {
+      yield* terminal.log(
+        `${outcome.path} — created ${provenance.createdAt.slice(0, 10)}, updated ${provenance.updatedAt.slice(0, 10)}, ${provenance.writeCount} write(s), written by ${provenance.writtenBy.join(", ")}\n`,
+      );
+    }
+    yield* terminal.log(outcome.content);
+    yield* terminal.log(`\nEdit it directly: ${outcome.path}`);
+  });
+}
+
+/** `jazz memory forget <agent> <path>` — delete one file for good. */
+export function forgetMemoryCommand(identifier: string, memoryPath: string) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const memoryService = yield* MemoryServiceTag;
+    const agent = yield* getAgentByIdentifier(identifier);
+    const scopes = resolveScopes(agent);
+
+    const outcome = yield* memoryService.delete(scopes, memoryPath);
+    if (!outcome.success) {
+      return yield* Effect.fail(new CLIError({ command: "memory", message: outcome.message }));
+    }
+    yield* terminal.success(`Forgotten. ${outcome.message}`);
+  });
+}
+
+/**
+ * `jazz memory recall` — the measured rate at which runs consulted memory
+ * before answering, split by surface.
+ *
+ * `view_memory` is tool-call-gated with no preload, so recall is something the
+ * model chooses rather than something the harness guarantees. This is how you
+ * find out whether it actually happens, per front door, instead of assuming.
+ */
+export function memoryRecallCommand(options: { readonly surface?: string }) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const entries = yield* readMemoryRecalls(
+      options.surface !== undefined ? { surface: options.surface } : undefined,
+    );
+    const rates = summarizeMemoryRecalls(entries);
+
+    if (rates.length === 0) {
+      yield* terminal.info(
+        "No runs recorded yet. The log fills as agents with memory enabled complete runs.",
+      );
+      return;
+    }
+
+    yield* terminal.log("Runs that consulted memory before answering:\n");
+    for (const rate of rates) {
+      const percent = (rate.rate * 100).toFixed(0);
+      yield* terminal.log(
+        `  ${rate.surface.padEnd(10)} ${percent.padStart(3)}%  (${rate.viewedBeforeFirstAnswer}/${rate.eligibleRuns} runs)`,
+      );
+    }
+    yield* terminal.log(
+      "\nRuns never offered the memory tools are excluded — they cannot be a miss.",
+    );
+  });
+}

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -5,6 +5,7 @@
  */
 
 import { Cause, Effect, Fiber, Option, Ref } from "effect";
+import { recordMemoryRecall, VIEW_MEMORY_TOOL_NAME } from "@/core/agent/memory-recall-log";
 import { isRunParkRequested, withTranscript } from "@/core/agent/run/park-signal";
 import { isLocalServerProvider } from "@/core/constants/local-providers";
 import { AgentConfigServiceTag, type AgentConfigService } from "@/core/interfaces/agent-config";
@@ -1329,6 +1330,16 @@ export function executeAgentLoop(
             }
           }
         }
+
+        // Before finalizeRun, which may rewrite the transcript: whether a
+        // `view_memory` call landed before the answer is an ordering fact about
+        // the messages this loop actually produced.
+        yield* recordMemoryRecall({
+          agentId: agent.id,
+          conversationId: runContext.actualConversationId,
+          messages: state.currentMessages,
+          memoryToolsOffered: runContext.expandedToolNames.includes(VIEW_MEMORY_TOOL_NAME),
+        });
 
         return yield* finalizeRun(
           {

--- a/packages/core/src/agent/memory-recall-log.test.ts
+++ b/packages/core/src/agent/memory-recall-log.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "bun:test";
+import type { ChatMessage } from "@/core/types/message";
+import {
+  analyzeMemoryRecall,
+  summarizeMemoryRecalls,
+  type MemoryRecallEntry,
+} from "./memory-recall-log";
+
+function assistantToolCall(name: string): ChatMessage {
+  return {
+    role: "assistant",
+    content: "",
+    tool_calls: [{ id: `call-${name}`, type: "function", function: { name, arguments: "{}" } }],
+  };
+}
+
+function toolResult(): ChatMessage {
+  return { role: "tool", content: "ok", tool_call_id: "call-view_memory" };
+}
+
+function answer(content = "Here you go."): ChatMessage {
+  return { role: "assistant", content };
+}
+
+describe("analyzeMemoryRecall", () => {
+  test("counts a view that lands before the first answer", () => {
+    const observation = analyzeMemoryRecall(
+      [{ role: "user", content: "hey" }, assistantToolCall("view_memory"), toolResult(), answer()],
+      true,
+    );
+    expect(observation.viewedBeforeFirstAnswer).toBe(true);
+    expect(observation.viewCallCount).toBe(1);
+    expect(observation.writeCallCount).toBe(0);
+  });
+
+  test("counts a view that lands only after the first answer as a miss", () => {
+    const observation = analyzeMemoryRecall(
+      [
+        { role: "user", content: "hey" },
+        answer(),
+        { role: "user", content: "actually, remember I use bun" },
+        assistantToolCall("view_memory"),
+        toolResult(),
+      ],
+      true,
+    );
+    expect(observation.viewedBeforeFirstAnswer).toBe(false);
+    expect(observation.viewCallCount).toBe(1);
+  });
+
+  test("reports a miss when memory is never consulted", () => {
+    const observation = analyzeMemoryRecall([{ role: "user", content: "hey" }, answer()], true);
+    expect(observation.viewedBeforeFirstAnswer).toBe(false);
+    expect(observation.viewCallCount).toBe(0);
+  });
+
+  test("a run that never answers still counts a view as in time", () => {
+    const observation = analyzeMemoryRecall(
+      [{ role: "user", content: "hey" }, assistantToolCall("view_memory"), toolResult()],
+      true,
+    );
+    expect(observation.viewedBeforeFirstAnswer).toBe(true);
+  });
+
+  test("ignores an empty assistant turn when locating the first answer", () => {
+    const observation = analyzeMemoryRecall(
+      [
+        { role: "user", content: "hey" },
+        { role: "assistant", content: "   " },
+        assistantToolCall("view_memory"),
+        toolResult(),
+        answer(),
+      ],
+      true,
+    );
+    expect(observation.viewedBeforeFirstAnswer).toBe(true);
+  });
+
+  test("does not treat a compaction summary as the first answer", () => {
+    const observation = analyzeMemoryRecall(
+      [
+        { role: "user", content: "hey" },
+        { role: "assistant", content: "earlier context", kind: "summary" },
+        assistantToolCall("view_memory"),
+        toolResult(),
+        answer(),
+      ],
+      true,
+    );
+    expect(observation.viewedBeforeFirstAnswer).toBe(true);
+  });
+
+  test("counts writes separately from views", () => {
+    const observation = analyzeMemoryRecall(
+      [
+        { role: "user", content: "I use bun" },
+        assistantToolCall("view_memory"),
+        toolResult(),
+        assistantToolCall("manage_memory"),
+        toolResult(),
+        assistantToolCall("manage_memory"),
+        toolResult(),
+        answer(),
+      ],
+      true,
+    );
+    expect(observation.viewCallCount).toBe(1);
+    expect(observation.writeCallCount).toBe(2);
+  });
+
+  test("records whether the tools were offered at all", () => {
+    expect(analyzeMemoryRecall([answer()], false).memoryToolsOffered).toBe(false);
+    expect(analyzeMemoryRecall([answer()], true).memoryToolsOffered).toBe(true);
+  });
+});
+
+describe("summarizeMemoryRecalls", () => {
+  function entry(
+    surface: string,
+    viewedBeforeFirstAnswer: boolean,
+    memoryToolsOffered = true,
+  ): MemoryRecallEntry {
+    return {
+      timestamp: "2026-09-08T00:00:00.000Z",
+      surface,
+      agentId: "agent-1",
+      memoryToolsOffered,
+      viewedBeforeFirstAnswer,
+      viewCallCount: viewedBeforeFirstAnswer ? 1 : 0,
+      writeCallCount: 0,
+    };
+  }
+
+  test("reports a rate per surface", () => {
+    const rates = summarizeMemoryRecalls([
+      entry("cli", true),
+      entry("cli", true),
+      entry("telegram", false),
+      entry("telegram", false),
+      entry("telegram", true),
+    ]);
+    expect(rates).toEqual([
+      { surface: "cli", eligibleRuns: 2, viewedBeforeFirstAnswer: 2, rate: 1 },
+      { surface: "telegram", eligibleRuns: 3, viewedBeforeFirstAnswer: 1, rate: 1 / 3 },
+    ]);
+  });
+
+  test("excludes runs that were never offered the tools from the denominator", () => {
+    const rates = summarizeMemoryRecalls([
+      entry("cli", true),
+      entry("cli", false, false),
+      entry("cli", false, false),
+    ]);
+    expect(rates).toEqual([
+      { surface: "cli", eligibleRuns: 1, viewedBeforeFirstAnswer: 1, rate: 1 },
+    ]);
+  });
+});

--- a/packages/core/src/agent/memory-recall-log.ts
+++ b/packages/core/src/agent/memory-recall-log.ts
@@ -1,0 +1,225 @@
+/**
+ * A record of whether each run actually consulted memory before answering.
+ *
+ * `view_memory` is tool-call-gated with no preload: nothing injects memory into
+ * context, so a run's continuity depends entirely on the model choosing to spend
+ * a call before it answers. Whether that happens is an empirical question about
+ * a specific surface, not something the unit suite can settle — a casual opener
+ * on a chat bridge is the case most likely to skip it, and the least likely to
+ * be noticed. This sink makes the rate measurable.
+ *
+ * Append-only JSONL, unparseable lines skipped, failures swallowed — the same
+ * discipline as the misfire log, for the same reason: losing a recall entry must
+ * never fail the run that produced it.
+ */
+import * as nodeFs from "node:fs/promises";
+import * as path from "node:path";
+import { Effect } from "effect";
+import type { ChatMessage } from "@/core/types/message";
+import { getMemoryRecallLogDirectory } from "@/core/utils/paths";
+
+const MEMORY_RECALL_LOG_FILENAME = "memory-recall.jsonl";
+
+export const VIEW_MEMORY_TOOL_NAME = "view_memory";
+export const MANAGE_MEMORY_TOOL_NAME = "manage_memory";
+
+/** What one finished run did with memory. */
+export interface MemoryRecallObservation {
+  /**
+   * False when the run was never offered the memory tools at all (memory not in
+   * `AgentConfig.tools`, or an ephemeral run). Such a run cannot be a miss, and
+   * mixing it into the denominator would understate the recall rate.
+   */
+  readonly memoryToolsOffered: boolean;
+  /**
+   * The question this log exists to answer: did a `view_memory` call land before
+   * the run's first substantive answer?
+   */
+  readonly viewedBeforeFirstAnswer: boolean;
+  readonly viewCallCount: number;
+  readonly writeCallCount: number;
+}
+
+export interface MemoryRecallEntry extends MemoryRecallObservation {
+  readonly timestamp: string;
+  /** Which front door this run came through: `cli`, `telegram`, `discord`, … */
+  readonly surface: string;
+  readonly agentId: string;
+  readonly conversationId?: string;
+}
+
+export function memoryRecallLogPath(): string {
+  return path.join(getMemoryRecallLogDirectory(), MEMORY_RECALL_LOG_FILENAME);
+}
+
+/**
+ * The surface that started this run. Bots shell out to `jazz run`, so the
+ * command name alone cannot tell a Telegram turn from a terminal one; each
+ * bridge sets `JAZZ_SURFACE` instead. Absent the marker a run is plain CLI.
+ */
+export function currentSurface(): string {
+  const declared = process.env["JAZZ_SURFACE"]?.trim();
+  return declared !== undefined && declared.length > 0 ? declared : "cli";
+}
+
+function isSubstantiveAnswer(message: ChatMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    (message.tool_calls?.length ?? 0) === 0 &&
+    message.content.trim().length > 0 &&
+    // A compaction summary is bookkeeping the loop wrote, not an answer to the
+    // user, so a view that lands after one has still landed before the answer.
+    message.kind !== "summary"
+  );
+}
+
+/**
+ * Derives the observation from a finished transcript rather than from hooks
+ * inside the loop: the ordering question is answerable from the messages alone,
+ * which keeps this a pure function and leaves the loop untouched.
+ */
+export function analyzeMemoryRecall(
+  messages: readonly ChatMessage[],
+  memoryToolsOffered: boolean,
+): MemoryRecallObservation {
+  let viewCallCount = 0;
+  let writeCallCount = 0;
+  let firstViewIndex: number | undefined;
+  let firstAnswerIndex: number | undefined;
+
+  for (const [index, message] of messages.entries()) {
+    for (const toolCall of message.tool_calls ?? []) {
+      if (toolCall.function.name === VIEW_MEMORY_TOOL_NAME) {
+        viewCallCount += 1;
+        firstViewIndex ??= index;
+      } else if (toolCall.function.name === MANAGE_MEMORY_TOOL_NAME) {
+        writeCallCount += 1;
+      }
+    }
+    if (firstAnswerIndex === undefined && isSubstantiveAnswer(message)) {
+      firstAnswerIndex = index;
+    }
+  }
+
+  const viewedBeforeFirstAnswer =
+    firstViewIndex !== undefined &&
+    (firstAnswerIndex === undefined || firstViewIndex < firstAnswerIndex);
+
+  return { memoryToolsOffered, viewedBeforeFirstAnswer, viewCallCount, writeCallCount };
+}
+
+/**
+ * Whether the last write was cut off mid-line: a process killed mid-append must
+ * not splice the next entry into a broken line.
+ */
+async function endsMidLine(): Promise<boolean> {
+  let handle;
+  try {
+    handle = await nodeFs.open(memoryRecallLogPath(), "r");
+    const { size } = await handle.stat();
+    if (size === 0) return false;
+    const tail = Buffer.alloc(1);
+    await handle.read(tail, 0, 1, size - 1);
+    return tail.toString("utf-8") !== "\n";
+  } catch {
+    return false;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+/** Append one recall entry. Failure is swallowed: see file header. */
+export function recordMemoryRecall(input: {
+  readonly agentId: string;
+  readonly conversationId?: string;
+  readonly messages: readonly ChatMessage[];
+  readonly memoryToolsOffered: boolean;
+}): Effect.Effect<void, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      const entry: MemoryRecallEntry = {
+        timestamp: new Date().toISOString(),
+        surface: currentSurface(),
+        agentId: input.agentId,
+        ...(input.conversationId !== undefined ? { conversationId: input.conversationId } : {}),
+        ...analyzeMemoryRecall(input.messages, input.memoryToolsOffered),
+      };
+      await nodeFs.mkdir(getMemoryRecallLogDirectory(), { recursive: true });
+      const line = `${JSON.stringify(entry)}\n`;
+      await nodeFs.appendFile(
+        memoryRecallLogPath(),
+        (await endsMidLine()) ? `\n${line}` : line,
+        "utf-8",
+      );
+    },
+    catch: (error) => error,
+  }).pipe(Effect.catchAll(() => Effect.void));
+}
+
+function parseLine(line: string): MemoryRecallEntry | undefined {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const entry = parsed as MemoryRecallEntry;
+    if (typeof entry.surface !== "string" || typeof entry.agentId !== "string") return undefined;
+    if (typeof entry.viewedBeforeFirstAnswer !== "boolean") return undefined;
+    return entry;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Entries newest first, optionally filtered by surface. */
+export function readMemoryRecalls(filter?: {
+  readonly surface?: string;
+  readonly limit?: number;
+}): Effect.Effect<readonly MemoryRecallEntry[], never> {
+  return Effect.tryPromise({
+    try: () => nodeFs.readFile(memoryRecallLogPath(), "utf-8"),
+    catch: (error) => error,
+  }).pipe(
+    Effect.map((content) => {
+      const entries: MemoryRecallEntry[] = [];
+      for (const line of content.split("\n")) {
+        const entry = parseLine(line);
+        if (entry === undefined) continue;
+        if (filter?.surface !== undefined && entry.surface !== filter.surface) continue;
+        entries.push(entry);
+      }
+      entries.reverse();
+      return filter?.limit !== undefined ? entries.slice(0, filter.limit) : entries;
+    }),
+    Effect.catchAll(() => Effect.succeed([] as readonly MemoryRecallEntry[])),
+  );
+}
+
+/** Recall rate per surface, counting only runs that were offered the tools. */
+export interface MemoryRecallRate {
+  readonly surface: string;
+  readonly eligibleRuns: number;
+  readonly viewedBeforeFirstAnswer: number;
+  readonly rate: number;
+}
+
+export function summarizeMemoryRecalls(
+  entries: readonly MemoryRecallEntry[],
+): readonly MemoryRecallRate[] {
+  const bySurface = new Map<string, { eligible: number; viewed: number }>();
+  for (const entry of entries) {
+    if (!entry.memoryToolsOffered) continue;
+    const bucket = bySurface.get(entry.surface) ?? { eligible: 0, viewed: 0 };
+    bucket.eligible += 1;
+    if (entry.viewedBeforeFirstAnswer) bucket.viewed += 1;
+    bySurface.set(entry.surface, bucket);
+  }
+  return [...bySurface.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([surface, bucket]) => ({
+      surface,
+      eligibleRuns: bucket.eligible,
+      viewedBeforeFirstAnswer: bucket.viewed,
+      rate: bucket.eligible === 0 ? 0 : bucket.viewed / bucket.eligible,
+    }));
+}

--- a/packages/core/src/agent/tools/memory-tools.test.ts
+++ b/packages/core/src/agent/tools/memory-tools.test.ts
@@ -80,7 +80,7 @@ describe("manage_memory tool", () => {
       tool.execute({ command: "create", path: "notes.txt", file_text: "hi" }, context),
     );
     expect(result.success).toBe(true);
-    expect(receivedArgs).toEqual([["agent-1"], "notes.txt", "hi"]);
+    expect(receivedArgs).toEqual([["agent-1"], "notes.txt", "hi", { agentId: "agent-1" }]);
   });
 
   test("surfaces a failed mutation as a failed tool result", async () => {

--- a/packages/core/src/agent/tools/memory-tools.ts
+++ b/packages/core/src/agent/tools/memory-tools.ts
@@ -7,7 +7,11 @@
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import { z } from "zod";
-import type { MemoryService, MemoryViewOutcome } from "@/core/interfaces/memory-service";
+import type {
+  MemoryService,
+  MemoryViewOutcome,
+  MemoryWriteContext,
+} from "@/core/interfaces/memory-service";
 import { MemoryServiceTag } from "@/core/interfaces/memory-service";
 import type { Tool } from "@/core/interfaces/tool-registry";
 import type { ToolExecutionResult } from "@/core/types/tools";
@@ -222,19 +226,32 @@ export function createManageMemoryTool(): Tool<MemoryToolDeps> {
       Effect.gen(function* () {
         const memoryService = yield* MemoryServiceTag;
         const scopes = context.memoryScopes ?? [context.agentId];
+        const writeContext: MemoryWriteContext = { agentId: context.agentId };
 
         const outcome = yield* (() => {
           switch (args.command) {
             case "create":
-              return memoryService.create(scopes, args.path, args.file_text);
+              return memoryService.create(scopes, args.path, args.file_text, writeContext);
             case "str_replace":
-              return memoryService.strReplace(scopes, args.path, args.old_str, args.new_str);
+              return memoryService.strReplace(
+                scopes,
+                args.path,
+                args.old_str,
+                args.new_str,
+                writeContext,
+              );
             case "insert":
-              return memoryService.insert(scopes, args.path, args.insert_line, args.insert_text);
+              return memoryService.insert(
+                scopes,
+                args.path,
+                args.insert_line,
+                args.insert_text,
+                writeContext,
+              );
             case "delete":
               return memoryService.delete(scopes, args.path);
             case "rename":
-              return memoryService.rename(scopes, args.old_path, args.new_path);
+              return memoryService.rename(scopes, args.old_path, args.new_path, writeContext);
           }
         })();
 

--- a/packages/core/src/agent/tools/memory-tools.ts
+++ b/packages/core/src/agent/tools/memory-tools.ts
@@ -59,8 +59,8 @@ const viewMemoryParameters = z
       .default("")
       .describe(
         'Path starting with a scope name (e.g. "personal/notes.txt" or "github-project-a/status.md"). ' +
-          'Empty string or "/" lists the scopes you can access, each as a directory — use that to discover ' +
-          "them instead of guessing.",
+          'Empty string or "/" lists every scope you can access along with the files inside each one — ' +
+          "use that to discover them instead of guessing.",
       ),
     view_range: z
       .tuple([z.number().int(), z.number().int()])
@@ -79,8 +79,10 @@ export function createViewMemoryTool(): Tool<MemoryToolDeps> {
     disclosure: "private",
     description:
       "Call this first, before you answer, at the start of every conversation — even a casual one. " +
-      'No path lists the memory scopes you can access (e.g. "personal", "github-project-a"); ' +
-      'a path like "personal/notes.md" reads one file within a scope. ' +
+      "Calling it with no path is the whole survey: it returns every memory scope you can access " +
+      '(e.g. "personal", "github-project-a") and the files saved in each, with sizes, so one call tells you ' +
+      "whether there is anything worth reading. " +
+      'A path like "personal/notes.md" then reads one file. ' +
       "An empty or missing directory just means nothing has been saved yet — that is a normal answer, not an error.",
     parameters: viewMemoryParameters,
     riskLevel: "read-only",

--- a/packages/core/src/interfaces/memory-provenance.ts
+++ b/packages/core/src/interfaces/memory-provenance.ts
@@ -1,0 +1,43 @@
+/**
+ * Provenance for memory files: who asserted a fact, when it was written, and
+ * when it was last read back.
+ *
+ * Kept in a hidden per-scope sidecar rather than in the memory files
+ * themselves. Memory files are the artifact a person edits directly — with
+ * `$EDITOR` and `git diff` — and they are also exactly what reaches the model,
+ * so injecting a header into them would both mean the reviewed artifact is no
+ * longer the injected one and shift every line number `str_replace` and
+ * `insert` address.
+ *
+ * There is no trust field: memory holds facts about a person, so a fact the
+ * person never stated has no business being here at all. Rather than record a
+ * tier and warn on read, `manage_memory` refuses to write once untrusted
+ * external content has entered the run, which is why everything stored is
+ * first-hand by construction.
+ */
+
+export interface MemoryFileProvenance {
+  /** ISO 8601. */
+  readonly createdAt: string;
+  /** ISO 8601, bumped on every successful write. */
+  readonly updatedAt: string;
+  /**
+   * ISO 8601 of the last `view` that read this file. Recorded but deliberately
+   * wired to nothing: personal memory is not re-derivable, so "unused" is a bad
+   * proxy for "unimportant" — an allergy is read once a year. The signal is here
+   * for a human reviewing memory, not for an automatic deleter.
+   */
+  readonly lastViewedAt?: string;
+  readonly writeCount: number;
+  /** Agent ids that have written to this file. */
+  readonly writtenBy: readonly string[];
+}
+
+export interface MemoryScopeProvenance {
+  readonly version: 1;
+  readonly files: Readonly<Record<string, MemoryFileProvenance>>;
+}
+
+export const MEMORY_PROVENANCE_FILENAME = ".provenance.json";
+
+export const EMPTY_MEMORY_SCOPE_PROVENANCE: MemoryScopeProvenance = { version: 1, files: {} };

--- a/packages/core/src/interfaces/memory-service.ts
+++ b/packages/core/src/interfaces/memory-service.ts
@@ -7,6 +7,7 @@
  */
 import { FileSystem } from "@effect/platform";
 import { Context, Effect } from "effect";
+import type { MemoryFileProvenance } from "./memory-provenance";
 
 export interface MemoryDirectoryEntry {
   readonly name: string;
@@ -48,6 +49,17 @@ export interface MemoryMutationOutcome {
 }
 
 /**
+ * Who is writing. Required on every mutating call so a shared scope can report
+ * which agents have touched a file.
+ *
+ * Whether a write is *allowed* is decided before this, in `manage_memory`: a
+ * run that has ingested untrusted external content cannot write memory at all.
+ */
+export interface MemoryWriteContext {
+  readonly agentId: string;
+}
+
+/**
  * File-backed memory an agent manages via tool calls (view/create/str_replace/
  * insert/delete/rename), partitioned into named scopes rather than one silo
  * per agent.
@@ -72,6 +84,7 @@ export interface MemoryService {
     scopes: readonly string[],
     virtualPath: string,
     fileText: string,
+    writeContext: MemoryWriteContext,
   ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
 
   readonly strReplace: (
@@ -79,6 +92,7 @@ export interface MemoryService {
     virtualPath: string,
     oldStr: string,
     newStr: string | undefined,
+    writeContext: MemoryWriteContext,
   ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
 
   readonly insert: (
@@ -86,6 +100,7 @@ export interface MemoryService {
     virtualPath: string,
     insertLine: number,
     insertText: string,
+    writeContext: MemoryWriteContext,
   ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
 
   readonly delete: (
@@ -93,10 +108,20 @@ export interface MemoryService {
     virtualPath: string,
   ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
 
+  /**
+   * Provenance for one file, or undefined when nothing is recorded for it —
+   * a file written before provenance tracking, or edited outside Jazz.
+   */
+  readonly provenance: (
+    scopes: readonly string[],
+    virtualPath: string,
+  ) => Effect.Effect<MemoryFileProvenance | undefined, Error, FileSystem.FileSystem>;
+
   readonly rename: (
     scopes: readonly string[],
     oldVirtualPath: string,
     newVirtualPath: string,
+    writeContext: MemoryWriteContext,
   ) => Effect.Effect<MemoryMutationOutcome, Error, FileSystem.FileSystem>;
 }
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -278,3 +278,12 @@ export function getBuiltinWorkflowsDirectory(): string | null {
 export function getGlobalWorkflowsDirectory(): string {
   return path.join(getJazzHomeDirectory(), "workflows");
 }
+
+/**
+ * Returns the directory holding the memory-recall log: a JSONL record of
+ * whether each run consulted memory before answering, kept separate from
+ * ordinary logs so the per-surface recall rate can be measured.
+ */
+export function getMemoryRecallLogDirectory(): string {
+  return path.join(getJazzHomeDirectory(), "memory-recall");
+}

--- a/packages/core/src/utils/storage.ts
+++ b/packages/core/src/utils/storage.ts
@@ -39,6 +39,16 @@ export function resolveStorageDirectory(storage: StorageConfig): string {
 }
 
 /**
+ * Whether a storage key satisfies Jazz's storage-safe format. Prefer
+ * {@link requireValidStorageKey} where an invalid key should fail; this
+ * predicate exists for callers that must skip an invalid key without
+ * aborting the surrounding operation.
+ */
+export function isValidStorageKey(key: string): boolean {
+  return AGENT_ID_PATTERN.test(key);
+}
+
+/**
  * Require a storage key (agent id, memory scope name, etc.) to satisfy Jazz's
  * storage-safe format: 1–64 ASCII letters, digits, underscores, and hyphens,
  * since these values become file and lock names. `label` names the kind of

--- a/packages/discord-bot/src/bridge.ts
+++ b/packages/discord-bot/src/bridge.ts
@@ -713,7 +713,7 @@ async function runJazz(
       stdout: "pipe",
       stderr: "pipe",
       stdin: "pipe",
-      env: sandboxEnv(sandbox, process.env),
+      env: sandboxEnv(sandbox, process.env, "discord"),
     },
   );
   activeRuns.set(runToken, { child, cancelled: false });
@@ -1039,7 +1039,7 @@ async function jazzJson(
       ...extraArgs,
       prompt,
     ]),
-    { stdout: "pipe", stderr: "pipe", env: sandboxEnv(sandbox, process.env) },
+    { stdout: "pipe", stderr: "pipe", env: sandboxEnv(sandbox, process.env, "discord") },
   );
   const timeout = setTimeout(() => child.kill(), 90_000);
   const [stdout] = await Promise.all([

--- a/packages/discord-bot/src/chat-shell.ts
+++ b/packages/discord-bot/src/chat-shell.ts
@@ -34,6 +34,6 @@ const child = Bun.spawn(sandboxCommand(sandbox, target), {
   stdin: "inherit",
   stdout: "inherit",
   stderr: "inherit",
-  env: sandboxEnv(sandbox, process.env),
+  env: sandboxEnv(sandbox, process.env, "discord"),
 });
 process.exit(await child.exited);

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -495,6 +495,68 @@ function registerAgentCommands(program: Command): void {
 }
 
 /**
+ * Register `jazz memory` — the operator's view of what an agent has written
+ * down about them, plus the measured rate at which runs actually consult it.
+ */
+function registerMemoryCommands(program: Command): void {
+  const memoryCommand = program
+    .command("memory")
+    .description("Inspect and control what an agent remembers");
+
+  memoryCommand
+    .command("list <agent>")
+    .description("List every memory file an agent can read")
+    .action((agent: string) =>
+      runCliAction(
+        () => import("@jazz/cli/commands/memory").then((mod) => mod.listMemoryCommand(agent)),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  memoryCommand
+    .command("show <agent> <path>")
+    .description("Print one memory file exactly as the agent reads it")
+    .action((agent: string, memoryPath: string) =>
+      runCliAction(
+        () =>
+          import("@jazz/cli/commands/memory").then((mod) =>
+            mod.showMemoryCommand(agent, memoryPath),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  memoryCommand
+    .command("forget <agent> <path>")
+    .description("Delete one memory file permanently")
+    .action((agent: string, memoryPath: string) =>
+      runCliAction(
+        () =>
+          import("@jazz/cli/commands/memory").then((mod) =>
+            mod.forgetMemoryCommand(agent, memoryPath),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+
+  memoryCommand
+    .command("recall")
+    .description("Show how often runs consulted memory before answering, by surface")
+    .option("--surface <name>", "Only report one surface (cli, telegram, discord)")
+    .action((options: { surface?: string }) =>
+      runCliAction(
+        () =>
+          import("@jazz/cli/commands/memory").then((mod) =>
+            mod.memoryRecallCommand(
+              options.surface !== undefined ? { surface: options.surface } : {},
+            ),
+          ),
+        cliRuntimeOptions(program),
+      ),
+    );
+}
+
+/**
  * Register configuration-related commands
  */
 function registerConfigCommands(program: Command): void {
@@ -1582,6 +1644,7 @@ export function createCLIApp(): Command {
   registerAgentCommands(program);
   registerPersonaCommands(program);
   registerConfigCommands(program);
+  registerMemoryCommands(program);
   registerWebhookCommands(program);
   registerMCPCommands(program);
   registerUpdateCommand(program);

--- a/packages/telegram-bot/src/bridge.ts
+++ b/packages/telegram-bot/src/bridge.ts
@@ -1019,7 +1019,7 @@ async function runJazz(
       stdout: "pipe",
       stderr: "pipe",
       stdin: "pipe",
-      env: sandboxEnv(sandbox, process.env),
+      env: sandboxEnv(sandbox, process.env, "telegram"),
     },
   );
   // Register so the ⏹ Cancel button can find and kill this process.
@@ -1358,7 +1358,7 @@ async function jazzJson(
       ...extraArgs,
       prompt,
     ]),
-    { stdout: "pipe", stderr: "pipe", env: sandboxEnv(sandbox, process.env) },
+    { stdout: "pipe", stderr: "pipe", env: sandboxEnv(sandbox, process.env, "telegram") },
   );
   const timeout = setTimeout(() => child.kill(), 90_000);
   const [stdout] = await Promise.all([

--- a/packages/telegram-bot/src/chat-shell.ts
+++ b/packages/telegram-bot/src/chat-shell.ts
@@ -35,6 +35,6 @@ const child = Bun.spawn(sandboxCommand(sandbox, target), {
   stdin: "inherit",
   stdout: "inherit",
   stderr: "inherit",
-  env: sandboxEnv(sandbox, process.env),
+  env: sandboxEnv(sandbox, process.env, "telegram"),
 });
 process.exit(await child.exited);


### PR DESCRIPTION
## What

**Budget fix.** The scope-wide byte/file caps were only checked in `create`, so `str_replace`/`insert` could grow a scope to ~128MB against a 10MB budget. One shared guard now covers all three write paths, charging an edit its net delta. Had no test coverage before, which is why it survived.

**Root listing.** `view_memory` with no path returned scope names with `sizeBytes: 0` and never walked in — so the one call the prompt asks for at the start of every conversation said nothing about whether anything was saved. It now returns each scope's files with sizes, and still creates nothing.

**Provenance.** Who wrote each file, when, how often, last read back. Hidden per-scope sidecar, not a file header — keeps the artifact a person edits identical to what the model reads, and keeps `insert_line` stable.

**Recall metric.** Each run records whether `view_memory` fired before the first answer, tagged by surface (bridges set `JAZZ_SURFACE`). `jazz memory recall` reports the rate. Recall is model-chosen, not harness-guaranteed, so it needed measuring.

**Operator surface.** `jazz memory list|show|forget|recall`, and `/memory` in chat. Both read the real files.

## Notes

- `MemoryWriteContext` is required, not optional-with-default — broke 49 call sites on purpose, so a new write path has to decide.
- Hidden entries excluded from the quota walk; the sidecar was eating the operator's budget.
- No trust tier, no TTL. Outside content isn't automatically untrusted, and gating writes on it breaks "look up my flight and remember it". TTL is worse: personal memory isn't re-derivable, so a false delete is silent and permanent.
- `MEMORY_INSTRUCTIONS` untouched.

## Verify

`bun test` (3774 pass), typecheck, lint. Live round-trip of `jazz memory list|show|forget` against a real agent, including provenance cleanup on delete.
