### PR TITLE
fix(context): clear tool results only under pressure, and keep the last five cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,19 @@ test when you do.
 Tests live beside the code they cover. Cover the failure modes, not just the
 happy path. A test that cannot fail is worse than no test.
 
+### Checks
+
+CI runs all four. `typecheck` does not cover test files; `test:typecheck` does.
+When a task starts from a failing check, run that exact command first and see
+it fail, then again before you report.
+
+```
+bun run typecheck
+bun run test:typecheck
+bun run lint
+bun test
+```
+
 ### Code
 
 Write advanced TypeScript. Use the type system for real: discriminated unions,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ CI runs all four. `typecheck` does not cover test files; `test:typecheck` does.
 When a task starts from a failing check, run that exact command first and see
 it fail, then again before you report.
 
-```
+```sh
 bun run typecheck
 bun run test:typecheck
 bun run lint

--- a/packages/core/src/agent/context/context-window-manager.ts
+++ b/packages/core/src/agent/context/context-window-manager.ts
@@ -7,9 +7,18 @@ import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./toke
 /**
  * The compaction ladder's thresholds and `ContextWindowManager`, which decides
  * whether a conversation needs compaction or trimming before the next LLM call
- * and carries out that decision. Tool-result clearing runs every iteration in
- * the agent loop and does not use a window-fill gate.
+ * and carries out that decision. Tool-result clearing, the rung below both,
+ * is gated by `CONTEXT_CLEAR_THRESHOLD_RATIO` in the agent loop.
  */
+
+/**
+ * Fraction of the context budget below which old tool results are left verbatim.
+ *
+ * Clearing is only worth its cost under pressure. Below this line the model keeps
+ * every result it has read, so evidence gathered three turns ago is still there when
+ * it decides; above it, results older than `PROTECTED_TOOL_CYCLES` are stubbed.
+ */
+export const CONTEXT_CLEAR_THRESHOLD_RATIO = 0.5;
 
 /**
  * Fraction of the context budget at which the user is told the window is filling up,

--- a/packages/core/src/agent/context/tool-result-clearing.test.ts
+++ b/packages/core/src/agent/context/tool-result-clearing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { ChatMessage } from "@/core/types/message";
-import { clearToolResults, toolResultsProtectFromIndex } from "./tool-result-clearing";
+import {
+  clearToolResults,
+  PROTECTED_TOOL_CYCLES,
+  toolResultsProtectFromIndex,
+} from "./tool-result-clearing";
 
 const modelHint = { provider: "openai", modelId: "gpt-4o" };
 
@@ -34,24 +38,33 @@ function conversation(pairs: number): ChatMessage[] {
 }
 
 describe("toolResultsProtectFromIndex", () => {
-  it("protects the live tool cycle so the model still sees what it just asked for", () => {
-    const messages = conversation(3);
-    const protectFrom = toolResultsProtectFromIndex(messages);
-    let lastCall = -1;
-    for (let index = messages.length - 1; index >= 0; index--) {
-      if (messages[index]?.role === "assistant") {
-        lastCall = index;
-        break;
-      }
-    }
-    expect(protectFrom).toBe(lastCall);
+  function callIndexes(messages: readonly ChatMessage[]): number[] {
+    return messages.flatMap((message, index) =>
+      message.role === "assistant" && message.tool_calls?.length ? [index] : [],
+    );
+  }
+
+  it("protects the last PROTECTED_TOOL_CYCLES cycles so evidence survives a read-compare-edit", () => {
+    const messages = conversation(PROTECTED_TOOL_CYCLES + 3);
+    const calls = callIndexes(messages);
+    expect(calls.at(-PROTECTED_TOOL_CYCLES)).toBe(toolResultsProtectFromIndex(messages));
   });
 
-  it("protects nothing once a later assistant message has consumed the cycle", () => {
+  it("protects everything when the transcript has fewer cycles than the window", () => {
+    const messages = conversation(2);
+    expect(callIndexes(messages)[0]).toBe(toolResultsProtectFromIndex(messages));
+  });
+
+  it("keeps protecting after a plain assistant reply; the cycles behind it are still recent", () => {
     const messages = [
       ...conversation(2),
       { role: "assistant", content: "here is the answer" } as ChatMessage,
     ];
+    expect(callIndexes(messages)[0]).toBe(toolResultsProtectFromIndex(messages));
+  });
+
+  it("protects nothing when there are no tool cycles", () => {
+    const messages: ChatMessage[] = [{ role: "system", content: "system" }];
     expect(toolResultsProtectFromIndex(messages)).toBe(messages.length);
   });
 });

--- a/packages/core/src/agent/context/tool-result-clearing.ts
+++ b/packages/core/src/agent/context/tool-result-clearing.ts
@@ -6,9 +6,9 @@ import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./toke
  * rung of the ladder.
  *
  * A long run's tokens are overwhelmingly raw tool results, and most of them
- * stop mattering the moment the model has read them once. The latest tool
- * cycle stays verbatim so the model can act on what it just asked for; older
- * large results are stubbed. When the bytes were persisted, the stub names
+ * stop mattering once the model has acted on them. The last few tool cycles
+ * stay verbatim so the model can still compare what it read against what it
+ * is about to change; older large results are stubbed. When the bytes were persisted, the stub names
  * `retrieve_tool_result`. When the disk would not take them (read-only CI,
  * container, Telegram host), the stub tells the model to re-run the original
  * tool instead. Either way the message and `tool_call_id` stay, so
@@ -25,6 +25,15 @@ import { DEFAULT_TOKEN_COUNTER, type ModelHint, type TokenCounter } from "./toke
  * back, so a small stub is cheap to undo.
  */
 export const MIN_CLEARABLE_RESULT_TOKENS = 256;
+
+/**
+ * Tool cycles kept verbatim, counting back from the live one.
+ *
+ * One cycle is not enough: a model that reads a file, then lists a directory,
+ * then edits has already lost the file by the time it edits, and refetches it
+ * every turn. Five covers a read-compare-edit sequence with room to spare.
+ */
+export const PROTECTED_TOOL_CYCLES = 5;
 
 export interface ClearToolResultsOptions {
   /** Messages at this index and after must not be touched (the live tool cycle). */
@@ -43,26 +52,25 @@ export interface ClearToolResultsOutcome {
 }
 
 /**
- * Index of the live tool cycle: the last assistant message that still has
- * `tool_calls`, through the end of the list.
+ * Index from which tool results stay verbatim: the assistant message that opened
+ * the `cycles`-th most recent tool cycle, through the end of the list.
  *
- * Those results have not been fed to the model yet (or are the ones it is
- * about to use). Everything before that cycle is fair game. A later assistant
- * message without tool calls means the previous cycle was already consumed —
- * protect nothing, clear the lot.
+ * Fewer cycles than that in the transcript means every result is still recent;
+ * none at all means there is nothing to clear.
  */
-export function toolResultsProtectFromIndex(messages: readonly ChatMessage[]): number {
-  for (let index = messages.length - 1; index >= 0; index--) {
+export function toolResultsProtectFromIndex(
+  messages: readonly ChatMessage[],
+  cycles = PROTECTED_TOOL_CYCLES,
+): number {
+  let protectFrom = messages.length;
+  let seen = 0;
+  for (let index = messages.length - 1; index >= 0 && seen < cycles; index--) {
     const message = messages[index];
-    if (!message || message.role !== "assistant") continue;
-    if (message.tool_calls && message.tool_calls.length > 0) {
-      return index;
-    }
-    if ((message.content?.trim().length ?? 0) > 0) {
-      return messages.length;
-    }
+    if (message?.role !== "assistant" || !message.tool_calls?.length) continue;
+    protectFrom = index;
+    seen++;
   }
-  return messages.length;
+  return protectFrom;
 }
 
 function placeholderFor(

--- a/packages/core/src/agent/execution/agent-loop.test.ts
+++ b/packages/core/src/agent/execution/agent-loop.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { DEFAULT_MAX_ITERATIONS } from "@/core/constants/agent";
 import { GenerationInterruptedError } from "@/core/types/errors";
-import type { ConversationMessages } from "@/core/types/message";
+import type { ChatMessage, ConversationMessages } from "@/core/types/message";
 import type { DisplayConfig } from "@/core/types/output";
 import { clearModelsDevCache } from "@/core/utils/models-dev";
 import {
@@ -42,6 +42,7 @@ import { WorkspaceServiceTag } from "../../interfaces/workspace-service";
 import { SkillServiceTag } from "../../skills/skill-service";
 import type { RecursiveRunner } from "../context/summarizer";
 import { DEFAULT_TOKEN_COUNTER } from "../context/token-counter";
+import { PROTECTED_TOOL_CYCLES } from "../context/tool-result-clearing";
 import type { AgentRunContext, AgentRunnerOptions, AgentResponse } from "../types";
 
 // Shared mocks
@@ -1384,6 +1385,78 @@ describe("executeAgentLoop context window accounting", () => {
   it("compacts against the pinned num_ctx rather than the advertised model maximum", async () => {
     const { compactions } = await runWithHistory(PINNED_CONTEXT_WINDOW);
     expect(compactions).toBeGreaterThan(0);
+  });
+
+  // PROTECTED_TOOL_CYCLES + 1 read cycles, so exactly the first result is old enough to clear.
+  function toolHistory(resultChars: number): ChatMessage[] {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: "go" },
+    ];
+    for (let cycle = 0; cycle <= PROTECTED_TOOL_CYCLES; cycle++) {
+      const id = `call_${cycle}`;
+      messages.push({
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id, type: "function", function: { name: "read_file", arguments: "{}" } }],
+      } as ChatMessage);
+      messages.push({
+        role: "tool",
+        tool_call_id: id,
+        content: (cycle === 0 ? "oldest " : "recent ").padEnd(resultChars, "x"),
+      } as ChatMessage);
+    }
+    messages.push({ role: "user", content: "now decide" });
+    return messages;
+  }
+
+  async function toolResultsSeenByModel(resultChars: number, numCtx?: number): Promise<string[]> {
+    let seen: ConversationMessages | undefined;
+    const strategy: CompletionStrategy = {
+      shouldShowReasoning: false,
+      getCompletion: (messages) => {
+        seen ??= messages;
+        return Effect.succeed({
+          completion: { id: "c1", model: "qwen3.6:27b", content: "done" },
+          interrupted: false,
+        });
+      },
+      presentResponse: () => Effect.void,
+      onComplete: () => Effect.void,
+      getRenderer: () => null,
+    };
+    await Effect.runPromise(
+      executeAgentLoop(
+        makeOptions({ agent: ollamaAgent(numCtx) as AgentRunnerOptions["agent"] }),
+        makeRunContext({
+          provider: "ollama",
+          model: "qwen3.6:27b",
+          agent: ollamaAgent(numCtx) as AgentRunContext["agent"],
+          messages: toolHistory(resultChars) as AgentRunContext["messages"],
+        }),
+        displayConfig,
+        strategy,
+        defaultObserver,
+        runRecursive,
+      ).pipe(Effect.provide(TestLayer)),
+    );
+    return (seen ?? []).filter((message) => message.role === "tool").map((m) => m.content ?? "");
+  }
+
+  it("leaves every tool result verbatim while the window is under the clear threshold", async () => {
+    // 6 × 20k chars ≈ 34k tokens: about 13% of the advertised window. Nothing is under pressure,
+    // so the evidence the model read six cycles ago is still there when it decides.
+    const results = await toolResultsSeenByModel(20_000);
+    expect(results).toHaveLength(PROTECTED_TOOL_CYCLES + 1);
+    expect(results[0]).toStartWith("oldest ");
+  });
+
+  it("stubs only results older than the protected cycles once past the clear threshold", async () => {
+    // The same 34k tokens against a pinned 60k window is ~57%: over the clear line, under compaction.
+    const results = await toolResultsSeenByModel(20_000, 60_000);
+    expect(results).toHaveLength(PROTECTED_TOOL_CYCLES + 1);
+    expect(results[0]).toStartWith("[tool result");
+    for (const recent of results.slice(1)) expect(recent).toStartWith("recent ");
   });
 
   it("tells the model to resume the original task after mid-run compaction", async () => {

--- a/packages/core/src/agent/execution/agent-loop.ts
+++ b/packages/core/src/agent/execution/agent-loop.ts
@@ -38,6 +38,7 @@ import { ToolExecutor } from "./tool-executor";
 import { logContextRung } from "../context/context-telemetry";
 import { resolveContextThresholds } from "../context/context-thresholds";
 import {
+  CONTEXT_CLEAR_THRESHOLD_RATIO,
   CONTEXT_COMPACT_THRESHOLD_RATIO,
   CONTEXT_TRIM_THRESHOLD_RATIO,
   CONTEXT_WARN_THRESHOLD_RATIO,
@@ -864,12 +865,14 @@ function runIteration(
       yield* observer.onThinking(agent.name, iterationIndex === 0);
     }
 
-    // Cheapest rung first: persist large tool bodies, then stub every cycle
-    // except the live one. Runs every iteration — each result is rewritten at
-    // most once (`cleared` sticks), so the prompt-cache prefix only jumps when
-    // a result actually ages out. A failed write (read-only CI, container)
-    // still stubs; the placeholder then says to re-run the original tool.
-    {
+    // Cheapest rung first, and only under pressure: persist large tool bodies,
+    // then stub every cycle older than the protected window. Below the clear
+    // threshold nothing is touched, so the model keeps the evidence it gathered
+    // and the prompt-cache prefix never moves. A failed write (read-only CI,
+    // container) still stubs; the placeholder then says to re-run the tool.
+    if (
+      runContextWindowManager.usage(state.currentMessages).ratio >= CONTEXT_CLEAR_THRESHOLD_RATIO
+    ) {
       const before = runContextWindowManager.totalRequestTokens(state.currentMessages);
       const modelHint = { provider, modelId: model };
       const retrievableIds = yield* persistLargeToolResults(state.currentMessages, {

--- a/packages/core/src/agent/persona-contract.test.ts
+++ b/packages/core/src/agent/persona-contract.test.ts
@@ -11,10 +11,10 @@ import { describe, expect, test } from "bun:test";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
 
-const PERSONA_SOURCES = [
-  { label: "personas", dir: join(REPO_ROOT, "personas") },
-  { label: "marketplace/personas", dir: join(REPO_ROOT, "marketplace/personas") },
-] as const;
+const PERSONA_SOURCES: [label: string, dir: string][] = [
+  ["personas", join(REPO_ROOT, "personas")],
+  ["marketplace/personas", join(REPO_ROOT, "marketplace/personas")],
+];
 
 // Identity placeholders, substituted from the agent's own config.
 const IDENTITY_PLACEHOLDERS = ["{agentName}", "{agentDescription}"] as const;
@@ -36,7 +36,7 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
-describe.each(PERSONA_SOURCES)("persona placeholder contract ($label)", ({ label, dir }) => {
+describe.each(PERSONA_SOURCES)("persona placeholder contract (%s)", (label, dir) => {
   const personaNames = readdirSync(dir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);

--- a/packages/core/src/agent/prompts/shared.ts
+++ b/packages/core/src/agent/prompts/shared.ts
@@ -84,6 +84,7 @@ export const COMPLETION_INSTRUCTIONS = `
 6. Never guess a value you can fetch. If a tool call can resolve a URL, an ID, a number, or a fact, make the call — a wrong guess costs more than one more tool call. Look up live docs instead of relying on training for how a CLI is installed or configured.
 7. When asked about something you did earlier, answer from the record — re-read the file, re-fetch the resource, check the actual tool results. Never reconstruct your own past actions from memory or from what seems plausible.
 8. When the requested job is done, stop. Do not invent a larger next job or ask whether to expand the scope. If they want more, they will say so.
+9. Reproduce before you fix. When the task is a failing check, run the exact command that failed and watch it fail before changing anything; a passing neighbour (\`typecheck\` when CI ran \`test:typecheck\`) proves nothing. Rerun that same command before you report, and report only what it printed.
 `;
 
 export const TOOL_SELECTION_INSTRUCTIONS = `


### PR DESCRIPTION
## Why

A Jazz run on the persona-contract typecheck failure looped on `retrieve_tool_result`, tripped the meltdown detector, then edited the test based on a claim its own `ls` output contradicted. The log shows 82 clear events at a small fraction of the context window.

Cause: tool-result clearing ran every iteration, protected only the live tool cycle, and stubbed anything over 256 tokens. Retrieval output is itself a tool result, so it was stubbed the next turn too. The model effectively had one turn of memory for anything longer than ~20 lines.

## What

- **Gate the clear rung on pressure.** New `CONTEXT_CLEAR_THRESHOLD_RATIO = 0.5` in `context-window-manager.ts`, below the existing 0.7 warn / 0.8 compact / 0.95 trim. Below it nothing is stubbed and the prompt prefix never moves.
- **Protect the last five cycles**, not one. `PROTECTED_TOOL_CYCLES = 5`; `toolResultsProtectFromIndex` counts back that many tool-call cycles. The rule that cleared everything after a plain assistant reply is gone.
- **Document the checks.** `AGENTS.md` gains a Checks section (`typecheck` does not cover test files; `test:typecheck` does). The completion rules gain rule 9: run the exact failing command, watch it fail, rerun it before reporting.
- **Persona contract test** (separate commit): `describe.each` table as `[label, dir]` tuples so `test:typecheck` accepts it. This was the CI failure on main.

Not in this PR: pinning results the model requested twice. Deferred until a rerun shows repeat retrievals past half the budget.

## Tests

- Four unit tests for the protect index: five-cycle window, fewer cycles than the window, trailing text reply, no cycles.
- Two loop-level tests through the existing Ollama harness: at 13% of the window every result reaches the model verbatim; at 57% of a pinned window only the result older than five cycles is stubbed.

Full suite: 4122 pass. `typecheck`, `test:typecheck`, `lint` clean.