### PR TITLE
fix(agent): enforce a run's tool allowlist at execution, not just advertisement

### DIFF
--- a/docs/internals/tools-and-approval.md
+++ b/docs/internals/tools-and-approval.md
@@ -33,7 +33,9 @@ terminal; headless and remote surfaces retain their own authorization contracts.
 flowchart TD
     IN(["Model emits a tool call"]) --> PARSE{"Arguments<br/>valid JSON?"}
     PARSE -->|no| ERR["Return an error result —<br/>the agent can retry"]
-    PARSE -->|yes| LOOKUP["Look up in the registry:<br/>schema · risk level · timeout"]
+    PARSE -->|yes| SET{"Name in this run's<br/>effective tool set?"}
+    SET -->|no| ERR
+    SET -->|yes| LOOKUP["Look up in the registry:<br/>schema · risk level · timeout"]
 
     LOOKUP --> RUN["<b>Invoke the tool</b><br/>timeout: per-tool, else 3 min<br/>(longRunning tools: no timeout)"]
 
@@ -55,9 +57,54 @@ flowchart TD
 
     classDef gate fill:#f9a03f,stroke:#b3541e,color:#1a1a1a
     classDef act fill:#4f9d9d,stroke:#2f6d6d,color:#ffffff
-    class POLICY,PROMPT gate
+    class SET,POLICY,PROMPT gate
     class RUN,EXEC act
 ```
+
+---
+
+## Which tools a run can reach
+
+The tier gate above decides whether a call is _approved_. A separate, earlier question is
+whether the run may make it at all.
+
+A run resolves its toolset once at the start: the agent's own tools, plus the built-in
+categories its persona admits, minus the persona and agent deny lists, minus the carve-outs
+for a run that cannot persist (`manage_memory`) or cannot ask a human anything
+(`ask_user_question`, `ask_file_picker`), narrowed by any `toolAllowlist` it inherited. That list
+is then expanded with the names its tools also answer to — advertised aliases (`glob` for
+`find`) and the hidden execute half of each gated pair (`execute_execute_command`) — and the
+denials are re-applied over what expansion added, so a deny entry cannot be undone by an
+alias one step below it. The result is the run's **effective tool set**.
+
+That one set does three jobs:
+
+- **Advertisement.** `eager`-tier members are sent as schemas with every request;
+  `deferred`-tier ones appear as a name/summary index and their schemas arrive via
+  `search_tools`. Hidden execute halves are never advertised at all.
+- **Execution.** The executor tests every call against the set before handing the name to
+  the registry, and returns a plain tool-error result — the same treatment as unparseable
+  arguments — for anything outside it.
+- **Inheritance.** `spawn_subagent` hands it down as the child's `toolAllowlist`, so a child
+  can never hold a tool its parent lacks.
+
+The second is not redundant. The registry resolves a name against every tool registered in
+the process, so a narrowed advertisement only shapes what a model is _likely_ to ask for.
+Nothing stops a model from naming a tool it was never offered, and the AI SDK does not drop
+such a call: it forwards it flagged `invalid` and lets the caller decide. Constrained
+decoding at a hosted provider makes it unlikely; a local model, or any path where tool calls
+are parsed out of text, makes it ordinary.
+
+One member of the set is deliberately unreachable from a model-issued call: **the hidden
+execute half of a gated pair.** It has to be in the set for the approval branch to run it,
+and it is refused when the model writes the name itself — otherwise guessing
+`execute_write_file` would skip the approval the pair exists to collect. Every other member
+runs through whatever gate its risk level demands, and a name outside the set does not run
+at all.
+
+This is what makes `toolAllowlist` an authorization boundary rather than a hint, and it is
+what [`/a2a` peer serving](./peer-invites.md) relies on: a peer-served run auto-approves
+everything, on the grounds that the tier decided reachability before the run started.
 
 ---
 
@@ -234,8 +281,11 @@ approved: "git status"
 ```
 
 The strongest control isn't a policy at all: **an agent whose toolset omits
-`execute_command` cannot run shell commands regardless of tier.** Trim the toolset in the
-agent config when the blast radius matters — see [Chat platforms](../use-cases/chat-platforms.md#security-for-chat-surfaces).
+`execute_command` cannot run shell commands regardless of tier.** Not merely because the
+tool is never offered — the executor refuses a call to it outright, so a model that names it
+anyway gets a tool error rather than a shell. Trim the toolset in the agent config when the
+blast radius matters — see [Chat platforms](../use-cases/chat-platforms.md#security-for-chat-surfaces),
+and [Which tools a run can reach](#which-tools-a-run-can-reach) for how that set is built.
 
 ---
 

--- a/packages/core/src/agent/agent-runner.test.ts
+++ b/packages/core/src/agent/agent-runner.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import { FileSystem } from "@effect/platform";
-import { describe, expect, it, mock, type Mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, type Mock } from "bun:test";
 import { Effect, Layer, Stream } from "effect";
 import { AgentRunner } from "./agent-runner";
 import type { AgentRunnerOptions } from "./types";
@@ -437,6 +437,81 @@ describe("AgentRunner", () => {
       );
 
       expect(lastRequestedToolNames()).toContain("ask_user_question");
+    });
+  });
+
+  describe("the effective tool set", () => {
+    /**
+     * Every name the run resolved, aliases and hidden execute halves included — the list
+     * `partitionByTier` is handed, which is also the set the executor rejects off-list
+     * calls against.
+     */
+    function lastEffectiveToolNames(): readonly string[] {
+      const partitionMock = mockToolRegistry.partitionByTier as Mock<
+        ToolRegistry["partitionByTier"]
+      >;
+      return partitionMock.mock.calls.at(-1)?.[0] ?? [];
+    }
+
+    // The registry mock is shared by every test in this file, so a swapped-in `getTool`
+    // has to be put back or the next describe inherits tool1's alias.
+    const originalGetTool = (
+      mockToolRegistry.getTool as Mock<ToolRegistry["getTool"]>
+    ).getMockImplementation();
+    afterEach(() => {
+      const getToolMock = mockToolRegistry.getTool as Mock<ToolRegistry["getTool"]>;
+      if (originalGetTool !== undefined) getToolMock.mockImplementation(originalGetTool);
+    });
+
+    /** Gives `tool1` an alias and a gated execute half, as the real shell tool has. */
+    function withDerivedNames(): void {
+      const getToolMock = mockToolRegistry.getTool as Mock<ToolRegistry["getTool"]>;
+      getToolMock.mockImplementation((name: string) =>
+        Effect.succeed({
+          name,
+          ...(name === "tool1"
+            ? { aliases: ["tool1_alias"], approvalExecuteToolName: "execute_tool1" }
+            : { approvalExecuteToolName: undefined }),
+          longRunning: false,
+          timeoutMs: undefined,
+          function: { name, description: `Description for ${name}` },
+        } as never),
+      );
+    }
+
+    it("admits the alias and execute half of a tool it granted", async () => {
+      withDerivedNames();
+
+      await runWithTestLayers(
+        AgentRunner.run({ ...defaultOptions, stream: true, maxIterations: 1 }),
+      );
+
+      // The execute half has to be in here or an approved gated call has nothing to run.
+      expect(lastEffectiveToolNames()).toContain("tool1");
+      expect(lastEffectiveToolNames()).toContain("tool1_alias");
+      expect(lastEffectiveToolNames()).toContain("execute_tool1");
+    });
+
+    it("does not let expansion hand back a name the deny list removed", async () => {
+      withDerivedNames();
+
+      await runWithTestLayers(
+        AgentRunner.run({
+          ...defaultOptions,
+          agent: {
+            ...mockAgent,
+            config: { ...mockAgent.config, deniedTools: ["tool1_alias", "execute_tool1"] },
+          },
+          stream: true,
+          maxIterations: 1,
+        }),
+      );
+
+      // Denying only the alias leaves the tool itself granted — nonsense as a config, but
+      // the denial must still hold, or every deny entry is one alias away from meaningless.
+      expect(lastEffectiveToolNames()).toContain("tool1");
+      expect(lastEffectiveToolNames()).not.toContain("tool1_alias");
+      expect(lastEffectiveToolNames()).not.toContain("execute_tool1");
     });
   });
 

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -344,7 +344,11 @@ function initializeAgentRun(
     const allToolNames = yield* toolRegistry.listAllTools();
     combinedToolNames = combinedToolNames.filter((toolName) => allToolNames.includes(toolName));
 
-    // Expand tool names to include approval execute tools and advertised aliases
+    // Expand tool names to include approval execute tools and advertised aliases. These are
+    // other names for a tool that already survived every filter above, so they are granted
+    // with it: a run that may call `execute_command` has to be able to reach
+    // `execute_execute_command` once the approval is answered, and the registry resolves
+    // `glob` to `find`.
     const expandedToolNameSet = new Set(combinedToolNames);
     for (const toolName of combinedToolNames) {
       const tool = yield* toolRegistry.getTool(toolName);
@@ -357,6 +361,18 @@ function initializeAgentRun(
       if (tool.approvalExecuteToolName) {
         expandedToolNameSet.add(tool.approvalExecuteToolName);
       }
+    }
+
+    // Denials run again over what expansion added, because expansion grants: a persona that
+    // denies `glob` would otherwise get it back the moment `find` is granted. Denial has to
+    // be the last word, or a deny entry is one alias away from meaningless.
+    //
+    // The allowlist deliberately is not re-applied. A peer's allowlist is built from
+    // `listTools()`, which omits hidden tools, so it never names an execute half; narrowing
+    // to it here would leave every gated tool proposable and none of them executable.
+    // Advertisement and execution agree by sharing this one set instead.
+    for (const toolName of expandedToolNameSet) {
+      if (denied.has(toolName)) expandedToolNameSet.delete(toolName);
     }
 
     const expandedToolNames = Array.from(expandedToolNameSet);
@@ -467,7 +483,10 @@ function initializeAgentRun(
       // subsequent isAutoApproved checks within the same agent run.
       autoApprovedCommands,
       autoApprovedTools,
-      parentToolNames: expandedToolNames,
+      // What the executor rejects off-list calls against, and what a sub-agent inherits as
+      // its allowlist: this run may execute the list it was offered, not whatever the
+      // registry happens to hold.
+      effectiveToolNames: expandedToolNameSet,
       ...(deferredToolNames.length > 0 ? { deferredToolNames } : {}),
       // `tools` is a real mutable array (see AgentRunContext) reused by reference across every
       // iteration of this run's loop, so pushing here makes a fetched schema callable on the

--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -177,7 +177,7 @@ function makeOptions(overrides?: Partial<AgentRunnerOptions>): AgentRunnerOption
 function makeRunContext(overrides?: Partial<AgentRunContext>): AgentRunContext {
   return {
     actualConversationId: "conv-123",
-    context: { agentId: "agent-1", conversationId: "conv-123" },
+    context: { agentId: "agent-1", conversationId: "conv-123", unrestrictedTools: true },
     tools: [],
     messages: [{ role: "user", content: "hello" }],
     runMetrics: {

--- a/packages/core/src/agent/execution/streaming-executor.test.ts
+++ b/packages/core/src/agent/execution/streaming-executor.test.ts
@@ -118,6 +118,7 @@ describe("executeWithStreaming", () => {
       context: {
         agentId: "agent-1",
         conversationId: "conv-123",
+        unrestrictedTools: true,
       },
       tools: [],
       messages: [{ role: "user", content: "hello" }],
@@ -328,6 +329,7 @@ describe("executeWithStreaming", () => {
       context: {
         agentId: "agent-1",
         conversationId: "conv-123",
+        unrestrictedTools: true,
       },
       tools: [],
       messages: [{ role: "user", content: "run tool" }],
@@ -447,6 +449,7 @@ describe("executeWithStreaming", () => {
       context: {
         agentId: "agent-1",
         conversationId: "conv-123",
+        unrestrictedTools: true,
       },
       tools: [],
       messages: [{ role: "user", content: "hello" }],

--- a/packages/core/src/agent/execution/tool-executor.test.ts
+++ b/packages/core/src/agent/execution/tool-executor.test.ts
@@ -83,6 +83,36 @@ const emptyMcp = {} as unknown as MCPServerManager;
 const emptyMemory = {} as unknown as MemoryService;
 const emptyReminders = {} as unknown as ReminderService;
 
+/**
+ * The tool pipeline's full service set, with the three services these tests actually vary.
+ * The rest are discharged rather than cast away so a tool reaching for one fails loudly.
+ */
+function makeTestLayer(services: {
+  registry: ToolRegistry;
+  presentation?: PresentationService;
+  llm?: LLMService;
+}) {
+  return Layer.mergeAll(
+    Layer.succeed(LoggerServiceTag, mockLogger),
+    Layer.succeed(PresentationServiceTag, services.presentation ?? mockPresentationService),
+    Layer.succeed(ToolRegistryTag, services.registry),
+    Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
+    Layer.succeed(FileSystem.FileSystem, emptyFs),
+    Layer.succeed(TerminalServiceTag, emptyTerminal),
+    Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
+    Layer.succeed(SkillServiceTag, mockSkillService),
+    Layer.succeed(LLMServiceTag, services.llm ?? emptyLlm),
+    Layer.succeed(MCPServerManagerTag, emptyMcp),
+    Layer.succeed(MemoryServiceTag, emptyMemory),
+    Layer.succeed(WorkspaceServiceTag, {} as any),
+    Layer.succeed(WakeTriggerServiceTag, {} as any),
+    Layer.succeed(JobQueueServiceTag, {} as any),
+    Layer.succeed(ReminderServiceTag, emptyReminders),
+    Layer.succeed(PeerLedgerServiceTag, {} as any),
+    Layer.succeed(PeerTokenServiceTag, {} as any),
+  );
+}
+
 function makeRunMetrics(): ReturnType<typeof createAgentRunMetrics> {
   return {
     runId: "test-run",
@@ -139,25 +169,7 @@ describe("ToolExecutor.executeTool", () => {
       executeTool: () => Effect.succeed({ success: true, result: { data: "ok" } }),
     } as unknown as ToolRegistry;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     const result = await Effect.runPromise(
       ToolExecutor.executeTool(
@@ -180,25 +192,7 @@ describe("ToolExecutor.executeTool", () => {
       executeTool: () => Effect.succeed({ success: true, result: "ok" }),
     } as unknown as ToolRegistry;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     // executeTool still works even if getTool fails for timeout lookup
     const result = await Effect.runPromise(
@@ -229,25 +223,7 @@ describe("ToolExecutor.executeToolCall", () => {
       executeTool: () => Effect.succeed({ success: true, result: "ok" }),
     } as unknown as ToolRegistry;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     const toolCall: ToolCall = {
       id: "call_1",
@@ -274,25 +250,7 @@ describe("ToolExecutor.executeToolCall", () => {
 
   it("should skip non-function tool calls", async () => {
     const emptyRegistry = {} as unknown as ToolRegistry;
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, emptyRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: emptyRegistry });
 
     const toolCall = {
       id: "call_1",
@@ -331,25 +289,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       executeTool: (_name: string) => Effect.succeed({ success: true, result: { data: "ok" } }),
     } as unknown as ToolRegistry;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     const toolCalls: ToolCall[] = [
       {
@@ -409,25 +349,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       flush: () => Effect.void,
     };
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     const toolCalls: ToolCall[] = [
       {
@@ -512,25 +434,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       flush: () => Effect.void,
     };
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, mockPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({ registry: mockToolRegistry });
 
     const toolCalls: ToolCall[] = [
       {
@@ -656,25 +560,10 @@ describe("ToolExecutor.executeToolCall approval events", () => {
       flush: () => Effect.void,
     };
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, approvingPresentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({
+      registry: mockToolRegistry,
+      presentation: approvingPresentationService,
+    });
 
     const toolCall: ToolCall = {
       id: "call_approval_1",
@@ -763,25 +652,11 @@ describe("ToolExecutor.executeToolCall approval events", () => {
         Effect.succeed({ id: "1", model: "gpt-4o-mini", content: "read-only" }),
     } as unknown as LLMService;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, promptingPresentation),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, classifyingLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({
+      registry: mockToolRegistry,
+      presentation: promptingPresentation,
+      llm: classifyingLlm,
+    });
 
     const toolCall: ToolCall = {
       id: "call_cmd_1",
@@ -876,25 +751,10 @@ describe("ToolExecutor picker-style approvals", () => {
       },
     } as unknown as PresentationService;
 
-    const testLayer = Layer.mergeAll(
-      Layer.succeed(LoggerServiceTag, mockLogger),
-      Layer.succeed(PresentationServiceTag, presentationService),
-      Layer.succeed(ToolRegistryTag, mockToolRegistry),
-      Layer.succeed(AgentConfigServiceTag, mockAgentConfigService),
-      Layer.succeed(FileSystem.FileSystem, emptyFs),
-      Layer.succeed(TerminalServiceTag, emptyTerminal),
-      Layer.succeed(FileSystemContextServiceTag, emptyFsContext),
-      Layer.succeed(SkillServiceTag, mockSkillService),
-      Layer.succeed(LLMServiceTag, emptyLlm),
-      Layer.succeed(MCPServerManagerTag, emptyMcp),
-      Layer.succeed(MemoryServiceTag, emptyMemory),
-      Layer.succeed(WorkspaceServiceTag, {} as any),
-      Layer.succeed(WakeTriggerServiceTag, {} as any),
-      Layer.succeed(JobQueueServiceTag, {} as any),
-      Layer.succeed(ReminderServiceTag, emptyReminders),
-      Layer.succeed(PeerLedgerServiceTag, {} as any),
-      Layer.succeed(PeerTokenServiceTag, {} as any),
-    );
+    const testLayer = makeTestLayer({
+      registry: mockToolRegistry,
+      presentation: presentationService,
+    });
 
     return { testLayer, executeArgsSeen, receivedRequests };
   }
@@ -932,5 +792,150 @@ describe("ToolExecutor picker-style approvals", () => {
     expect(executeArgsSeen).toHaveLength(1);
     const seen = executeArgsSeen[0] as Record<string, unknown> | undefined;
     expect(seen?.["_selectedOptionId"]).toBe("anthropic/claude-sonnet-4-5");
+  });
+});
+
+describe("a run's effective tool set as the execution boundary", () => {
+  /**
+   * A registry holding both halves of one gated pair plus an unrelated tool, standing in for
+   * the process-wide registry that resolves any name the model writes.
+   */
+  function makeFullRegistry(executed: string[]): ToolRegistry {
+    const tools: Record<string, Record<string, unknown>> = {
+      read_file: { name: "read_file", riskLevel: "read-only" },
+      execute_command: {
+        name: "execute_command",
+        riskLevel: "unknown",
+        approvalExecuteToolName: "execute_execute_command",
+      },
+      execute_execute_command: {
+        name: "execute_execute_command",
+        riskLevel: "unknown",
+        hidden: true,
+      },
+    };
+    return {
+      getTool: (name: string) =>
+        tools[name] !== undefined
+          ? Effect.succeed(tools[name])
+          : Effect.fail(new Error(`Tool not found: ${name}`)),
+      executeTool: (name: string) =>
+        Effect.sync(() => {
+          executed.push(name);
+          return name === "execute_command"
+            ? {
+                success: true,
+                result: {
+                  approvalRequired: true,
+                  message: "Run ls",
+                  executeToolName: "execute_execute_command",
+                  executeArgs: { command: "ls" },
+                },
+              }
+            : { success: true, result: { stdout: "ok", exitCode: 0 } };
+        }),
+    } as unknown as ToolRegistry;
+  }
+
+  function callToolNamed(
+    name: string,
+    effectiveToolNames: ReadonlySet<string>,
+    executed: string[],
+    presentation?: PresentationService,
+  ): Promise<ToolCallExecutionResult> {
+    const toolCall: ToolCall = {
+      id: `call_${name}`,
+      type: "function",
+      function: { name, arguments: '{"command":"ls"}' },
+    };
+    return Effect.runPromise(
+      ToolExecutor.executeToolCall(
+        toolCall,
+        {
+          agentId: "agent-1",
+          conversationId: "sess-1",
+          effectiveToolNames,
+          // Yolo, as a peer-served run sets it: nothing here should pass because approval
+          // was skipped, only because the name was granted in the first place.
+          getAutoApprovePolicy: () => true,
+        },
+        displayConfig,
+        null,
+        makeRunMetrics(),
+        "agent-1",
+        "conv-123",
+        new Set(["execute_command"]),
+      ).pipe(
+        Effect.provide(
+          makeTestLayer({
+            registry: makeFullRegistry(executed),
+            ...(presentation !== undefined ? { presentation } : {}),
+          }),
+        ),
+      ) as Effect.Effect<ToolCallExecutionResult, unknown, never>,
+    );
+  }
+
+  it("refuses a tool the run was never granted, however well the registry knows it", async () => {
+    const executed: string[] = [];
+    const result = await callToolNamed("execute_command", new Set(["read_file"]), executed);
+
+    expect(executed).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.result).toMatchObject({
+      error: expect.stringContaining("not available to this agent"),
+    });
+  });
+
+  it("hands the refusal back as a tool result the model can act on, not a failed run", async () => {
+    const executed: string[] = [];
+    const result = await callToolNamed("execute_command", new Set(["read_file"]), executed);
+
+    // Same shape as unparseable arguments: a settled tool result on the original call id,
+    // so the transcript stays valid and the next turn can choose a tool it does have.
+    expect(result.toolCallId).toBe("call_execute_command");
+    expect(result.name).toBe("execute_command");
+  });
+
+  it("still runs the hidden execute half once its proposal is approved", async () => {
+    const executed: string[] = [];
+    const result = await callToolNamed(
+      "execute_command",
+      new Set(["execute_command", "execute_execute_command"]),
+      executed,
+    );
+
+    expect(executed).toEqual(["execute_command", "execute_execute_command"]);
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("execute_execute_command");
+  });
+
+  it("refuses the hidden execute half when the model names it directly", async () => {
+    const executed: string[] = [];
+    // In the effective set — the approval path needs it there — so only the fact that the
+    // model wrote the name itself can be what stops it.
+    const result = await callToolNamed(
+      "execute_execute_command",
+      new Set(["execute_command", "execute_execute_command"]),
+      executed,
+    );
+
+    expect(executed).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.result).toMatchObject({
+      error: expect.stringContaining("cannot be called directly"),
+    });
+  });
+
+  it("leaves a caller with no effective set unrestricted", async () => {
+    const executed: string[] = [];
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool("read_file", {}, { agentId: "agent-1" }).pipe(
+        Effect.provide(makeTestLayer({ registry: makeFullRegistry(executed) })),
+      ) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(executed).toEqual(["read_file"]);
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/core/src/agent/execution/tool-executor.test.ts
+++ b/packages/core/src/agent/execution/tool-executor.test.ts
@@ -178,6 +178,7 @@ describe("ToolExecutor.executeTool", () => {
         {
           agentId: "agent-1",
           conversationId: "sess-1",
+          unrestrictedTools: true,
         },
       ).pipe(Effect.provide(testLayer)) as Effect.Effect<ToolExecutionResult, unknown, never>,
     );
@@ -202,6 +203,7 @@ describe("ToolExecutor.executeTool", () => {
         {
           agentId: "agent-1",
           conversationId: "sess-1",
+          unrestrictedTools: true,
         },
       ).pipe(Effect.provide(testLayer)) as Effect.Effect<ToolExecutionResult, unknown, never>,
     );
@@ -234,7 +236,7 @@ describe("ToolExecutor.executeToolCall", () => {
     const result = await Effect.runPromise(
       ToolExecutor.executeToolCall(
         toolCall,
-        { agentId: "agent-1", conversationId: "sess-1" },
+        { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
         displayConfig,
         null,
         makeRunMetrics(),
@@ -261,7 +263,7 @@ describe("ToolExecutor.executeToolCall", () => {
     const result = await Effect.runPromise(
       ToolExecutor.executeToolCall(
         toolCall,
-        { agentId: "agent-1", conversationId: "sess-1" },
+        { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
         displayConfig,
         null,
         makeRunMetrics(),
@@ -307,7 +309,7 @@ describe("ToolExecutor.executeToolCalls", () => {
     const results = await Effect.runPromise(
       ToolExecutor.executeToolCalls(
         toolCalls,
-        { agentId: "agent-1", conversationId: "sess-1" },
+        { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
         { showReasoning: false, showToolExecution: false, mode: "hybrid" as const },
         null,
         makeRunMetrics(),
@@ -364,7 +366,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       const fiber = yield* Effect.fork(
         ToolExecutor.executeToolCalls(
           toolCalls,
-          { agentId: "agent-1", conversationId: "sess-1" },
+          { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
           { showReasoning: false, showToolExecution: true, mode: "hybrid" as const },
           recordingRenderer,
           makeRunMetrics(),
@@ -451,7 +453,7 @@ describe("ToolExecutor.executeToolCalls", () => {
       const fiber = yield* Effect.fork(
         ToolExecutor.executeToolCalls(
           toolCalls,
-          { agentId: "agent-1", conversationId: "sess-1" },
+          { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
           { showReasoning: false, showToolExecution: true, mode: "hybrid" as const },
           recordingRenderer,
           makeRunMetrics(),
@@ -574,7 +576,7 @@ describe("ToolExecutor.executeToolCall approval events", () => {
     await Effect.runPromise(
       ToolExecutor.executeToolCall(
         toolCall,
-        { agentId: "agent-1", conversationId: "sess-1" },
+        { agentId: "agent-1", conversationId: "sess-1", unrestrictedTools: true },
         displayConfig,
         recordingRenderer,
         makeRunMetrics(),
@@ -670,6 +672,7 @@ describe("ToolExecutor.executeToolCall approval events", () => {
         {
           agentId: "agent-1",
           conversationId: "sess-1",
+          unrestrictedTools: true,
           parentAgent: {
             id: "agent-1",
             name: "test",
@@ -775,6 +778,7 @@ describe("ToolExecutor picker-style approvals", () => {
         // Yolo: every other high-risk tool would sail through. A picker must not.
         {
           agentId: "agent-1",
+          unrestrictedTools: true,
           getAutoApprovePolicy: () => true,
         },
         displayConfig,
@@ -927,7 +931,26 @@ describe("a run's effective tool set as the execution boundary", () => {
     });
   });
 
-  it("leaves a caller with no effective set unrestricted", async () => {
+  it("runs when the caller explicitly opts into unrestrictedTools", async () => {
+    const executed: string[] = [];
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "read_file",
+        {},
+        {
+          agentId: "agent-1",
+          unrestrictedTools: true,
+        },
+      ).pipe(
+        Effect.provide(makeTestLayer({ registry: makeFullRegistry(executed) })),
+      ) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(executed).toEqual(["read_file"]);
+    expect(result.success).toBe(true);
+  });
+
+  it("refuses when neither effectiveToolNames nor unrestrictedTools is set", async () => {
     const executed: string[] = [];
     const result = await Effect.runPromise(
       ToolExecutor.executeTool("read_file", {}, { agentId: "agent-1" }).pipe(
@@ -935,7 +958,65 @@ describe("a run's effective tool set as the execution boundary", () => {
       ) as Effect.Effect<ToolExecutionResult, unknown, never>,
     );
 
-    expect(executed).toEqual(["read_file"]);
+    expect(executed).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no effective tool set/i);
+  });
+
+  it("refuses via executeTool when the name is outside effectiveToolNames", async () => {
+    const executed: string[] = [];
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "execute_command",
+        { command: "ls" },
+        { agentId: "agent-1", effectiveToolNames: new Set(["read_file"]) },
+      ).pipe(
+        Effect.provide(makeTestLayer({ registry: makeFullRegistry(executed) })),
+      ) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(executed).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not available to this agent/);
+  });
+
+  it("refuses a hidden tool via executeTool without allowHiddenExecute", async () => {
+    const executed: string[] = [];
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "execute_execute_command",
+        { command: "ls" },
+        {
+          agentId: "agent-1",
+          effectiveToolNames: new Set(["execute_command", "execute_execute_command"]),
+        },
+      ).pipe(
+        Effect.provide(makeTestLayer({ registry: makeFullRegistry(executed) })),
+      ) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(executed).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/cannot be called directly/);
+  });
+
+  it("runs a hidden tool via executeTool when allowHiddenExecute is set", async () => {
+    const executed: string[] = [];
+    const result = await Effect.runPromise(
+      ToolExecutor.executeTool(
+        "execute_execute_command",
+        { command: "ls" },
+        {
+          agentId: "agent-1",
+          effectiveToolNames: new Set(["execute_command", "execute_execute_command"]),
+          allowHiddenExecute: true,
+        },
+      ).pipe(
+        Effect.provide(makeTestLayer({ registry: makeFullRegistry(executed) })),
+      ) as Effect.Effect<ToolExecutionResult, unknown, never>,
+    );
+
+    expect(executed).toEqual(["execute_execute_command"]);
     expect(result.success).toBe(true);
   });
 });

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -82,39 +82,60 @@ export class ToolExecutor {
       const registry = yield* ToolRegistryTag;
       const logger = yield* LoggerServiceTag;
 
-      // The registry resolves a name against every tool registered in the process, so
-      // whether a run may reach one is decided here or nowhere: advertising a narrowed list
-      // only shapes what the model is likely to ask for. Peer-served runs lean on this —
-      // their allowlist is the whole authorization boundary and they auto-approve
-      // everything inside it.
-      //
-      // Reported as a failed result rather than a raised error, the same as unparseable
-      // arguments: the model asked for something it does not have, which is a turn it can
-      // recover from by picking a tool it does have.
-      if (context.effectiveToolNames !== undefined && !context.effectiveToolNames.has(name)) {
-        yield* logger.warn("Blocked tool call outside this run's tool set", {
-          agentId: context.agentId,
-          toolName: name,
-        });
-        return {
-          success: false,
-          result: null,
-          error: `Tool '${name}' is not available to this agent. Use one of the tools you were given.`,
-        } satisfies ToolExecutionResult;
+      // Registry resolves against every tool in the process — reachability is decided here.
+      // Fail closed unless the run set an allowlist or the caller opted into unrestricted.
+      if (context.unrestrictedTools !== true) {
+        if (context.effectiveToolNames === undefined) {
+          yield* logger.warn("Blocked tool call with no effective tool set configured", {
+            agentId: context.agentId,
+            toolName: name,
+          });
+          return {
+            success: false,
+            result: null,
+            error: `Tool '${name}' cannot run: no effective tool set was configured for this call.`,
+          } satisfies ToolExecutionResult;
+        }
+        if (!context.effectiveToolNames.has(name)) {
+          yield* logger.warn("Blocked tool call outside this run's tool set", {
+            agentId: context.agentId,
+            toolName: name,
+          });
+          return {
+            success: false,
+            result: null,
+            error: `Tool '${name}' is not available to this agent. Use one of the tools you were given.`,
+          } satisfies ToolExecutionResult;
+        }
       }
 
-      // Use caller-provided timeout, or look up per-tool timeout, or fall back to default
+      // Use caller-provided timeout, or look up per-tool timeout, or fall back to default.
+      // Always resolve meta so the hidden-tool gate below cannot be skipped when a timeout
+      // override is passed.
       let timeoutMs = overrideTimeoutMs;
-      const toolMeta =
-        timeoutMs === undefined
-          ? yield* registry.getTool(name).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
-          : undefined;
+      const toolMeta = yield* registry
+        .getTool(name)
+        .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
       if (timeoutMs === undefined) {
         timeoutMs = toolMeta?.timeoutMs;
         // Long-running tools (e.g. user interaction) with no explicit timeout run indefinitely
         if (timeoutMs === undefined && !toolMeta?.longRunning) {
           timeoutMs = TOOL_TIMEOUT_MS;
         }
+      }
+
+      // Hidden execute halves skip approval if called directly. Only the post-approval
+      // path sets allowHiddenExecute when invoking the name the propose half returned.
+      if (toolMeta?.hidden === true && context.allowHiddenExecute !== true) {
+        yield* logger.warn("Blocked direct call to hidden execute tool", {
+          agentId: context.agentId,
+          toolName: name,
+        });
+        return {
+          success: false,
+          result: null,
+          error: `Tool '${name}' cannot be called directly. Call the tool that proposes it and the approved operation will run.`,
+        } satisfies ToolExecutionResult;
       }
 
       const execution = registry.executeTool(name, args, context);
@@ -209,15 +230,23 @@ export class ToolExecutor {
           .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
         const isLongRunning = toolMeta?.longRunning === true;
 
-        // A hidden tool is the execute half of a propose/execute pair, and is never in any
-        // tool list the model is shown — so a model that names one guessed it, and running
-        // it would skip the very approval the pair exists to collect. The legitimate route
-        // to that half is the approval branch further down, which calls it by the name the
-        // propose half returned rather than by a name the model wrote.
-        if (toolMeta?.hidden === true) {
-          throw new Error(
-            `Tool '${name}' cannot be called directly. Call the tool that proposes it and the approved operation will run.`,
-          );
+        // Hidden tools are refused in executeTool unless allowHiddenExecute is set.
+        // Bail before UI start events when the model named one directly.
+        if (toolMeta?.hidden === true && context.allowHiddenExecute !== true) {
+          const errorMessage = `Tool '${name}' cannot be called directly. Call the tool that proposes it and the approved operation will run.`;
+          recordToolError(runMetrics, name, new Error(errorMessage));
+          yield* logger.warn("Blocked direct call to hidden execute tool", {
+            agentId,
+            conversationId,
+            toolName: name,
+            toolCallId: toolCall.id,
+          });
+          return {
+            toolCallId: toolCall.id,
+            result: { error: errorMessage },
+            success: false,
+            name,
+          };
         }
 
         // Emit tool execution start - skip for approval tools to avoid interleaving with
@@ -493,12 +522,12 @@ export class ToolExecutor {
               }
             }
 
-            // Execute the actual tool
-            result = yield* ToolExecutor.executeTool(
-              approvalResult.executeToolName,
-              executeArgs,
-              context,
-            );
+            // Execute the actual tool. allowHiddenExecute is required: executeTool refuses
+            // hidden tools unless the post-approval path opts in.
+            result = yield* ToolExecutor.executeTool(approvalResult.executeToolName, executeArgs, {
+              ...context,
+              allowHiddenExecute: true,
+            });
             toolDuration = Date.now() - executeStartTime;
             finalToolName = approvalResult.executeToolName;
 

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -82,6 +82,27 @@ export class ToolExecutor {
       const registry = yield* ToolRegistryTag;
       const logger = yield* LoggerServiceTag;
 
+      // The registry resolves a name against every tool registered in the process, so
+      // whether a run may reach one is decided here or nowhere: advertising a narrowed list
+      // only shapes what the model is likely to ask for. Peer-served runs lean on this —
+      // their allowlist is the whole authorization boundary and they auto-approve
+      // everything inside it.
+      //
+      // Reported as a failed result rather than a raised error, the same as unparseable
+      // arguments: the model asked for something it does not have, which is a turn it can
+      // recover from by picking a tool it does have.
+      if (context.effectiveToolNames !== undefined && !context.effectiveToolNames.has(name)) {
+        yield* logger.warn("Blocked tool call outside this run's tool set", {
+          agentId: context.agentId,
+          toolName: name,
+        });
+        return {
+          success: false,
+          result: null,
+          error: `Tool '${name}' is not available to this agent. Use one of the tools you were given.`,
+        } satisfies ToolExecutionResult;
+      }
+
       // Use caller-provided timeout, or look up per-tool timeout, or fall back to default
       let timeoutMs = overrideTimeoutMs;
       const toolMeta =
@@ -187,6 +208,17 @@ export class ToolExecutor {
           .getTool(name)
           .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
         const isLongRunning = toolMeta?.longRunning === true;
+
+        // A hidden tool is the execute half of a propose/execute pair, and is never in any
+        // tool list the model is shown — so a model that names one guessed it, and running
+        // it would skip the very approval the pair exists to collect. The legitimate route
+        // to that half is the approval branch further down, which calls it by the name the
+        // propose half returned rather than by a name the model wrote.
+        if (toolMeta?.hidden === true) {
+          throw new Error(
+            `Tool '${name}' cannot be called directly. Call the tool that proposes it and the approved operation will run.`,
+          );
+        }
 
         // Emit tool execution start - skip for approval tools to avoid interleaving with
         // approval UI when multiple tools run in parallel (approval wrapper returns

--- a/packages/core/src/agent/run/park-resume.integration.test.ts
+++ b/packages/core/src/agent/run/park-resume.integration.test.ts
@@ -38,7 +38,7 @@ const AGENT: Agent = {
     persona: "default",
     llmProvider: "openai",
     llmModel: "gpt-4",
-    tools: ["danger"],
+    tools: ["danger", "harmless"],
   },
   createdAt: new Date("2026-08-01T00:00:00Z"),
   updatedAt: new Date("2026-08-01T00:00:00Z"),
@@ -140,8 +140,8 @@ function makeLayers(
   const registry = {
     registerTool: mock(() => Effect.succeed(undefined)),
     registerForCategory: mock(() => mock(() => Effect.succeed(undefined))),
-    listTools: mock(() => Effect.succeed(["danger"])),
-    listAllTools: mock(() => Effect.succeed(["danger", "danger_execute"])),
+    listTools: mock(() => Effect.succeed(["danger", "harmless"])),
+    listAllTools: mock(() => Effect.succeed(["danger", "danger_execute", "harmless"])),
     getToolsInCategory: mock(() => Effect.succeed([])),
     getTool: mock((name: string) =>
       Effect.succeed(

--- a/packages/core/src/agent/tools/subagent-tools.test.ts
+++ b/packages/core/src/agent/tools/subagent-tools.test.ts
@@ -463,7 +463,7 @@ describe("spawn_subagent tool ceiling", () => {
     try {
       const { presentation } = createPresentationHarness();
       await runSpawn(presentation, {
-        parentToolNames: ["read_file", "grep", "spawn_subagent"],
+        effectiveToolNames: new Set(["read_file", "grep", "spawn_subagent"]),
       });
 
       expect(captured?.toolAllowlist).toEqual(["read_file", "grep", "spawn_subagent"]);

--- a/packages/core/src/agent/tools/subagent-tools.ts
+++ b/packages/core/src/agent/tools/subagent-tools.ts
@@ -335,7 +335,9 @@ ${args.task}${args.resultSchema ? structuredCompletionInstructions(args.resultSc
             maxIterations: context.maxSubagentIterations ?? DEFAULT_MAX_SUBAGENT_ITERATIONS,
             ephemeralRegionId: regionId,
             // Cap the child at the parent's own effective tools.
-            ...(context.parentToolNames ? { toolAllowlist: context.parentToolNames } : {}),
+            ...(context.effectiveToolNames
+              ? { toolAllowlist: [...context.effectiveToolNames] }
+              : {}),
             subagentDepth: currentDepth + 1,
             ...(context.getAutoApprovePolicy
               ? { autoApprovePolicy: context.getAutoApprovePolicy }

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -339,11 +339,6 @@ export interface ToolExecutionContext {
   /** Iteration budget for a sub-agent spawned here — its own, not the parent's remainder. */
   readonly maxSubagentIterations?: number;
   /**
-   * The parent's effective tool names. `spawn_subagent` passes these down as
-   * the child's allowlist so a child can never hold a tool its parent lacks.
-   */
-  readonly parentToolNames?: readonly string[];
-  /**
    * How many sub-agent levels sit above the run executing this tool. 0 at the
    * top level; `spawn_subagent` increments it and refuses past the limit.
    */
@@ -355,6 +350,22 @@ export interface ToolExecutionContext {
    * Used by summarize_context to actually update the executor's message array.
    */
   readonly compactConversation?: (compacted: readonly ChatMessage[]) => void;
+  /**
+   * Every tool name this run may execute: its resolved toolset plus the alias and
+   * hidden-execute-half names those tools answer to.
+   *
+   * The executor tests each call against this set before handing the name to the registry,
+   * which resolves against every tool registered in the process and would otherwise run one
+   * this run was never granted. Advertising a narrowed list is not enough on its own — a
+   * model that names an unadvertised tool anyway reaches the registry all the same.
+   *
+   * `spawn_subagent` also hands it down as the child's allowlist, so a child can never hold
+   * a tool its parent lacks. One set for both: a second copy of the same list is one edit
+   * away from letting a child execute something the parent could not.
+   *
+   * Undefined means unrestricted, for callers that run a tool outside an agent run.
+   */
+  readonly effectiveToolNames?: ReadonlySet<string>;
   /** Names of this run's `deferred`-tier tools `search_tools` may look up. */
   readonly deferredToolNames?: readonly string[];
   /** Called by `search_tools` to make fetched schemas callable for the rest of this run — mirrors `compactConversation`. */

--- a/packages/core/src/types/tools.ts
+++ b/packages/core/src/types/tools.ts
@@ -351,21 +351,24 @@ export interface ToolExecutionContext {
    */
   readonly compactConversation?: (compacted: readonly ChatMessage[]) => void;
   /**
-   * Every tool name this run may execute: its resolved toolset plus the alias and
-   * hidden-execute-half names those tools answer to.
+   * Every tool name this run may execute: resolved toolset plus aliases and hidden
+   * execute halves. The executor refuses anything outside it before hitting the registry.
+   * `spawn_subagent` hands the same set down as the child's allowlist.
    *
-   * The executor tests each call against this set before handing the name to the registry,
-   * which resolves against every tool registered in the process and would otherwise run one
-   * this run was never granted. Advertising a narrowed list is not enough on its own — a
-   * model that names an unadvertised tool anyway reaches the registry all the same.
-   *
-   * `spawn_subagent` also hands it down as the child's allowlist, so a child can never hold
-   * a tool its parent lacks. One set for both: a second copy of the same list is one edit
-   * away from letting a child execute something the parent could not.
-   *
-   * Undefined means unrestricted, for callers that run a tool outside an agent run.
+   * Required for agent runs. Omitting it without `unrestrictedTools` fails closed.
    */
   readonly effectiveToolNames?: ReadonlySet<string>;
+  /**
+   * Explicit escape hatch for one-shot callers outside an agent run. Without this (or
+   * `effectiveToolNames`), `executeTool` refuses rather than treating a missing set as
+   * allow-all.
+   */
+  readonly unrestrictedTools?: boolean;
+  /**
+   * Set only by the post-approval path when invoking a gated pair's hidden execute half.
+   * Hidden tools are refused in `executeTool` unless this is true.
+   */
+  readonly allowHiddenExecute?: boolean;
   /** Names of this run's `deferred`-tier tools `search_tools` may look up. */
   readonly deferredToolNames?: readonly string[];
   /** Called by `search_tools` to make fetched schemas callable for the rest of this run — mirrors `compactConversation`. */


### PR DESCRIPTION
## Summary

Tool allowlists only controlled what the model was *shown*. Execution still resolved any name against the process-wide registry — including hidden `execute_*` halves that skip approval. `/a2a` peer runs auto-approve everything on the assumption that the allowlist was the real boundary. It wasn't.

## Fix

- One **effective tool set**: granted tools + aliases + hidden execute halves, with denials reapplied after expansion
- **Executor refuses** off-set names (tool-error result, run continues)
- **Model-direct calls to `hidden` tools refused**; approval path still reaches them via the propose half's returned name
- `parentToolNames` folded into `effectiveToolNames` so subagents inherit the same set

## Test plan

- [x] Off-allowlist refusal never hits the registry
- [x] Hidden execute half runs after approval, refused when named directly
- [x] Deny list still wins after alias/execute expansion
- [x] Peer-tier wiring cannot reach tools it never granted
- [x] `bun test` / typecheck / lint / docs checks green