### PR TITLE
test(bots): catch the bridge tool list drifting between its three copies

### DIFF
--- a/packages/bot-shared/src/seed-agent.test.ts
+++ b/packages/bot-shared/src/seed-agent.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_BRIDGE_TOOLS } from "./seed-agent";
+
+/**
+ * The containerised bridges seed their template agent from a JSON file rather
+ * than from this constant: their entrypoint substitutes a provider and model
+ * into it with `sed`, long before any TypeScript runs, so it cannot import one.
+ *
+ * That leaves the same list written out three times with nothing keeping them
+ * together - and drift is silent, because a tool added here simply never
+ * reaches Telegram or Discord. Until the container path seeds itself through
+ * `ensureSeedAgent` too, this is what notices.
+ */
+const TEMPLATES = [
+  "../../telegram-bot/src/agent.telegram.json",
+  "../../discord-bot/src/agent.discord.json",
+] as const;
+
+describe("DEFAULT_BRIDGE_TOOLS", () => {
+  for (const relative of TEMPLATES) {
+    const surface = relative.includes("telegram") ? "telegram" : "discord";
+
+    test(`matches the ${surface} container template, which is seeded separately`, () => {
+      const template = JSON.parse(readFileSync(join(import.meta.dir, relative), "utf8")) as {
+        config: { tools: readonly string[] };
+      };
+
+      expect(template.config.tools).toEqual([...DEFAULT_BRIDGE_TOOLS]);
+    });
+  }
+});


### PR DESCRIPTION
`DEFAULT_BRIDGE_TOOLS` is written out three times, byte-identical including order:

| Copy | Tools |
| --- | --- |
| `packages/bot-shared/src/seed-agent.ts` | 21 |
| `packages/telegram-bot/src/agent.telegram.json` | 21 |
| `packages/discord-bot/src/agent.discord.json` | 21 |

`seed-agent.ts` already acknowledges it in its own docstring: *"the container templates already agreed on this list."*

## Why there are three

Two seeding paths. The native bridges (iMessage, WhatsApp) call `ensureSeedAgent`, which reads the constant. The containerised bridges seed from JSON, because `entrypoint.sh` substitutes `__JAZZ_PROVIDER__`, `__JAZZ_MODEL__` and `__JAZZ_REASONING__` into it with `sed` before any TypeScript runs - so it cannot import a TS constant.

Nothing kept the copies together, and the drift is silent: add a tool to the constant and Telegram and Discord simply never get it. No test, no type, no build step notices.

## What this adds

One test that fails when they diverge. Verified by appending a tool to the Telegram template - it fails naming the surface - then reverting.

This is deliberately a guard, not the fix.

## The actual fix, not done here

Have the container bridges call `ensureSeedAgent` too, then delete both JSON templates and the `sed` block. The three values the `sed` substitutes are exactly the `SeedAgentSpec` fields, so the shape already fits.

It is a behaviour change rather than a refactor, which is why it is not in this PR: the entrypoint **rewrites** the template on every restart, where `ensureSeedAgent` deliberately never overwrites, so a model or persona chosen from a phone survives. Unifying them means container restarts stop clobbering the template - defensible, arguably a fix, but it wants testing against Docker.