### PR TITLE
fix(cli): a queued slash command runs as a command, not as text the model has to answer

### DIFF
--- a/packages/cli/src/chat-service.ts
+++ b/packages/cli/src/chat-service.ts
@@ -206,27 +206,23 @@ export class ChatServiceImpl implements ChatService {
 
       while (chatActive) {
         let userMessage: string | undefined;
-        const queuedEntryCount = store.getMessageQueueSnapshot().length;
         const queued = store.peekQueue();
         // A flush (Esc with queued messages during a run) takes priority over the
         // error path: even though the prior turn was interrupted, the user asked
         // for the queue to go into the chat now, not to be re-edited.
         const flushRequested = store.consumeFlushQueue();
-        // A multi-entry drain is prose for the agent even if the first entry
-        // starts with "/" — parsing the joined text as one command would
-        // silently discard the other entries.
-        let drainedMultipleEntries = false;
 
         if (queued.length > 0 && (!lastTurnErrored || flushRequested)) {
-          // Clean prior turn → drain the queue as the next user message
-          // without re-prompting. Record entries in input history for ↑
-          // recall parity with interactively typed messages.
-          for (const entry of store.getMessageQueueSnapshot()) {
+          // Clean prior turn → drain the next queued turn without re-prompting.
+          // A command at the head runs alone through the command path below;
+          // prose entries are combined. Anything left is picked up next loop.
+          // Record entries in input history for ↑ recall parity with
+          // interactively typed messages.
+          const entries = store.takeQueuedTurn();
+          for (const entry of entries) {
             store.pushInputHistory(entry);
           }
-          store.takeQueue();
-          userMessage = queued;
-          drainedMultipleEntries = queuedEntryCount > 1;
+          userMessage = entries.join("\n");
           // Echo "You: <prompt>" to scrollback so the user can see when their
           // queued message was actually popped (vs when the LLM started
           // responding to it). The interactive ask() path emits the same
@@ -297,12 +293,10 @@ export class ChatServiceImpl implements ChatService {
         let messageForAgent = userMessage;
 
         // A message with interior newlines (multi-line composition or a
-        // multi-line queued entry) is prose even when it starts with "/" or
-        // "!" —
+        // combined prose drain) is prose even when it starts with "/" or "!" —
         // command parsing would silently discard everything after line one.
         if (
           (trimmedMessage.startsWith("/") || trimmedMessage.startsWith("!")) &&
-          !drainedMultipleEntries &&
           !trimmedMessage.includes("\n")
         ) {
           const specialCommand = parseSpecialCommand(userMessage);
@@ -508,7 +502,7 @@ export class ChatServiceImpl implements ChatService {
               }
             },
             checkQueuedMessage: () => {
-              const queued = store.takeQueue();
+              const queued = store.takeQueuedProse().join("\n");
               if (queued.length === 0) return undefined;
               Effect.runSync(terminal.user(queued));
               return queued;

--- a/packages/cli/src/ui/QueueInput.tsx
+++ b/packages/cli/src/ui/QueueInput.tsx
@@ -39,7 +39,8 @@ function truncateEntry(entry: string): string {
  * Each Enter appends a new entry to the in-memory message queue. The queue
  * preview shows entries stacked one per line; on agent completion the chat
  * loop drains the queue (joining with `\n`) and sends it as a single
- * combined turn. `↑` recalls the whole queue into the input for editing
+ * combined turn; a queued slash command runs alone through the command path.
+ * `↑` recalls the whole queue into the input for editing
  * (any typed draft is kept below the recalled text). `Ctrl-X` clears the
  * queue when the input buffer is empty.
  */
@@ -122,11 +123,6 @@ export function QueueInput({
             >
               {`  ${G.bullet} `}
               {truncateEntry(entry)}
-              {/* Slash commands only run when queued alone — a mixed queue is
-                  sent to the agent as prose. Warn while it's still editable. */}
-              {entry.trimStart().startsWith("/") && queue.length > 1 ? (
-                <Text color={THEME.warning}> (sent as text, not run — queue it alone)</Text>
-              ) : null}
             </Text>
           ))}
         </Box>

--- a/packages/cli/src/ui/fullscreen/Input.tsx
+++ b/packages/cli/src/ui/fullscreen/Input.tsx
@@ -150,23 +150,13 @@ function previewQueuedEntry(entry: string): string {
   return entry.replace(/\s+/g, " ").trim();
 }
 
-function queuePreviewRows(
-  entries: readonly string[],
-  width: number,
-  glyphs: GlyphSet,
-  mixedQueue: boolean,
-): InputRow[] {
+function queuePreviewRows(entries: readonly string[], width: number, glyphs: GlyphSet): InputRow[] {
   return entries.map((entry, index) => {
     const oneLine = previewQueuedEntry(entry);
-    // Slash commands only run when they are the whole queue; mixed in they
-    // go to the model as prose, so say so while the entry is still editable.
-    const slashWarning =
-      mixedQueue && oneLine.startsWith("/") ? " (sent as text, not run — queue it alone)" : "";
     const segments: InputSegment[] = [
       { text: `${glyphs.rail} `, fg: THEME.border },
       { text: `${glyphs.bullet} `, fg: THEME.muted },
       { text: oneLine, fg: THEME.muted },
-      ...(slashWarning.length > 0 ? [{ text: slashWarning, fg: THEME.warning }] : []),
     ];
     return {
       key: `queue:${String(index)}:${oneLine}`,
@@ -334,7 +324,7 @@ export function inputRows(
     rows.push(alignRow("chrome", left, right, width));
   }
   if (visibleQueued.length > 0) {
-    rows.push(...queuePreviewRows(visibleQueued, width, glyphs, queuedCount > 1));
+    rows.push(...queuePreviewRows(visibleQueued, width, glyphs));
   }
 
   // The caret's own line may have scrolled out of `visible` — the window

--- a/packages/cli/src/ui/fullscreen/live-input.test.tsx
+++ b/packages/cli/src/ui/fullscreen/live-input.test.tsx
@@ -621,14 +621,14 @@ describe("input", () => {
     expect(some).toHaveLength(2 + MAX_VISIBLE_QUEUED);
   });
 
-  it("collapses queued newlines and warns when a slash command is mixed in", () => {
+  it("collapses queued newlines in the preview", () => {
     const some = inputRows(
       { ...base, queued: ["/clear", "keep going"] },
       { width: WIDTH, height: HEIGHT },
     );
     const text = some.map((row) => row.segments.map((s) => s.text).join("")).join("\n");
     expect(text).toContain("/clear");
-    expect(text).toContain("sent as text, not run");
+    expect(text).not.toContain("sent as text, not run");
     expect(text).toContain("keep going");
 
     const wrapped = inputRows(

--- a/packages/cli/src/ui/store.test.ts
+++ b/packages/cli/src/ui/store.test.ts
@@ -624,6 +624,45 @@ describe("UIStore", () => {
       expect(s.takeQueue()).toBe("");
     });
 
+    test("takeQueuedTurn pops a head command alone and leaves the rest queued", () => {
+      const s = new UIStore();
+      s.appendToQueue("/info");
+      s.appendToQueue("keep going");
+      s.appendToQueue("and this");
+
+      expect(s.takeQueuedTurn()).toEqual(["/info"]);
+      expect(s.getMessageQueueSnapshot()).toEqual(["keep going", "and this"]);
+      expect(s.takeQueuedTurn()).toEqual(["keep going", "and this"]);
+      expect(s.getMessageQueueSnapshot()).toEqual([]);
+    });
+
+    test("takeQueuedTurn stops a prose run at the next command", () => {
+      const s = new UIStore();
+      s.appendToQueue("first");
+      s.appendToQueue("! git status");
+      s.appendToQueue("last");
+
+      expect(s.takeQueuedTurn()).toEqual(["first"]);
+      expect(s.takeQueuedTurn()).toEqual(["! git status"]);
+      expect(s.takeQueuedTurn()).toEqual(["last"]);
+      expect(s.takeQueuedTurn()).toEqual([]);
+    });
+
+    test("takeQueuedProse never pops a command, so mid-run injection skips it", () => {
+      const s = new UIStore();
+      s.appendToQueue("/compact");
+      s.appendToQueue("note");
+      expect(s.takeQueuedProse()).toEqual([]);
+      expect(s.getMessageQueueSnapshot()).toEqual(["/compact", "note"]);
+
+      const t = new UIStore();
+      t.appendToQueue("a");
+      t.appendToQueue("/slash\nstill prose");
+      t.appendToQueue("/help");
+      expect(t.takeQueuedProse()).toEqual(["a", "/slash\nstill prose"]);
+      expect(t.getMessageQueueSnapshot()).toEqual(["/help"]);
+    });
+
     test("clearQueue empties the array", () => {
       const s = new UIStore();
       s.appendToQueue("a");

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -20,6 +20,11 @@ type ModeSwitchHandler = (mode: "safe" | "yolo") => void;
 const EMPTY_STREAM = "";
 const EMPTY_OUTPUT_ENTRIES: readonly OutputEntryWithId[] = [];
 const EMPTY_QUEUE: readonly string[] = [];
+
+function isQueuedCommand(entry: string): boolean {
+  const trimmed = entry.trim();
+  return (trimmed.startsWith("/") || trimmed.startsWith("!")) && !trimmed.includes("\n");
+}
 const EMPTY_REGIONS: readonly EphemeralRegion[] = [];
 const EMPTY_CONNECTORS: ReadonlyMap<string, ConnectorStatus> = new Map();
 const EMPTY_RUN_STATS: RunStats = {};
@@ -466,6 +471,33 @@ export class UIStore {
     const value = queue.join("\n");
     patchSlice(this.prompt, { messageQueue: EMPTY_QUEUE });
     return value;
+  };
+
+  /**
+   * Pop the leading run of prose entries, leaving any slash/shell command at
+   * the head (and everything behind it) queued. Used mid-run so a queued
+   * command is never injected into the model conversation as text.
+   */
+  takeQueuedProse = (): readonly string[] => {
+    const queue = this.prompt.getSnapshot().messageQueue;
+    const firstCommand = queue.findIndex(isQueuedCommand);
+    const end = firstCommand === -1 ? queue.length : firstCommand;
+    if (end === 0) return EMPTY_QUEUE;
+    patchSlice(this.prompt, { messageQueue: queue.slice(end) });
+    return queue.slice(0, end);
+  };
+
+  /**
+   * Pop the next turn: a command at the head runs alone, otherwise the
+   * leading prose run is sent as one combined message.
+   */
+  takeQueuedTurn = (): readonly string[] => {
+    const queue = this.prompt.getSnapshot().messageQueue;
+    const head = queue[0];
+    if (head === undefined) return EMPTY_QUEUE;
+    if (!isQueuedCommand(head)) return this.takeQueuedProse();
+    patchSlice(this.prompt, { messageQueue: queue.slice(1) });
+    return [head];
   };
 
   clearQueue = (): void => {


### PR DESCRIPTION
## Problem

A slash command typed while the agent was busy did not run. It went to the model as text. Two drains caused this:

- **Mid-run.** At every tool-phase boundary the agent loop called `checkQueuedMessage`, which took the whole queue and pushed it into the conversation as a user message. A queued `/info` became prose the model had to answer.
- **Between turns.** The chat loop joined every queued entry into one message. A command queued next to anything else was sent as text, and the queue preview warned "sent as text, not run, queue it alone".

## Fix

The store now owns what counts as a command in the queue: a single-line entry starting with `/` or `!`. Two takes replace the join-everything drain:

- `takeQueuedProse` pops the leading run of prose entries and stops at the first command. The mid-run hook uses it, so a queued command is never injected into a running conversation.
- `takeQueuedTurn` pops the next turn. A command at the head comes out alone and runs through the existing command parser. A prose run comes out combined, as before. The chat loop drains one turn per iteration and comes back for the rest.

Order is preserved: prose queued behind a command waits until the command has run. Multi-line entries starting with `/` still count as prose. The "queue it alone" warnings are removed from both the Ink and fullscreen queue previews since the case no longer exists.

## Not in this PR

Read-only commands such as `/info` and `/cost` still wait for the turn to end. Running them immediately mid-turn needs the command context published from the chat loop and is a separate change.

## Tests

- New store tests: command at head runs alone, prose run stops at the next command, mid-run take skips commands.
- Fullscreen preview test updated to assert the warning is gone.
- CLI package typecheck, lint, and the UI and chat-service test directories pass.
