### PR TITLE
fix(llm): run the stream logs that void had been discarding, cap the awaits the idle watchdog never saw

### DIFF
--- a/packages/adapters/src/llm/ai-sdk-service.ts
+++ b/packages/adapters/src/llm/ai-sdk-service.ts
@@ -86,7 +86,7 @@ import {
   type ToolSet,
   type TypedToolCall,
 } from "ai";
-import { Chunk, Effect, Layer, Option, Stream } from "effect";
+import { Chunk, Duration, Effect, Layer, Option, Stream } from "effect";
 import { createOllama } from "ollama-ai-provider-v2";
 import shortUUID from "short-uuid";
 import { minimax } from "vercel-minimax-ai-provider";
@@ -103,7 +103,7 @@ import {
 } from "./models";
 import { selectParser } from "./reasoning";
 import { extractReasoningParts } from "./reasoning-parts";
-import { StreamProcessor } from "./stream-processor";
+import { resolveStreamIdleTimeoutMs, StreamProcessor } from "./stream-processor";
 
 /** DelayedPromise fields on streamText results reject when the stream fails. */
 const STREAM_TEXT_PROMISE_FIELDS = [
@@ -588,8 +588,10 @@ function getProviderNativeWebSearchTool(
     }
   } catch (error) {
     if (logger) {
-      void logger.warn(
-        `[Web Search Error] Failed to get native web search tool for ${providerName}: ${error instanceof Error ? error.message : String(error)}`,
+      Effect.runFork(
+        logger.warn(
+          `[Web Search Error] Failed to get native web search tool for ${providerName}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
       );
     }
     return null;
@@ -1304,6 +1306,9 @@ class AISDKService implements LLMService {
   ): Promise<ModelInfo | undefined> {
     const models = await Effect.runPromise(
       this.getProviderModels(providerName).pipe(
+        Effect.timeout(
+          Duration.millis(resolveStreamIdleTimeoutMs(this.config.llmConfig?.streamIdleTimeoutMs)),
+        ),
         Effect.catchAll(() => Effect.succeed([] as readonly ModelInfo[])),
       ),
     );
@@ -1396,8 +1401,10 @@ class AISDKService implements LLMService {
         !selectedExternalProvider &&
         !hasSelectedProviderKey;
       if (isXaiLiveSearch) {
-        void this.logger.debug(
-          `[Web Search] Using xAI Live Search (searchParameters) for ${providerName}`,
+        Effect.runFork(
+          this.logger.debug(
+            `[Web Search] Using xAI Live Search (searchParameters) for ${providerName}`,
+          ),
         );
         delete tools["web_search"];
         providerNativeToolNames.add("web_search");
@@ -1409,19 +1416,25 @@ class AISDKService implements LLMService {
       const shouldUseExternal = selectedExternalProvider && hasSelectedProviderKey;
 
       if (!isXaiLiveSearch && shouldUseProviderNative) {
-        void this.logger.debug(
-          `[Web Search] Using provider-native web search tool for ${providerName} (builtin selected, no external provider configured)`,
+        Effect.runFork(
+          this.logger.debug(
+            `[Web Search] Using provider-native web search tool for ${providerName} (builtin selected, no external provider configured)`,
+          ),
         );
         tools["web_search"] = providerNativeWebSearch;
         providerNativeToolNames.add("web_search");
       } else if (shouldUseExternal) {
-        void this.logger.debug(
-          `[Web Search] Using Jazz web_search tool with external provider: ${selectedExternalProvider}`,
+        Effect.runFork(
+          this.logger.debug(
+            `[Web Search] Using Jazz web_search tool with external provider: ${selectedExternalProvider}`,
+          ),
         );
         // Keep Jazz's web_search tool - it will route to the external provider
       } else if (!isXaiLiveSearch && !providerNativeWebSearch && !shouldUseExternal) {
-        void this.logger.debug(
-          `[Web Search] web_search tool available but may fail: provider ${providerName} has no native support and no external provider configured`,
+        Effect.runFork(
+          this.logger.debug(
+            `[Web Search] web_search tool available but may fail: provider ${providerName} has no native support and no external provider configured`,
+          ),
         );
         // Keep Jazz's web_search tool but it will return an error when called
       }
@@ -1432,8 +1445,8 @@ class AISDKService implements LLMService {
     if (hasWebFetch) {
       const providerNativeWebFetch = getProviderNativeWebFetchTool(providerName);
       if (providerNativeWebFetch) {
-        void this.logger.debug(
-          `[Web Fetch] Using provider-native web fetch tool for ${providerName}`,
+        Effect.runFork(
+          this.logger.debug(`[Web Fetch] Using provider-native web fetch tool for ${providerName}`),
         );
         tools["web_fetch"] = providerNativeWebFetch;
         providerNativeToolNames.add("web_fetch");
@@ -1449,11 +1462,15 @@ class AISDKService implements LLMService {
         schemaCharCount(toolDef);
     }
 
-    void this.logger.debug(
-      `[Tool Telemetry] ${Object.keys(tools).length} tools, ~${toolDefinitionChars} chars (~${Math.ceil(toolDefinitionChars / 4)} tokens est.) sent to ${providerName}`,
+    Effect.runFork(
+      this.logger.debug(
+        `[Tool Telemetry] ${Object.keys(tools).length} tools, ~${toolDefinitionChars} chars (~${Math.ceil(toolDefinitionChars / 4)} tokens est.) sent to ${providerName}`,
+      ),
     );
-    void this.logger.debug(
-      `[LLM Timing] Tool conversion (${Object.keys(tools).length} tools) took ${Date.now() - toolConversionStart}ms`,
+    Effect.runFork(
+      this.logger.debug(
+        `[LLM Timing] Tool conversion (${Object.keys(tools).length} tools) took ${Date.now() - toolConversionStart}ms`,
+      ),
     );
 
     return { tools, providerNativeToolNames, toolDefinitionChars };
@@ -1471,14 +1488,16 @@ class AISDKService implements LLMService {
           options.providerApiKeys,
         );
         const timingStart = Date.now();
-        void this.logger.debug(
-          `[LLM Timing] Starting non-streaming completion for ${providerName}:${options.model}`,
+        Effect.runFork(
+          this.logger.debug(
+            `[LLM Timing] Starting non-streaming completion for ${providerName}:${options.model}`,
+          ),
         );
 
         const modelSelectStart = Date.now();
         const model = selectModel(providerName, options.model, effectiveLLMConfig, this.modelCache);
-        void this.logger.debug(
-          `[LLM Timing] Model selection took ${Date.now() - modelSelectStart}ms`,
+        Effect.runFork(
+          this.logger.debug(`[LLM Timing] Model selection took ${Date.now() - modelSelectStart}ms`),
         );
 
         const modelInfo = await this.resolveModelInfo(providerName, options.model);
@@ -1514,12 +1533,14 @@ class AISDKService implements LLMService {
           this.logger,
         );
         const coreMessages = toCoreMessages(options.messages, providerName, resolvedAttachments);
-        void this.logger.debug(
-          `[LLM Timing] Message conversion (${options.messages.length} messages) took ${Date.now() - messageConversionStart}ms`,
+        Effect.runFork(
+          this.logger.debug(
+            `[LLM Timing] Message conversion (${options.messages.length} messages) took ${Date.now() - messageConversionStart}ms`,
+          ),
         );
 
         const generateTextStart = Date.now();
-        void this.logger.debug(`[LLM Timing] Calling generateText...`);
+        Effect.runFork(this.logger.debug(`[LLM Timing] Calling generateText...`));
         const result = await generateText({
           model,
           messages: coreMessages,
@@ -1533,14 +1554,20 @@ class AISDKService implements LLMService {
           ...(providerOptions ? { providerOptions } : {}),
           stopWhen: stepCountIs(AI_SDK_MAX_STEPS),
         });
-        void this.logger.debug(
-          `[LLM Timing] generateText completed in ${Date.now() - generateTextStart}ms`,
+        Effect.runFork(
+          this.logger.debug(
+            `[LLM Timing] generateText completed in ${Date.now() - generateTextStart}ms`,
+          ),
         );
-        void this.logger.info(`[LLM Timing] Total completion time: ${Date.now() - timingStart}ms`);
+        Effect.runFork(
+          this.logger.info(`[LLM Timing] Total completion time: ${Date.now() - timingStart}ms`),
+        );
 
         if (toolsDisabled) {
-          void this.logger.info(
-            `Tools were provided but skipped because ${options.model} does not support tools`,
+          Effect.runFork(
+            this.logger.info(
+              `Tools were provided but skipped because ${options.model} does not support tools`,
+            ),
           );
         }
 
@@ -1579,10 +1606,12 @@ class AISDKService implements LLMService {
           // Log provider-native tool calls so they're visible to the user
           for (const tc of result.toolCalls) {
             if (providerNativeToolNames.has(tc.toolName)) {
-              void this.logger.info(`Provider-native tool used: ${tc.toolName}`, {
-                provider: providerName,
-                toolName: tc.toolName,
-              });
+              Effect.runFork(
+                this.logger.info(`Provider-native tool used: ${tc.toolName}`, {
+                  provider: providerName,
+                  toolName: tc.toolName,
+                }),
+              );
             }
           }
 
@@ -1644,7 +1673,7 @@ class AISDKService implements LLMService {
         const cleanMessage = extractCleanErrorMessage(error);
 
         // Log clean error message at error level (user-facing)
-        void this.logger.error(`LLM Error: ${llmError._tag} - ${cleanMessage}`);
+        Effect.runFork(this.logger.error(`LLM Error: ${llmError._tag} - ${cleanMessage}`));
 
         // Log detailed error information at debug level (for debugging)
         const errorDetails: Record<string, unknown> = {
@@ -1671,7 +1700,7 @@ class AISDKService implements LLMService {
           errorDetails["requestBodyValues"] = truncatedRequestBody;
         }
 
-        void this.logger.debug("LLM Error Details", errorDetails);
+        Effect.runFork(this.logger.debug("LLM Error Details", errorDetails));
 
         return llmError;
       },
@@ -1713,14 +1742,16 @@ class AISDKService implements LLMService {
           options.providerApiKeys,
         );
         const timingStart = Date.now();
-        void this.logger.debug(
-          `[LLM Timing] ⏱️  Starting streaming completion for ${providerName}:${options.model}`,
+        Effect.runFork(
+          this.logger.debug(
+            `[LLM Timing] ⏱️  Starting streaming completion for ${providerName}:${options.model}`,
+          ),
         );
 
         const modelSelectStart = Date.now();
         const model = selectModel(providerName, options.model, effectiveLLMConfig, this.modelCache);
-        void this.logger.debug(
-          `[LLM Timing] Model selection took ${Date.now() - modelSelectStart}ms`,
+        Effect.runFork(
+          this.logger.debug(`[LLM Timing] Model selection took ${Date.now() - modelSelectStart}ms`),
         );
 
         const providerOptions = buildProviderOptions(
@@ -1738,8 +1769,10 @@ class AISDKService implements LLMService {
           this.logger,
         );
         const coreMessages = toCoreMessages(options.messages, providerName, resolvedAttachments);
-        void this.logger.debug(
-          `[LLM Timing] Message conversion (${options.messages.length} messages) took ${Date.now() - messageConversionStart}ms`,
+        Effect.runFork(
+          this.logger.debug(
+            `[LLM Timing] Message conversion (${options.messages.length} messages) took ${Date.now() - messageConversionStart}ms`,
+          ),
         );
 
         return { timingStart, model, providerOptions, coreMessages };
@@ -1762,8 +1795,10 @@ class AISDKService implements LLMService {
               let streamTextResult: Awaited<ReturnType<typeof streamText>> | undefined;
               try {
                 const streamTextStart = Date.now();
-                void this.logger.debug(
-                  `[LLM Timing] 🚀 Calling streamText at +${streamTextStart - timingStart}ms...`,
+                Effect.runFork(
+                  this.logger.debug(
+                    `[LLM Timing] 🚀 Calling streamText at +${streamTextStart - timingStart}ms...`,
+                  ),
                 );
 
                 const modelInfo = await this.resolveModelInfo(providerName, options.model);
@@ -1787,8 +1822,10 @@ class AISDKService implements LLMService {
                 const tools = prepared?.tools;
 
                 if (toolsDisabled) {
-                  void this.logger.info(
-                    `Tools were provided but skipped because ${options.model} does not support tools`,
+                  Effect.runFork(
+                    this.logger.info(
+                      `Tools were provided but skipped because ${options.model} does not support tools`,
+                    ),
                   );
                 }
 
@@ -1809,8 +1846,10 @@ class AISDKService implements LLMService {
                 });
                 const result = streamTextResult;
 
-                void this.logger.debug(
-                  `[LLM Timing] ✓ streamText returned (initialization) in ${Date.now() - streamTextStart}ms`,
+                Effect.runFork(
+                  this.logger.debug(
+                    `[LLM Timing] ✓ streamText returned (initialization) in ${Date.now() - streamTextStart}ms`,
+                  ),
                 );
 
                 const providerNativeToolNames = prepared?.providerNativeToolNames;
@@ -1847,10 +1886,19 @@ class AISDKService implements LLMService {
                 // `files` resolves once the stream finishes, so media a model emitted mid-answer
                 // is saved after the text has already been rendered. Awaited here rather than in
                 // the processor so streaming stays purely about text deltas.
-                const streamedArtifacts = await saveModelGeneratedFiles(
-                  await result.files,
-                  options.model,
-                );
+                const files = await Promise.race([
+                  result.files,
+                  new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 5_000)),
+                ]);
+                if (files === undefined) {
+                  Effect.runFork(
+                    this.logger.warn(
+                      "[LLM] Stream finished but `files` never resolved; skipping generated-file capture",
+                      { provider: providerName, model: options.model },
+                    ),
+                  );
+                }
+                const streamedArtifacts = await saveModelGeneratedFiles(files ?? [], options.model);
 
                 // Resolve deferred for consumers who just await response
                 responseDeferred.resolve(
@@ -1906,9 +1954,9 @@ class AISDKService implements LLMService {
 
                 const cleanMessage = extractCleanErrorMessage(error);
                 // Log clean error message at error level (user-facing)
-                void this.logger.error(`LLM Error: ${llmError._tag} - ${cleanMessage}`);
+                Effect.runFork(this.logger.error(`LLM Error: ${llmError._tag} - ${cleanMessage}`));
                 // Log detailed error information at debug level (for debugging)
-                void this.logger.debug("LLM Error Details", errorDetails);
+                Effect.runFork(this.logger.debug("LLM Error Details", errorDetails));
 
                 void emit(Effect.fail(Option.some(llmError)));
 

--- a/packages/adapters/src/llm/stream-processor.test.ts
+++ b/packages/adapters/src/llm/stream-processor.test.ts
@@ -10,9 +10,10 @@ import {
 } from "./stream-processor";
 
 describe("StreamProcessor", () => {
+  const logged: string[] = [];
   const mockLogger = {
-    debug: mock(() => {}),
-    warn: mock(() => {}),
+    debug: mock((message: string) => Effect.sync(() => logged.push(`debug:${message}`))),
+    warn: mock((message: string) => Effect.sync(() => logged.push(`warn:${message}`))),
   } as unknown as LoggerService;
 
   it("should process text deltas and emit events", async () => {
@@ -407,6 +408,30 @@ describe("StreamProcessor", () => {
   });
 
   // -------------------------------------------------------------------------
+  it("runs its log effects instead of discarding them", async () => {
+    logged.length = 0;
+    const emit = (eff: Effect.Effect<Chunk.Chunk<any>, any>) => {
+      Effect.runSync(eff);
+    };
+
+    const processor = new StreamProcessor(
+      { providerName: "p1", modelName: "m1", hasReasoningEnabled: false, startTime: Date.now() },
+      emit,
+      mockLogger,
+    );
+
+    await processor.process({
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "hi" };
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 1, totalTokens: 2 }),
+    } as any);
+
+    expect(logged.some((line) => line.includes("Starting to process fullStream"))).toBe(true);
+    expect(logged.some((line) => line.includes("FIRST TOKEN arrived"))).toBe(true);
+  });
+
   // Integration: selectParser → StreamProcessor end-to-end routing
   //
   // These tests cross the seam between the parser registry and the stream

--- a/packages/adapters/src/llm/stream-processor.ts
+++ b/packages/adapters/src/llm/stream-processor.ts
@@ -259,7 +259,7 @@ export class StreamProcessor {
     });
 
     // Start processing stream
-    void this.logger.debug(`[LLM Timing] 🔄 Starting to process fullStream...`);
+    Effect.runFork(this.logger.debug(`[LLM Timing] 🔄 Starting to process fullStream...`));
     const streamProcessStart = Date.now();
     await this.processFullStream(result);
 
@@ -267,8 +267,10 @@ export class StreamProcessor {
       this.routeParsedChunk(this.config.reasoningParser.flush());
     }
 
-    void this.logger.debug(
-      `[LLM Timing] ✓ Stream processing completed in ${Date.now() - streamProcessStart}ms`,
+    Effect.runFork(
+      this.logger.debug(
+        `[LLM Timing] ✓ Stream processing completed in ${Date.now() - streamProcessStart}ms`,
+      ),
     );
 
     // Wait for completion
@@ -357,8 +359,10 @@ export class StreamProcessor {
             // remain visible to the user rather than be silently dropped.
             if (this.state.reasoningSequence === 0) {
               const firstReasoningLatency = Date.now() - this.config.startTime;
-              void this.logger.debug(
-                `[LLM Timing] 🧠 REASONING START arrived after ${firstReasoningLatency}ms`,
+              Effect.runFork(
+                this.logger.debug(
+                  `[LLM Timing] 🧠 REASONING START arrived after ${firstReasoningLatency}ms`,
+                ),
               );
               void this.emitEvent({ type: "thinking_start", provider: this.config.providerName });
               this.recordFirstToken("reasoning");
@@ -375,8 +379,10 @@ export class StreamProcessor {
               // Emit thinking start if we haven't received reasoning-start event
               if (this.state.reasoningSequence === 0) {
                 const firstReasoningLatency = Date.now() - this.config.startTime;
-                void this.logger.debug(
-                  `[LLM Timing] 🧠 FIRST REASONING TOKEN arrived after ${firstReasoningLatency}ms`,
+                Effect.runFork(
+                  this.logger.debug(
+                    `[LLM Timing] 🧠 FIRST REASONING TOKEN arrived after ${firstReasoningLatency}ms`,
+                  ),
                 );
                 void this.emitEvent({ type: "thinking_start", provider: this.config.providerName });
                 this.recordFirstToken("reasoning");
@@ -523,7 +529,9 @@ export class StreamProcessor {
               finishReason !== "length" &&
               finishReason !== "tool-calls"
             ) {
-              void this.logger.warn(`[StreamProcessor] Unexpected finish reason: ${finishReason}`);
+              Effect.runFork(
+                this.logger.warn(`[StreamProcessor] Unexpected finish reason: ${finishReason}`),
+              );
             }
             break;
           }
@@ -535,13 +543,15 @@ export class StreamProcessor {
       }
     } catch (error) {
       if (error instanceof Error && error.name === "AI_TypeValidationError") {
-        void this.logger.warn(
-          `[StreamProcessor] AI SDK validation error (likely due to provider-specific content format): ${error.message}`,
-          {
-            provider: this.config.providerName,
-            model: this.config.modelName,
-            errorName: error.name,
-          },
+        Effect.runFork(
+          this.logger.warn(
+            `[StreamProcessor] AI SDK validation error (likely due to provider-specific content format): ${error.message}`,
+            {
+              provider: this.config.providerName,
+              model: this.config.modelName,
+              errorName: error.name,
+            },
+          ),
         );
 
         throw error;
@@ -556,7 +566,9 @@ export class StreamProcessor {
   private emitVisibleText(textChunk: string): void {
     if (!this.state.hasStartedText) {
       const firstTokenLatency = Date.now() - this.config.startTime;
-      void this.logger.debug(`[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`);
+      Effect.runFork(
+        this.logger.debug(`[LLM Timing] 🎯 FIRST TOKEN arrived after ${firstTokenLatency}ms`),
+      );
       void this.emitEvent({ type: "text_start" });
       this.state.hasStartedText = true;
       this.recordFirstToken("text");
@@ -573,8 +585,10 @@ export class StreamProcessor {
   private routeParsedChunk(chunk: ParseChunk): void {
     if (chunk.thinkingStarted && this.state.reasoningSequence === 0) {
       const firstReasoningLatency = Date.now() - this.config.startTime;
-      void this.logger.debug(
-        `[LLM Timing] 🧠 PARSER REASONING START after ${firstReasoningLatency}ms`,
+      Effect.runFork(
+        this.logger.debug(
+          `[LLM Timing] 🧠 PARSER REASONING START after ${firstReasoningLatency}ms`,
+        ),
       );
       void this.emitEvent({ type: "thinking_start", provider: this.config.providerName });
       this.recordFirstToken("reasoning");

--- a/packages/cli/src/chat/commands/constants.ts
+++ b/packages/cli/src/chat/commands/constants.ts
@@ -58,6 +58,7 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "new", description: "Start a new conversation (clear context)" },
   { name: "skills", description: "List and view available skills" },
   { name: "stats", description: "Show session statistics and usage summary" },
+  { name: "info", description: "Show conversation id, title, and log file paths (same as /stats)" },
   {
     name: "switch",
     description: "Switch to a different agent in the same conversation",

--- a/packages/cli/src/chat/commands/constants.ts
+++ b/packages/cli/src/chat/commands/constants.ts
@@ -57,8 +57,10 @@ export const CHAT_COMMANDS: readonly ChatCommandInfo[] = [
   { name: "retry", description: "Re-send your last message" },
   { name: "new", description: "Start a new conversation (clear context)" },
   { name: "skills", description: "List and view available skills" },
-  { name: "stats", description: "Show session statistics and usage summary" },
-  { name: "info", description: "Show conversation id, title, and log file paths (same as /stats)" },
+  {
+    name: "info",
+    description: "Show conversation id, title, usage, and log file paths for this session",
+  },
   {
     name: "switch",
     description: "Switch to a different agent in the same conversation",

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -164,8 +164,8 @@ export function handleSpecialCommand(
       case "workflows":
         return yield* handleWorkflowsCommand(terminal);
 
-      case "stats":
-        return yield* handleStatsCommand(terminal, agent, context);
+      case "info":
+        return yield* handleInfoCommand(terminal, agent, context);
 
       case "mcp":
         return yield* handleMcpCommand(terminal, command.args);
@@ -1204,7 +1204,7 @@ function handleReasoningCommand(
  * "Session-wide" means the limit stays in effect for the rest of this
  * conversation (not just the current turn) and is checked before every turn
  * against this conversation's accumulated usage — the same numbers /cost and
- * /stats show. With no args in an interactive terminal this opens the picker
+ * /info show. With no args in an interactive terminal this opens the picker
  * (select the metric, then type a value); with no args elsewhere it prints
  * current usage and limits. A limit that's already exceeded the moment it's
  * set is reported immediately here — enforcement itself happens on the next
@@ -1892,15 +1892,15 @@ function handleSkillsCommand(
 }
 
 /**
- * Handle /stats command - Show session statistics and usage summary
+ * Handle /info command - Show session identity, usage, and where its logs are
  */
-function handleStatsCommand(
+function handleInfoCommand(
   terminal: TerminalService,
   agent: CommandContext["agent"],
   context: CommandContext,
 ): Effect.Effect<CommandResult, never, FileSystemContextService | FileSystem.FileSystem> {
   return Effect.gen(function* () {
-    yield* terminal.log(fmt.heading("Session Statistics"));
+    yield* terminal.log(fmt.heading("Session Info"));
 
     const conversation = yield* loadConversation(agent.id, context.conversationId).pipe(
       Effect.catchAll(() => Effect.succeed(null)),

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
+import path from "node:path";
 import { FileSystem } from "@effect/platform";
 import { loadConversation, loadHistory } from "@jazz/adapters/history/conversation-history-service";
+import { getLogsDirectory } from "@jazz/adapters/logger";
 import { authorizeServer, clearServerAuth, hasStoredAuth } from "@jazz/adapters/mcp/oauth";
 import { AgentRunner } from "@jazz/core/agent/agent-runner";
 import { getAgentByIdentifier } from "@jazz/core/agent/agent-service";
@@ -50,6 +52,7 @@ import type { AutoApprovePolicy } from "@jazz/core/types/tools";
 import { generateConversationId } from "@jazz/core/utils/conversation-id";
 import { describeCronSchedule } from "@jazz/core/utils/cron";
 import { createSanitizedEnv } from "@jazz/core/utils/env";
+import { conversationLogGroup } from "@jazz/core/utils/log-group";
 import { getModelsDevMetadata } from "@jazz/core/utils/models-dev";
 import type { WorkflowMetadata } from "@jazz/core/workflows/workflow-service";
 import { WorkflowServiceTag, type WorkflowService } from "@jazz/core/workflows/workflow-service";
@@ -1895,9 +1898,16 @@ function handleStatsCommand(
   terminal: TerminalService,
   agent: CommandContext["agent"],
   context: CommandContext,
-): Effect.Effect<CommandResult, never, FileSystemContextService> {
+): Effect.Effect<CommandResult, never, FileSystemContextService | FileSystem.FileSystem> {
   return Effect.gen(function* () {
     yield* terminal.log(fmt.heading("Session Statistics"));
+
+    const conversation = yield* loadConversation(agent.id, context.conversationId).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
+    yield* terminal.log(fmt.keyValueCompact("Conversation", context.conversationId));
+    yield* terminal.log(fmt.keyValueCompact("Title", conversation?.title ?? "(not saved yet)"));
+    yield* terminal.log(fmt.blank());
 
     // Session duration
     const now = new Date();
@@ -1932,6 +1942,11 @@ function handleStatsCommand(
     yield* terminal.log(fmt.blank());
     yield* terminal.log(fmt.keyValueCompact("Duration", duration));
     yield* terminal.log(fmt.keyValueCompact("Messages", `${context.conversationHistory.length}`));
+    const toolCalls = context.conversationHistory.reduce(
+      (count, message) => count + (message.tool_calls?.length ?? 0),
+      0,
+    );
+    yield* terminal.log(fmt.keyValueCompact("Tool calls", `${toolCalls}`));
 
     const { promptTokens, completionTokens } = context.sessionUsage;
     const totalTokens = promptTokens + completionTokens;
@@ -1952,6 +1967,16 @@ function handleStatsCommand(
     const outputCost = (completionTokens / 1_000_000) * outputPricePerMillion;
     const totalCost = inputCost + outputCost;
     yield* terminal.log(fmt.keyValueCompact("Est. cost", formatUsd(totalCost)));
+
+    const logsDir = getLogsDirectory();
+    yield* terminal.log(fmt.blank());
+    yield* terminal.log(
+      fmt.keyValueCompact(
+        "Session log",
+        path.join(logsDir, `${conversationLogGroup(agent.id, context.conversationId)}.log`),
+      ),
+    );
+    yield* terminal.log(fmt.keyValueCompact("Main log", path.join(logsDir, "jazz.log")));
 
     yield* terminal.log(fmt.blank());
     return { shouldContinue: true };

--- a/packages/cli/src/chat/commands/parser.test.ts
+++ b/packages/cli/src/chat/commands/parser.test.ts
@@ -70,14 +70,14 @@ describe("parseSpecialCommand", () => {
       expect(result.args).toEqual([]);
     });
 
-    it("should parse /stats command", () => {
-      const result = parseSpecialCommand("/stats");
-      expect(result.type).toBe("stats");
+    it("should parse /info command", () => {
+      const result = parseSpecialCommand("/info");
+      expect(result.type).toBe("info");
       expect(result.args).toEqual([]);
     });
 
-    it("should parse /info as an alias of /stats", () => {
-      expect(parseSpecialCommand("/info").type).toBe("stats");
+    it("should parse /stats as an alias of /info", () => {
+      expect(parseSpecialCommand("/stats").type).toBe("info");
     });
 
     it("should parse /mcp command", () => {

--- a/packages/cli/src/chat/commands/parser.test.ts
+++ b/packages/cli/src/chat/commands/parser.test.ts
@@ -76,6 +76,10 @@ describe("parseSpecialCommand", () => {
       expect(result.args).toEqual([]);
     });
 
+    it("should parse /info as an alias of /stats", () => {
+      expect(parseSpecialCommand("/info").type).toBe("stats");
+    });
+
     it("should parse /mcp command", () => {
       const result = parseSpecialCommand("/mcp");
       expect(result.type).toBe("mcp");

--- a/packages/cli/src/chat/commands/parser.ts
+++ b/packages/cli/src/chat/commands/parser.ts
@@ -60,9 +60,9 @@ export function parseSpecialCommand(input: string): SpecialCommand {
       return { type: "cost", args };
     case "workflows":
       return { type: "workflows", args };
-    case "stats":
     case "info":
-      return { type: "stats", args };
+    case "stats":
+      return { type: "info", args };
     case "mcp":
       return { type: "mcp", args };
     case "mode":

--- a/packages/cli/src/chat/commands/parser.ts
+++ b/packages/cli/src/chat/commands/parser.ts
@@ -61,6 +61,7 @@ export function parseSpecialCommand(input: string): SpecialCommand {
     case "workflows":
       return { type: "workflows", args };
     case "stats":
+    case "info":
       return { type: "stats", args };
     case "mcp":
       return { type: "mcp", args };

--- a/packages/cli/src/chat/commands/types.ts
+++ b/packages/cli/src/chat/commands/types.ts
@@ -28,7 +28,7 @@ export type CommandType =
   | "work"
   | "cost"
   | "workflows"
-  | "stats"
+  | "info"
   | "mcp"
   | "mode"
   | "resume"
@@ -87,7 +87,7 @@ export interface SessionUsage {
 
 /**
  * Session-wide caps set by /limit. Checked against this conversation's
- * accumulated usage (the same numbers /cost and /stats show) before every
+ * accumulated usage (the same numbers /cost and /info show) before every
  * turn; an absent field means that metric is uncapped.
  */
 export interface SessionLimits {
@@ -112,7 +112,7 @@ export interface CommandContext {
   sessionTurnCount: number;
   /** Session-wide turn/cost/token caps set by /limit (persists across /new). */
   sessionLimits: SessionLimits;
-  /** Timestamp when the chat session started (for /stats duration). */
+  /** Timestamp when the chat session started (for /info duration). */
   sessionStartedAt: Date;
   /** Current auto-approve policy (for /mode display). */
   autoApprovePolicy?: AutoApprovePolicy;

--- a/packages/core/src/agent/execution/tool-executor.ts
+++ b/packages/core/src/agent/execution/tool-executor.ts
@@ -151,7 +151,7 @@ export class ToolExecutor {
             Effect.catchAll((error) => {
               const message = error instanceof Error ? error.message : String(error);
               if (message.includes("timed out")) {
-                void logger.warn(`Tool timeout: ${name}: ${message}`);
+                Effect.runFork(logger.warn(`Tool timeout: ${name}: ${message}`));
                 return Effect.succeed({
                   success: false,
                   result: null,


### PR DESCRIPTION
## What happened

A chat run stalled for 6m42s after a successful `write_file`. The session log had exactly nothing between `Sending LLM request … iteration 6` and `Interruption handled` — no response, no error, no watchdog. Every other iteration in the run answered within seconds.

## Why the log was empty

`LoggerService.debug/info/warn/error` return a lazy `Effect`. Every log in `stream-processor.ts`, `ai-sdk-service.ts` and the tool-timeout path in `tool-executor.ts` was written as `void this.logger.x(...)`, which discards the Effect without running it. 35 sites — including both `LLM Error` logs and the `Tool timeout` warn. `grep -c "StreamProcessor\|LLM Timing" ~/.jazz/logs/jazz.log` → 0 across 2.6 MB at debug level.

All 35 now go through `Effect.runFork`, the pattern already used in telemetry and the Ink presentation service. The stream-processor test's mock logger now returns real Effects and asserts the timing lines actually fire, so a future `void` fails the suite.

## Why the watchdog didn't fire

`withIdleTimeout` (120s) wraps `result.fullStream` and works. Two awaits sit outside it:

- `resolveModelInfo` before `streamText` — now `Effect.timeout` with the same `streamIdleTimeoutMs` budget, falling into the existing `catchAll → []`.
- `await result.files` after processing — a DelayedPromise that settles when the provider **closes the connection**, not when the last part arrives. A socket left open hangs here forever, silently. Now raced against 5s with a warn, mirroring the 50ms caps already on `usage` and `response` in `buildFinalResponse`.

## `/info`

`/stats` is renamed to `/info` and gains **Conversation** id, **Title**, **Tool calls**, **Session log** and **Main log** paths alongside what it already showed (agent, model, tools, cwd, duration, messages, tokens, cost) — one place to look when debugging a run. `/stats` remains as a parser alias.

## Verification

`bun run typecheck`, `bun eslint` on touched packages, `bun test packages/adapters/src/llm packages/cli/src/chat/commands` — 290 pass, 0 fail.
