### PR TITLE
fix(agent): inject the meltdown signal after the tool results, not between a call and its result

### DIFF
--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -18,6 +18,7 @@ import {
   dedupeToolCalls,
   detectMeltdown,
   executeAgentLoop,
+  MELTDOWN_WINDOW_SIZE,
   type CompletionStrategy,
   type TrackedToolCall,
 } from "./agent-loop";
@@ -1799,6 +1800,64 @@ describe("executeAgentLoop cost and token caps", () => {
     const secondIterationMessages = seenMessages[1] ?? [];
     expect(firstIterationMessages.some((m) => m.content?.includes("TOKEN NOTICE"))).toBe(false);
     expect(secondIterationMessages.some((m) => m.content?.includes("TOKEN NOTICE"))).toBe(true);
+  });
+
+  it("injects the meltdown signal after the tool results, never between a call and its result", async () => {
+    const originalExecute = ToolExecutor.executeToolCalls;
+    ToolExecutor.executeToolCalls = mockToolExecutor((toolCalls) =>
+      succeedWithToolResults(toolCalls),
+    );
+
+    const seenMessages: ConversationMessages[] = [];
+    let call = 0;
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: (messages) => {
+        call++;
+        seenMessages.push(messages);
+        return Effect.succeed({
+          completion: {
+            id: `c${call}`,
+            model: "gpt-4",
+            content: "",
+            toolCalls: [
+              {
+                id: `call_${call}`,
+                type: "function" as const,
+                function: { name: "read_file", arguments: '{"path":"README.md"}' },
+              },
+            ],
+          },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+
+    await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ maxIterations: MELTDOWN_WINDOW_SIZE + 1 }),
+        makeRunContext({ maxIterations: MELTDOWN_WINDOW_SIZE + 1 }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+
+    ToolExecutor.executeToolCalls = originalExecute;
+
+    const lastRequest = seenMessages[seenMessages.length - 1] ?? [];
+    const meltdownIndex = lastRequest.findIndex((m) => m.content?.includes("MELTDOWN DETECTED"));
+    expect(meltdownIndex).toBeGreaterThan(0);
+    expect(lastRequest[meltdownIndex - 1]?.role).toBe("tool");
+    for (const [index, message] of lastRequest.entries()) {
+      if (message.role === "assistant" && (message.tool_calls?.length ?? 0) > 0) {
+        expect(lastRequest[index + 1]?.role).toBe("tool");
+      }
+    }
   });
 });
 

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -597,15 +597,11 @@ function handleToolPhase(
       state.recentToolCalls.splice(0, state.recentToolCalls.length - MELTDOWN_WINDOW_SIZE);
     }
 
-    if (detectMeltdown(state.recentToolCalls)) {
+    const meltdown = detectMeltdown(state.recentToolCalls);
+    if (meltdown) {
       yield* logger.warn("Meltdown detected — injecting recovery signal", {
         agentId: agent.id,
         recentTools: state.recentToolCalls.slice(-10).map((tc) => tc.name),
-      });
-      state.currentMessages.push({
-        role: "user",
-        content:
-          "[MELTDOWN DETECTED: You have been repeating the same tool calls without progress. Stop the current approach. Summarize what you have found so far, identify what is still missing, and either proceed directly to output or try a fundamentally different search strategy. Do not repeat your last action.]",
       });
       state.recentToolCalls.length = 0;
     }
@@ -752,6 +748,16 @@ function handleToolPhase(
           recordToolResultTokens(runMetrics, toolCall.function.name, formattedResult.length);
         }
       }
+    }
+
+    // Only after every tool result is in place: a user message between an assistant's
+    // tool_calls and their results is an invalid transcript that providers reject.
+    if (meltdown) {
+      state.currentMessages.push({
+        role: "user",
+        content:
+          "[MELTDOWN DETECTED: You have been repeating the same tool calls without progress. Stop the current approach. Summarize what you have found so far, identify what is still missing, and either proceed directly to output or try a fundamentally different search strategy. Do not repeat your last action.]",
+      });
     }
 
     // Media attached by tools rides on a user message after the tool results. A `role: "tool"`


### PR DESCRIPTION
## What happened

A chat run on `openai:gpt-5.6-luna` died on iteration 37 with `Could not reach the LLM API (retries exhausted): Tool result is missing for tool call call_HV0I8dkq2hWWIj7lwd7dYDUG.` The `read_file` behind that id had run and succeeded 1ms earlier — the session log shows the result right there.

## Why

Ten consecutive `read_file` calls tripped `detectMeltdown` inside `handleToolPhase`. That check runs before the tools execute, and it pushed its `[MELTDOWN DETECTED…]` user message immediately — ahead of the tool results appended later in the same phase. Iteration 37 went out as:

```
assistant  tool_calls: [call_HV0I…]
user       [MELTDOWN DETECTED: …]
tool       call_HV0I…
```

OpenAI requires each tool message to directly follow the assistant message that requested it, so it rejected the transcript. The error surfaced without an HTTP status, `isRetryableLLMError` read that as a connection failure, and the schedule burned three retries on a request that could never be accepted.

## Fix

Detection stays where it was (it needs `recentToolCalls` before the reset). The message is pushed only after the tool-result loop, next to the media attachments that already ride on a trailing user message for the same reason.

## Verification

New test in `agent-loop.test.ts` drives eleven identical `read_file` calls and asserts the meltdown message sits after a tool message and every assistant `tool_calls` is immediately followed by its result. It fails on the old ordering.

`bun test packages/core/src/agent/execution/agent-loop.test.ts` — 65 pass, 0 fail. `bun eslint` and `tsc --noEmit` on `packages/core` clean.

Not in this PR: the misleading "Could not reach the LLM API" label on status-less provider rejections.
