### PR TITLE
perf(build): bytecode-compile the binary, require Bun >= 1.4, and smoke-test it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,40 @@ jobs:
       - name: Build
         run: bun run build:binary
 
+      # The build above proves the binary compiles; it does not prove it runs.
+      # A release once shipped a binary where every command that loaded the
+      # agent stack died during module instantiation, while `--version` and
+      # `--help` still worked — the build was green throughout.
+      #
+      # Asserts on output rather than exit status on purpose: that failure
+      # printed "Fatal error" and still exited 0, so a status check would have
+      # sailed past it.
+      - name: Smoke-test the compiled binary
+        env:
+          JAZZ_HOME: ${{ runner.temp }}/jazz-smoke-home
+        run: |
+          set -euo pipefail
+          binary="deploy/binaries/jazz-linux-$(if [ "$(uname -m)" = "x86_64" ]; then echo x64; else echo arm64; fi)"
+          version="$(bun --print 'require("./package.json").version')"
+
+          check() {
+            expected="$1"
+            shift
+            printf '  jazz %s\n' "$*"
+            output="$("$binary" "$@" 2>&1 || true)"
+            if ! printf '%s' "$output" | grep -qF -- "$expected"; then
+              printf 'expected %s in the output of `jazz %s`, got:\n%s\n' "$expected" "$*" "$output" >&2
+              exit 1
+            fi
+          }
+
+          check "$version" --version
+          check "Usage: jazz" --help
+          # Reaches the agent stack, which is what the shipped crash broke.
+          check "No agents found" agent list
+          # Reads a persona out of the binary's embedded assets.
+          check "Personas" persona list
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,14 +101,8 @@ jobs:
       - name: Build
         run: bun run build:binary
 
-      # The build above proves the binary compiles; it does not prove it runs.
-      # A release once shipped a binary where every command that loaded the
-      # agent stack died during module instantiation, while `--version` and
-      # `--help` still worked — the build was green throughout.
-      #
-      # Asserts on output rather than exit status on purpose: that failure
-      # printed "Fatal error" and still exited 0, so a status check would have
-      # sailed past it.
+      # Building proves it compiles, not that it runs. Asserts on output, not
+      # exit status: the crash this exists for printed "Fatal error" and exited 0.
       - name: Smoke-test the compiled binary
         env:
           JAZZ_HOME: ${{ runner.temp }}/jazz-smoke-home

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "description": "One agent. Every surface. Your rules.",
   "engines": {
+    "bun": ">=1.4.0",
     "node": ">=22.16.0",
     "npm": ">=10.0.0"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -182,6 +182,12 @@ async function buildStandaloneBinary(compileTarget: string): Promise<string> {
     target: "bun",
     minify: true,
     splitting: true,
+    // ESM bytecode needs Bun >= 1.4 (1.3 rejected it: "format must be 'cjs'").
+    // CI installs `latest`, so this is a floor on contributors' local Bun, and
+    // the failure if it is older is an explicit build error rather than a
+    // silently slower binary.
+    format: "esm",
+    bytecode: true,
     plugins: createStandalonePlugins(generatedAssets),
     compile: { target: compileTarget, outfile },
   });

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -10,14 +10,9 @@ import { ensureNativeLibrariesForTarget } from "./opentui-natives";
  * only into macOS binaries; the others are platform-independent.
  */
 /**
- * Minimum Bun for the compile step.
- *
- * `bytecode: true` below needs ESM bytecode support, which landed in Bun 1.4;
- * 1.3 refuses it from deep inside the bundler with "format must be 'cjs' when
- * bytecode is true", which says nothing about what to do about it. Bun does
- * not enforce `engines.bun` itself — an impossible range installs cleanly —
- * so the requirement is checked here, where it actually applies. Everything
- * else in the repo (tests, the CLI from source) still runs on older Bun.
+ * `bytecode: true` below needs ESM bytecode, added in Bun 1.4. Checked here
+ * rather than via `engines.bun`, which Bun does not enforce — and only here,
+ * since tests and the CLI from source still run on older Bun.
  */
 const MINIMUM_BUN_VERSION = [1, 4] as const;
 
@@ -204,10 +199,6 @@ async function buildStandaloneBinary(compileTarget: string): Promise<string> {
     target: "bun",
     minify: true,
     splitting: true,
-    // ESM bytecode needs Bun >= 1.4 (1.3 rejected it: "format must be 'cjs'").
-    // CI installs `latest`, so this is a floor on contributors' local Bun, and
-    // the failure if it is older is an explicit build error rather than a
-    // silently slower binary.
     format: "esm",
     bytecode: true,
     plugins: createStandalonePlugins(generatedAssets),

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,6 +9,28 @@ import { ensureNativeLibrariesForTarget } from "./opentui-natives";
  * `vendor/` holds the macOS `terminal-notifier` app bundles and is embedded
  * only into macOS binaries; the others are platform-independent.
  */
+/**
+ * Minimum Bun for the compile step.
+ *
+ * `bytecode: true` below needs ESM bytecode support, which landed in Bun 1.4;
+ * 1.3 refuses it from deep inside the bundler with "format must be 'cjs' when
+ * bytecode is true", which says nothing about what to do about it. Bun does
+ * not enforce `engines.bun` itself — an impossible range installs cleanly —
+ * so the requirement is checked here, where it actually applies. Everything
+ * else in the repo (tests, the CLI from source) still runs on older Bun.
+ */
+const MINIMUM_BUN_VERSION = [1, 4] as const;
+
+function assertBunSupportsBytecode(): void {
+  const [major = 0, minor = 0] = Bun.version.split(".").map((part) => Number.parseInt(part, 10));
+  const [requiredMajor, requiredMinor] = MINIMUM_BUN_VERSION;
+  if (major > requiredMajor || (major === requiredMajor && minor >= requiredMinor)) return;
+  throw new Error(
+    `Compiling a binary needs Bun >= ${requiredMajor}.${requiredMinor} (found ${Bun.version}): ` +
+      `ESM bytecode compilation is unavailable before it. Run \`bun upgrade\`.`,
+  );
+}
+
 const ASSET_DIRECTORIES = ["personas", "skills", "workflows"] as const;
 const DARWIN_ONLY_ASSET_DIRECTORIES = ["vendor"] as const;
 
@@ -305,6 +327,8 @@ async function main(): Promise<void> {
       : [`bun-${process.platform}-${process.arch}`];
 
   const stageNpm = args.includes("--npm-packages");
+
+  assertBunSupportsBytecode();
 
   fs.mkdirSync(path.join("deploy", "binaries"), { recursive: true });
   for (const target of targets) {


### PR DESCRIPTION
You were right that Bun supports ESM bytecode — I had read the restriction off the locally installed Bun 1.3.4, which rejects it with *"format must be 'cjs' when bytecode is true. Eventually we'll add esm support as well."* Bun 1.4 supports it, exactly as the bundler docs say. Three commits: the bytecode itself, the version floor it needs, and the CI gap that let a broken binary ship in the first place.

## 1. Bytecode

Compiled binary, same machine, minimum of 6–8 runs each:

| | before #556 | after #556 (splitting) | this PR (+ bytecode) |
| --- | --- | --- | --- |
| `jazz --version` | 230 ms | 40 ms | **10 ms** |
| `jazz --help` | — | — | **10 ms** |
| `jazz agent list` | crash | 1.08 s | **0.28 s** |
| binary | 82.0 MB | 82.0 MB | **121.6 MB** |

#556 stopped the whole module graph loading up front. What it could not help is the work a real command does on arrival — `agent list` still spent ~1.08 s parsing and instantiating the chunks it pulls in. Bytecode removes that parse by building JavaScriptCore's cache at compile time instead of on every launch.

Both settings earn their place: bytecode alone gives 20 ms startup and the same 0.28 s for `agent list`; splitting takes startup to 10 ms. Neither subsumes the other, so the build keeps both.

**The trade:** the binary grows ~40 MB (+48%), carried by every platform's npm package. Roughly 4× off the cost of every command a user runs, against a one-time download half again as large. Dropping `bytecode: true` reverts it and leaves #556's 40 ms startup intact.

## 2. The Bun floor

ESM bytecode needs Bun ≥ 1.4. On 1.3 the build fails from inside the bundler with a message that is accurate and no help in working out that the answer is `bun upgrade`, so the compile path now checks first and says so itself.

`engines.bun` records the requirement where people look for it, but the check does not rely on it — **Bun does not enforce `engines` at all**, which I confirmed by setting `">=99.0.0"` and watching `bun install` finish happily. There is no `engine-strict` equivalent in bunfig either.

Scoped to the compile step, not the whole repo: tests and the CLI from source still run on older Bun, so a contributor who never builds a binary is unaffected. Every workflow already installs `bun-version: latest`, so CI needs no change.

## 3. CI runs the binary now

CI already ran `build:binary` — so the compile was covered, and nothing ever *ran* the result. That is precisely how #556's crash shipped: every command reaching the agent stack died during module instantiation while `--version` and `--help` worked, with CI green throughout.

Four checks after the existing build step, in the same job so there is no second install or compile: `--version` (against the manifest version), `--help`, `agent list` (the agent stack), and `persona list` (a read out of the embedded assets).

They assert on **output, not exit status**, which is the part that matters: that crash printed `Fatal error` and still exited 0, so a status check would have sailed past it. Verified in both directions — the checks pass against a working binary, and fail against one that does not answer `agent list`.

One honest note on that crash: it no longer reproduces on current `main`. Dropping `@tavily/core` in #556 shifted the bundle enough to stop triggering what looks like a module-hoisting bug in Bun's single-bundle output. So it was latent rather than fixed, which is an argument for the smoke test rather than against it — the next dependency change could bring it back, and splitting plus bytecode avoid that eager-instantiation path altogether.

## Verification

Exercised on the compiled binary: `--version`, `--help`, `agent list`, `persona list`, `config`, `peers --help`. The version guard was tested by temporarily raising the floor to 99.0 and confirming the error fires. Prettier, ESLint and typecheck clean; the CI YAML parses and its smoke script was run locally against the real binary. No source changes, so the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
