### PR TITLE
fix(update): install Bun updates correctly

### DIFF
--- a/docs/start/quick-start.md
+++ b/docs/start/quick-start.md
@@ -31,8 +31,8 @@ binary:
 # npm
 npm install -g jazz-ai
 
-# bun
-bun add -g jazz-ai
+# bun (--trust lets the postinstall script fetch the platform binary)
+bun add -g --trust jazz-ai
 
 # pnpm
 pnpm add -g jazz-ai

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { buildInstallArgs } from "./update";
+
+describe("buildInstallArgs", () => {
+  it("passes --trust on bun so the postinstall script can fetch the binary", () => {
+    expect(buildInstallArgs("bun", "jazz-ai")).toEqual(["add", "-g", "--trust", "jazz-ai@latest"]);
+  });
+
+  it("installs globally with every other package manager", () => {
+    expect(buildInstallArgs("pnpm", "jazz-ai")).toEqual(["add", "-g", "jazz-ai@latest"]);
+    expect(buildInstallArgs("yarn", "jazz-ai")).toEqual(["global", "add", "jazz-ai@latest"]);
+    expect(buildInstallArgs("npm", "jazz-ai")).toEqual(["install", "-g", "jazz-ai@latest"]);
+  });
+
+  it("falls back to the npm form for an unrecognised package manager", () => {
+    expect(buildInstallArgs("corepack", "jazz-ai")).toEqual(["install", "-g", "jazz-ai@latest"]);
+  });
+
+  it("pins the requested package to @latest", () => {
+    expect(buildInstallArgs("bun", "@scope/pkg")).toContain("@scope/pkg@latest");
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -308,6 +308,33 @@ function detectPackageManager(): Effect.Effect<PackageManagerInfo, UpdateInstall
 }
 
 /**
+ * Builds the arguments a package manager needs to install Jazz globally.
+ *
+ * Bun needs `--trust` so the published package's `postinstall` script is allowed
+ * to run. That script downloads the platform binary, so without the flag Bun
+ * skips it and still exits 0, leaving behind a launcher that fails on every
+ * invocation. The release workflow already installs with `--trust`.
+ *
+ * @param packageManager - Name of the detected package manager.
+ * @param packageName - Name of the npm package to install.
+ * @returns Arguments to pass to the package manager executable.
+ */
+export function buildInstallArgs(packageManager: string, packageName: string): string[] {
+  const target = `${packageName}@latest`;
+
+  switch (packageManager) {
+    case "bun":
+      return ["add", "-g", "--trust", target];
+    case "pnpm":
+      return ["add", "-g", target];
+    case "yarn":
+      return ["global", "add", target];
+    default:
+      return ["install", "-g", target];
+  }
+}
+
+/**
  * Install the latest version.
  *
  * Binary installations replace themselves from the GitHub release; package
@@ -341,20 +368,13 @@ function installUpdate(
               "Please update Jazz using one of:\n" +
               "- npm: npm install -g jazz-ai@latest\n" +
               "- pnpm: pnpm add -g jazz-ai@latest\n" +
-              "- bun: bun add -g jazz-ai@latest",
+              "- bun: bun add -g --trust jazz-ai@latest",
           }),
         );
       }
     }
 
-    const installArgs =
-      pmInfo.name === "bun"
-        ? ["add", "-g", `${packageName}@latest`]
-        : pmInfo.name === "pnpm"
-          ? ["add", "-g", `${packageName}@latest`]
-          : pmInfo.name === "yarn"
-            ? ["global", "add", `${packageName}@latest`]
-            : ["install", "-g", `${packageName}@latest`];
+    const installArgs = buildInstallArgs(pmInfo.name, packageName);
 
     yield* Effect.async<void, UpdateInstallError>((resume) => {
       const child = spawn(pmInfo.name, installArgs, {
@@ -456,7 +476,7 @@ export function updateCommand(options?: {
           if (!isStandaloneBinary()) {
             yield* terminal.log("\n💡 You can manually update by running:");
             yield* terminal.log(`   npm install -g ${packageJson.name}@latest`);
-            yield* terminal.log(`   bun add -g ${packageJson.name}@latest`);
+            yield* terminal.log(`   bun add -g --trust ${packageJson.name}@latest`);
             yield* terminal.log(`   pnpm add -g ${packageJson.name}@latest`);
           }
         });


### PR DESCRIPTION
## What & why

Makes `jazz update` work when Jazz was installed with Bun. Bun skips the installer that downloads the Jazz executable unless it is trusted, so the old updater could report success while leaving a broken command behind.

The updater and the Bun quick-start command now use Bun's `--trust` flag.

## How to verify

- Install or update `jazz-ai` globally with Bun and run `jazz --version`.
- Confirm the updater's remediation command includes `--trust`.
- Follow the Bun quick-start command and confirm the installed CLI starts.
