### PR TITLE
jazz daemon: background by default + stop

### DIFF
--- a/packages/adapters/src/daemon/service-install.test.ts
+++ b/packages/adapters/src/daemon/service-install.test.ts
@@ -25,7 +25,7 @@ describe("the systemd unit", () => {
   it("points at the daemon command with the resolved invocation and options", () => {
     const unit = buildSystemdUnit(OPTIONS);
     expect(unit).toContain(
-      "ExecStart='/home/bob/.local/bin/jazz' 'daemon' '--serve-peers' 'bob' " +
+      "ExecStart='/home/bob/.local/bin/jazz' 'daemon' '--foreground' '--serve-peers' 'bob' " +
         "'--host' '100.101.102.103' '--port' '4747'",
     );
   });
@@ -54,6 +54,7 @@ describe("the launchd plist", () => {
     const plistXml = buildLaunchdPlist(OPTIONS);
     expect(plistXml).toContain("source '/etc/jazz/daemon.env'");
     expect(plistXml).toContain("'/home/bob/.local/bin/jazz'");
+    expect(plistXml).toContain("'--foreground'");
     expect(plistXml).toContain("'--serve-peers'");
     expect(plistXml).toContain("'bob'");
   });

--- a/packages/adapters/src/daemon/service-install.ts
+++ b/packages/adapters/src/daemon/service-install.ts
@@ -144,6 +144,7 @@ export function buildSystemdUnit(options: ServiceInstallOptions): string {
   const execStart = [
     ...options.invocation,
     "daemon",
+    "--foreground",
     "--serve-peers",
     options.agentId,
     "--host",
@@ -177,6 +178,7 @@ export function buildLaunchdPlist(options: ServiceInstallOptions): string {
   const programArgs = [
     ...options.invocation,
     "daemon",
+    "--foreground",
     "--serve-peers",
     options.agentId,
     "--host",

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,15 +1,13 @@
 /**
- * @fileoverview `jazz daemon` — run the HTTP server in the foreground.
+ * @fileoverview `jazz daemon` — run the HTTP server (background by default).
  *
- * Foreground on purpose. Supervision is the host's job, and the host already has one: the
- * Telegram bridge ships as a container with an entrypoint, and scheduled workflows use
- * launchd. A daemon that forks and writes a pidfile would be a third mechanism competing
- * with both, and the first thing anyone deploying it would have to work around.
+ * Interactive use backgrounds after the socket is up and writes a pidfile under `$JAZZ_HOME`
+ * so `jazz daemon stop` can SIGTERM it. Pass `--foreground` to stay attached (what
+ * systemd/launchd need for Type=simple / KeepAlive).
  *
- * `install`/`uninstall` do not change that — they don't add a jazz-owned supervision
- * mechanism, they wire this same foreground command into whichever supervisor the host
- * already has (systemd/launchd), which is exactly "the host's job" rather than a jazz pidfile
- * competing with it. See `@jazz/adapters/daemon/service-install` for that half.
+ * `install`/`uninstall` still wire the host supervisor: those units invoke
+ * `jazz daemon --foreground …` so the supervisor owns the process tree, not our pidfile.
+ * See `@jazz/adapters/daemon/service-install`.
  */
 
 import { randomBytes } from "node:crypto";
@@ -55,6 +53,12 @@ import { TerminalServiceTag } from "@jazz/core/interfaces/terminal";
 import { OneShotPresentationServiceLayer } from "@jazz/core/presentation/oneshot-presentation-service";
 import type { AppConfig } from "@jazz/core/types/config";
 import { getJazzSchedulerInvocation } from "@jazz/core/utils/runtime";
+import {
+  clearDaemonPid,
+  stopDaemonProcess,
+  waitForDaemonHealth,
+  writeDaemonPid,
+} from "../helpers/daemon-process";
 import { SchedulerServiceTag } from "@jazz/core/workflows/scheduler-service";
 import { Effect, Runtime } from "effect";
 
@@ -71,6 +75,12 @@ const WORKFLOW_CATCH_UP_INTERVAL_MS = 60_000;
 export interface DaemonCommandOptions {
   readonly port: number;
   readonly host: string;
+  /**
+   * Stay attached to the terminal. Default is background (pidfile + detach) so a normal
+   * `jazz daemon` returns once healthy. System services pass this so the supervisor owns the
+   * process.
+   */
+  readonly foreground?: boolean;
   /**
    * Agent that answers peer questions. Omitted means peers are not served at all.
    *
@@ -194,6 +204,11 @@ function formatServiceInstalledMessage(
  */
 export function daemonCommand(options: DaemonCommandOptions) {
   return Effect.gen(function* () {
+    if (options.foreground !== true) {
+      yield* startDaemonInBackground(options);
+      return;
+    }
+
     const provisioned = yield* resolveOrProvisionDaemonToken();
     if (!provisioned.ok && !isLoopback(options.host)) {
       // A precise, OS-aware explanation instead of `refuseReason`'s generic "no token" —
@@ -353,6 +368,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
         `jazz daemon listening on http://${daemonOptions.host}:${String(server.port)}` +
           `${token === undefined ? " (unauthenticated: no token could be stored)" : ""}\n`,
       );
+      void writeDaemonPid(daemonOptions.port, process.pid);
 
       // In-process alternative to depending on launchd/crontab existing on the host: every
       // tick, run whatever workflow catch-up is due and fire any self-registered wake
@@ -390,6 +406,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
         // Not awaited: the process is going away, and blocking the signal handler on a
         // drain that may never finish is how a daemon becomes unkillable.
         clearInterval(ticker);
+        void clearDaemonPid(daemonOptions.port);
         void server.stop(true);
         resume(Effect.void);
       };
@@ -398,6 +415,7 @@ export function daemonCommand(options: DaemonCommandOptions) {
 
       return Effect.sync(() => {
         clearInterval(ticker);
+        void clearDaemonPid(daemonOptions.port);
         void server.stop(true);
       });
     });
@@ -413,6 +431,83 @@ export function daemonCommand(options: DaemonCommandOptions) {
     Effect.provide(OneShotPresentationServiceLayer),
     Effect.provide(makeFileRunStoreLayer()),
   );
+}
+
+/**
+ * Re-exec this CLI with `--foreground`, detach, wait until `/health` answers, then exit.
+ */
+function startDaemonInBackground(options: DaemonCommandOptions) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const invocation = yield* getJazzSchedulerInvocation();
+    const args = [
+      ...invocation,
+      "daemon",
+      "--foreground",
+      "--port",
+      String(options.port),
+      "--host",
+      options.host,
+      ...(options.peerAgent !== undefined ? ["--serve-peers", options.peerAgent] : []),
+    ];
+
+    const child = Bun.spawn({
+      cmd: args,
+      stdout: "ignore",
+      stderr: "ignore",
+      stdin: "ignore",
+      env: process.env,
+    });
+    child.unref();
+
+    const healthy = yield* Effect.promise(() => waitForDaemonHealth(options.host, options.port));
+    if (!healthy) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+      yield* terminal.error(
+        `jazz daemon did not become healthy on http://${options.host}:${String(options.port)} — not leaving it running.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    yield* Effect.promise(() => writeDaemonPid(options.port, child.pid));
+    yield* terminal.success(
+      `jazz daemon running in the background on http://${options.host}:${String(options.port)} (pid ${String(child.pid)})`,
+    );
+    yield* terminal.info(`Stop it with: jazz daemon stop --port ${String(options.port)}`);
+    yield* terminal.info("Logs stay quiet in background mode; use --foreground to watch them.");
+  });
+}
+
+/**
+ * Stop a background (or still-attached) daemon for this port via SIGTERM.
+ * Idempotent: nothing running is not an error.
+ */
+export function stopDaemonCommand(options: { readonly port: number }) {
+  return Effect.gen(function* () {
+    const terminal = yield* TerminalServiceTag;
+    const result = yield* Effect.promise(() => stopDaemonProcess(options.port));
+    switch (result.kind) {
+      case "nothing":
+        yield* terminal.info(`No jazz daemon on port ${String(options.port)}.`);
+        return;
+      case "stopped":
+        yield* terminal.success(
+          `Stopped jazz daemon on port ${String(options.port)} (pid ${String(result.pid)}).`,
+        );
+        return;
+      case "failed":
+        yield* terminal.error(
+          `Could not stop pid ${String(result.pid)} on port ${String(options.port)}: ${result.detail}`,
+        );
+        process.exitCode = 1;
+        return;
+    }
+  });
 }
 
 /**

--- a/packages/cli/src/helpers/daemon-process.test.ts
+++ b/packages/cli/src/helpers/daemon-process.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { daemonPidPath } from "./daemon-process";
+
+describe("daemonPidPath", () => {
+  it("scopes the pidfile to the port under JAZZ_HOME", () => {
+    const previous = process.env["JAZZ_HOME"];
+    process.env["JAZZ_HOME"] = "/tmp/jazz-home-test";
+    try {
+      expect(daemonPidPath(4747)).toBe("/tmp/jazz-home-test/daemon-4747.pid");
+    } finally {
+      if (previous === undefined) delete process.env["JAZZ_HOME"];
+      else process.env["JAZZ_HOME"] = previous;
+    }
+  });
+});

--- a/packages/cli/src/helpers/daemon-process.ts
+++ b/packages/cli/src/helpers/daemon-process.ts
@@ -1,0 +1,128 @@
+/**
+ * Background jazz daemon lifecycle: pidfile under `$JAZZ_HOME`, start/stop without
+ * competing with launchd/systemd. Installed services pass `--foreground` and skip this.
+ */
+
+import * as nodeFs from "node:fs/promises";
+import path from "node:path";
+import { getJazzHomeDirectory } from "@jazz/core/utils/paths";
+
+export function daemonPidPath(port: number): string {
+  return path.join(getJazzHomeDirectory(), `daemon-${String(port)}.pid`);
+}
+
+export async function writeDaemonPid(port: number, pid: number): Promise<void> {
+  const file = daemonPidPath(port);
+  await nodeFs.mkdir(path.dirname(file), { recursive: true });
+  await nodeFs.writeFile(file, `${String(pid)}\n`, { encoding: "utf-8", mode: 0o600 });
+}
+
+export async function readDaemonPid(port: number): Promise<number | undefined> {
+  try {
+    const raw = await nodeFs.readFile(daemonPidPath(port), "utf-8");
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function clearDaemonPid(port: number): Promise<void> {
+  await nodeFs.rm(daemonPidPath(port), { force: true }).catch(() => undefined);
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type StopDaemonResult =
+  | { readonly kind: "nothing" }
+  | { readonly kind: "stopped"; readonly pid: number }
+  | { readonly kind: "failed"; readonly pid: number; readonly detail: string };
+
+/**
+ * Stop the daemon for this port: prefer the pidfile, fall back to the listener on the port.
+ * Idempotent — nothing running is success.
+ */
+export async function stopDaemonProcess(port: number): Promise<StopDaemonResult> {
+  let pid = await readDaemonPid(port);
+  if (pid === undefined || !isProcessAlive(pid)) {
+    pid = await findListenerPid(port);
+  }
+  if (pid === undefined) {
+    await clearDaemonPid(port);
+    return { kind: "nothing" };
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    await clearDaemonPid(port);
+    const detail = error instanceof Error ? error.message : String(error);
+    if (!isProcessAlive(pid)) return { kind: "stopped", pid };
+    return { kind: "failed", pid, detail };
+  }
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      await clearDaemonPid(port);
+      return { kind: "stopped", pid };
+    }
+    await Bun.sleep(100);
+  }
+
+  if (!isProcessAlive(pid)) {
+    await clearDaemonPid(port);
+    return { kind: "stopped", pid };
+  }
+  return { kind: "failed", pid, detail: "still running after SIGTERM (5s)" };
+}
+
+/**
+ * PID listening on TCP `port`, or undefined. Uses `lsof` when present (macOS/Linux).
+ */
+export async function findListenerPid(port: number): Promise<number | undefined> {
+  try {
+    const child = Bun.spawn({
+      cmd: ["lsof", "-nP", `-iTCP:${String(port)}`, "-sTCP:LISTEN", "-t"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(child.stdout).text();
+    const code = await child.exited;
+    if (code !== 0) return undefined;
+    for (const line of stdout.split("\n")) {
+      const pid = Number.parseInt(line.trim(), 10);
+      if (Number.isInteger(pid) && pid > 0) return pid;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+export async function waitForDaemonHealth(
+  host: string,
+  port: number,
+  timeoutMs = 8_000,
+): Promise<boolean> {
+  const probeHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+  const url = `http://${probeHost}:${String(port)}/health`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return true;
+    } catch {
+      // keep polling
+    }
+    await Bun.sleep(150);
+  }
+  return false;
+}

--- a/packages/runtime/src/cli-app.ts
+++ b/packages/runtime/src/cli-app.ts
@@ -896,9 +896,8 @@ function registerUpdateCommand(program: Command): void {
 /**
  * Register `jazz daemon` — the long-lived HTTP server.
  *
- * One command, in the foreground. Supervision belongs to whatever already supervises this
- * host: the bridge ships as a container, scheduled workflows use launchd. A daemon that
- * forked and wrote a pidfile would be a third mechanism competing with both.
+ * Background by default (pidfile under `$JAZZ_HOME`); `--foreground` for supervisors.
+ * `jazz daemon stop` SIGTERMs the process for that port.
  */
 function registerDaemonCommand(program: Command): void {
   const daemonCommand = program
@@ -916,7 +915,11 @@ function registerDaemonCommand(program: Command): void {
       "--serve-peers <agentId>",
       "Also answer questions from configured peers, using this agent. Off unless given: a daemon for your own use should not quietly answer strangers.",
     )
-    .action((options: { port: number; host: string; servePeers?: string }) =>
+    .option(
+      "--foreground",
+      "Stay attached to the terminal (default is background). Required for systemd/launchd.",
+    )
+    .action((options: { port: number; host: string; servePeers?: string; foreground?: boolean }) =>
       // No `{ session: true }` — that opts into the fullscreen alternate-screen TUI, meant
       // for commands a human actively drives (agent create/edit, chat, persona edit). A
       // daemon is long-running but headless: it logs plain lines to stderr and blocks,
@@ -927,6 +930,7 @@ function registerDaemonCommand(program: Command): void {
             mod.daemonCommand({
               port: options.port,
               host: options.host,
+              ...(options.foreground === true ? { foreground: true } : {}),
               ...(options.servePeers !== undefined ? { peerAgent: options.servePeers } : {}),
             }),
           ),
@@ -955,6 +959,20 @@ function registerDaemonCommand(program: Command): void {
         cliRuntimeOptions(program),
       ),
     );
+
+  daemonCommand
+    .command("stop")
+    .description("Stop a background jazz daemon for this port (SIGTERM via pidfile / listener)")
+    .action(() => {
+      const daemonOptions = daemonCommand.opts<{ readonly port: number }>();
+      return runCliAction(
+        () =>
+          import("@jazz/cli/commands/daemon").then((mod) =>
+            mod.stopDaemonCommand({ port: daemonOptions.port }),
+          ),
+        cliRuntimeOptions(program),
+      );
+    });
 
   daemonCommand
     .command("install")


### PR DESCRIPTION
## Summary
- `jazz daemon` runs **in the background by default** (pidfile `$JAZZ_HOME/daemon-<port>.pid`, waits for `/health`, then returns).
- New `jazz daemon stop [--port]` — SIGTERM via pidfile / listener; no-op if nothing is running.
- `--foreground` keeps the old attached behavior; **systemd/launchd install** passes `--foreground` so Type=simple / KeepAlive still work.

## Test plan
- [ ] `jazz daemon` → prints background pid and returns to shell; `curl localhost:4747/health` works
- [ ] `jazz daemon stop` → stops it; second `stop` says nothing running
- [ ] `jazz daemon --foreground` stays attached (Ctrl+C stops)
- [ ] CI: service-install + daemon unit tests