### PR TITLE
feat(cli): show the persona and its PERSONA.md path in /info

### DIFF
--- a/packages/adapters/src/persona-service.ts
+++ b/packages/adapters/src/persona-service.ts
@@ -24,13 +24,17 @@ import matter from "gray-matter";
 const PERSONA_DEFINITION_FILENAMES = ["PERSONA.md", "persona.md"] as const;
 const PERSONA_DEFINITION_FILENAME = PERSONA_DEFINITION_FILENAMES[0];
 
-async function readPersonaDefinition(personaDir: string): Promise<string> {
+async function readPersonaDefinition(
+  personaDir: string,
+): Promise<{ readonly filePath: string; readonly content: string }> {
   const [canonical, legacy] = PERSONA_DEFINITION_FILENAMES;
+  const canonicalPath = path.join(personaDir, canonical);
   try {
-    return await fs.readFile(path.join(personaDir, canonical), "utf-8");
+    return { filePath: canonicalPath, content: await fs.readFile(canonicalPath, "utf-8") };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    return await fs.readFile(path.join(personaDir, legacy), "utf-8");
+    const legacyPath = path.join(personaDir, legacy);
+    return { filePath: legacyPath, content: await fs.readFile(legacyPath, "utf-8") };
   }
 }
 
@@ -185,7 +189,7 @@ export class PersonaServiceImpl implements PersonaService {
   ): Effect.Effect<Persona, StorageError | StorageNotFoundError> {
     return Effect.gen(function* () {
       const filePath = path.join(personaDir, PERSONA_DEFINITION_FILENAME);
-      const content = yield* Effect.tryPromise({
+      const { filePath: definitionPath, content } = yield* Effect.tryPromise({
         try: () => readPersonaDefinition(personaDir),
         catch: (error) => {
           if (
@@ -219,6 +223,7 @@ export class PersonaServiceImpl implements PersonaService {
         name: typeof data["name"] === "string" ? data["name"] : path.basename(personaDir),
         description: typeof data["description"] === "string" ? data["description"] : "",
         systemPrompt: parsed.content.trim(),
+        filePath: definitionPath,
         ...(typeof data["tone"] === "string" && data["tone"].length > 0 && { tone: data["tone"] }),
         ...(typeof data["style"] === "string" &&
           data["style"].length > 0 && { style: data["style"] }),

--- a/packages/cli/src/chat/commands/handler.ts
+++ b/packages/cli/src/chat/commands/handler.ts
@@ -1922,6 +1922,14 @@ function handleInfoCommand(
     const duration = durationParts.join(" ");
 
     yield* terminal.log(fmt.keyValueCompact("Agent", `${agent.name} (${agent.id})`));
+    const personaServiceOption = yield* Effect.serviceOption(PersonaServiceTag);
+    const persona = Option.isSome(personaServiceOption)
+      ? yield* personaServiceOption.value
+          .getPersonaByIdentifier(agent.config.persona)
+          .pipe(Effect.catchAll(() => Effect.succeed(null)))
+      : null;
+    yield* terminal.log(fmt.keyValueCompact("Persona", persona?.name ?? agent.config.persona));
+    yield* terminal.log(fmt.keyValueCompact("Persona file", persona?.filePath ?? "(not found)"));
     yield* terminal.log(
       fmt.keyValueCompact("Model", `${agent.config.llmProvider}/${agent.config.llmModel}`),
     );

--- a/packages/core/src/types/persona.ts
+++ b/packages/core/src/types/persona.ts
@@ -71,6 +71,8 @@ export interface Persona {
    * `agent.config.tools` and the default built-in bundle would provide.
    */
   readonly toolProfile?: PersonaToolProfile;
+  /** Absolute path of the PERSONA.md this persona was loaded from, when it came from disk. */
+  readonly filePath?: string;
   /** Creation timestamp */
   readonly createdAt: Date;
   /** Last update timestamp */


### PR DESCRIPTION
## Summary

`/info` showed the agent, model, and tools but never which persona was driving the conversation or where its definition lives. It now prints both, right after the Agent line:

```
Agent         coder (abc123)
Persona       coder
Persona file  /Users/me/github/jazz/personas/coder/PERSONA.md
Model         anthropic/claude-...
```

- `Persona` gains an optional `filePath`, set by the persona service when a persona is loaded from disk. It records the file that was actually read, so a legacy lowercase `persona.md` shows its real name.
- `/info` resolves the persona the same way `/tools` already does and prints the two lines. When the persona cannot be resolved, it prints the raw name from the agent config and `(not found)` for the file.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test packages/adapters/src/persona-service packages/cli/src/chat/commands/handler`
- [x] eslint on the touched files
- [ ] Run `jazz`, type `/info`, confirm the Persona and Persona file lines point at the right PERSONA.md