### PR TITLE
per: 230ms→40ms startup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "@opentui/core": "^0.5.8",
         "@opentui/react": "^0.5.8",
         "@perplexity-ai/perplexity_ai": "^0.38.3",
-        "@tavily/core": "^0.7.8",
         "@types/bun": "^1.4.0",
         "@types/marked": "^6.0.0",
         "@types/marked-terminal": "^6.1.1",
@@ -123,7 +122,6 @@
         "@effect/platform-node": "^0.108.1",
         "@modelcontextprotocol/client": "^2.0.0",
         "@perplexity-ai/perplexity_ai": "^0.38.3",
-        "@tavily/core": "^0.7.8",
         "ai": "^7.0.79",
         "chalk": "^6.0.0",
         "cron-parser": "^5.10.0",
@@ -689,8 +687,6 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tavily/core": ["@tavily/core@0.7.8", "", { "dependencies": { "axios": "^1.7.7", "https-proxy-agent": "^7.0.6", "js-tiktoken": "^1.0.14" } }, "sha512-XV3SB2AxpD52SMyTjLHxoZED8K+zWLBxsQ778iCXwmYmp1zTQXwNPV7gUmJX6qLKFHwq7Tum9XVqxFqqbCwagA=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
@@ -875,7 +871,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ai": ["ai@7.0.79", "", { "dependencies": { "@ai-sdk/gateway": "4.0.64", "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zZkSUq6MgmXjwIfML2wkPFeQ5Azk8kGEWkciAtE0NgnFy3slj4ljsw5LvigsCbYXxTSVr+6iCHBTPZafpx1P0w=="],
 
@@ -918,8 +914,6 @@
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
 
@@ -1333,7 +1327,7 @@
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -1378,8 +1372,6 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
-
-    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
@@ -2003,8 +1995,6 @@
 
     "astro/js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
-    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
     "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -2124,8 +2114,6 @@
     "@puppeteer/browsers/yargs/string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
     "astro/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@opentui/core": "^0.5.8",
     "@opentui/react": "^0.5.8",
     "@perplexity-ai/perplexity_ai": "^0.38.3",
-    "@tavily/core": "^0.7.8",
     "@types/bun": "^1.4.0",
     "@types/marked": "^6.0.0",
     "@types/marked-terminal": "^6.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,6 @@
     "@effect/platform-node": "^0.108.1",
     "@modelcontextprotocol/client": "^2.0.0",
     "@perplexity-ai/perplexity_ai": "^0.38.3",
-    "@tavily/core": "^0.7.8",
     "ai": "^7.0.79",
     "chalk": "^6.0.0",
     "cron-parser": "^5.10.0",

--- a/packages/core/src/agent/tools/web-search-tools.ts
+++ b/packages/core/src/agent/tools/web-search-tools.ts
@@ -4,7 +4,6 @@
  */
 
 import Perplexity from "@perplexity-ai/perplexity_ai";
-import { tavily } from "@tavily/core";
 import { Effect, Schedule } from "effect";
 import Exa from "exa-js";
 import { LinkupClient } from "linkup-sdk";
@@ -368,26 +367,70 @@ function executeParallelSearch(
   });
 }
 
+const TAVILY_SEARCH_URL = "https://api.tavily.com/search";
+
+/**
+ * What `@tavily/core` used as its default request timeout. `fetch` has none, so
+ * without this a stalled connection would hang the tool run instead of failing.
+ */
+const TAVILY_TIMEOUT_MS = 60_000;
+
+/** The fields this tool reads from Tavily's `/search` response. */
+interface TavilySearchResponse {
+  readonly results?: readonly {
+    readonly title?: string;
+    readonly url?: string;
+    readonly content?: string;
+    readonly raw_content?: string;
+    readonly published_date?: string;
+    readonly score?: number;
+  }[];
+}
+
+/**
+ * Calls Tavily's REST endpoint directly, like every other provider in this file.
+ *
+ * Not through `@tavily/core`: that SDK depends on `js-tiktoken`, whose embedded
+ * BPE tables were 5.6MB of the compiled binary's 20MB of JavaScript — a quarter
+ * of the bundle, and about 55ms of parse on every `jazz` invocation, for a token
+ * counter this tool never asks it to use (jazz counts with `gpt-tokenizer`). The
+ * request and response shapes below are the SDK's own wire format.
+ */
 function executeTavilySearch(
   args: WebSearchArgs,
   apiKey: string,
 ): Effect.Effect<WebSearchResult, Error, LoggerService> {
   return Effect.gen(function* () {
     const logger = yield* LoggerServiceTag;
-    const client = tavily({ apiKey });
 
     yield* logger.info(`Executing Tavily search for query: "${args.query}"`);
 
     const response = yield* Effect.retry(
       Effect.tryPromise({
-        try: () =>
-          client.search(args.query, {
-            searchDepth: "basic",
-            maxResults: args.maxResults ?? DEFAULT_MAX_RESULTS,
-            includeRawContent: false,
-            ...(args.fromDate ? { startDate: args.fromDate } : {}),
-            ...(args.toDate ? { endDate: args.toDate } : {}),
-          }),
+        try: async () => {
+          const res = await fetch(TAVILY_SEARCH_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+              query: args.query,
+              search_depth: "basic",
+              max_results: args.maxResults ?? DEFAULT_MAX_RESULTS,
+              include_raw_content: false,
+              ...(args.fromDate ? { start_date: args.fromDate } : {}),
+              ...(args.toDate ? { end_date: args.toDate } : {}),
+            }),
+            signal: AbortSignal.timeout(TAVILY_TIMEOUT_MS),
+          });
+
+          if (!res.ok) {
+            throw new Error(`Tavily search failed: ${res.statusText}`);
+          }
+
+          return (await res.json()) as TavilySearchResponse;
+        },
         catch: (error) =>
           new Error(
             `Tavily search failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -396,11 +439,11 @@ function executeTavilySearch(
       SEARCH_RETRY_POLICY,
     );
 
-    const results: WebSearchItem[] = (response.results || []).map((result) => ({
+    const results: WebSearchItem[] = (response.results ?? []).map((result) => ({
       title: result.title || "",
       url: result.url || "",
-      snippet: result.rawContent || result.content || "",
-      ...(result.publishedDate ? { publishedDate: result.publishedDate } : {}),
+      snippet: result.raw_content || result.content || "",
+      ...(result.published_date ? { publishedDate: result.published_date } : {}),
       ...(result.score !== undefined ? { metadata: { score: result.score } } : {}),
     }));
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -181,6 +181,7 @@ async function buildStandaloneBinary(compileTarget: string): Promise<string> {
     entrypoints: ["packages/runtime/src/entry.ts"],
     target: "bun",
     minify: true,
+    splitting: true,
     plugins: createStandalonePlugins(generatedAssets),
     compile: { target: compileTarget, outfile },
   });


### PR DESCRIPTION
Chasing the compiled binary's startup turned up something worse than slow startup: **every command that loads the agent stack currently crashes in the release binary.**

## The crash

On a binary built from this branch's base, with no changes:

```
$ jazz agent list
Fatal error: ... ReferenceError: RpN is not defined
$ jazz persona list
Fatal error: ... ReferenceError: ...
```

`--version` and `--help` work, because they never reach past Commander. Everything that goes through `runCliAction` dies. Unminified, the error names its cause: `ReferenceError: undici is not defined` — a hoisted-variable reference evaluated during Bun's eager instantiation of the single bundled module graph, before the entrypoint's first statement runs.

I verified this is pre-existing by building from a completely untouched tree, so it is not introduced by either commit here.

## The fix, and the startup answer

`splitting: true` emits the dynamically-imported parts as separate chunks inside the binary. The entry chunk is all that loads up front and the rest arrives when a command asks for it — which is what `cli-app.ts`'s lazy `import()`s were written to expect. That fixes the crash *and* the startup cost:

| | before | after |
| --- | --- | --- |
| `jazz --version` | 230 ms | **40 ms** |
| `jazz agent list` | crash | **1.08 s** |
| binary | 82.0 MB | 81.9 MB |

1.08 s is not a regression — the same command from source takes ~1.3 s, so on-demand chunk loading costs less than the transpile it replaces.

## What I ruled out along the way

- **Bytecode compilation**, the usual answer to instantiation cost: Bun 1.3.4 supports it for CommonJS output only ("Eventually we'll add esm support as well"), and CommonJS cannot express the top-level await in `@opentui/core`. Worth revisiting when Bun adds ESM support — it would be a one-line change.
- **Bundle size.** The pre-entry cost tracks module count, not bytes: cutting 5.7 MB (28% of the bundle) moved it from 218 ms to 221 ms, i.e. not at all. Effect is 822 of the 3462 modules but only 0.56 MB, so byte-based intuitions mislead here.
- **Embedded assets.** All of `personas/`, `skills/`, `workflows/` and `vendor/` together are 1.2 MB. Not a factor.

## Second commit: dropping `@tavily/core`

Found while measuring: `@tavily/core` pulls `js-tiktoken`, whose embedded BPE tables were 5.6 MB of the binary's 20 MB of JavaScript — a quarter of it, for a token counter this tool never asks Tavily to use, in a codebase that already counts with `gpt-tokenizer`. It also brought axios and https-proxy-agent for one HTTP POST.

The single call site now uses `fetch`, as the Brave, Exa and Perplexity branches beside it already do. Request and response shapes come from the SDK's own compiled wire format rather than from documentation, so the body (`search_depth`, `max_results`, `include_raw_content`, `start_date`/`end_date`) and the fields read back (`raw_content`, `published_date`, `score`) match what it sent and parsed; its 60-second default timeout is kept explicitly, since `fetch` has none.

Bundled JavaScript 20.70 MB → 14.99 MB; binary 87.5 MB → 82.0 MB. **Startup is unchanged by it** — this is dependency and download-size hygiene, not a speed fix. Easy to drop if you would rather keep the SDK.

## Verification

- `bun test` — 3864 pass, 0 fail
- `bun run typecheck` — clean; eslint and prettier — clean
- Compiled binary exercised by hand: `--version`, `--help`, `agent list`, `persona list`, `config`

Worth noting for CI: nothing in the test suite builds or runs the compiled binary, which is why a crash on every real command could sit in the release artifact unnoticed. A smoke test that builds the host binary and runs `agent list` would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
