### PR TITLE
Rename workspace tools to scratchpad

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -74,7 +74,7 @@ cannot be added without someone deciding.
 | ---------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `public`   | safe to tell anyone                                             | `add_reminder`, `cp`, `mkdir`, `mv`, `rm`, `web_fetch`, `web_search`, `write_file`                                                                                                                                                                                                                                     |
 | `internal` | the shape of this machine — paths, names, what is installed     | `analyze_media`, `cancel_batch`, `cancel_trigger`, `cd`, `context_info`, `create_pdf`, `create_web_app`, `find`, `get_time`, `list_jobs`, `list_triggers`, `ls`, `pdf_page_count`, `pwd`, `register_trigger`, `search_tools`, `stat`                                                                                                                               |
-| `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `enqueue_batch`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `manage_workspace`, `read_file`, `read_pdf`, `retrieve_tool_result`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory`, `view_workspace`, `wait_for` |
+| `private`  | your own material — file contents, memory, schedule, transcript | `ask_file_picker`, `ask_user_question`, `cancel_reminder`, `edit_file`, `enqueue_batch`, `execute_command`, `grep`, `http_request`, `list_reminders`, `list_todos`, `manage_memory`, `manage_todos`, `manage_scratchpad`, `read_file`, `read_pdf`, `retrieve_tool_result`, `spawn_subagent`, `summarize_context`, `update_work_state`, `view_memory`, `view_scratchpad`, `wait_for` |
 
 A tool spanning two levels takes the more sensitive one — `edit_file` writes, but its approval
 message carries a diff of your file, so it is `private`. `http_request` reaches private
@@ -200,8 +200,8 @@ dumps, and intermediate artifacts live, referenced from memory rather than dupli
 
 | Tool               | Risk        | Approval pair | What it does                                                                                       |
 | ------------------- | ----------- | ------------- | --------------------------------------------------------------------------------------------------- |
-| `view_workspace`   | `read-only` | —             | View your durable scratch space: working drafts, research dumps, and intermediate artifacts too…  |
-| `manage_workspace` | `low-risk`  | —             | Save durable working drafts, research dumps, or intermediate artifacts too large or provisional…  |
+| `view_scratchpad`   | `read-only` | —             | View your durable scratchpad: working drafts, research dumps, and intermediate artifacts too…  |
+| `manage_scratchpad` | `low-risk`  | —             | Save durable working drafts, research dumps, or intermediate artifacts too large or provisional…  |
 
 ### Reminders
 

--- a/packages/adapters/src/llm/ai-sdk-service.test.ts
+++ b/packages/adapters/src/llm/ai-sdk-service.test.ts
@@ -1219,7 +1219,7 @@ describe("buildToolInputSchema", () => {
   });
 
   it("flattens a top-level discriminated union, which Anthropic rejects both for a missing type and for the oneOf keyword itself", () => {
-    // Matches manage_memory/manage_workspace's shape: argument shape keyed by a
+    // Matches manage_memory/manage_scratchpad's shape: argument shape keyed by a
     // "command" field, which serializes to `oneOf` with no top-level `type` —
     // and Anthropic separately rejects `oneOf` at the top level regardless.
     const parameters = z.discriminatedUnion("command", [

--- a/packages/core/src/agent/tools/tool-categories.ts
+++ b/packages/core/src/agent/tools/tool-categories.ts
@@ -59,7 +59,7 @@ export const MEMORY_CATEGORY: ToolCategory = {
 };
 export const WORKSPACE_CATEGORY: ToolCategory = {
   id: "workspace",
-  displayName: "Workspace",
+  displayName: "Scratchpad",
   loadTier: "eager",
 };
 export const PEERS_CATEGORY: ToolCategory = {

--- a/packages/core/src/agent/tools/workspace-tools.ts
+++ b/packages/core/src/agent/tools/workspace-tools.ts
@@ -1,10 +1,12 @@
 /**
- * `view_workspace` and `manage_workspace`: read and edit an agent's durable
+ * `view_scratchpad` and `manage_scratchpad`: read and edit an agent's durable
  * scratch space, presented with the same line-numbered, view-a-range
  * ergonomics as the memory tools. Unlike memory (small, curated notes),
- * workspace is where large working drafts, research dumps, and intermediate
- * artifacts live — reference a workspace path from a memory entry once the
+ * the scratchpad is where large working drafts, research dumps, and intermediate
+ * artifacts live — reference a scratchpad path from a memory entry once the
  * work is done, rather than duplicating it there.
+ *
+ * Legacy aliases: `view_workspace` / `manage_workspace`.
  */
 
 import { FileSystem } from "@effect/platform";
@@ -77,10 +79,11 @@ type ViewWorkspaceArgs = z.infer<typeof viewWorkspaceParameters>;
 
 export function createViewWorkspaceTool(): Tool<WorkspaceToolDeps> {
   return defineTool<WorkspaceToolDeps, ViewWorkspaceArgs>({
-    name: "view_workspace",
+    name: "view_scratchpad",
+    aliases: ["view_workspace"],
     disclosure: "private",
     description:
-      "View your durable scratch space: working drafts, research dumps, and intermediate " +
+      "View your durable scratchpad: working drafts, research dumps, and intermediate " +
       "artifacts too large or too provisional for memory. No path lists everything you've " +
       "saved; a path reads one file. An empty or missing directory just means nothing has " +
       "been saved yet — that is a normal answer, not an error.",
@@ -123,9 +126,9 @@ export function createViewWorkspaceTool(): Tool<WorkspaceToolDeps> {
       if (!result.success) return undefined;
       const data = result.result as { outcome: WorkspaceViewOutcome };
       if (data.outcome.kind === "directory")
-        return `Listed workspace (${data.outcome.entries.length} item(s))`;
+        return `Listed scratchpad (${data.outcome.entries.length} item(s))`;
       if (data.outcome.kind === "file")
-        return `Read workspace file (${data.outcome.totalLines} line(s))`;
+        return `Read scratchpad file (${data.outcome.totalLines} line(s))`;
       return undefined;
     },
   });
@@ -135,14 +138,14 @@ const manageWorkspaceParameters = z.discriminatedUnion("command", [
   z
     .object({
       command: z.literal("create"),
-      path: z.string().min(1).describe("Workspace file path relative to the workspace directory."),
+      path: z.string().min(1).describe("Scratchpad file path relative to the scratchpad directory."),
       file_text: z.string().describe("Full file contents. Errors if the path already exists."),
     })
     .strict(),
   z
     .object({
       command: z.literal("str_replace"),
-      path: z.string().min(1).describe("Workspace file path relative to the workspace directory."),
+      path: z.string().min(1).describe("Scratchpad file path relative to the scratchpad directory."),
       old_str: z.string().min(1).describe("Exact unique snippet to replace."),
       new_str: z.string().optional().describe("Replacement text. Omit to delete the snippet."),
     })
@@ -150,13 +153,13 @@ const manageWorkspaceParameters = z.discriminatedUnion("command", [
   z
     .object({
       command: z.literal("insert"),
-      path: z.string().min(1).describe("Workspace file path relative to the workspace directory."),
+      path: z.string().min(1).describe("Scratchpad file path relative to the scratchpad directory."),
       insert_line: z
         .number()
         .int()
         .nonnegative()
         .describe(
-          "0-based line index to insert after (0 = beginning of the file). Note that view_workspace view_range is 1-based.",
+          "0-based line index to insert after (0 = beginning of the file). Note that view_scratchpad view_range is 1-based.",
         ),
       insert_text: z.string().describe("Text to insert."),
     })
@@ -164,14 +167,14 @@ const manageWorkspaceParameters = z.discriminatedUnion("command", [
   z
     .object({
       command: z.literal("delete"),
-      path: z.string().min(1).describe("Workspace file path to delete."),
+      path: z.string().min(1).describe("Scratchpad file path to delete."),
     })
     .strict(),
   z
     .object({
       command: z.literal("rename"),
-      old_path: z.string().min(1).describe("Current path, relative to the workspace directory."),
-      new_path: z.string().min(1).describe("New path, relative to the workspace directory."),
+      old_path: z.string().min(1).describe("Current path, relative to the scratchpad directory."),
+      new_path: z.string().min(1).describe("New path, relative to the scratchpad directory."),
     })
     .strict(),
 ]);
@@ -180,13 +183,14 @@ type ManageWorkspaceArgs = z.infer<typeof manageWorkspaceParameters>;
 
 export function createManageWorkspaceTool(): Tool<WorkspaceToolDeps> {
   return defineTool<WorkspaceToolDeps, ManageWorkspaceArgs>({
-    name: "manage_workspace",
+    name: "manage_scratchpad",
+    aliases: ["manage_workspace"],
     disclosure: "private",
     description:
       "Save durable working drafts, research dumps, or intermediate artifacts that are too " +
       "large or too provisional for memory — full research results, scraped data, long " +
-      "in-progress documents. Once work is done, reference the workspace path from a memory " +
-      'entry (e.g. "full research at workspace/research/topic.md") instead of duplicating ' +
+      "in-progress documents. Once work is done, reference the scratchpad path from a memory " +
+      'entry (e.g. "full research at scratchpad/research/topic.md") instead of duplicating ' +
       "the content into memory. Never write secrets (account numbers, passwords, health data).",
     parameters: manageWorkspaceParameters,
     riskLevel: "low-risk",


### PR DESCRIPTION
## Summary
- Rename agent tools `view_workspace` / `manage_workspace` → `view_scratchpad` / `manage_scratchpad` (names matched durable scratch space, not a project workspace).
- Keep old names as `aliases` so existing agent configs and model calls still resolve.
- Category display name: Workspace → Scratchpad (`id: workspace` unchanged).
- Docs + a test comment updated. `WorkspaceService` / on-disk paths unchanged.

## Test plan
- [ ] `bun test` tools/registry (or CI)
- [ ] Confirm `/tools` (or agents UI) lists Scratchpad with `view_scratchpad` / `manage_scratchpad`
- [ ] Call tools by old names and confirm aliases still work