### PR TITLE
fix(website): docs prose had no vertical spacing at all

### DIFF
--- a/packages/website/src/layouts/Blog.astro
+++ b/packages/website/src/layouts/Blog.astro
@@ -131,7 +131,7 @@ const { title, description, image, jsonLd } = Astro.props;
     overflow-x: auto;
     font-size: 13.5px;
     line-height: 1.7;
-    margin: 1rem 0;
+    margin: 1.6rem 0;
   }
   article.post pre code {
     background: none;

--- a/packages/website/src/layouts/Docs.astro
+++ b/packages/website/src/layouts/Docs.astro
@@ -262,7 +262,7 @@ const jsonLd = [
 
 <style is:global>
   /* Docs prose — calm on purpose: no ambient motion on these pages. */
-  article > :global(*) + :global(*) {
+  article > * + * {
     margin-top: 0.9em;
   }
   article h1 {
@@ -308,6 +308,7 @@ const jsonLd = [
     border: 1px solid var(--jz-border);
     border-radius: 6px;
     padding: 14px 16px;
+    margin: 1.6rem 0;
     overflow-x: auto;
     font-size: 13.5px;
     line-height: 1.7;


### PR DESCRIPTION
Started as "more room around code blocks", turned out to be a dead selector.

## Root cause

`Docs.astro` had this inside a `<style is:global>` block:

```css
article > :global(*) + :global(*) { margin-top: 0.9em; }
```

Astro only rewrites `:global()` in **scoped** style blocks. In a global block it ships the selector verbatim, `:global()` isn't real CSS, so the browser threw the whole rule away. Every docs page has been rendering with zero margin between prose elements — paragraphs, lists, code blocks, all of it.

Fixed to `article > * + *`.

## Also

`margin: 1.6rem 0` on `article pre` (docs) and `article.post pre` (blog, was `1rem`), so code blocks get their own breathing room rather than the generic sibling gap.

## Verified

In the rebuilt CSS: `article>*+*{margin-top:.9em}`, `article pre{…margin:1.6rem 0…}`, and no `:global(` left anywhere in the output.

## Worth a look before merging

Re-enabling that rule adds 0.9em between *all* docs prose elements, not just code blocks — docs pages read noticeably looser now. That was clearly the original intent, but this is the first build where it actually renders, so it's worth eyeballing a docs page.